### PR TITLE
fix: validate modular Claude plugin layout in skills sync check

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ Skills, and operational guides.
 
 ## Hard rules (must follow)
 
-- **Generated files** under `providers/claude/plugin/skills/` and
+- **Generated files** under `providers/claude/plugins/<plugin>/skills/` and
   `providers/cursor/plugin/skills/` are produced by
   `./scripts/sync-skills.sh` from `skills/`. **Never hand-edit them.**
   Edit the source under `skills/` and run the sync script.

--- a/.cursor/rules/main.mdc
+++ b/.cursor/rules/main.mdc
@@ -13,7 +13,7 @@ guidance.
 ## Hard rules (don't break these)
 
 - **Generated files**: never hand-edit under
-  `providers/claude/plugin/skills/` or `providers/cursor/plugin/skills/`.
+  `providers/claude/plugins/<plugin>/skills/` or `providers/cursor/plugin/skills/`.
   Edit the source under `skills/` and run `./scripts/sync-skills.sh`.
 - **Per-package install/test**: `npm ci` and tests run from each
   package's directory, not the repo root. Don't introduce a root-level

--- a/.cursorrules
+++ b/.cursorrules
@@ -10,11 +10,12 @@ rules in sync with it when changing project-wide guidance.
 Telnyx AI — agent toolkits, plugins for Claude Code / Cursor / Gemini /
 OpenCode, an MCP proxy, 235+ agent skills, and operational guides.
 The skills under `skills/` are the source of truth; they are synced to
-`providers/{claude,cursor}/plugin/skills/` via `scripts/sync-skills.sh`.
+`providers/claude/plugins/<plugin>/skills/` and `providers/cursor/plugin/skills/`
+via `scripts/sync-skills.sh`.
 
 ## Hard rules (don't break these)
-- **Don't hand-edit** files under `providers/claude/plugin/skills/` or
-  `providers/cursor/plugin/skills/` — they are generated. Edit the
+- **Don't hand-edit** files under `providers/claude/plugins/<plugin>/skills/`
+  or `providers/cursor/plugin/skills/` — they are generated. Edit the
   source under `skills/` and run `./scripts/sync-skills.sh`.
 - **Don't run `npm install` at the repo root.** Each package has its
   own `package.json` and `node_modules/`. Install per-package:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ To make changes yourself, follow these steps:
 
 ## Skills
 
-Skills in `skills/` are the canonical source. They are synced to `providers/claude/plugin/skills/` and `providers/cursor/plugin/skills/` via `scripts/sync-skills.sh`. After modifying skills, run:
+Skills in `skills/` are the canonical source. They are synced to `providers/claude/plugins/<plugin>/skills/` and `providers/cursor/plugin/skills/` via `scripts/sync-skills.sh`. After modifying skills, run:
 
 ```bash
 ./scripts/sync-skills.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ The capability list in `agent.json` is the source of truth for what Telnyx surfa
 
 ### Don'ts
 
-- Don't edit files under `providers/claude/plugin/skills/` or `providers/cursor/plugin/skills/` directly — they are generated. Edit the source under `skills/` and run `./scripts/sync-skills.sh`.
+- Don't edit files under `providers/claude/plugins/<plugin>/skills/` or `providers/cursor/plugin/skills/` directly — they are generated. Edit the source under `skills/` and run `./scripts/sync-skills.sh`.
 - Don't introduce a root-level test runner — each package has its own.
 - Don't commit credentials, API keys, or `.env` files. Use the patterns in existing `.env.example` files.
 - Don't `npm install` at the root and expect it to install workspace deps — each package has its own `package.json` and `node_modules/`.

--- a/scripts/check-skills-sync.sh
+++ b/scripts/check-skills-sync.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Checks that provider plugin skill directories match the canonical skills/ source.
-# Both are flat: skills/<skill-name>/SKILL.md
+#
+# Canonical layout is flat: skills/<skill-name>/SKILL.md
+# Claude Code copies live in modular plugins: providers/claude/plugins/<plugin>/skills/<skill-name>
+# Cursor copies live in one flat plugin: providers/cursor/plugin/skills/<skill-name>
 
 set -euo pipefail
 
@@ -26,23 +29,54 @@ if [ -n "$deep" ]; then
   exit 1
 fi
 
-for provider in claude cursor; do
-  target="$REPO_ROOT/providers/$provider/plugin/skills"
+# ── Claude Code: modular plugins layout ─────────────────────────────────────
+CLAUDE_PLUGINS="$REPO_ROOT/providers/claude/plugins"
+if [ ! -d "$CLAUDE_PLUGINS" ]; then
+  echo "WARNING: $CLAUDE_PLUGINS does not exist"
+else
+  # Every provider copy must byte-match its canonical source, and no copy may
+  # exist without a canonical source.
+  while IFS= read -r skill_copy; do
+    skill_name="$(basename "$skill_copy")"
+    plugin_rel="${skill_copy#"$REPO_ROOT"/}"
+    if [ ! -d "$SKILLS_SRC/$skill_name" ]; then
+      echo "Out of sync (no canonical source): $plugin_rel"
+      out_of_sync=true
+    elif ! diff -r "$SKILLS_SRC/$skill_name" "$skill_copy" > /dev/null 2>&1; then
+      echo "Out of sync: $plugin_rel"
+      out_of_sync=true
+    fi
+  done < <(find "$CLAUDE_PLUGINS" -mindepth 3 -maxdepth 3 -type d -path "*/skills/*")
 
-  if [ ! -d "$target" ]; then
-    echo "WARNING: $target does not exist"
-    continue
-  fi
-
+  # Every canonical skill must appear exactly once across the Claude plugins.
   for skill_dir in "$SKILLS_SRC"/*/; do
     [ -d "$skill_dir" ] || continue
     skill_name="$(basename "$skill_dir")"
-    if ! diff -r "$skill_dir" "$target/$skill_name" > /dev/null 2>&1; then
-      echo "Out of sync: providers/$provider/plugin/skills/$skill_name"
+    count=$(find "$CLAUDE_PLUGINS" -mindepth 3 -maxdepth 3 -type d -path "*/skills/$skill_name" | wc -l | tr -d ' ')
+    if [ "$count" -eq 0 ]; then
+      echo "Missing from Claude plugins: $skill_name"
+      out_of_sync=true
+    elif [ "$count" -gt 1 ]; then
+      echo "Duplicated across Claude plugins ($count copies): $skill_name"
       out_of_sync=true
     fi
   done
-done
+fi
+
+# ── Cursor: flat plugin layout ──────────────────────────────────────────────
+CURSOR_SKILLS="$REPO_ROOT/providers/cursor/plugin/skills"
+if [ ! -d "$CURSOR_SKILLS" ]; then
+  echo "WARNING: $CURSOR_SKILLS does not exist"
+else
+  for skill_dir in "$SKILLS_SRC"/*/; do
+    [ -d "$skill_dir" ] || continue
+    skill_name="$(basename "$skill_dir")"
+    if ! diff -r "$skill_dir" "$CURSOR_SKILLS/$skill_name" > /dev/null 2>&1; then
+      echo "Out of sync: providers/cursor/plugin/skills/$skill_name"
+      out_of_sync=true
+    fi
+  done
+fi
 
 if [ "$out_of_sync" = true ]; then
   echo ""

--- a/scripts/check-skills-sync.sh
+++ b/scripts/check-skills-sync.sh
@@ -30,17 +30,25 @@ if [ -n "$deep" ]; then
 fi
 
 # ── Claude Code: modular plugins layout ─────────────────────────────────────
+# Plugin groupings shared with sync-skills.sh.
+source "$REPO_ROOT/scripts/plugin-patterns.sh"
+
 CLAUDE_PLUGINS="$REPO_ROOT/providers/claude/plugins"
 if [ ! -d "$CLAUDE_PLUGINS" ]; then
   echo "WARNING: $CLAUDE_PLUGINS does not exist"
 else
-  # Every provider copy must byte-match its canonical source, and no copy may
-  # exist without a canonical source.
+  # Every provider copy must byte-match its canonical source, exist under the
+  # plugin PLUGIN_PATTERNS assigns it to, and have a canonical source.
   while IFS= read -r skill_copy; do
     skill_name="$(basename "$skill_copy")"
+    plugin_name="$(basename "$(dirname "$(dirname "$skill_copy")")")"
     plugin_rel="${skill_copy#"$REPO_ROOT"/}"
+    expected_plugin="$(claude_plugin_for "$skill_name")"
     if [ ! -d "$SKILLS_SRC/$skill_name" ]; then
       echo "Out of sync (no canonical source): $plugin_rel"
+      out_of_sync=true
+    elif [ "$plugin_name" != "$expected_plugin" ]; then
+      echo "Wrong plugin (expected $expected_plugin): $plugin_rel"
       out_of_sync=true
     elif ! diff -r "$SKILLS_SRC/$skill_name" "$skill_copy" > /dev/null 2>&1; then
       echo "Out of sync: $plugin_rel"
@@ -48,16 +56,13 @@ else
     fi
   done < <(find "$CLAUDE_PLUGINS" -mindepth 3 -maxdepth 3 -type d -path "*/skills/*")
 
-  # Every canonical skill must appear exactly once across the Claude plugins.
+  # Every canonical skill must be present in its assigned plugin.
   for skill_dir in "$SKILLS_SRC"/*/; do
     [ -d "$skill_dir" ] || continue
     skill_name="$(basename "$skill_dir")"
-    count=$(find "$CLAUDE_PLUGINS" -mindepth 3 -maxdepth 3 -type d -path "*/skills/$skill_name" | wc -l | tr -d ' ')
-    if [ "$count" -eq 0 ]; then
-      echo "Missing from Claude plugins: $skill_name"
-      out_of_sync=true
-    elif [ "$count" -gt 1 ]; then
-      echo "Duplicated across Claude plugins ($count copies): $skill_name"
+    expected_plugin="$(claude_plugin_for "$skill_name")"
+    if [ ! -d "$CLAUDE_PLUGINS/$expected_plugin/skills/$skill_name" ]; then
+      echo "Missing from Claude plugin $expected_plugin: $skill_name"
       out_of_sync=true
     fi
   done

--- a/scripts/plugin-patterns.sh
+++ b/scripts/plugin-patterns.sh
@@ -1,0 +1,39 @@
+# Shared Claude Code plugin groupings, sourced by sync-skills.sh and
+# check-skills-sync.sh so syncing and validation always agree.
+#
+# Format: "plugin_name|prefix1,prefix2,...|catch_all_flag"
+# catch_all_flag=1 means this plugin gets all skills not matched by other plugins.
+# To add a new product plugin, add it here.
+PLUGIN_PATTERNS=(
+  "telnyx-whatsapp|telnyx-whatsapp-|0"
+  "telnyx-voice|telnyx-voice-,telnyx-ai-outbound-voice|0"
+  "telnyx-messaging|telnyx-messaging-|0"
+  "telnyx-tts|telnyx-tts-|0"
+  "telnyx-stt|telnyx-stt-|0"
+  "telnyx-verify|telnyx-verify-|0"
+  "telnyx-ai|telnyx-ai-assistants-,telnyx-ai-inference-|0"
+  "telnyx-numbers|telnyx-numbers-,telnyx-10dlc-,telnyx-porting-|0"
+  "telnyx-webrtc|telnyx-webrtc-,telnyx-video-|0"
+  "telnyx-platform||1"
+)
+
+# Print the plugin that claims a skill name under PLUGIN_PATTERNS.
+claude_plugin_for() {
+  local skill_name="$1"
+  local entry plugin_name prefixes catch_all prefix catch_all_plugin=""
+  for entry in "${PLUGIN_PATTERNS[@]}"; do
+    IFS='|' read -r plugin_name prefixes catch_all <<< "$entry"
+    if [ "$catch_all" = "1" ]; then
+      catch_all_plugin="$plugin_name"
+      continue
+    fi
+    IFS=',' read -ra prefix_list <<< "$prefixes"
+    for prefix in "${prefix_list[@]}"; do
+      if [[ "$skill_name" == "$prefix"* ]]; then
+        echo "$plugin_name"
+        return
+      fi
+    done
+  done
+  echo "$catch_all_plugin"
+}

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -4,8 +4,9 @@
 # Claude Code: multi-plugin structure under providers/claude/plugins/<plugin-name>/skills/
 # Cursor: flat structure under providers/cursor/plugin/skills/
 #
-# Plugin groupings are defined by prefix patterns in this script.
-# To add a new product plugin, add it to the PLUGIN_PATTERNS array.
+# Plugin groupings are defined by prefix patterns in scripts/plugin-patterns.sh
+# (shared with check-skills-sync.sh). To add a new product plugin, add it to
+# the PLUGIN_PATTERNS array there.
 
 set -euo pipefail
 
@@ -13,20 +14,8 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILLS_SRC="$REPO_ROOT/skills"
 
 # ── Plugin groupings ────────────────────────────────────────────────────────
-# Format: "plugin_name|prefix1,prefix2,...|catch_all_flag"
-# catch_all_flag=1 means this plugin gets all skills not matched by other plugins
-PLUGIN_PATTERNS=(
-  "telnyx-whatsapp|telnyx-whatsapp-|0"
-  "telnyx-voice|telnyx-voice-,telnyx-ai-outbound-voice|0"
-  "telnyx-messaging|telnyx-messaging-|0"
-  "telnyx-tts|telnyx-tts-|0"
-  "telnyx-stt|telnyx-stt-|0"
-  "telnyx-verify|telnyx-verify-|0"
-  "telnyx-ai|telnyx-ai-assistants-,telnyx-ai-inference-|0"
-  "telnyx-numbers|telnyx-numbers-,telnyx-10dlc-,telnyx-porting-|0"
-  "telnyx-webrtc|telnyx-webrtc-,telnyx-video-|0"
-  "telnyx-platform||1"
-)
+# PLUGIN_PATTERNS is shared with check-skills-sync.sh via plugin-patterns.sh.
+source "$REPO_ROOT/scripts/plugin-patterns.sh"
 
 # ── Claude Code: multi-plugin sync ──────────────────────────────────────────
 CLAUDE_PLUGINS="$REPO_ROOT/providers/claude/plugins"


### PR DESCRIPTION
## Summary

PR #273 split the monolithic Claude plugin into 10 modular plugins under `providers/claude/plugins/<plugin>/skills/`, but `scripts/check-skills-sync.sh` still validated the old `providers/claude/plugin/skills` path. Since that path no longer exists, the script printed a warning and **silently skipped Claude validation entirely** — Claude skill drift was undetectable. (This is the ai-repo side of the stale-path breakage Barry flagged for the skills publish pipeline; the `telnyx-ext-skills-generator` side has a matching fix.)

## Changes

- Rewrite the Claude check for the modular layout:
  - every provider skill copy must byte-match its canonical `skills/` source
  - copies without a canonical source are flagged
  - every canonical skill must appear in exactly one Claude plugin (catches both missing skills and duplicates across plugins)
- Keep the Cursor flat-plugin check unchanged.
- Update stale `providers/claude/plugin/skills` doc references in `AGENTS.md`, `.claude/CLAUDE.md`, `.cursorrules`, `.cursor/rules/main.mdc`, and `CONTRIBUTING.md`.

## Testing

- `./scripts/check-skills-sync.sh` passes on the current tree ("All provider skill directories are in sync").
- Injected a one-line drift into `providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-python/SKILL.md` → script correctly reported it and exited 1 (previously undetected).

## Known follow-ups (not in this PR)

- `providers/cursor/plugins/` contains three partial plugin dirs (telnyx-platform, telnyx-voice, telnyx-webrtc with only `agents/`/`scripts/`) left by #273 while `.cursor-plugin/marketplace.json` still points at the flat `plugin/`; the Cursor modular migration needs finishing or reverting.
- When Email skills land, `sync-skills.sh`'s `telnyx-platform` catch-all will claim `telnyx-email-*` unless an email plugin/prefix rule is added — needs handling before Email GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)