### PR TITLE
feat: Add Edge Compute v0.4.1 capability detection

### DIFF
--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -21,6 +21,8 @@ import {
   supportsResetFuncNonInteractiveConfirmation,
   supportsSecretsAdd,
   supportsShip,
+  supportsShipStatus,
+  supportsSqlBoundParameters,
   supportsSqlDatabases,
   supportsStatefulActors,
   supportsTypes,
@@ -37,6 +39,7 @@ interface EdgeDoctorResult {
   new_func_from_dir_supported: boolean;
   secrets_add_supported: boolean;
   ship_supported: boolean;
+  ship_status_supported: boolean;
   stateful_actors_supported: boolean;
   inspect_supported: boolean;
   actor_instances_supported: boolean;
@@ -47,6 +50,7 @@ interface EdgeDoctorResult {
   kv_storage_supported: boolean;
   kv_key_management_supported: boolean;
   sql_databases_supported: boolean;
+  sql_bound_parameters_supported: boolean;
   checks: Array<{ name: string; ok: boolean; detail: string }>;
   next_steps: string[];
 }
@@ -63,6 +67,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let newFuncFromDirSupported = false;
   let secretsAddSupported = false;
   let shipSupported = false;
+  let shipStatusSupported = false;
   let statefulActorsSupported = false;
   let inspectSupported = false;
   let actorInstancesSupported = false;
@@ -73,6 +78,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let kvStorageSupported = false;
   let kvKeyManagementSupported = false;
   let sqlDatabasesSupported = false;
+  let sqlBoundParametersSupported = false;
 
   try {
     getEdgeHelp();
@@ -95,6 +101,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     newFuncFromDirSupported = supportsNewFuncFromDir();
     secretsAddSupported = supportsSecretsAdd();
     shipSupported = supportsShip();
+    shipStatusSupported = supportsShipStatus();
     statefulActorsSupported = supportsStatefulActors();
     inspectSupported = supportsInspect();
     actorInstancesSupported = supportsActorInstances();
@@ -105,6 +112,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     kvStorageSupported = supportsKvStorage();
     kvKeyManagementSupported = supportsKvKeyManagement();
     sqlDatabasesSupported = supportsSqlDatabases();
+    sqlBoundParametersSupported = supportsSqlBoundParameters();
 
     checks.push({
       name: "API-key auth supported",
@@ -129,6 +137,13 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       name: "Function shipping",
       ok: shipSupported,
       detail: shipSupported ? "ship is available" : "ship --help capability was not detected",
+    });
+    checks.push({
+      name: "Ship failure diagnostics",
+      ok: shipStatusSupported,
+      detail: shipStatusSupported
+        ? "ship status <function> --logs is available"
+        : "ship status --help did not advertise both <function> usage and --logs",
     });
     checks.push({
       name: "Stateful actors supported",
@@ -193,6 +208,13 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       detail: sqlDatabasesSupported
         ? "storage sqldb execute supports --remote, --command, and --file"
         : "storage sqldb execute --help did not advertise --remote, --command, and --file",
+    });
+    checks.push({
+      name: "Bound SQL parameters",
+      ok: sqlBoundParametersSupported,
+      detail: sqlBoundParametersSupported
+        ? "storage sqldb execute supports --param and --param-json"
+        : "storage sqldb execute --help did not advertise both --param and --param-json",
     });
 
     try {
@@ -286,6 +308,9 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     } else if (statefulActorsSupported) {
       nextSteps.push("Actor scaffolding is available, but this CLI does not expose actors instances; upgrade telnyx-edge for that view.");
     }
+    if (shipStatusSupported) {
+      nextSteps.push("Diagnose the latest ship before resetting it: telnyx-edge ship status <function-name> --logs");
+    }
     if (resetFuncSupported) {
       nextSteps.push(`Recover a failed deployment with: telnyx-edge reset-func <function-name>${resetFuncNoninteractiveConfirmationSupported ? " --yes" : ""}`);
     }
@@ -298,7 +323,11 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     if (sqlDatabasesSupported) {
       nextSteps.push("Run remote SQL with: telnyx-edge storage sqldb execute <database> --remote --command \"SELECT 1\"");
     }
+    if (sqlBoundParametersSupported) {
+      nextSteps.push("Bind SQL inputs safely with repeatable --param (strings) and --param-json (numbers, booleans, or null).");
+    }
     const missingOptional = [
+      !shipStatusSupported && "ship status <function> --logs diagnostics",
       !resetFuncSupported && "reset-func",
       resetFuncSupported && !resetFuncNoninteractiveConfirmationSupported && "reset-func --yes",
       !noninteractiveConfirmationSupported && "destructive-command --yes",
@@ -306,6 +335,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       !kvStorageSupported && "KV namespaces",
       !kvKeyManagementSupported && "KV keys",
       !sqlDatabasesSupported && "remote SQL execution",
+      !sqlBoundParametersSupported && "SQL --param/--param-json bindings",
     ].filter((value): value is string => Boolean(value));
     if (missingOptional.length > 0) {
       nextSteps.push(`Optional capabilities not detected; upgrade telnyx-edge if needed: ${missingOptional.join(", ")}.`);
@@ -323,6 +353,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     new_func_from_dir_supported: newFuncFromDirSupported,
     secrets_add_supported: secretsAddSupported,
     ship_supported: shipSupported,
+    ship_status_supported: shipStatusSupported,
     stateful_actors_supported: statefulActorsSupported,
     inspect_supported: inspectSupported,
     actor_instances_supported: actorInstancesSupported,
@@ -333,6 +364,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     kv_storage_supported: kvStorageSupported,
     kv_key_management_supported: kvKeyManagementSupported,
     sql_databases_supported: sqlDatabasesSupported,
+    sql_bound_parameters_supported: sqlBoundParametersSupported,
     checks,
     next_steps: nextSteps,
   };

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -76,6 +76,16 @@ export function supportsShip(): boolean {
   }
 }
 
+/** Detect the read-only failed-ship diagnostic and its detailed log output. */
+export function supportsShipStatus(): boolean {
+  try {
+    const out = runEdge(["ship", "status", "--help"]);
+    return /\bship\s+status\s+<function>(?:\s|\[|$)/i.test(out) && /--logs\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
 /** Detect non-interactive confirmation from a destructive command's own help. */
 export function supportsNonInteractiveConfirmation(): boolean {
   try {
@@ -160,6 +170,16 @@ export function supportsSqlDatabases(): boolean {
     const out = runEdge(["storage", "sqldb", "execute", "--help"]);
     return /\bstorage\s+sqldb\s+execute\s+<[^>]+>/i.test(out) &&
       ["remote", "command", "file"].every((flag) => new RegExp(`--${flag}\\b`, "i").test(out));
+  } catch {
+    return false;
+  }
+}
+
+/** Detect both forms of v0.4.1 positional SQL parameter binding directly. */
+export function supportsSqlBoundParameters(): boolean {
+  try {
+    const out = runEdge(["storage", "sqldb", "execute", "--help"]);
+    return /--param(?:[\s=,]|$)/i.test(out) && /--param-json\b/i.test(out);
   } catch {
     return false;
   }

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -18,6 +18,8 @@ type FakeEdgeOptions = {
   newFuncFromDir?: boolean;
   secretsAdd?: boolean;
   ship?: boolean;
+  shipStatusFunctionUsage?: boolean;
+  shipStatusLogs?: boolean;
   resetFunc?: boolean;
   resetNoninteractiveConfirmation?: boolean;
   noninteractiveConfirmation?: boolean;
@@ -26,6 +28,8 @@ type FakeEdgeOptions = {
   kvStorage?: boolean;
   kvKeyManagement?: boolean;
   sqlDatabases?: boolean;
+  sqlParam?: boolean;
+  sqlParamJson?: boolean;
   argLog?: boolean;
 };
 
@@ -38,6 +42,8 @@ function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
   const newFuncFromDir = config.newFuncFromDir ?? true;
   const secretsAdd = config.secretsAdd ?? true;
   const ship = config.ship ?? true;
+  const shipStatusFunctionUsage = config.shipStatusFunctionUsage ?? true;
+  const shipStatusLogs = config.shipStatusLogs ?? true;
   const resetFunc = config.resetFunc ?? true;
   const resetNoninteractiveConfirmation = config.resetNoninteractiveConfirmation ?? false;
   const noninteractiveConfirmation = config.noninteractiveConfirmation ?? true;
@@ -46,6 +52,8 @@ function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
   const kvStorage = config.kvStorage ?? true;
   const kvKeyManagement = config.kvKeyManagement ?? true;
   const sqlDatabases = config.sqlDatabases ?? true;
+  const sqlParam = config.sqlParam ?? true;
+  const sqlParamJson = config.sqlParamJson ?? true;
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-edge-fake-"));
   const binDir = join(tempDir, "bin");
   const argsLog = join(tempDir, "args.jsonl");
@@ -77,6 +85,10 @@ if (args[0] === 'secrets' && args[1] === 'add' && args.includes('--help')) {
   }
   process.stderr.write('unknown command "add"\\n');
   process.exit(1);
+}
+if (args[0] === 'ship' && args[1] === 'status' && args.includes('--help')) {
+  console.log(['Show why a function ship failed', 'Usage: telnyx-edge ship status ${shipStatusFunctionUsage ? "<function>" : "[flags]"}', ...(${shipStatusLogs} ? ['      --logs  Also print the build log or crash output'] : [])].join('\\n'));
+  process.exit(0);
 }
 if (args[0] === 'ship' && args.includes('--help')) {
   if (${ship}) {
@@ -128,7 +140,7 @@ if (args[0] === 'storage' && args[1] === 'kv' && args.includes('--help')) {
 }
 if (args[0] === 'storage' && args[1] === 'sqldb' && args[2] === 'execute' && args.includes('--help')) {
   if (${sqlDatabases}) {
-    console.log('Run SQL against a SQL database\\nUsage: telnyx-edge storage sqldb execute <database> [flags]\\n--remote  --command string  --file string');
+    console.log(['Run SQL against a SQL database', 'Usage: telnyx-edge storage sqldb execute <database> [flags]', '--remote  --command string  --file string', ...(${sqlParam} ? ['--param string'] : []), ...(${sqlParamJson} ? ['--param-json string'] : [])].join('\\n'));
     process.exit(0);
   }
   console.log('Usage: telnyx-edge storage sqldb execute <database> [flags]\\n--remote --command string');
@@ -252,6 +264,7 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.new_func_from_dir_supported, true);
     assert.equal(data.secrets_add_supported, true);
     assert.equal(data.ship_supported, true);
+    assert.equal(data.ship_status_supported, true);
     assert.equal(data.stateful_actors_supported, true);
     assert.equal(data.inspect_supported, true);
     assert.equal(data.actor_instances_supported, true);
@@ -261,6 +274,7 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.kv_storage_supported, true);
     assert.equal(data.kv_key_management_supported, true);
     assert.equal(data.sql_databases_supported, true);
+    assert.equal(data.sql_bound_parameters_supported, true);
   });
 
   it("edge-doctor stays unready when root status exits zero but reports a failed check", () => {
@@ -301,7 +315,7 @@ describe("CLI — Edge Compute handoff", () => {
     assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["actors", "instances", "--help"])));
   });
 
-  it("edge-doctor probes v0.3 capabilities conservatively instead of inferring from version", () => {
+  it("edge-doctor probes optional capabilities conservatively instead of inferring from version", () => {
     const fake = withFakeEdgeCli({
       auth: "api_key",
       resetFunc: false,
@@ -310,21 +324,28 @@ describe("CLI — Edge Compute handoff", () => {
       kvStorage: false,
       kvKeyManagement: false,
       sqlDatabases: false,
+      shipStatusFunctionUsage: false,
+      shipStatusLogs: false,
+      sqlParam: false,
+      sqlParamJson: false,
       argLog: true,
     });
     const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
     assert.equal(data.telnyx_edge_version, "v0.2.5");
-    assert.equal(data.ready, true, "optional v0.3 capabilities do not block the core handoff");
+    assert.equal(data.ready, true, "optional capabilities do not block the core handoff");
+    assert.equal(data.ship_status_supported, false);
     assert.equal(data.reset_func_supported, false);
     assert.equal(data.noninteractive_confirmation_supported, false);
     assert.equal(data.types_supported, false);
     assert.equal(data.kv_storage_supported, false);
     assert.equal(data.kv_key_management_supported, false);
     assert.equal(data.sql_databases_supported, false);
+    assert.equal(data.sql_bound_parameters_supported, false);
     assert.ok(data.next_steps.some((step: string) => step.includes("Optional capabilities not detected")));
     const calls = readFileSync(fake.argsLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
     for (const expected of [
       ["reset-func", "--help"],
+      ["ship", "status", "--help"],
       ["delete-func", "--help"],
       ["secrets", "add", "--help"],
       ["types", "--help"],
@@ -333,6 +354,36 @@ describe("CLI — Edge Compute handoff", () => {
       ["storage", "sqldb", "execute", "--help"],
     ]) {
       assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(expected)), `missing probe ${expected.join(" ")}`);
+    }
+  });
+
+  it("requires function usage and --logs on the ship status help surface", () => {
+    for (const config of [
+      { shipStatusFunctionUsage: false },
+      { shipStatusLogs: false },
+    ]) {
+      const fake = withFakeEdgeCli({ auth: "api_key", ...config, argLog: true });
+      const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+      assert.equal(data.ready, true, "ship diagnostics remain optional for setup handoffs");
+      assert.equal(data.ship_supported, true, "the existing ship compatibility field is unchanged");
+      assert.equal(data.ship_status_supported, false);
+      assert.ok(data.next_steps.some((step: string) => step.includes("ship status <function> --logs diagnostics")));
+      const calls = readFileSync(fake.argsLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+      assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["ship", "status", "--help"])));
+    }
+  });
+
+  it("requires both SQL parameter flags without changing SQL or handoff compatibility", () => {
+    for (const config of [
+      { sqlParam: false },
+      { sqlParamJson: false },
+    ]) {
+      const fake = withFakeEdgeCli({ auth: "api_key", ...config });
+      const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+      assert.equal(data.ready, true, "bound SQL parameters remain optional for setup handoffs");
+      assert.equal(data.sql_databases_supported, true, "the existing SQL compatibility field is unchanged");
+      assert.equal(data.sql_bound_parameters_supported, false);
+      assert.ok(data.next_steps.some((step: string) => step.includes("SQL --param/--param-json bindings")));
     }
   });
 

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -185,6 +185,13 @@ telnyx-edge inspect my-function
 
 `inspect <function>` is the per-function detail view: deployment status, invoke URL, timestamps, and **every binding the deployed function declares**. Binding rows show the `env.<NAME>` handle, kind, target, and status; actor rows also show their owner/reference role. Probe it with `telnyx-edge inspect --help` when supporting multiple CLI releases.
 
+Before resetting a failed function, inspect the latest ship outcome. The first command prints one actionable, stage-classified reason; `--logs` also prints the build-log or crash-output snippet when the platform supplied one. The function argument may be a name or ID.
+
+```bash
+telnyx-edge ship status my-function
+telnyx-edge ship status my-function --logs
+```
+
 A failed function can be reset to `created` without changing its identity, fixed, and shipped again:
 
 ```bash
@@ -274,7 +281,7 @@ limit = 100
 period = 60
 ```
 
-Install `@telnyx/edge-runtime` **0.9.0 or newer**, then regenerate declarations. `telnyx-edge types` emits the binding as a runtime `RateLimiter`:
+Install `@telnyx/edge-runtime` **0.9.2 or newer**, then regenerate declarations. `telnyx-edge types` emits the binding as a runtime `RateLimiter`:
 
 ```bash
 npm install @telnyx/edge-runtime@latest
@@ -333,7 +340,7 @@ telnyx-edge types
 
 `types` generates `telnyx-env.d.ts`; KV handles are typed as `KvNamespace`. Rerun it whenever binding declarations change.
 
-### SQL databases (v0.3.0)
+### SQL databases (v0.3.0; bound parameters v0.4.1)
 
 A SQL database is an account-scoped SQLite database. It exists independently of functions and can be shared by every function that binds its UUID.
 
@@ -358,9 +365,16 @@ telnyx-edge storage sqldb execute "$SQLDB_ID" --remote \
 telnyx-edge storage sqldb execute "$SQLDB_ID" --remote -f ./schema.sql
 telnyx-edge storage sqldb execute "$SQLDB_ID" --remote \
   -c "SELECT id, url FROM links ORDER BY id" --json
+
+# Bind untrusted values instead of interpolating them into SQL.
+telnyx-edge storage sqldb execute "$SQLDB_ID" --remote \
+  --command "SELECT id, url FROM links WHERE url = ? AND id > ?" \
+  --param "https://example.com" --param-json 42
 ```
 
-Do not combine `--command` and `--file`, and do not omit both. Versioned migrations are created locally, then listed or applied against the remote database. Applied migrations are recorded in the database, so `apply` is safe to rerun and applies only pending files in numeric order.
+Do not combine `--command` and `--file`, and do not omit both. `--param` and `--param-json` are repeatable and fill `?` placeholders from left to right in the exact order the flags appear, even when the two flag forms are interleaved. `--param` always binds a string; use `--param-json` for a JSON number, boolean, or null. The number of bound values must exactly match the number of placeholders. Parameters cannot be combined with `--file`; use a parameterized `--command` instead. Prefer bindings for values from outside your own script rather than interpolating them into SQL.
+
+Versioned migrations are created locally, then listed or applied against the remote database. Applied migrations are recorded in the database, so `apply` is safe to rerun and applies only pending files in numeric order.
 
 ```bash
 telnyx-edge storage sqldb migrations create "$SQLDB_ID" add-links-table

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -185,16 +185,10 @@ telnyx-edge inspect my-function
 
 `inspect <function>` is the per-function detail view: deployment status, invoke URL, timestamps, and **every binding the deployed function declares**. Binding rows show the `env.<NAME>` handle, kind, target, and status; actor rows also show their owner/reference role. Probe it with `telnyx-edge inspect --help` when supporting multiple CLI releases.
 
-Before resetting a failed function, inspect the latest ship outcome. The first command prints one actionable, stage-classified reason; `--logs` also prints the build-log or crash-output snippet when the platform supplied one. The function argument may be a name or ID.
+Before resetting a failed function, inspect the latest ship outcome: `ship status <function>` prints one actionable, stage-classified reason, and `--logs` adds the build-log or crash-output snippet when the platform supplied one. A failed function can then be reset to `created` without changing its identity, fixed, and shipped again:
 
 ```bash
-telnyx-edge ship status my-function
 telnyx-edge ship status my-function --logs
-```
-
-A failed function can be reset to `created` without changing its identity, fixed, and shipped again:
-
-```bash
 telnyx-edge reset-func my-function --yes
 telnyx-edge ship --from-dir=./my-function
 ```
@@ -334,11 +328,7 @@ Declare a runtime binding in `telnyx.toml` or supported classic project manifest
 id = "<namespace-uuid>"
 ```
 
-```bash
-telnyx-edge types
-```
-
-`types` generates `telnyx-env.d.ts`; KV handles are typed as `KvNamespace`. Rerun it whenever binding declarations change.
+Then run `telnyx-edge types`: it generates `telnyx-env.d.ts` with KV handles typed as `KvNamespace`. Rerun it whenever binding declarations change.
 
 ### SQL databases (v0.3.0; bound parameters v0.4.1)
 
@@ -365,16 +355,12 @@ telnyx-edge storage sqldb execute "$SQLDB_ID" --remote \
 telnyx-edge storage sqldb execute "$SQLDB_ID" --remote -f ./schema.sql
 telnyx-edge storage sqldb execute "$SQLDB_ID" --remote \
   -c "SELECT id, url FROM links ORDER BY id" --json
-
 # Bind untrusted values instead of interpolating them into SQL.
 telnyx-edge storage sqldb execute "$SQLDB_ID" --remote \
-  --command "SELECT id, url FROM links WHERE url = ? AND id > ?" \
-  --param "https://example.com" --param-json 42
+  -c "SELECT id, url FROM links WHERE url = ? AND id > ?" --param "https://example.com" --param-json 42
 ```
 
-Do not combine `--command` and `--file`, and do not omit both. `--param` and `--param-json` are repeatable and fill `?` placeholders from left to right in the exact order the flags appear, even when the two flag forms are interleaved. `--param` always binds a string; use `--param-json` for a JSON number, boolean, or null. The number of bound values must exactly match the number of placeholders. Parameters cannot be combined with `--file`; use a parameterized `--command` instead. Prefer bindings for values from outside your own script rather than interpolating them into SQL.
-
-Versioned migrations are created locally, then listed or applied against the remote database. Applied migrations are recorded in the database, so `apply` is safe to rerun and applies only pending files in numeric order.
+Do not combine `--command` and `--file`, and do not omit both. `--param` (binds a string) and `--param-json` (binds a JSON number, boolean, or null) are repeatable and fill `?` placeholders left to right in flag order; the count must match the placeholders exactly, and they only work with `--command`. Prefer bindings over interpolating outside values into SQL. Versioned migrations are created locally, then listed or applied against the remote database. Applied migrations are recorded in the database, so `apply` is safe to rerun and applies only pending files in numeric order.
 
 ```bash
 telnyx-edge storage sqldb migrations create "$SQLDB_ID" add-links-table


### PR DESCRIPTION
## Audit finding
The edge wrapper did not detect v0.4.x `ship status --logs` or v0.4.1 SQL bound parameters. The guide stated the wrong RateLimiter runtime minimum and omitted both capabilities.

## Scope
- detect `ship status <function> --logs` and SQL `--param`/`--param-json` independently
- expose optional edge-doctor checks and upgrade/diagnostic guidance without changing handoff readiness
- correct RateLimiter minimum to edge-runtime 0.9.2
- document ship-status diagnosis and safe SQL binding semantics

## Validation
- edge handoff tests: 20/20 passed
- `npx tsc --noEmit` passed
- probes verified against edge-compute-cli v0.4.1 help