### PR TITLE
docs: remove stale SETI references (companion to #352)

### DIFF
--- a/providers/claude/plugins/telnyx-platform/agents/telnyx-developer.md
+++ b/providers/claude/plugins/telnyx-platform/agents/telnyx-developer.md
@@ -64,7 +64,6 @@ Read the SKILL.md for each skill before making API calls:
 
 ### Other
 - `skills/telnyx-missions-curl` — Automated workflows, tasks, and sub-resources
-- `skills/telnyx-seti-curl` — SETI (Space Exploration Telecommunications Infrastructure) APIs
 
 ## Conditional: Friction Reporting Wrapper
 
@@ -141,7 +140,7 @@ Use the `--team` value from the skill's `product` metadata in its SKILL.md. Comm
 | IoT | iot | iot |
 | Fax | fax | fax |
 | WebRTC | webrtc | webrtc |
-| Other | default | verify, oauth, account, storage, video, missions, seti |
+| Other | default | verify, oauth, account, storage, video, missions |
 
 ## Rules
 

--- a/providers/cursor/plugins/telnyx-platform/agents/telnyx-developer.md
+++ b/providers/cursor/plugins/telnyx-platform/agents/telnyx-developer.md
@@ -64,7 +64,6 @@ Read the SKILL.md for each skill before making API calls:
 
 ### Other
 - `skills/telnyx-missions-curl` — Automated workflows, tasks, and sub-resources
-- `skills/telnyx-seti-curl` — SETI (Space Exploration Telecommunications Infrastructure) APIs
 
 ## Conditional: Friction Reporting Wrapper
 
@@ -141,7 +140,7 @@ Use the `--team` value from the skill's `product` metadata in its SKILL.md. Comm
 | IoT | iot | iot |
 | Fax | fax | fax |
 | WebRTC | webrtc | webrtc |
-| Other | default | verify, oauth, account, storage, video, missions, seti |
+| Other | default | verify, oauth, account, storage, video, missions |
 
 ## Rules
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -169,7 +169,6 @@ npx skills add team-telnyx/ai --skill telnyx-messaging-python --agent cursor
 | `telnyx-storage-*` | S3-compatible cloud storage |
 | `telnyx-video-*` | Video rooms and conferencing |
 | `telnyx-fax-*` | Programmable fax |
-| `telnyx-seti-*` | Space Exploration Telecommunications Infrastructure |
 | `telnyx-oauth-*` | OAuth 2.0 authentication flows |
 
 #### Account


### PR DESCRIPTION
## Summary

Companion to #352 (merge together, either order): the publish removes the six `telnyx-seti-*` skills, and Codex correctly flagged that three hand-maintained surfaces still advertised them — the `skills/README.md` catalog row and the `telnyx-developer` agent files in both provider trees, which pointed users at a now-missing `SKILL.md`.

All three references removed. `grep -rn seti` across skills/README and both agent files is clean.

These files are outside the publish pipeline's boundary (hand-maintained), so this won't be clobbered by future publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)