### PR TITLE
feat: Add route-to-mobile to agent CLI

### DIFF
--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -154,6 +154,7 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   const deepfakeDetection = flags["deepfake-detection"] === true;
   const record = flags.record === true;
   const webhookUrl = flags["webhook-url"] as string | undefined;
+  const routeToMobile = flags["route-to-mobile"];
   // Flags for the advanced call-control actions.
   const audioUrl = flags["audio-url"] as string | undefined;
   const queueName = flags["queue-name"] as string | undefined;
@@ -178,6 +179,17 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     process.exit(1);
   }
   const act = action as Action;
+
+  if (
+    routeToMobile !== undefined
+    && routeToMobile !== true
+    && routeToMobile !== false
+    && routeToMobile !== "true"
+    && routeToMobile !== "false"
+  ) {
+    printError(`Invalid --route-to-mobile: ${String(routeToMobile)}. Must be true or false`);
+    process.exit(1);
+  }
 
   // Every action needs a call-control-id (bridge uses it as the first leg).
   if (!callControlId) {
@@ -276,6 +288,7 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     deepfakeDetection,
     record,
     webhookUrl,
+    routeToMobile,
     audioUrl,
     queueName,
     body,
@@ -341,6 +354,7 @@ function buildActionArgs(
     deepfakeDetection: boolean;
     record: boolean;
     webhookUrl?: string;
+    routeToMobile?: string | boolean;
     audioUrl?: string;
     queueName?: string;
     body?: string;
@@ -368,7 +382,16 @@ function buildActionArgs(
     case "hangup":
       return ["calls:actions", "hangup", "--call-control-id", opts.callControlId];
     case "transfer":
-      return ["calls:actions", "transfer", "--call-control-id", opts.callControlId, "--to", opts.to!];
+      return [
+        "calls:actions", "transfer",
+        "--call-control-id", opts.callControlId,
+        "--to", opts.to!,
+        ...(opts.routeToMobile === undefined
+          ? []
+          : opts.routeToMobile === true || opts.routeToMobile === "true"
+            ? ["--route-to-mobile"]
+            : ["--route-to-mobile=false"]),
+      ];
     case "dtmf":
       return ["calls:actions", "send-dtmf", "--call-control-id", opts.callControlId, "--digits", opts.digits!];
     case "start-recording":

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -304,7 +304,11 @@ export async function callControlCommand(flags: Record<string, string | boolean>
 
   try {
     if (!jsonOutput) console.log(`\n📞 Call Control: ${act}...`);
-    const res = await telnyxCli(args);
+    // --route-to-mobile on transfer was added in Go CLI v0.25.0; gate so an
+    // older PATH/TELNYX_CLI_PATH binary gets a clear error instead of an arg-parse failure.
+    const res = await telnyxCli(args, args.includes("--route-to-mobile") || args.includes("--route-to-mobile=false")
+      ? { minimumVersion: "0.25.0" }
+      : undefined);
     const data = res?.data ?? res;
 
     const result: CallControlResult = {

--- a/cli/src/commands/call-dial.ts
+++ b/cli/src/commands/call-dial.ts
@@ -45,6 +45,7 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
   const audioUrl = flags["audio-url"] as string | undefined;
   const timeoutSecs = flags["timeout-secs"] as string | undefined;
   const retryOnTimeout = flags["retry-on-timeout"];
+  const routeToMobile = flags["route-to-mobile"];
   // New flags (number masking + advanced dial options).
   const privacy = flags["privacy"] as string | undefined;
   const fromDisplayName = flags["from-display-name"] as string | undefined;
@@ -91,6 +92,16 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
     printError(`Invalid --retry-on-timeout: ${String(retryOnTimeout)}. Must be true or false`);
     process.exit(1);
   }
+  if (
+    routeToMobile !== undefined
+    && routeToMobile !== true
+    && routeToMobile !== false
+    && routeToMobile !== "true"
+    && routeToMobile !== "false"
+  ) {
+    printError(`Invalid --route-to-mobile: ${String(routeToMobile)}. Must be true or false`);
+    process.exit(1);
+  }
   if (privacy !== undefined && !["id", "none"].includes(privacy)) {
     printError(`Invalid --privacy: ${privacy}. Must be 'id' (number masking) or 'none'`);
     process.exit(1);
@@ -125,6 +136,9 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
   if (timeoutSecs) body.timeout_secs = Number(timeoutSecs);
   if (retryOnTimeout !== undefined) {
     body.retry_on_timeout = retryOnTimeout === true || retryOnTimeout === "true";
+  }
+  if (routeToMobile !== undefined) {
+    body.route_to_mobile = routeToMobile === true || routeToMobile === "true";
   }
   if (privacy) body.privacy = privacy;
   if (fromDisplayName) body.from_display_name = fromDisplayName;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -501,6 +501,7 @@ Voice Call Flags:
   --audio-url                    Audio URL to play on answer (call-dial); start-playback (required); gather-using-audio (optional)
   --timeout-secs                 Dial timeout in seconds (call-dial)
   --retry-on-timeout [true|false] Continue through remaining routing paths after a dial timeout (call-dial, default: true)
+  --route-to-mobile [true|false]   Route directly to a Telnyx Mobile device, bypassing inbound call interception (call-dial, call-control transfer; default: false)
   --privacy                      Number masking: 'id' hides caller ID, 'none' is normal (call-dial, default: none)
   --from-display-name            Caller ID display name (call-dial)
   --time-limit-secs              Max call duration in seconds (call-dial)
@@ -831,11 +832,13 @@ Examples:
   telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234 --answering-machine-detection --json
   telnyx-agent call-control --action hangup --call-control-id <id>
   telnyx-agent call-control --action transfer --call-control-id <id> --to +131****9999
+  telnyx-agent call-control --action transfer --call-control-id <id> --to +131****9999 --route-to-mobile
   telnyx-agent call-control --action dtmf --call-control-id <id> --digits 1234
   telnyx-agent call-control --action speak --call-control-id <id> --payload "Hello there" --voice female
   telnyx-agent call-control --action start-recording --call-control-id <id> --channels dual --format mp3
   telnyx-agent call-control --action bridge --call-control-id <id> --call-control-id-2 <id2>
   telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234 --privacy id
+  telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234 --route-to-mobile
   telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234 --transcription --time-limit-secs 600
   telnyx-agent call-control --action start-playback --call-control-id <id> --audio-url https://example.com/hello.wav
   telnyx-agent call-control --action stop-playback --call-control-id <id>
@@ -1085,10 +1088,10 @@ const KNOWN_FLAGS = new Set<string>([
   "query", "queue-name", "reaction", "record", "recording-id", "region",
   "remaining-numbers-action", "reply-to", "reply-to-all", "requirement-group-id",
   "research-effort", "resource-group-id", "response-format", "retrieval-type", "retry-on-timeout",
-  "role", "room-id", "room-participant-id", "room-session-id", "rx", "safesearch",
-  "sample-message", "sample-message-2", "sample1", "sample2", "sandbox-mode", "scheduled-at",
-  "send-at", "service-level", "service-tier", "service-type", "sim-card-group-id", "sim-card-id",
-  "sip-address", "slug", "smart-encoding", "sole-prop", "sort", "source", "sources",
+  "role", "room-id", "room-participant-id", "room-session-id", "route-to-mobile", "rx",
+  "safesearch", "sample-message", "sample-message-2", "sample1", "sample2", "sandbox-mode",
+  "scheduled-at", "send-at", "service-level", "service-tier", "service-type", "sim-card-group-id",
+  "sim-card-id", "sip-address", "slug", "smart-encoding", "sole-prop", "sort", "source", "sources",
   "speak-on-enter", "sql", "start-conference-on-create", "start-message", "starts-with", "status",
   "sticker", "stop", "stop-message", "stop-sequence", "store-media", "store-preview", "stream",
   "stream-type", "subject", "submit", "summarize-on-end", "system", "t38-enabled", "tag", "tags",

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -112,8 +112,8 @@ export const BOOLEAN_FLAGS = new Set<string>([
 ]);
 
 const COMMAND_BOOLEAN_FLAGS = new Map<string, Set<string>>([
-  ["call-control", new Set(["trigger-response"])],
-  ["call-dial", new Set(["retry-on-timeout", "transcription"])],
+  ["call-control", new Set(["route-to-mobile", "trigger-response"])],
+  ["call-dial", new Set(["retry-on-timeout", "route-to-mobile", "transcription"])],
   ["create-conference", new Set(["comfort-noise", "start-conference-on-create"])],
   ["conference-control", new Set([
     "end-conference-on-exit", "hold", "mute", "play-beep",

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -20,7 +20,7 @@ const testDialFrom = "+1" + "5551001000";
 const testDialTo = "+1" + "5551001001";
 const testTransferTo = "+1" + "3125559999";
 
-function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+function setupFakeTelnyx(version = "0.27.0"): { logPath: string; env: NodeJS.ProcessEnv } {
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-voice-"));
   const binDir = join(tempDir, "bin");
   const logPath = join(tempDir, "args.jsonl");
@@ -33,6 +33,10 @@ function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+if (args[0] === "--version") {
+  console.log("telnyx version ${version}");
+  process.exit(0);
+}
 
 // Strip --format json for command matching (the wrapper always appends it).
 const command = args.filter((a) => a !== "--format" && a !== "json");
@@ -492,6 +496,21 @@ describe("Voice API action commands", () => {
     assert.ok(transferCall, "should invoke `calls:actions transfer`");
     assert.ok(transferCall!.includes("--route-to-mobile=false"));
     assert.ok(!transferCall!.includes("--route-to-mobile"));
+  });
+
+  it("call-control transfer with --route-to-mobile rejects a pre-0.25 Go CLI before dispatch", () => {
+    const fake = setupFakeTelnyx("0.24.0");
+    const stderr = runFailure(
+      [
+        "call-control", "--action", "transfer", "--call-control-id", "call-1",
+        "--to", testTransferTo, "--route-to-mobile",
+      ],
+      fake.env,
+    );
+    assert.match(stderr, /requires >= 0\.25\.0/);
+    const transferCall = readLoggedArgs(fake.logPath)
+      .find((args) => args.slice(0, 2).join(" ") === "calls:actions transfer");
+    assert.equal(transferCall, undefined, "must not invoke calls:actions transfer on an old CLI");
   });
 
   it("call-control rejects invalid --route-to-mobile before invoking the Go CLI", () => {

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -16,6 +16,9 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliRoot = join(__dirname, "..");
 const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+const testDialFrom = "+1" + "5551001000";
+const testDialTo = "+1" + "5551001001";
+const testTransferTo = "+1" + "3125559999";
 
 function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-voice-"));
@@ -176,6 +179,7 @@ describe("Voice API action commands", () => {
       assert.equal(received?.answering_machine_detection, undefined);
       assert.equal(received?.deepfake_detection, undefined);
       assert.equal(received?.retry_on_timeout, undefined);
+      assert.equal(received?.route_to_mobile, undefined);
       // Must NOT shell out to the Go CLI anymore.
       assertNoLoggedCalls(fake.logPath);
     } finally {
@@ -257,6 +261,83 @@ describe("Voice API action commands", () => {
       { ...fake.env, TELNYX_API_KEY: "***", TELNYX_API_BASE_URL: "http://127.0.0.1:1" },
     );
     assert.match(stderr, /Invalid --retry-on-timeout: sometimes\. Must be true or false/);
+    assertNoLoggedCalls(fake.logPath);
+  });
+
+  for (const [label, routeArgs] of [
+    ["bare", ["--route-to-mobile"]],
+    ["explicit true", ["--route-to-mobile", "true"]],
+  ] as const) {
+    it(`call-dial maps ${label} --route-to-mobile to true in the REST body`, async () => {
+      let received: Record<string, unknown> | undefined;
+      const mock = await startMockApi((req, res) => {
+        let raw = "";
+        req.on("data", (c) => (raw += c.toString()));
+        req.on("end", () => {
+          received = JSON.parse(raw);
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ data: { call_control_id: "call-dial-123" } }));
+        });
+      });
+      try {
+        const fake = setupFakeTelnyx();
+        const { status } = await runAsync(
+          [
+            "call-dial", "--connection-id", "conn-1",
+            "--from", testDialFrom, "--to", testDialTo,
+            ...routeArgs, "--json",
+          ],
+          { ...fake.env, TELNYX_API_KEY: "***", TELNYX_API_BASE_URL: mock.baseUrl },
+        );
+        assert.equal(status, 0);
+        assert.equal(received?.route_to_mobile, true);
+        assertNoLoggedCalls(fake.logPath);
+      } finally {
+        await mock.close();
+      }
+    });
+  }
+
+  it("call-dial maps explicit false --route-to-mobile to false in the REST body", async () => {
+    let received: Record<string, unknown> | undefined;
+    const mock = await startMockApi((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c.toString()));
+      req.on("end", () => {
+        received = JSON.parse(raw);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ data: { call_control_id: "call-dial-123" } }));
+      });
+    });
+    try {
+      const fake = setupFakeTelnyx();
+      const { status } = await runAsync(
+        [
+          "call-dial", "--connection-id", "conn-1",
+          "--from", testDialFrom, "--to", testDialTo,
+          "--route-to-mobile", "false", "--json",
+        ],
+        { ...fake.env, TELNYX_API_KEY: "***", TELNYX_API_BASE_URL: mock.baseUrl },
+      );
+      assert.equal(status, 0);
+      assert.equal(received?.route_to_mobile, false);
+      assertNoLoggedCalls(fake.logPath);
+    } finally {
+      await mock.close();
+    }
+  });
+
+  it("call-dial rejects invalid --route-to-mobile before any network call", () => {
+    const fake = setupFakeTelnyx();
+    const stderr = runFailure(
+      [
+        "call-dial", "--connection-id", "conn-1",
+        "--from", testDialFrom, "--to", testDialTo,
+        "--route-to-mobile", "sometimes", "--json",
+      ],
+      { ...fake.env, TELNYX_API_KEY: "***", TELNYX_API_BASE_URL: "http://127.0.0.1:1" },
+    );
+    assert.match(stderr, /Invalid --route-to-mobile: sometimes\. Must be true or false/);
     assertNoLoggedCalls(fake.logPath);
   });
 
@@ -370,7 +451,72 @@ describe("Voice API action commands", () => {
     const transferCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions transfer");
     assert.ok(transferCall, "should invoke `calls:actions transfer`");
     assertFlagValue(transferCall!, "--call-control-id", "call-1");
-    assertFlagValue(transferCall!, "--to", "+13125559999");
+    assertFlagValue(transferCall!, "--to", testTransferTo);
+    assert.ok(!transferCall!.some((arg) => arg.startsWith("--route-to-mobile")));
+  });
+
+  for (const [label, routeArgs] of [
+    ["bare", ["--route-to-mobile"]],
+    ["explicit true", ["--route-to-mobile", "true"]],
+  ] as const) {
+    it(`call-control transfer maps ${label} --route-to-mobile to the generated Go CLI boolean flag`, () => {
+      const fake = setupFakeTelnyx();
+      run(
+        [
+          "call-control", "--action", "transfer", "--call-control-id", "call-1",
+          "--to", testTransferTo, ...routeArgs, "--json",
+        ],
+        fake.env,
+      );
+
+      const transferCall = readLoggedArgs(fake.logPath)
+        .find((args) => args.slice(0, 2).join(" ") === "calls:actions transfer");
+      assert.ok(transferCall, "should invoke `calls:actions transfer`");
+      assert.ok(transferCall!.includes("--route-to-mobile"));
+      assert.ok(!transferCall!.includes("--route-to-mobile=false"));
+    });
+  }
+
+  it("call-control transfer maps explicit false --route-to-mobile to generated Go CLI syntax", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      [
+        "call-control", "--action", "transfer", "--call-control-id", "call-1",
+        "--to", testTransferTo, "--route-to-mobile", "false", "--json",
+      ],
+      fake.env,
+    );
+
+    const transferCall = readLoggedArgs(fake.logPath)
+      .find((args) => args.slice(0, 2).join(" ") === "calls:actions transfer");
+    assert.ok(transferCall, "should invoke `calls:actions transfer`");
+    assert.ok(transferCall!.includes("--route-to-mobile=false"));
+    assert.ok(!transferCall!.includes("--route-to-mobile"));
+  });
+
+  it("call-control rejects invalid --route-to-mobile before invoking the Go CLI", () => {
+    const fake = setupFakeTelnyx();
+    const stderr = runFailure(
+      [
+        "call-control", "--action", "transfer", "--call-control-id", "call-1",
+        "--to", testTransferTo, "--route-to-mobile", "sometimes", "--json",
+      ],
+      fake.env,
+    );
+    assert.match(stderr, /Invalid --route-to-mobile: sometimes\. Must be true or false/);
+    assertNoLoggedCalls(fake.logPath);
+  });
+
+  it("--route-to-mobile does not swallow following help tokens", () => {
+    for (const [command, help] of [
+      ["call-dial", "-h"],
+      ["call-control", "--help"],
+    ] as const) {
+      const fake = setupFakeTelnyx();
+      const output = run([command, "--route-to-mobile", help], fake.env);
+      assert.match(output, /Usage:/);
+      assertNoLoggedCalls(fake.logPath);
+    }
   });
 
   it("call-control --action dtmf calls `calls:actions send-dtmf` with --digits", () => {


### PR DESCRIPTION
## Summary
- expose upstream `--route-to-mobile` for `call-dial` and Call Control transfers
- preserve bare, explicit true, and explicit false boolean semantics
- bump the vendored Telnyx Go CLI to v0.25.0, which contains the generated transfer flag
- document the option and add REST/fake-binary coverage

## Audit finding
Telnyx Go CLI v0.25.0 added `route_to_mobile` support for dial and transfer, but the agent CLI could not request it. This option is useful when transferring an intercepted Telnyx Mobile call back to the mobile device without triggering interception again.

## Validation
- `npx tsc --noEmit`
- `npx tsx --test tests/voice.test.ts tests/platform-release.test.ts tests/postinstall.test.ts` (97 passed)
- full unit suite run by implementation worker (465 passed)

The scheduled audit also ran the requested broad `npx tsx --test tests/*.test.ts`; two live write integration cases failed independently and are reported separately rather than changed here.