### PR TITLE
fix(cli): omit provider for namespaced TTS voice ids (fixes live 422)

### DIFF
--- a/cli/src/commands/tts.ts
+++ b/cli/src/commands/tts.ts
@@ -17,6 +17,15 @@
  * wrapper only supports `base64_output` (exposed as the friendly alias
  * `base64`) because `binary_output` returns raw audio bytes, which cannot be
  * transported through the JSON pipeline.
+ *
+ * AIF-331 follow-up: When the voice id is namespaced as `Provider.Model.Voice`
+ * (e.g. `Telnyx.Bayan.Amanda`), the API derives the provider FROM the voice id
+ * and rejects a separately-supplied `provider` field with a 422
+ * `{"errors":{"telnyx":["can't be blank"]}}`. Verified live against the API:
+ * `provider:"telnyx"` + a namespaced telnyx voice always 422s, while omitting
+ * `provider` returns audio. So we only send `provider` in the body when the
+ * voice id is NOT namespaced (a bare name that needs the provider for routing).
+ * The `--provider` flag is still validated (typo guard) and echoed in output.
  */
 
 import { writeFileSync } from "node:fs";
@@ -107,15 +116,20 @@ export async function ttsCommand(flags: Record<string, string | boolean>): Promi
       console.log("\n🔊 Generating speech...\n");
     }
 
+    // A namespaced voice id (`Provider.Model.Voice`) already encodes the
+    // provider; the API derives it and rejects a redundant `provider` field.
+    const voiceIsNamespaced = voice.includes(".");
+
     // Build request body — all snake_case for the REST API
     const body: Record<string, unknown> = {
       text,
       language,
-      provider,
       output_type: outputType,
       text_type: textType,
     };
     if (voice) body.voice = voice;
+    // Only send provider when the voice id does not already namespace it.
+    if (!voiceIsNamespaced) body.provider = provider;
     if (disableCache) body.disable_cache = true;
 
     const client = new TelnyxClient();

--- a/cli/tests/tts.test.ts
+++ b/cli/tests/tts.test.ts
@@ -228,6 +228,34 @@ describe("tts (text-to-speech) command — REST (AIF-331)", () => {
     assert.equal(body.text_type, "ssml");
   });
 
+  // AIF-331 follow-up: a namespaced voice id (`Provider.Model.Voice`) already
+  // encodes the provider. The live API rejects a redundant `provider` field for
+  // these with 422 `{"errors":{"telnyx":["can't be blank"]}}`, so the body must
+  // OMIT `provider` when the voice id is namespaced. This is exactly the
+  // cookbook example (`--provider telnyx --voice Telnyx.Bayan.Amanda`) that
+  // failed live before this fix.
+  it("omits provider from the body when the voice id is namespaced (Provider.Model.Voice)", async () => {
+    lastRequest = null;
+    const r = await runTtsAsync(["--text", "Hello", "--voice", "Telnyx.Bayan.Amanda", "--provider", "telnyx", "--json"]);
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}`);
+    const body = capturedRequest().body;
+    assert.ok(body);
+    assert.equal(body.voice, "Telnyx.Bayan.Amanda");
+    assert.equal(body.provider, undefined, "provider must be omitted for a namespaced voice id");
+    // --provider is still echoed in the command output for the user.
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.provider, "telnyx");
+  });
+
+  it("still sends provider in the body for a bare (non-namespaced) voice name", async () => {
+    lastRequest = null;
+    await runTtsAsync(["--text", "Hello", "--voice", "Amy", "--provider", "aws", "--json"]);
+    const body = capturedRequest().body;
+    assert.ok(body);
+    assert.equal(body.voice, "Amy");
+    assert.equal(body.provider, "aws", "provider is required to route a bare voice name");
+  });
+
   it("accepts the xai provider", async () => {
     lastRequest = null;
     const r = await runTtsAsync(["--text", "Hello", "--voice", "xai-voice", "--provider", "xai", "--json"]);


### PR DESCRIPTION
## Problem

The Comms API Cookbook v2 TTS example fails live:

```
telnyx-agent tts --text "..." --provider telnyx --voice Telnyx.Bayan.Amanda
```

returns **422 Unprocessable Entity** → `{"errors":{"telnyx":["can't be blank"]}}`.

## Root cause

`tts` always sent `provider` in the `POST /text-to-speech/speech` body. When the voice id is namespaced as `Provider.Model.Voice` (e.g. `Telnyx.Bayan.Amanda`), the API derives the provider **from the voice id** and rejects a redundant `provider` field.

Verified live (deterministic, 3× each):

| request | result |
|---|---|
| `provider:"telnyx"` + `Telnyx.Bayan.Amanda` | ❌ 422 `can't be blank` |
| no `provider` + `Telnyx.Bayan.Amanda` | ✅ audio |

The mock E2E passed before because the mock accepted `provider`+`voice`, so this live-only failure slipped through the AIF-331 work.

## Fix

Only include `provider` in the request body when the voice id is **not** namespaced (a bare name still needs the provider for routing). The `--provider` flag is still validated (typo guard) and echoed in command output.

## Tests

- Added 2 regression tests:
  - namespaced voice id omits `provider` from the body (the cookbook case)
  - bare voice name still sends `provider`
- `npm run typecheck`: clean
- Unit: **458/458** pass
- E2E harness (`tests/e2e-full.sh`): **28/28** pass
- Live: the exact cookbook command now generates audio + writes a WAV file ✅

## Note (out of scope)

Separately observed live: AWS Polly voices reject `language:"en"` (they want a full locale like `en-US`). Pre-existing, unrelated to this fix, and not used by the cookbook (which uses a telnyx voice). Happy to file/fix separately if wanted.