### PR TITLE
feat: Add advanced messaging actions to agent CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -161,7 +161,7 @@ Output: `{ waba_id, phone_number, verified, profile_configured, ready }`
 
 ### `telnyx-agent whatsapp-send`
 
-**Send a WhatsApp message (text or template).**
+**Send a WhatsApp text, template, media, interactive, location, reaction, sticker, contacts, or video message.**
 
 Constructs the WhatsApp message JSON from simple flags and sends via the Telnyx API.
 
@@ -169,6 +169,10 @@ Constructs the WhatsApp message JSON from simple flags and sends via the Telnyx 
 telnyx-agent whatsapp-send --from +155****4567 --to +155****6543 --text "Hello!"
 telnyx-agent whatsapp-send --from +155****4567 --to +155****6543 --template-name order_ready
 telnyx-agent whatsapp-send --from +155****4567 --to +155****6543 --text "Hi" --messaging-profile-id msgprof_123
+telnyx-agent whatsapp-send --from +155****4567 --to +155****6543 \
+  --image '{"link":"https://example.com/photo.jpg","caption":"Hello"}'
+telnyx-agent whatsapp-send --from +155****4567 --to +155****6543 \
+  --location '{"latitude":41.8781,"longitude":-87.6298,"name":"Chicago"}'
 ```
 
 **Flags:**
@@ -178,9 +182,37 @@ telnyx-agent whatsapp-send --from +155****4567 --to +155****6543 --text "Hi" --m
 - `--text` — Text message body
 - `--template-name` — Template name to send
 - `--template-language` — Template language code (default: en_US)
+- `--audio`, `--document`, `--image`, `--interactive`, `--location`, `--reaction`, `--sticker`, `--video` — The selected WhatsApp payload object as JSON (mutually exclusive)
+- `--contacts` — A non-empty JSON array of WhatsApp contact objects
+- `--biz-opaque-callback-data` — Custom data returned in message status updates
 - `--messaging-profile-id` — Messaging profile ID (required if `--from` is not SMS-enabled)
+- `--webhook-url` — Message status webhook URL
+
+The wrapper inspects the local Go CLI's `messages --help` output before sending,
+so it supports both the legacy `messages send-whatsapp` spelling and v0.27's
+`messages whatsapp`. If command help is unavailable, its local semantic version
+is used as the fallback. No API request is used for compatibility detection.
 
 Output: `{ from, to, message_type, message_id, status }`
+
+### Advanced `send-sms` sender modes
+
+`send-sms` infers the correct generated Go CLI action from its sender inputs:
+
+```bash
+# E.164 sender (`messages send`)
+telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "Hello"
+
+# Messaging-profile number pool (`messages send-number-pool`); no --from
+telnyx-agent send-sms --messaging-profile-id msgprof_123 --to +131****0001 --text "Hello"
+
+# Alphanumeric sender (`messages send-with-alphanumeric-sender`)
+telnyx-agent send-sms --from MyCompany --messaging-profile-id msgprof_123 \
+  --to +131****0001 --text "Hello"
+```
+
+Number-pool and E.164 modes also support MMS via `--media-url`. Alphanumeric
+sender IDs are SMS-only and require both `--text` and `--messaging-profile-id`.
 
 ### `telnyx-agent whatsapp-templates`
 

--- a/cli/scripts/postinstall.ts
+++ b/cli/scripts/postinstall.ts
@@ -14,7 +14,7 @@ import {
   vendoredTelnyxCliPath,
 } from "../src/platform-release.ts";
 
-const VERSION = TELNYX_CLI_VERSION; // Includes Anthropic Messages and calls dial --retry-on-timeout
+const VERSION = TELNYX_CLI_VERSION; // Includes messages whatsapp and the advanced messaging sender actions
 
 async function main() {
   const binDir = join(import.meta.dirname || __dirname, "..", "vendor");

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -12,7 +12,7 @@ interface Capability {
 
 const CAPABILITIES: Record<string, Capability[]> = {
   "📱 Messaging": [
-    { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages and messaging profiles", actions: ["send_sms", "send_mms", "send_group_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile", "get_messaging_profile", "update_messaging_profile", "delete_messaging_profile"] },
+    { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages and messaging profiles", actions: ["send_sms", "send_mms", "send_sms_from_number_pool", "send_sms_with_alphanumeric_sender", "send_group_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile", "get_messaging_profile", "update_messaging_profile", "delete_messaging_profile"] },
   ],
   "💬 RCS": [
     { name: "RCS Messaging", description: "Send RCS text messages and check recipient capabilities", actions: ["send_rcs_message", "check_rcs_capabilities"] },
@@ -78,13 +78,13 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "Port-Out", description: "List and inspect port-out activity, reject or comment on port-out orders", actions: ["list_portout_orders", "get_portout_order", "list_portout_rejection_codes"] },
   ],
   "💬 WhatsApp": [
-    { name: "WhatsApp Business", description: "Send WhatsApp messages, manage business accounts, phone numbers, and templates", actions: ["setup_whatsapp", "send_whatsapp_message", "list_whatsapp_templates", "create_whatsapp_template", "verify_whatsapp_number", "manage_whatsapp_profile"] },
+    { name: "WhatsApp Business", description: "Send text, template, media, interactive, location, reaction, sticker, contact, and video WhatsApp messages; manage business accounts, phone numbers, and templates", actions: ["setup_whatsapp", "send_whatsapp_message", "send_whatsapp_audio", "send_whatsapp_document", "send_whatsapp_image", "send_whatsapp_interactive", "send_whatsapp_location", "send_whatsapp_reaction", "send_whatsapp_sticker", "send_whatsapp_contacts", "send_whatsapp_video", "list_whatsapp_templates", "create_whatsapp_template", "verify_whatsapp_number", "manage_whatsapp_profile"] },
   ],
 };
 
 const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-sms", description: "Zero to SMS: creates messaging profile, buys number, assigns it" },
-  { name: "telnyx-agent send-sms", description: "Send an SMS or MMS message (pass --media-url to send MMS)" },
+  { name: "telnyx-agent send-sms", description: "Send SMS/MMS from an E.164 number, alphanumeric sender, or messaging-profile number pool" },
   { name: "telnyx-agent list-messaging-profiles", description: "List messaging profiles with name filters and pagination" },
   { name: "telnyx-agent create-messaging-profile", description: "Create a messaging profile with explicit destination controls" },
   { name: "telnyx-agent get-messaging-profile", description: "Retrieve one messaging profile by ID" },
@@ -136,6 +136,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent tts", description: "Generate speech from text (text-to-speech) across multiple providers, returning base64-encoded audio data" },
   { name: "telnyx-agent tts-voices", description: "List available TTS voices, optionally filtered by provider (telnyx, aws, azure, minimax, inworld, rime, resemble, fishaudio, humain, xai)" },
   { name: "telnyx-agent setup-whatsapp", description: "Zero to WhatsApp: lists WABA, buys number, initializes & verifies, sets profile" },
+  { name: "telnyx-agent whatsapp-send", description: "Send text, template, media, interactive, location, reaction, stickers, contacts, or video over WhatsApp" },
   { name: "telnyx-agent stt", description: "Transcribe audio to text (speech-to-text) — accepts an audio URL and returns the transcript with optional language, model, and keyword biasing" },
   { name: "telnyx-agent stt", description: "Transcribe audio to text (speech-to-text) — accepts a hosted audio file URL and returns the transcript with optional model and language selection" },
   { name: "telnyx-agent stt-providers", description: "List available speech-to-text providers, optionally filtered by provider name or service type" },

--- a/cli/src/commands/send-sms.ts
+++ b/cli/src/commands/send-sms.ts
@@ -1,75 +1,98 @@
 /**
  * telnyx-agent send-sms — Send an SMS or MMS message.
  *
- * Shells out to the Go telnyx CLI `messages send` subcommand.
- * Pass --media-url to send an MMS (sets --type MMS automatically).
+ * Sender mode is inferred from the intuitive sender inputs:
+ * - E.164 --from: regular phone-number send
+ * - alphanumeric --from + --messaging-profile-id: alphanumeric sender send
+ * - no --from + --messaging-profile-id: number-pool send
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
-import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { printSuccess, printError, outputJson, failWith } from "../utils/output.ts";
 import { deriveMessageStatus } from "../utils/message-status.ts";
+
+type SmsSenderMode = "phone-number" | "alphanumeric" | "number-pool";
 
 interface SendSmsResult {
   message_id: string;
   status: string;
-  type: string;
-  from: string;
+  type: "SMS" | "MMS";
+  sender_mode: SmsSenderMode;
+  from?: string;
   to: string;
+  messaging_profile_id?: string;
 }
+
+const E164 = /^\+[1-9]\d{1,14}$/;
 
 export async function sendSmsCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
-  const from = flags["from"] as string | undefined;
-  const to = flags["to"] as string | undefined;
-  const text = flags["text"] as string | undefined;
+  const from = flags.from as string | undefined;
+  const to = flags.to as string | undefined;
+  const text = flags.text as string | undefined;
   const mediaUrl = flags["media-url"] as string | undefined;
   const messagingProfileId = flags["messaging-profile-id"] as string | undefined;
   const webhookUrl = flags["webhook-url"] as string | undefined;
-  const subject = flags["subject"] as string | undefined;
+  const subject = flags.subject as string | undefined;
 
-  if (!from) {
-    printError("--from is required (E.164 format, e.g., +13125550000)");
-    process.exit(1);
-  }
-  if (!to) {
-    printError("--to is required (E.164 format, e.g., +13125550001)");
-    process.exit(1);
-  }
+  if (!to) failWith("--to is required (E.164 format, e.g., +131****0001)", jsonOutput);
   // --text is required for a plain SMS, but the Telnyx API supports
   // media-only MMS, so only require text when no --media-url is provided.
   if (!text && !mediaUrl) {
-    printError("--text is required (or pass --media-url for a media-only MMS)");
-    process.exit(1);
+    failWith("--text is required (or pass --media-url for a media-only MMS)", jsonOutput);
   }
 
-  // media-url upgrades the send to MMS
-  const type = mediaUrl ? "MMS" : "SMS";
+  const senderMode: SmsSenderMode = !from
+    ? "number-pool"
+    : E164.test(from)
+      ? "phone-number"
+      : "alphanumeric";
+  const type: "SMS" | "MMS" = mediaUrl ? "MMS" : "SMS";
 
-  const args: string[] = [
-    "messages", "send",
-    "--from", from,
-    "--to", to,
-    "--type", type,
-  ];
-  if (text) args.push("--text", text);
-  if (mediaUrl) args.push("--media-url", mediaUrl);
-  if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
-  if (webhookUrl) args.push("--webhook-url", webhookUrl);
-  if (subject) args.push("--subject", subject);
+  if (senderMode !== "phone-number" && !messagingProfileId) {
+    failWith(
+      senderMode === "number-pool"
+        ? "--messaging-profile-id is required when sending from a number pool without --from"
+        : "--messaging-profile-id is required for an alphanumeric --from sender",
+      jsonOutput,
+    );
+  }
+  if (senderMode === "alphanumeric" && mediaUrl) {
+    failWith("Alphanumeric sender IDs support SMS text only; remove --media-url", jsonOutput);
+  }
+  if (senderMode === "alphanumeric" && subject) {
+    failWith("--subject is not supported with an alphanumeric sender", jsonOutput);
+  }
+
+  const args = buildSendArgs({
+    senderMode,
+    from,
+    to,
+    text,
+    mediaUrl,
+    messagingProfileId,
+    webhookUrl,
+    subject,
+    type,
+  });
 
   try {
     const res = await telnyxCli(args);
     const data = (res?.data ?? res) as Record<string, unknown>;
     const messageId = String(data.id ?? data.message_id ?? "");
-    // Delivery state lives on each recipient (data.to[].status), not top-level.
     const status = deriveMessageStatus(data, "queued");
+    const responseFrom = data.from && typeof data.from === "object"
+      ? String((data.from as Record<string, unknown>).phone_number ?? "")
+      : "";
 
     const result: SendSmsResult = {
       message_id: messageId,
       status,
       type,
-      from,
+      sender_mode: senderMode,
+      ...(from || responseFrom ? { from: from ?? responseFrom } : {}),
       to,
+      ...(messagingProfileId ? { messaging_profile_id: messagingProfileId } : {}),
     };
 
     if (jsonOutput) {
@@ -79,7 +102,8 @@ export async function sendSmsCommand(flags: Record<string, string | boolean>): P
         "Message ID": messageId,
         Status: status,
         Type: type,
-        From: from,
+        "Sender Mode": senderMode,
+        From: from || responseFrom || "number pool",
         To: to,
       });
     }
@@ -91,6 +115,61 @@ export async function sendSmsCommand(flags: Record<string, string | boolean>): P
     }
     process.exit(1);
   }
+}
+
+interface SendArgsInput {
+  senderMode: SmsSenderMode;
+  from?: string;
+  to: string;
+  text?: string;
+  mediaUrl?: string;
+  messagingProfileId?: string;
+  webhookUrl?: string;
+  subject?: string;
+  type: "SMS" | "MMS";
+}
+
+function buildSendArgs(input: SendArgsInput): string[] {
+  const { senderMode, from, to, text, mediaUrl, messagingProfileId, webhookUrl, subject, type } = input;
+
+  if (senderMode === "number-pool") {
+    const args = [
+      "messages", "send-number-pool",
+      "--messaging-profile-id", messagingProfileId!,
+      "--to", to,
+      "--type", type,
+    ];
+    if (mediaUrl) args.push("--media-url", mediaUrl);
+    if (subject) args.push("--subject", subject);
+    if (text) args.push("--text", text);
+    if (webhookUrl) args.push("--webhook-url", webhookUrl);
+    return args;
+  }
+
+  if (senderMode === "alphanumeric") {
+    const args = [
+      "messages", "send-with-alphanumeric-sender",
+      "--from", from!,
+      "--messaging-profile-id", messagingProfileId!,
+      "--text", text!,
+      "--to", to,
+    ];
+    if (webhookUrl) args.push("--webhook-url", webhookUrl);
+    return args;
+  }
+
+  const args = [
+    "messages", "send",
+    "--from", from!,
+    "--to", to,
+    "--type", type,
+  ];
+  if (text) args.push("--text", text);
+  if (mediaUrl) args.push("--media-url", mediaUrl);
+  if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
+  if (webhookUrl) args.push("--webhook-url", webhookUrl);
+  if (subject) args.push("--subject", subject);
+  return args;
 }
 
 function errorMsg(err: unknown): string {

--- a/cli/src/commands/send-sms.ts
+++ b/cli/src/commands/send-sms.ts
@@ -2,7 +2,7 @@
  * telnyx-agent send-sms — Send an SMS or MMS message.
  *
  * Sender mode is inferred from the intuitive sender inputs:
- * - E.164 --from: regular phone-number send
+ * - E.164 or short-code --from: regular phone-number send
  * - alphanumeric --from + --messaging-profile-id: alphanumeric sender send
  * - no --from + --messaging-profile-id: number-pool send
  */
@@ -24,6 +24,9 @@ interface SendSmsResult {
 }
 
 const E164 = /^\+[1-9]\d{1,14}$/;
+// Short codes (e.g. 80001) are digit-only senders that `messages send` accepts
+// directly; they must not be mistaken for alphanumeric sender IDs.
+const SHORT_CODE = /^\d{4,8}$/;
 
 export async function sendSmsCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
@@ -44,7 +47,7 @@ export async function sendSmsCommand(flags: Record<string, string | boolean>): P
 
   const senderMode: SmsSenderMode = !from
     ? "number-pool"
-    : E164.test(from)
+    : E164.test(from) || SHORT_CODE.test(from)
       ? "phone-number"
       : "alphanumeric";
   const type: "SMS" | "MMS" = mediaUrl ? "MMS" : "SMS";

--- a/cli/src/commands/whatsapp-send.ts
+++ b/cli/src/commands/whatsapp-send.ts
@@ -1,71 +1,83 @@
 /**
- * telnyx-agent whatsapp-send — Send a WhatsApp message (text or template).
+ * telnyx-agent whatsapp-send — Send text, template, media, interactive,
+ * location, reaction, sticker, contact, and video WhatsApp messages.
  *
- * Shells out to the Go CLI's `messages send-whatsapp` subcommand, constructing
- * the `--whatsapp-message` JSON string from simpler flags.
+ * The wrapper builds `whatsapp_message` JSON from agent-friendly flags, then
+ * detects whether the local Go CLI exposes the legacy `messages send-whatsapp`
+ * spelling or the v0.27 `messages whatsapp` spelling.
  */
 
-import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import {
+  telnyxCli,
+  TelnyxCLIError,
+  resolveMessagesWhatsappSubcommand,
+} from "../telnyx-cli.ts";
 import { printSuccess, printError, outputJson, failWith } from "../utils/output.ts";
+import { deriveMessageStatus } from "../utils/message-status.ts";
+
+type WhatsappMessageType =
+  | "text"
+  | "template"
+  | "audio"
+  | "document"
+  | "image"
+  | "interactive"
+  | "location"
+  | "reaction"
+  | "sticker"
+  | "contacts"
+  | "video";
 
 interface WhatsappSendResult {
   from: string;
   to: string;
-  message_type: "text" | "template";
+  message_type: WhatsappMessageType;
   message_id: string;
   status: string;
 }
+
+const OBJECT_PAYLOAD_TYPES = [
+  "audio",
+  "document",
+  "image",
+  "interactive",
+  "location",
+  "reaction",
+  "sticker",
+  "video",
+] as const;
 
 export async function whatsappSendCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
   const from = flags.from as string;
   const to = flags.to as string;
-  const text = flags.text as string;
-  const templateName = flags["template-name"] as string;
-  const templateLanguage = (flags["template-language"] as string) || "en_US";
-  const messagingProfileId = flags["messaging-profile-id"] as string;
+  const messagingProfileId = flags["messaging-profile-id"] as string | undefined;
+  const webhookUrl = flags["webhook-url"] as string | undefined;
+  const callbackData = flags["biz-opaque-callback-data"] as string | undefined;
 
   if (!from || !to) {
     failWith("--from and --to are required (E.164 phone numbers)", jsonOutput);
   }
 
-  // Build the whatsapp_message JSON string. Initialize to keep strict mode happy.
-  let messageType: "text" | "template" = "text";
-  let whatsappMessage = "";
-  if (text) {
-    messageType = "text";
-    whatsappMessage = JSON.stringify({ type: "text", text: { body: text } });
-  } else if (templateName) {
-    messageType = "template";
-    whatsappMessage = JSON.stringify({
-      type: "template",
-      template: { name: templateName, language: { code: templateLanguage } },
-    });
-  } else {
-    failWith("Provide --text for a text message or --template-name for a template message", jsonOutput);
-  }
+  const { messageType, message } = buildWhatsappMessage(flags, jsonOutput);
+  if (callbackData) message.biz_opaque_callback_data = callbackData;
 
   try {
+    const subcommand = await resolveMessagesWhatsappSubcommand();
     const args = [
-      "messages", "send-whatsapp",
+      "messages", subcommand,
       "--from", from,
       "--to", to,
-      "--whatsapp-message", whatsappMessage,
+      "--whatsapp-message", JSON.stringify(message),
+      "--type", "WHATSAPP",
     ];
     if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
+    if (webhookUrl) args.push("--webhook-url", webhookUrl);
 
     const res = await telnyxCli(args);
     const data = (res.data ?? res) as Record<string, unknown>;
     const messageId = String(data.id ?? data.message_id ?? "");
-    // Extract the actual delivery status from the API response.
-    // The Telnyx WhatsApp send response returns the per-recipient state in
-    // data.to[0].status (e.g. queued/accepted/sent/delivered). Fall back to
-    // data.status/data.delivery_status for alternate envelopes, then
-    // "submitted" as a last resort — never assume "sent".
-    const recipient = (Array.isArray(data.to) ? data.to[0] : undefined) as
-      | Record<string, unknown>
-      | undefined;
-    const deliveryStatus = String(recipient?.status ?? data.status ?? data.delivery_status ?? "submitted");
+    const deliveryStatus = deriveMessageStatus(data, "submitted");
 
     const result: WhatsappSendResult = {
       from,
@@ -99,6 +111,73 @@ export async function whatsappSendCommand(flags: Record<string, string | boolean
     }
     process.exit(1);
   }
+}
+
+function buildWhatsappMessage(
+  flags: Record<string, string | boolean>,
+  jsonOutput: boolean,
+): { messageType: WhatsappMessageType; message: Record<string, unknown> } {
+  const text = flags.text as string | undefined;
+  const templateName = flags["template-name"] as string | undefined;
+  const selected: WhatsappMessageType[] = [];
+
+  if (text) selected.push("text");
+  if (templateName) selected.push("template");
+  for (const type of OBJECT_PAYLOAD_TYPES) {
+    if (flags[type] !== undefined) selected.push(type);
+  }
+  if (flags.contacts !== undefined) selected.push("contacts");
+
+  if (selected.length === 0) {
+    failWith(
+      "Provide exactly one message payload: --text, --template-name, --audio, --document, --image, --interactive, --location, --reaction, --sticker, --contacts, or --video",
+      jsonOutput,
+    );
+  }
+  if (selected.length > 1) {
+    failWith(`WhatsApp payload flags are mutually exclusive (received: ${selected.join(", ")})`, jsonOutput);
+  }
+
+  const messageType = selected[0];
+  if (messageType === "text") {
+    return { messageType, message: { type: "text", text: { body: text } } };
+  }
+  if (messageType === "template") {
+    const language = (flags["template-language"] as string) || "en_US";
+    return {
+      messageType,
+      message: {
+        type: "template",
+        template: { name: templateName, language: { code: language } },
+      },
+    };
+  }
+  if (messageType === "contacts") {
+    const contacts = parseJson(flags.contacts, "--contacts", jsonOutput);
+    if (!Array.isArray(contacts) || contacts.length === 0 || contacts.some((item) => !isObject(item))) {
+      failWith("--contacts must be a non-empty JSON array of contact objects", jsonOutput);
+    }
+    return { messageType, message: { type: "contacts", contacts } };
+  }
+
+  const payload = parseJson(flags[messageType], `--${messageType}`, jsonOutput);
+  if (!isObject(payload)) {
+    failWith(`--${messageType} must be a JSON object`, jsonOutput);
+  }
+  return { messageType, message: { type: messageType, [messageType]: payload } };
+}
+
+function parseJson(value: string | boolean | undefined, flag: string, jsonOutput: boolean): unknown {
+  if (typeof value !== "string") failWith(`${flag} requires a JSON value`, jsonOutput);
+  try {
+    return JSON.parse(value);
+  } catch (err) {
+    failWith(`${flag} must contain valid JSON: ${err instanceof Error ? err.message : String(err)}`, jsonOutput);
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function errorMsg(err: unknown): string {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -147,9 +147,9 @@ Commands:
   tts               Generate speech from text (text-to-speech)
   tts-voices        List available TTS voices (optionally filter by provider)
   setup-whatsapp    Zero to WhatsApp: list WABA, buy number, verify, set profile
-  whatsapp-send     Send a WhatsApp message (text or template)
+  whatsapp-send     Send a WhatsApp message (text, template, media, or rich payload)
   whatsapp-templates List or create WhatsApp message templates
-  send-sms          Send an SMS or MMS message (--media-url sends MMS)
+  send-sms          Send SMS/MMS from a number, alphanumeric sender, or number pool
   list-messaging-profiles List messaging profiles with name filters and pagination
   create-messaging-profile Create a messaging profile
   get-messaging-profile Get a messaging profile by ID
@@ -295,12 +295,15 @@ TTS-voices Flags:
   --provider        Filter voices by provider: telnyx, aws, azure, minimax, inworld, rime, resemble, fishaudio, humain, xai (optional)
   --api-key <key>   Provider API key forwarded to the Go CLI for provider-backed voice lists (e.g., resemble)
 SMS Action Flags:
-  --from <e164>          Sender number, E.164 (send-sms, send-group-mms, schedule-sms — required)
+  --from <sender>        E.164 number or alphanumeric sender ID (send-sms); omit with
+                         --messaging-profile-id to send from its number pool
+  --from <e164>          Sender number (send-group-mms and schedule-sms — required)
   --to <e164>            Recipient number, E.164 (send-sms, schedule-sms — required)
   --to <e164,...>        Comma-separated recipients, E.164 (send-group-mms — required)
   --text <msg>           Message text (send-sms, schedule-sms — required; send-group-mms — optional)
   --media-url <url>      Media URL; sends MMS instead of SMS (send-sms, schedule-sms, send-group-mms)
-  --messaging-profile-id <id> Messaging profile to use (send-sms, schedule-sms; not supported by group MMS)
+  --messaging-profile-id <id> Required for number-pool and alphanumeric sends; optional
+                              for E.164 send-sms (not supported by group MMS)
   --webhook-url <url>    Webhook for delivery status updates (send-sms)
   --subject <text>       MMS subject line (send-sms)
   --send-at <iso8601>    Send time, ISO 8601 (schedule-sms — required, e.g., 2024-12-31T00:00:00Z)
@@ -373,7 +376,18 @@ WhatsApp Flags:
   --text            Text message body (whatsapp-send)
   --template-name   Template name to send (whatsapp-send)
   --template-language Template language code, default en_US (whatsapp-send)
+  --audio <json>    Audio object, e.g. {"link":"https://..."} (whatsapp-send)
+  --document <json> Document object (whatsapp-send)
+  --image <json>    Image object (whatsapp-send)
+  --interactive <json> Interactive message object (whatsapp-send)
+  --location <json> Location object (whatsapp-send)
+  --reaction <json> Reaction object (whatsapp-send)
+  --sticker <json>  Sticker object (whatsapp-send)
+  --contacts <json> JSON array of contact objects (whatsapp-send)
+  --video <json>    Video object (whatsapp-send)
+  --biz-opaque-callback-data <text> Custom data returned with status updates
   --messaging-profile-id Messaging profile id (whatsapp-send)
+  --webhook-url     Message status webhook URL (whatsapp-send)
   --create          Switch to create mode (whatsapp-templates)
   --name            Template name (whatsapp-templates, create)
   --language        Template language, default en_US (whatsapp-templates, create)
@@ -628,9 +642,12 @@ Examples:
   telnyx-agent setup-whatsapp --waba-id <id> --display-name "My Biz" --code 123456
   telnyx-agent whatsapp-send --from +155****1111 --to +155****2222 --text "Hello!"
   telnyx-agent whatsapp-send --from +155****1111 --to +155****2222 --template-name order_ready
+  telnyx-agent whatsapp-send --from +155****1111 --to +155****2222 --image '{"link":"https://example.com/photo.jpg","caption":"Hello"}'
   telnyx-agent whatsapp-templates --waba-id <id> --json
   telnyx-agent whatsapp-templates --waba-id <id> --create --name promo --category MARKETING --component '[]'
   telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "Hello!"
+  telnyx-agent send-sms --messaging-profile-id <id> --to +131****0001 --text "From the pool"
+  telnyx-agent send-sms --from MyCompany --messaging-profile-id <id> --to +131****0001 --text "Hello!"
   telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "See this" --media-url https://example.com/img.png --subject "Photo"
   telnyx-agent list-messaging-profiles --name-contains production --json
   telnyx-agent create-messaging-profile --name "Production SMS" --whitelisted-destinations US,CA --webhook-url https://example.com/messages --json
@@ -821,51 +838,56 @@ const COMMANDS: Record<string, (
 // like `tts --output-typ base64` or `tts --ouput f.wav` doesn't silently no-op.
 // This never fails the run — a missing entry just costs a spurious warning.
 const KNOWN_FLAGS = new Set<string>([
-  "about", "action", "action-type", "actor", "administrative-area", "agent-id", "agent-message", "ai-assistant-id", "alpha-sender", "amount",
-  "about", "action", "active", "actor", "administrative-area", "agent-id", "agent-message", "ai-assistant-id", "alpha-sender", "amount",
-  "answering-machine-detection", "api-key", "api-key-ref", "area-code", "assistant", "assistant-id", "audio-url",
-  "authorized-person", "beep-enabled", "billing-group-id", "billing-phone", "black-threshold", "body", "brand-id",
-  "brand-name", "bulk-sim-card-action-id", "bundle-id", "call-control-id", "call-control-id-2", "call-control-id-to-bridge", "comfort-noise", "conference-id",
-  "call-control-id-to-bridge-with", "campaign-id", "cancel", "carrier-name", "category", "cause",
-  "channels", "clear-tags", "clear-tool-ids", "client-state", "code", "command-id", "company-name",
-  "component", "confirm", "connection-id", "connection-name", "contains", "content-type",
-  "context", "conversation-id", "country", "country-code", "create", "custom-code",
-  "customer-group-reference", "customer-name", "customer-reference", "deepfake-detection", "depth",
-  "description", "destinations", "digits", "dimensions", "disable-cache", "display-name", "duration-minutes",
-  "description", "destinations", "digits", "dimensions", "disable-cache", "display-name", "exclude",
-  "daily-spend-limit", "daily-spend-limit-enabled", "document-id", "document-type", "dtmf-detection", "dynamic-variables",
+  "about", "action", "action-type", "active", "actor", "administrative-area", "agent-id",
+  "agent-message", "ai-assistant-id", "alpha-sender", "amount", "answering-machine-detection",
+  "api-key", "api-key-ref", "area-code", "assistant", "assistant-id", "audio", "audio-url",
+  "authorized-person", "beep-enabled", "billing-group-id", "billing-phone",
+  "biz-opaque-callback-data", "black-threshold", "body", "brand-id", "brand-name",
+  "bulk-sim-card-action-id", "bundle-id", "call-control-id", "call-control-id-2",
+  "call-control-id-to-bridge", "call-control-id-to-bridge-with", "campaign-id", "cancel",
+  "carrier-name", "category", "cause", "channels", "clear-tags", "clear-tool-ids", "client-state",
+  "code", "comfort-noise", "command-id", "company-name", "component", "conference-id", "confirm",
+  "connection-id", "connection-name", "contacts", "contains", "content-type", "context",
+  "conversation-id", "country", "country-code", "create", "custom-code",
+  "customer-group-reference", "customer-name", "customer-reference", "daily-spend-limit",
+  "daily-spend-limit-enabled", "deepfake-detection", "depth", "description", "destinations",
+  "digits", "dimensions", "disable-cache", "display-name", "document", "document-id",
+  "document-type", "dtmf-detection", "duration-minutes", "dynamic-variables",
   "dynamic-variables-webhook-timeout-ms", "dynamic-variables-webhook-url", "email",
-  "emergency-address-id", "enable-messaging", "enabled", "encoding-format", "ends-with", "extension",
-  "fallback-config", "fast-port-eligible", "features", "file-url", "filter", "filter-sim-card-group-id", "flag",
-  "foc-after", "foc-before", "foc-datetime-requested", "force", "fork-rx", "fork-stream-type",
-  "fork-tx", "format", "fqdn", "from", "from-dir", "from-display-name", "greeting",
-  "guided-choice", "guided-json", "health-webhook-url", "help", "help-message", "hold-audio-url", "hold-media-name", "iccid", "id", "include-phone-numbers",
-  "guided-choice", "guided-json", "health-webhook-url", "help", "help-message", "iccid", "id", "include-participants", "include-phone-numbers",
-  "include-sim-card-group", "input", "instructions", "invoice-document-id", "json", "language",
-  "limit", "loa-document-id", "locality", "max-items", "max-participants", "max-retries", "max-tokens", "mcp-server", "media-encryption",
-  "media-name", "media-url", "message", "message-flow", "messaging-profile-id", "metadata", "method", "model",
-  "mms-fall-back-to-sms", "mms-transcoding", "mobile-only", "monochrome", "msisdn", "muted", "name", "name-contains", "national-destination-code", "network-id", "number-pool-settings",
-  "new-billing-phone-number", "number-type", "numbers", "old-provider", "on-hold", "opt-in-method",
+  "emergency-address-id", "enable-messaging", "enabled", "encoding-format", "ends-with", "exclude",
+  "extension", "fallback-config", "fast-port-eligible", "features", "file-url", "filter",
+  "filter-sim-card-group-id", "flag", "foc-after", "foc-before", "foc-datetime-requested", "force",
+  "fork-rx", "fork-stream-type", "fork-tx", "format", "fqdn", "from", "from-dir",
+  "from-display-name", "greeting", "guided-choice", "guided-json", "health-webhook-url", "help",
+  "help-message", "hold-audio-url", "hold-media-name", "iccid", "id", "image",
+  "include-participants", "include-phone-numbers", "include-sim-card-group", "input",
+  "instructions", "interactive", "invoice-document-id", "json", "language", "limit",
+  "loa-document-id", "locality", "location", "max-items", "max-participants", "max-retries",
+  "max-tokens", "mcp-server", "media-encryption", "media-name", "media-url", "message",
+  "message-flow", "messaging-profile-id", "metadata", "method", "mms-fall-back-to-sms",
+  "mms-transcoding", "mobile-only", "model", "monochrome", "msisdn", "muted", "name",
+  "name-contains", "national-destination-code", "network-id", "new-billing-phone-number",
+  "number-pool-settings", "number-type", "numbers", "old-provider", "on-hold", "opt-in-method",
   "optin-message", "optout-message", "outbound-voice-profile-id", "output", "output-file",
-  "output-type", "page-number", "page-size", "parameters", "parent-support-key", "participant", "participants",
-  "payload", "phone", "phone-number", "phone-number-id", "phone-numbers", "port-type",
-  "preview-format", "privacy", "profile-name", "promote-to-main", "provider", "quality",
-  "queue-name", "record", "recording-id", "region", "remaining-numbers-action", "requirement-group-id", "resource-group-id", "response-format", "retry-on-timeout",
-  "role", "rx", "sample-message", "sample-message-2", "sample1", "sample2", "send-at",
-  "service-tier", "service-type", "sim-card-group-id", "sim-card-id", "sip-address", "sole-prop", "sort", "source",
-  "start-conference-on-create", "start-message", "starts-with", "status", "stop", "stop-message", "stop-sequence", "store-media", "store-preview", "system",
-  "queue-name", "record", "remaining-numbers-action", "requirement-group-id", "resource-group-id", "response-format", "retry-on-timeout",
-  "role", "room-id", "room-participant-id", "room-session-id", "rx", "sample-message", "sample-message-2", "sample1", "sample2", "send-at",
-  "service-tier", "service-type", "sim-card-group-id", "sip-address", "sole-prop", "sort", "source",
-  "start-message", "starts-with", "status", "stop", "stop-message", "stop-sequence", "store-media", "store-preview", "system",
-  "stream", "stream-type", "subject", "submit", "t38-enabled", "tag", "tags", "temperature", "thinking", "timeout",
-  "smart-encoding",
-  "template-language", "template-name", "text", "text-type", "time-limit-secs", "timeout-secs",
-  "to", "tool", "tool-choice", "tool-ids", "top-k", "top-p", "transcription", "transcription-language",
-  "transcription-model", "ttl", "tx", "type", "url", "usecase", "user", "verification-id",
-  "url-shortener-settings", "v1-secret", "verify-profile-id", "version", "version-name", "vertical", "voice", "waba-id", "wallet-key",
-  "webhook", "webhook-api-version", "webhook-failover-url", "webhook-url", "webhook-url-method", "webhook-urls", "website", "whatsapp-message",
-  "whitelisted-destination", "whitelisted-destinations", "whispering",
+  "output-type", "page-number", "page-size", "parameters", "parent-support-key", "participant",
+  "participants", "payload", "phone", "phone-number", "phone-number-id", "phone-numbers",
+  "port-type", "preview-format", "privacy", "profile-name", "promote-to-main", "provider",
+  "quality", "queue-name", "reaction", "record", "recording-id", "region",
+  "remaining-numbers-action", "requirement-group-id", "resource-group-id", "response-format",
+  "retry-on-timeout", "role", "room-id", "room-participant-id", "room-session-id", "rx",
+  "sample-message", "sample-message-2", "sample1", "sample2", "send-at", "service-tier",
+  "service-type", "sim-card-group-id", "sim-card-id", "sip-address", "smart-encoding", "sole-prop",
+  "sort", "source", "start-conference-on-create", "start-message", "starts-with", "status",
+  "sticker", "stop", "stop-message", "stop-sequence", "store-media", "store-preview", "stream",
+  "stream-type", "subject", "submit", "system", "t38-enabled", "tag", "tags", "temperature",
+  "template-language", "template-name", "text", "text-type", "thinking", "time-limit-secs",
+  "timeout", "timeout-secs", "to", "tool", "tool-choice", "tool-ids", "top-k", "top-p",
+  "transcription", "transcription-language", "transcription-model", "ttl", "tx", "type", "url",
+  "url-shortener-settings", "usecase", "user", "v1-secret", "verification-id", "verify-profile-id",
+  "version", "version-name", "vertical", "video", "voice", "waba-id", "wallet-key", "webhook",
+  "webhook-api-version", "webhook-failover-url", "webhook-url", "webhook-url-method",
+  "webhook-urls", "website", "whatsapp-message", "whispering", "whitelisted-destination",
+  "whitelisted-destinations",
 ]);
 
 // Commands that accept an arbitrary/generated flag surface, where an

--- a/cli/src/platform-release.ts
+++ b/cli/src/platform-release.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-export const TELNYX_CLI_VERSION = "0.24.0";
+export const TELNYX_CLI_VERSION = "0.27.0";
 
 export interface TelnyxCliRelease {
   archiveName: string;

--- a/cli/src/telnyx-cli.ts
+++ b/cli/src/telnyx-cli.ts
@@ -127,6 +127,44 @@ function getTelnyxBinary(minimumVersion?: string): Promise<string> {
 }
 
 /**
+ * Resolve the WhatsApp message subcommand exposed by the locally selected Go
+ * CLI. Legacy releases such as v0.21 used `messages send-whatsapp`; v0.27 uses
+ * `messages whatsapp` (v0.24 did not expose either spelling).
+ *
+ * Command help is authoritative because it describes the binary we are about
+ * to execute (including custom/dev builds). If help is unavailable or does not
+ * enumerate either command, fall back to the local binary's semantic version.
+ * The final fallback preserves the command bundled with this package.
+ */
+export async function resolveMessagesWhatsappSubcommand(): Promise<"send-whatsapp" | "whatsapp"> {
+  const binary = await getTelnyxBinary();
+
+  try {
+    const { stdout, stderr } = await execFileAsync(binary, ["messages", "--help"], { timeout: 10000 });
+    const help = `${stdout ?? ""}\n${stderr ?? ""}`;
+    if (/^\s*whatsapp(?:\s|$)/m.test(help)) return "whatsapp";
+    if (/^\s*send-whatsapp(?:\s|$)/m.test(help)) return "send-whatsapp";
+  } catch {
+    // Some older/custom builds do not provide parent-command help. Version
+    // detection below remains a side-effect-free compatibility probe.
+  }
+
+  try {
+    const { stdout, stderr } = await execFileAsync(binary, ["--version"], { timeout: 10000 });
+    const version = parseTelnyxGoCliVersion(`${stdout ?? ""}${stderr ?? ""}`);
+    if (version && (compareSemanticVersions(version, "0.27.0") ?? -1) >= 0) return "whatsapp";
+  } catch (err: any) {
+    // A few releases print their version to stderr and exit non-zero.
+    const version = parseTelnyxGoCliVersion(`${err?.stdout ?? ""}${err?.stderr ?? ""}`);
+    if (version && (compareSemanticVersions(version, "0.27.0") ?? -1) >= 0) return "whatsapp";
+  }
+
+  // The package bundles v0.27, so prefer its spelling if an unusual binary
+  // exposes neither usable help nor a parseable version.
+  return "whatsapp";
+}
+
+/**
  * Find the start of JSON in CLI output that may have info messages before it.
  * Looks for the first `{` or `[` that starts valid JSON.
  *

--- a/cli/tests/platform-release.test.ts
+++ b/cli/tests/platform-release.test.ts
@@ -10,12 +10,12 @@ import {
 
 describe("Telnyx CLI platform releases", () => {
   const cases = [
-    ["darwin", "x64", "telnyx_0.24.0_macos_amd64.zip", "telnyx"],
-    ["darwin", "arm64", "telnyx_0.24.0_macos_arm64.zip", "telnyx"],
-    ["linux", "x64", "telnyx_0.24.0_linux_amd64.tar.gz", "telnyx"],
-    ["linux", "arm64", "telnyx_0.24.0_linux_arm64.tar.gz", "telnyx"],
-    ["win32", "x64", "telnyx_0.24.0_windows_amd64.zip", "telnyx.exe"],
-    ["win32", "arm64", "telnyx_0.24.0_windows_arm64.zip", "telnyx.exe"],
+    ["darwin", "x64", "telnyx_0.27.0_macos_amd64.zip", "telnyx"],
+    ["darwin", "arm64", "telnyx_0.27.0_macos_arm64.zip", "telnyx"],
+    ["linux", "x64", "telnyx_0.27.0_linux_amd64.tar.gz", "telnyx"],
+    ["linux", "arm64", "telnyx_0.27.0_linux_arm64.tar.gz", "telnyx"],
+    ["win32", "x64", "telnyx_0.27.0_windows_amd64.zip", "telnyx.exe"],
+    ["win32", "arm64", "telnyx_0.27.0_windows_arm64.zip", "telnyx.exe"],
   ] as const;
 
   for (const [platform, arch, archiveName, executableName] of cases) {
@@ -24,7 +24,7 @@ describe("Telnyx CLI platform releases", () => {
       assert.deepEqual(release, { archiveName, executableName });
       assert.equal(
         telnyxCliReleaseUrl(release!),
-        `https://github.com/team-telnyx/telnyx-cli/releases/download/v0.24.0/${archiveName}`,
+        `https://github.com/team-telnyx/telnyx-cli/releases/download/v0.27.0/${archiveName}`,
       );
     });
   }

--- a/cli/tests/postinstall.test.ts
+++ b/cli/tests/postinstall.test.ts
@@ -38,13 +38,13 @@ function runPostinstall(options: {
     mkdirSync(dirname(vendor), { recursive: true });
     executable(vendor, `echo "${options.vendorOutput}"\nexit ${options.vendorExitCode ?? 0}`);
   }
-  executable(join(root, "fake-bin", "telnyx"), `echo "${options.pathOutput ?? "telnyx version 0.24.0"}"`);
+  executable(join(root, "fake-bin", "telnyx"), `echo "${options.pathOutput ?? "telnyx version 0.27.0"}"`);
   executable(join(root, "fake-bin", "curl"), `printf '%s\\n' "$@" > "${join(root, "download-args")}"`);
   const installAfter = (flag: string) =>
     `printf '%s\\n' "$@" > "${join(root, "extract-args")}"; ` +
     `while [ "$#" -gt 0 ] && [ "$1" != "${flag}" ]; do shift; done; ` +
     `[ "$#" -ge 2 ] || exit 64; shift; mkdir -p "$1"; ` +
-    `printf '#!/bin/sh\\necho "telnyx version 0.24.0"\\n' > "$1/telnyx"`;
+    `printf '#!/bin/sh\\necho "telnyx version 0.27.0"\\n' > "$1/telnyx"`;
   executable(join(root, "fake-bin", "tar"), installAfter("-C"));
   executable(join(root, "fake-bin", "unzip"), installAfter("-d"));
   executable(join(root, "fake-bin", "rm"), "exit 0");
@@ -70,13 +70,13 @@ describe("postinstall vendor-first version decision", () => {
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.downloaded, true);
     assert.match(result.stdout, /Vendored telnyx CLI 0\.21\.0 found/);
-    assert.match(result.installedVersion, /0\.24\.0/);
+    assert.match(result.installedVersion, /0\.27\.0/);
   });
 
   it("keeps a current preferred vendor without downloading", () => {
     const result = runPostinstall({
-      vendorOutput: "telnyx version 0.24.0",
-      pathOutput: "telnyx version 0.25.0",
+      vendorOutput: "telnyx version 0.27.0",
+      pathOutput: "telnyx version 0.28.0",
     });
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.downloaded, false);
@@ -84,7 +84,7 @@ describe("postinstall vendor-first version decision", () => {
   });
 
   it("allows compatible PATH to suppress download only when vendor is absent", () => {
-    const result = runPostinstall({ pathOutput: "telnyx version 0.25.0" });
+    const result = runPostinstall({ pathOutput: "telnyx version 0.28.0" });
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.downloaded, false);
     assert.match(result.stdout, /already installed on PATH/);
@@ -92,17 +92,17 @@ describe("postinstall vendor-first version decision", () => {
 
   it("refreshes an unrelated preferred vendor even when PATH is compatible", () => {
     const result = runPostinstall({
-      vendorOutput: "@telnyx/api-cli/0.25.0 darwin-arm64",
-      pathOutput: "telnyx version 0.25.0",
+      vendorOutput: "@telnyx/api-cli/0.28.0 darwin-arm64",
+      pathOutput: "telnyx version 0.28.0",
     });
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.downloaded, true);
     assert.match(result.stdout, /Vendored telnyx CLI has an unrecognized version/);
-    assert.match(result.installedVersion, /0\.24\.0/);
+    assert.match(result.installedVersion, /0\.27\.0/);
   });
 
   it("does not let an unrelated PATH candidate suppress download", () => {
-    const result = runPostinstall({ pathOutput: "unrelated-tool v0.25.0" });
+    const result = runPostinstall({ pathOutput: "unrelated-tool v0.28.0" });
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.downloaded, true);
     assert.match(result.stdout, /telnyx CLI on PATH has an unrecognized version/);
@@ -117,7 +117,7 @@ describe("postinstall vendor-first version decision", () => {
 
   it("refreshes a preferred vendor whose version command fails", () => {
     const result = runPostinstall({
-      vendorOutput: "telnyx version 0.25.0",
+      vendorOutput: "telnyx version 0.28.0",
       vendorExitCode: 1,
     });
     assert.equal(result.status, 0, result.stderr);
@@ -134,9 +134,9 @@ describe("postinstall current-host release", () => {
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.downloaded, true);
     assert.ok(result.downloadArgs.trimEnd().endsWith(release.archiveName));
-    assert.ok(result.downloadArgs.includes(`releases/download/v0.24.0/${release.archiveName}`));
+    assert.ok(result.downloadArgs.includes(`releases/download/v0.27.0/${release.archiveName}`));
     assert.ok(result.extractArgs.includes(release.archiveName));
     assert.ok(result.extractArgs.split("\n").includes(release.executableName));
-    assert.match(result.installedVersion, /0\.24\.0/);
+    assert.match(result.installedVersion, /0\.27\.0/);
   });
 });

--- a/cli/tests/sms.test.ts
+++ b/cli/tests/sms.test.ts
@@ -40,6 +40,10 @@ function flags(f) { const out = []; for (let i = 0; i < command.length; i++) { i
 // recipient in data.to[].status — there is NO top-level status field.
 if (command[0] === "messages" && command[1] === "send") {
   console.log(JSON.stringify({ data: { id: "msg-123", record_type: "message", type: flag("--type"), from: { phone_number: flag("--from"), carrier: "", line_type: "" }, to: [{ phone_number: flag("--to"), status: "queued", carrier: "", line_type: "" }] } }));
+} else if (command[0] === "messages" && command[1] === "send-number-pool") {
+  console.log(JSON.stringify({ data: { id: "pool-123", record_type: "message", type: flag("--type"), from: { phone_number: "+131****0099" }, to: [{ phone_number: flag("--to"), status: "queued" }] } }));
+} else if (command[0] === "messages" && command[1] === "send-with-alphanumeric-sender") {
+  console.log(JSON.stringify({ data: { id: "alpha-123", record_type: "message", type: "SMS", from: { alphanumeric_sender_id: flag("--from") }, to: [{ phone_number: flag("--to"), status: "queued" }] } }));
 } else if (command[0] === "messages" && command[1] === "send-group-mms") {
   const recipients = flags("--to").map((p) => ({ phone_number: p, status: "queued", carrier: "", line_type: "" }));
   console.log(JSON.stringify({ data: { id: "grp-789", record_type: "message", type: "MMS", from: { phone_number: flag("--from") }, to: recipients } }));
@@ -258,6 +262,85 @@ describe("SMS action commands", () => {
     assertFlagValue(sendCall, "--messaging-profile-id", "prof-1");
     assertFlagValue(sendCall, "--webhook-url", "https://example.com/wh");
     assertFlagValue(sendCall, "--subject", "Sub");
+  });
+
+  it("send-sms without --from sends from a number pool with exact generated CLI argv", () => {
+    const fake = setupFakeTelnyx();
+    const out = runAgent([
+      "send-sms",
+      "--messaging-profile-id", "prof-pool",
+      "--to", "+131****0001",
+      "--text", "Pool hello",
+      "--json",
+    ], fake.env);
+
+    const data = JSON.parse(out);
+    assert.equal(data.message_id, "pool-123");
+    assert.equal(data.sender_mode, "number-pool");
+    assert.equal(data.from, "+131****0099");
+    assert.deepEqual(readLoggedArgs(fake.logPath), [[
+      "messages", "send-number-pool",
+      "--messaging-profile-id", "prof-pool",
+      "--to", "+131****0001",
+      "--type", "SMS",
+      "--text", "Pool hello",
+      "--format", "json",
+    ]]);
+    assert.equal(
+      readFileSync(fake.logPath, "utf8"),
+      JSON.stringify(readLoggedArgs(fake.logPath)[0]) + "\n",
+      "the argv mock log must contain exactly one newline-terminated call",
+    );
+  });
+
+  it("send-sms routes an alphanumeric --from through the dedicated generated action", () => {
+    const fake = setupFakeTelnyx();
+    const out = runAgent([
+      "send-sms",
+      "--from", "MyCompany",
+      "--messaging-profile-id", "prof-alpha",
+      "--to", "+131****0001",
+      "--text", "Alpha hello",
+      "--webhook-url", "https://example.com/status",
+      "--json",
+    ], fake.env);
+
+    const data = JSON.parse(out);
+    assert.equal(data.message_id, "alpha-123");
+    assert.equal(data.sender_mode, "alphanumeric");
+    assert.deepEqual(readLoggedArgs(fake.logPath), [[
+      "messages", "send-with-alphanumeric-sender",
+      "--from", "MyCompany",
+      "--messaging-profile-id", "prof-alpha",
+      "--text", "Alpha hello",
+      "--to", "+131****0001",
+      "--webhook-url", "https://example.com/status",
+      "--format", "json",
+    ]]);
+  });
+
+  it("send-sms requires a messaging profile for pooled and alphanumeric sends", () => {
+    const fake = setupFakeTelnyx();
+    runAgentExpectingFailure(
+      ["send-sms", "--to", "+131****0001", "--text", "pool", "--json"],
+      fake.env,
+      /--messaging-profile-id is required when sending from a number pool/,
+    );
+    runAgentExpectingFailure(
+      ["send-sms", "--from", "MyCompany", "--to", "+131****0001", "--text", "alpha", "--json"],
+      fake.env,
+      /--messaging-profile-id is required for an alphanumeric/,
+    );
+    assert.deepEqual(readLoggedArgs(fake.logPath), []);
+  });
+
+  it("send-sms rejects MMS for an alphanumeric sender", () => {
+    const fake = setupFakeTelnyx();
+    runAgentExpectingFailure([
+      "send-sms", "--from", "MyCompany", "--messaging-profile-id", "prof-alpha",
+      "--to", "+131****0001", "--media-url", "https://example.com/photo.jpg", "--json",
+    ], fake.env, /support SMS text only/);
+    assert.deepEqual(readLoggedArgs(fake.logPath), []);
   });
 
   it("send-group-mms POSTs /v2/messages/group_mms with a JSON to[] array (AIF-335)", async () => {
@@ -502,5 +585,15 @@ describe("SMS action commands", () => {
     assert.match(out, /send-group-mms/);
     assert.match(out, /schedule-sms/);
     assert.match(out, /sms-status/);
+    assert.match(out, /number pool/);
+    assert.match(out, /alphanumeric sender ID/);
+  });
+
+  it("capabilities registers number-pool and alphanumeric SMS actions", () => {
+    const fake = setupFakeTelnyx();
+    const data = JSON.parse(runAgent(["capabilities", "--json"], fake.env));
+    const actions = data.api_capabilities["📱 Messaging"][0].actions;
+    assert.ok(actions.includes("send_sms_from_number_pool"));
+    assert.ok(actions.includes("send_sms_with_alphanumeric_sender"));
   });
 });

--- a/cli/tests/sms.test.ts
+++ b/cli/tests/sms.test.ts
@@ -319,6 +319,23 @@ describe("SMS action commands", () => {
     ]]);
   });
 
+  it("send-sms treats a short-code --from as a phone-number sender, not alphanumeric", () => {
+    const fake = setupFakeTelnyx();
+    const out = runAgent([
+      "send-sms",
+      "--from", "80001",
+      "--to", "+131****0001",
+      "--text", "Short code hello",
+      "--json",
+    ], fake.env);
+
+    const data = JSON.parse(out);
+    assert.equal(data.sender_mode, "phone-number");
+    const [args] = readLoggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["messages", "send"]);
+    assert.ok(args.includes("80001"));
+  });
+
   it("send-sms requires a messaging profile for pooled and alphanumeric sends", () => {
     const fake = setupFakeTelnyx();
     runAgentExpectingFailure(

--- a/cli/tests/whatsapp.test.ts
+++ b/cli/tests/whatsapp.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for WhatsApp commands.
  *
- * whatsapp-send still shells out to the Go CLI (`messages send-whatsapp`), so
- * those tests use the fake `telnyx` binary and assert flag passing.
+ * whatsapp-send still shells out to the Go CLI, detecting the legacy
+ * `messages send-whatsapp` and v0.27 `messages whatsapp` spellings locally, so
+ * those tests use the fake `telnyx` binary and assert exact flag passing.
  *
  * whatsapp-templates and setup-whatsapp now call the Telnyx REST API directly
  * (AIF-326: the pinned Go CLI built a doubled `/v2/v2/whatsapp/...` path that
@@ -13,7 +14,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -26,7 +27,11 @@ const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
  * Create a fake `telnyx` binary that logs its args and returns canned JSON
  * based on the subcommand being called.
  */
-function setupFakeTelnyx(): { fakeTelnyx: string; logPath: string; env: NodeJS.ProcessEnv } {
+function setupFakeTelnyx(
+  whatsappCommand: "send-whatsapp" | "whatsapp" = "send-whatsapp",
+  advertiseWhatsappInHelp = true,
+  reportedVersion?: string,
+): { fakeTelnyx: string; logPath: string; env: NodeJS.ProcessEnv } {
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-wa-"));
   const binDir = join(tempDir, "bin");
   const logPath = join(tempDir, "args.jsonl");
@@ -39,10 +44,12 @@ function setupFakeTelnyx(): { fakeTelnyx: string; logPath: string; env: NodeJS.P
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+const whatsappCommand = ${JSON.stringify(whatsappCommand)};
+const reportedVersion = ${JSON.stringify(reportedVersion)};
 
 const fmtIdx = args.indexOf("--format");
 const format = fmtIdx >= 0 ? args[fmtIdx + 1] : "json";
-const cmd = args.filter((a, i) => i !== fmtIdx && i !== fmtIdx + 1);
+const cmd = fmtIdx >= 0 ? args.filter((a, i) => i !== fmtIdx && i !== fmtIdx + 1) : args;
 
 // Emulate the real Go CLI list behavior: with --format json, list commands
 // route through ShowJSONIterator and print each item as a SEPARATE
@@ -56,8 +63,15 @@ function printList(items) {
   }
 }
 
+// Side-effect-free WhatsApp command discovery used by the wrapper.
+if (cmd[0] === "messages" && cmd[1] === "--help") {
+  ${advertiseWhatsappInHelp ? 'console.log("COMMANDS:\\n   " + whatsappCommand + "  Send a WhatsApp message");' : 'console.log("COMMANDS:\\n   send  Send a message");'}
+}
+else if (cmd[0] === "--version") {
+  console.log(reportedVersion ?? ("telnyx version " + (whatsappCommand === "whatsapp" ? "0.27.0" : "0.21.0")));
+}
 // WhatsApp Business Accounts — list
-if (cmd[0] === "whatsapp:business-accounts" && cmd[1] === "list") {
+else if (cmd[0] === "whatsapp:business-accounts" && cmd[1] === "list") {
   printList([{ id: "waba_test123", name: "Test WABA" }]);
 }
 // WhatsApp Business Account phone numbers — list
@@ -88,8 +102,8 @@ else if (cmd[0] === "whatsapp:templates" && cmd[1] === "list") {
 else if (cmd[0] === "whatsapp:templates" && cmd[1] === "create") {
   console.log(JSON.stringify({ data: { id: "tpl_new", name: cmd[cmd.indexOf("--name") + 1], status: "PENDING" } }));
 }
-// Messages send-whatsapp
-else if (cmd[0] === "messages" && cmd[1] === "send-whatsapp") {
+// Messages send-whatsapp (legacy) / whatsapp (v0.27)
+else if (cmd[0] === "messages" && cmd[1] === whatsappCommand) {
   // Mirror the real Telnyx envelope: per-recipient state lives in to[0].status
   // while the top-level status is a coarse "submitted". The wrapper must
   // surface the recipient status, not the top-level one.
@@ -134,6 +148,7 @@ else {
 }
 
 function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
   return readFileSync(logPath, "utf8")
     .trim()
     .split("\n")
@@ -293,6 +308,9 @@ describe("WhatsApp commands", () => {
     assert.ok(output.includes("whatsapp-templates"), "help must list whatsapp-templates");
     assert.ok(output.includes("--waba-id"), "help must document --waba-id flag");
     assert.ok(output.includes("--template-name"), "help must document --template-name flag");
+    assert.ok(output.includes("--interactive <json>"), "help must document rich interactive payloads");
+    assert.ok(output.includes("--sticker <json>"), "help must document sticker payloads");
+    assert.ok(output.includes("--contacts <json>"), "help must document contacts payloads");
   });
 
   it("capabilities includes WhatsApp category", () => {
@@ -304,6 +322,9 @@ describe("WhatsApp commands", () => {
       data.api_capabilities["💬 WhatsApp"][0].actions.includes("send_whatsapp_message"),
       "WhatsApp capabilities must include send_whatsapp_message action",
     );
+    assert.ok(data.api_capabilities["💬 WhatsApp"][0].actions.includes("send_whatsapp_interactive"));
+    assert.ok(data.api_capabilities["💬 WhatsApp"][0].actions.includes("send_whatsapp_sticker"));
+    assert.ok(data.api_capabilities["💬 WhatsApp"][0].actions.includes("send_whatsapp_contacts"));
   });
 
   it("whatsapp-send constructs correct text message JSON and passes to Go CLI", () => {
@@ -329,6 +350,77 @@ describe("WhatsApp commands", () => {
     const msgJson = JSON.parse(sendCall[msgIdx + 1]);
     assert.equal(msgJson.type, "text");
     assert.equal(msgJson.text.body, "Hello World!");
+
+    const exactSendArgs = [
+      "messages", "send-whatsapp",
+      "--from", data.from,
+      "--to", data.to,
+      "--whatsapp-message", '{"type":"text","text":{"body":"Hello World!"}}',
+      "--type", "WHATSAPP",
+      "--format", "json",
+    ];
+    assert.deepEqual(calls, [["messages", "--help"], exactSendArgs]);
+    assert.equal(
+      readFileSync(fake.logPath, "utf8"),
+      `${JSON.stringify(["messages", "--help"])}\n${JSON.stringify(exactSendArgs)}\n`,
+      "compatibility probe and send argv must be exact newline-terminated JSONL",
+    );
+  });
+
+  it("whatsapp-send uses the v0.27 messages whatsapp spelling advertised by local help", () => {
+    const fake = setupFakeTelnyx("whatsapp");
+    const output = runCli([
+      "whatsapp-send", "--from", "+155****4567", "--to", "+155****6543",
+      "--image", '{"link":"https://example.com/photo.jpg","caption":"Hi"}',
+      "--messaging-profile-id", "prof-wa",
+      "--webhook-url", "https://example.com/status",
+      "--json",
+    ], fake.env);
+
+    assert.equal(JSON.parse(output).message_type, "image");
+    assert.deepEqual(readLoggedArgs(fake.logPath), [
+      ["messages", "--help"],
+      [
+        "messages", "whatsapp",
+        "--from", "+155****4567",
+        "--to", "+155****6543",
+        "--whatsapp-message", '{"type":"image","image":{"link":"https://example.com/photo.jpg","caption":"Hi"}}',
+        "--type", "WHATSAPP",
+        "--messaging-profile-id", "prof-wa",
+        "--webhook-url", "https://example.com/status",
+        "--format", "json",
+      ],
+    ]);
+  });
+
+  it("whatsapp-send falls back to local semantic version when help lacks both spellings", () => {
+    const fake = setupFakeTelnyx("whatsapp", false);
+    runCli([
+      "whatsapp-send", "--from", "+155****4567", "--to", "+155****6543",
+      "--text", "Version fallback", "--json",
+    ], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    assert.deepEqual(calls.map((args) => args.slice(0, 2)), [
+      ["messages", "--help"],
+      ["--version"],
+      ["messages", "whatsapp"],
+    ]);
+  });
+
+  it("whatsapp-send defaults to the bundled v0.27 spelling when compatibility probes are inconclusive", () => {
+    const fake = setupFakeTelnyx("whatsapp", false, "custom telnyx build");
+    runCli([
+      "whatsapp-send", "--from", "+155****4567", "--to", "+155****6543",
+      "--text", "Bundled fallback", "--json",
+    ], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    assert.deepEqual(calls.map((args) => args.slice(0, 2)), [
+      ["messages", "--help"],
+      ["--version"],
+      ["messages", "whatsapp"],
+    ]);
   });
 
   it("whatsapp-send constructs correct template message JSON", () => {
@@ -347,6 +439,53 @@ describe("WhatsApp commands", () => {
     assert.equal(msgJson.type, "template");
     assert.equal(msgJson.template.name, "order_ready");
     assert.equal(msgJson.template.language.code, "es_ES");
+  });
+
+  it("whatsapp-send constructs every supported rich WhatsApp payload", () => {
+    const cases: Array<{ type: string; value: string; expected: unknown }> = [
+      { type: "audio", value: '{"link":"https://example.com/a.mp3"}', expected: { link: "https://example.com/a.mp3" } },
+      { type: "document", value: '{"link":"https://example.com/a.pdf","filename":"a.pdf"}', expected: { link: "https://example.com/a.pdf", filename: "a.pdf" } },
+      { type: "image", value: '{"id":"media-image"}', expected: { id: "media-image" } },
+      { type: "interactive", value: '{"type":"button","body":{"text":"Choose"},"action":{"buttons":[]}}', expected: { type: "button", body: { text: "Choose" }, action: { buttons: [] } } },
+      { type: "location", value: '{"latitude":41.8,"longitude":-87.6,"name":"Chicago"}', expected: { latitude: 41.8, longitude: -87.6, name: "Chicago" } },
+      { type: "reaction", value: '{"message_id":"wamid.123","emoji":"👍"}', expected: { message_id: "wamid.123", emoji: "👍" } },
+      { type: "sticker", value: '{"id":"media-sticker"}', expected: { id: "media-sticker" } },
+      { type: "contacts", value: '[{"name":{"formatted_name":"Ada Lovelace"},"phones":[{"phone":"+155****6543"}]}]', expected: [{ name: { formatted_name: "Ada Lovelace" }, phones: [{ phone: "+155****6543" }] }] },
+      { type: "video", value: '{"link":"https://example.com/v.mp4","caption":"Watch"}', expected: { link: "https://example.com/v.mp4", caption: "Watch" } },
+    ];
+
+    for (const testCase of cases) {
+      const fake = setupFakeTelnyx("whatsapp");
+      const output = runCli([
+        "whatsapp-send", "--from", "+155****4567", "--to", "+155****6543",
+        `--${testCase.type}`, testCase.value,
+        "--biz-opaque-callback-data", "correlation-123",
+        "--json",
+      ], fake.env);
+      assert.equal(JSON.parse(output).message_type, testCase.type);
+
+      const sendCall = readLoggedArgs(fake.logPath)[1];
+      const payload = JSON.parse(sendCall[sendCall.indexOf("--whatsapp-message") + 1]);
+      assert.equal(payload.type, testCase.type);
+      assert.deepEqual(payload[testCase.type], testCase.expected);
+      assert.equal(payload.biz_opaque_callback_data, "correlation-123");
+      assert.equal(sendCall[sendCall.indexOf("--type") + 1], "WHATSAPP");
+    }
+  });
+
+  it("whatsapp-send rejects malformed, empty contacts, and competing payload flags", () => {
+    const fake = setupFakeTelnyx();
+    for (const args of [
+      ["--image", "not-json"],
+      ["--contacts", "[]"],
+      ["--text", "Hi", "--location", '{"latitude":1,"longitude":2}'],
+    ]) {
+      assert.throws(() => runCli([
+        "whatsapp-send", "--from", "+155****4567", "--to", "+155****6543",
+        ...args, "--json",
+      ], fake.env));
+    }
+    assert.deepEqual(readLoggedArgs(fake.logPath), [], "invalid payloads must fail before probing or sending");
   });
 
   it("whatsapp-send fails without --text or --template-name", () => {


### PR DESCRIPTION
## Audit finding

The weekly CLI parity audit found that the agent CLI only supported direct `--from` SMS and text/template WhatsApp, while Telnyx CLI v0.27.0 adds number-pool, alphanumeric-sender, and rich WhatsApp payloads. It also renames the WhatsApp subcommand to `messages whatsapp`.

## Scope

- add number-pool and alphanumeric SMS selection
- add rich WhatsApp audio/document/image/interactive/location/reaction/contacts/video/sticker payloads
- detect legacy/current WhatsApp command spellings safely
- upgrade the bundled Telnyx CLI from v0.24.0 to v0.27.0
- update help, capabilities, README, and release/postinstall tests

## Validation

- `npm test` — 466/466 passed
- `npm run typecheck` — passed
- focused WhatsApp tests — 22/22 passed
- verified all v0.27 release assets/checksums and exercised real postinstall
- compared v0.24/v0.27 help catalogs; no existing roots/subcommands were removed

Generated by the 2026-08-17 Telnyx CLI parity audit.