### PR TITLE
feat: Add SIM action status to agent CLI

### DIFF
--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -41,7 +41,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "Fax", description: "Send faxes programmatically", actions: ["send_fax"] },
   ],
   "📡 IoT": [
-    { name: "SIM Cards", description: "List, inspect, enable, and disable IoT SIM cards", actions: ["list_sim_cards", "retrieve_sim_card", "enable_sim_card", "disable_sim_card"] },
+    { name: "SIM Cards", description: "List, inspect, enable, and disable IoT SIM cards and observe asynchronous actions", actions: ["list_sim_cards", "retrieve_sim_card", "enable_sim_card", "disable_sim_card", "retrieve_sim_card_action", "list_sim_card_actions"] },
   ],
   "🔍 Lookup": [
     { name: "Number Lookup", description: "Carrier and caller ID lookups", actions: ["lookup_number"] },
@@ -98,6 +98,8 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent retrieve-sim-card", description: "Retrieve one IoT SIM card by ID" },
   { name: "telnyx-agent enable-sim-card", description: "Request asynchronous enablement of an IoT SIM card" },
   { name: "telnyx-agent disable-sim-card", description: "Request asynchronous disablement of an IoT SIM card" },
+  { name: "telnyx-agent retrieve-sim-card-action", description: "Retrieve the status and details of an asynchronous SIM card action" },
+  { name: "telnyx-agent list-sim-card-actions", description: "List asynchronous SIM card actions with status, type, SIM, bulk-action, and pagination filters" },
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },
   { name: "telnyx-agent ai-chat", description: "Create an OpenAI-compatible chat completion via Telnyx AI inference" },
   { name: "telnyx-agent ai-anthropic-message", description: "Create an Anthropic-compatible message response via Telnyx AI inference" },

--- a/cli/src/commands/sim-cards.ts
+++ b/cli/src/commands/sim-cards.ts
@@ -30,6 +30,17 @@ interface SimActionResult {
   status: string;
 }
 
+interface SimActionRetrieveResult {
+  action_id: string;
+  sim_card_action: JsonRecord;
+}
+
+interface SimActionListResult {
+  count: number;
+  sim_card_actions: JsonRecord[];
+  meta: JsonRecord;
+}
+
 export async function listSimCardsCommand(flags: Flags): Promise<void> {
   const jsonOutput = flags.json === true;
   const args = ["sim-cards", "list"];
@@ -78,6 +89,53 @@ export async function retrieveSimCardCommand(flags: Flags): Promise<void> {
         Status: simStatus(simCard) || "(not returned)",
       });
     }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function retrieveSimCardActionCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const actionId = stringFlag(flags, "id");
+  if (!actionId) fail("--id is required (SIM card action ID)", jsonOutput);
+
+  try {
+    const response = await telnyxCli(["sim-cards:actions", "retrieve", "--id", actionId]);
+    const action = asRecord(asRecord(response).data ?? response);
+    const result: SimActionRetrieveResult = {
+      action_id: stringValue(action.id) || actionId,
+      sim_card_action: action,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("SIM card action retrieved!", {
+        "Action ID": result.action_id,
+        "SIM Card ID": stringValue(action.sim_card_id) || "(not returned)",
+        "Action Type": stringValue(action.action_type) || "(not returned)",
+        Status: simStatus(action) || "(not returned)",
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function listSimCardActionsCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const args = ["sim-cards:actions", "list"];
+
+  addMappedFlag(args, flags, "sim-card-id", "--filter.sim-card-id");
+  addMappedFlag(args, flags, "status", "--filter.status");
+  addMappedFlag(args, flags, "bulk-sim-card-action-id", "--filter.bulk-sim-card-action-id");
+  addMappedFlag(args, flags, "action-type", "--filter.action-type");
+  addPositiveIntegerFlag(args, flags, "page-number", "--page-number", jsonOutput);
+  addPositiveIntegerFlag(args, flags, "page-size", "--page-size", jsonOutput);
+
+  try {
+    const response = await telnyxCli(args, { format: "raw" });
+    presentSimActionList(normalizeSimActionList(response), jsonOutput);
   } catch (err) {
     fail(errorMsg(err), jsonOutput);
   }
@@ -135,6 +193,20 @@ function normalizeSimList(response: unknown): SimListResult {
   };
 }
 
+function normalizeSimActionList(response: unknown): SimActionListResult {
+  const envelope = asRecord(response);
+  const actions = Array.isArray(envelope.data)
+    ? envelope.data.filter(
+        (item): item is JsonRecord => Boolean(item) && typeof item === "object" && !Array.isArray(item),
+      )
+    : [];
+  return {
+    count: actions.length,
+    sim_card_actions: actions,
+    meta: asRecord(envelope.meta),
+  };
+}
+
 function presentSimList(result: SimListResult, jsonOutput: boolean): void {
   if (jsonOutput) {
     outputJson(result);
@@ -151,6 +223,25 @@ function presentSimList(result: SimListResult, jsonOutput: boolean): void {
     console.log(`  • ${id}${details ? ` — ${details}` : ""}`);
   }
   if (result.count === 0) console.log("  (no SIM cards returned)");
+  console.log();
+}
+
+function presentSimActionList(result: SimActionListResult, jsonOutput: boolean): void {
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+
+  printSuccess("SIM card actions retrieved!", { Count: result.count });
+  for (const action of result.sim_card_actions) {
+    const id = stringValue(action.id) || "(unknown)";
+    const details = [action.action_type, action.sim_card_id, simStatus(action)]
+      .map(stringValue)
+      .filter(Boolean)
+      .join(" · ");
+    console.log(`  • ${id}${details ? ` — ${details}` : ""}`);
+  }
+  if (result.count === 0) console.log("  (no SIM card actions returned)");
   console.log();
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -70,7 +70,9 @@ import {
 import {
   disableSimCardCommand,
   enableSimCardCommand,
+  listSimCardActionsCommand,
   listSimCardsCommand,
+  retrieveSimCardActionCommand,
   retrieveSimCardCommand,
 } from "./commands/sim-cards.ts";
 import {
@@ -98,6 +100,8 @@ Commands:
   retrieve-sim-card Retrieve one IoT SIM card by ID
   enable-sim-card   Enable an IoT SIM card (asynchronous action)
   disable-sim-card  Disable an IoT SIM card (asynchronous action)
+  retrieve-sim-card-action Retrieve an asynchronous SIM card action by ID
+  list-sim-card-actions List asynchronous SIM card actions with filters and pagination
   setup-ai          Zero to AI: create assistant, buy number, wire them together
   setup-wireguard   Zero to VPN: create network, WireGuard interface, peer
   setup-verify      Zero to verification: create profile (no number bought)
@@ -500,15 +504,18 @@ AI Assistant Lifecycle Flags:
   --confirm         Explicitly confirm deletion (delete only, required)
 
 IoT SIM Action Flags:
-  --id <sim-card-id> SIM card ID (retrieve-sim-card, enable-sim-card, disable-sim-card — required)
+  --id <id>         SIM card ID (retrieve/enable/disable) or action ID (retrieve-sim-card-action) — required
   --iccid           Partial ICCID filter (list-sim-cards)
   --msisdn          MSISDN filter (list-sim-cards)
-  --status          Comma-separated SIM statuses (list-sim-cards)
+  --status          Comma-separated SIM statuses (list-sim-cards), or action status (list-sim-card-actions)
   --tags            Comma-separated tags that all matching SIMs must have (list-sim-cards)
   --sim-card-group-id SIM card group filter (list-sim-cards)
+  --sim-card-id     SIM card filter (list-sim-card-actions)
+  --bulk-sim-card-action-id Bulk action filter (list-sim-card-actions)
+  --action-type     Action type filter (list-sim-card-actions)
   --include-sim-card-group Include the associated SIM card group (list, retrieve)
-  --page-number     Result page (list-sim-cards)
-  --page-size       Results per page (list-sim-cards)
+  --page-number     Result page (SIM/action list commands)
+  --page-size       Results per page (SIM/action list commands)
   --sort            Sort field; prefix with - for descending (list-sim-cards)
 
 Environment:
@@ -627,6 +634,8 @@ Examples:
   telnyx-agent retrieve-sim-card --id <sim-card-id> --json
   telnyx-agent enable-sim-card --id <sim-card-id> --json
   telnyx-agent disable-sim-card --id <sim-card-id> --json
+  telnyx-agent retrieve-sim-card-action --id <action-id> --json
+  telnyx-agent list-sim-card-actions --sim-card-id <sim-card-id> --status in-progress --json
 `;
 
 const COMMANDS: Record<string, (
@@ -697,6 +706,8 @@ const COMMANDS: Record<string, (
   "retrieve-sim-card": retrieveSimCardCommand,
   "enable-sim-card": enableSimCardCommand,
   "disable-sim-card": disableSimCardCommand,
+  "retrieve-sim-card-action": retrieveSimCardActionCommand,
+  "list-sim-card-actions": listSimCardActionsCommand,
 };
 
 // Union of every flag any command reads (kept in sync with src/commands/*).
@@ -704,10 +715,10 @@ const COMMANDS: Record<string, (
 // like `tts --output-typ base64` or `tts --ouput f.wav` doesn't silently no-op.
 // This never fails the run — a missing entry just costs a spurious warning.
 const KNOWN_FLAGS = new Set<string>([
-  "about", "action", "actor", "administrative-area", "agent-id", "agent-message", "ai-assistant-id", "alpha-sender", "amount",
+  "about", "action", "action-type", "actor", "administrative-area", "agent-id", "agent-message", "ai-assistant-id", "alpha-sender", "amount",
   "answering-machine-detection", "api-key", "api-key-ref", "area-code", "assistant", "assistant-id", "audio-url",
   "authorized-person", "billing-group-id", "billing-phone", "black-threshold", "body", "brand-id",
-  "brand-name", "bundle-id", "call-control-id", "call-control-id-2", "call-control-id-to-bridge",
+  "brand-name", "bulk-sim-card-action-id", "bundle-id", "call-control-id", "call-control-id-2", "call-control-id-to-bridge",
   "call-control-id-to-bridge-with", "campaign-id", "cancel", "carrier-name", "category", "cause",
   "channels", "clear-tags", "clear-tool-ids", "client-state", "code", "command-id", "company-name",
   "component", "confirm", "connection-id", "connection-name", "contains", "content-type",
@@ -732,7 +743,7 @@ const KNOWN_FLAGS = new Set<string>([
   "preview-format", "privacy", "profile-name", "promote-to-main", "provider", "quality",
   "queue-name", "record", "remaining-numbers-action", "requirement-group-id", "resource-group-id", "response-format", "retry-on-timeout",
   "role", "rx", "sample-message", "sample-message-2", "sample1", "sample2", "send-at",
-  "service-tier", "service-type", "sim-card-group-id", "sip-address", "sole-prop", "sort", "source",
+  "service-tier", "service-type", "sim-card-group-id", "sim-card-id", "sip-address", "sole-prop", "sort", "source",
   "start-message", "starts-with", "status", "stop", "stop-message", "stop-sequence", "store-media", "store-preview", "system",
   "stream", "stream-type", "subject", "submit", "t38-enabled", "tag", "tags", "temperature", "thinking", "timeout",
   "smart-encoding",

--- a/cli/tests/iot.test.ts
+++ b/cli/tests/iot.test.ts
@@ -41,6 +41,26 @@ if (args[0] === "sim-cards" && args[1] === "list") {
     status: { value: "enabled", reason: "ready" },
     sim_card_group_id: "group-1"
   } }));
+} else if (args[0] === "sim-cards:actions" && args[1] === "retrieve") {
+  console.log(JSON.stringify({ data: {
+    id: flag("--id"),
+    sim_card_id: "sim-1",
+    action_type: "enable",
+    status: { value: "completed" },
+    created_at: "2026-08-17T12:00:00Z",
+    updated_at: "2026-08-17T12:00:01Z"
+  } }));
+} else if (args[0] === "sim-cards:actions" && args[1] === "list") {
+  console.log(JSON.stringify({
+    data: [{
+      id: "action-enable",
+      sim_card_id: "sim-1",
+      action_type: "enable",
+      status: { value: "completed" },
+      bulk_sim_card_action_id: "bulk-1"
+    }],
+    meta: { page_number: 3, page_size: 10, total_results: 1 }
+  }));
 } else if (args[0] === "sim-cards:actions" && (args[1] === "enable" || args[1] === "disable")) {
   console.log(JSON.stringify({ data: {
     id: "action-" + args[1],
@@ -154,6 +174,74 @@ describe("IoT SIM action commands", () => {
     assertFlag(args, "--format", "json");
   });
 
+  it("retrieves one SIM card action by an ID returned from enable or disable", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["retrieve-sim-card-action", "--id", "action-enable", "--json"], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      action_id: "action-enable",
+      sim_card_action: {
+        id: "action-enable",
+        sim_card_id: "sim-1",
+        action_type: "enable",
+        status: { value: "completed" },
+        created_at: "2026-08-17T12:00:00Z",
+        updated_at: "2026-08-17T12:00:01Z",
+      },
+    });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["sim-cards:actions", "retrieve"]);
+    assertFlag(args, "--id", "action-enable");
+    assertFlag(args, "--format", "json");
+  });
+
+  it("lists SIM card actions with generated filters and pagination flags", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "list-sim-card-actions",
+      "--sim-card-id", "sim-1",
+      "--status", "completed",
+      "--bulk-sim-card-action-id", "bulk-1",
+      "--action-type", "enable",
+      "--page-number", "3",
+      "--page-size", "10",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      count: 1,
+      sim_card_actions: [{
+        id: "action-enable",
+        sim_card_id: "sim-1",
+        action_type: "enable",
+        status: { value: "completed" },
+        bulk_sim_card_action_id: "bulk-1",
+      }],
+      meta: { page_number: 3, page_size: 10, total_results: 1 },
+    });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["sim-cards:actions", "list"]);
+    assertFlag(args, "--filter.sim-card-id", "sim-1");
+    assertFlag(args, "--filter.status", "completed");
+    assertFlag(args, "--filter.bulk-sim-card-action-id", "bulk-1");
+    assertFlag(args, "--filter.action-type", "enable");
+    assertFlag(args, "--page-number", "3");
+    assertFlag(args, "--page-size", "10");
+    assertFlag(args, "--format", "raw");
+  });
+
+  it("normalizes SIM card action status objects in human output", () => {
+    const fake = setupFakeTelnyx();
+    const retrieveOutput = runAgent(["retrieve-sim-card-action", "--id", "action-enable"], fake.env);
+    const listOutput = runAgent(["list-sim-card-actions"], fake.env);
+
+    assert.match(retrieveOutput, /Status\s+completed/);
+    assert.match(listOutput, /action-enable.*completed/);
+    assert.doesNotMatch(`${retrieveOutput}${listOutput}`, /\[object Object\]/);
+  });
+
   for (const action of ["enable", "disable"] as const) {
     it(`${action}s a SIM card and normalizes the documented status object`, () => {
       const fake = setupFakeTelnyx();
@@ -192,7 +280,14 @@ describe("IoT SIM action commands", () => {
   it("advertises all direct SIM commands in help and capabilities", () => {
     const help = runAgent(["help"]);
     const capabilities = JSON.parse(runAgent(["capabilities", "--json"]));
-    const commands = ["list-sim-cards", "retrieve-sim-card", "enable-sim-card", "disable-sim-card"];
+    const commands = [
+      "list-sim-cards",
+      "retrieve-sim-card",
+      "enable-sim-card",
+      "disable-sim-card",
+      "retrieve-sim-card-action",
+      "list-sim-card-actions",
+    ];
 
     for (const command of commands) {
       assert.match(help, new RegExp(command));
@@ -203,7 +298,14 @@ describe("IoT SIM action commands", () => {
     }
 
     const iotActions = capabilities.api_capabilities["📡 IoT"][0].actions;
-    for (const action of ["list_sim_cards", "retrieve_sim_card", "enable_sim_card", "disable_sim_card"]) {
+    for (const action of [
+      "list_sim_cards",
+      "retrieve_sim_card",
+      "enable_sim_card",
+      "disable_sim_card",
+      "retrieve_sim_card_action",
+      "list_sim_card_actions",
+    ]) {
       assert.ok(iotActions.includes(action), `IoT capabilities should include ${action}`);
     }
   });


### PR DESCRIPTION
## Audit finding
SIM enable/disable returns an asynchronous action ID, but the agent CLI could not retrieve or list those actions, so agents could not verify completion.

## Scope
- add `retrieve-sim-card-action`
- add `list-sim-card-actions` with SIM/status/type/bulk filters and pagination
- update human/JSON output, help, capabilities, and mock-binary tests

## Validation
- IoT tests: 11/11 passed
- `npx tsc --noEmit` passed
- `git diff --check` passed