### PR TITLE
feat: Add fax lifecycle actions to agent CLI

### DIFF
--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -38,7 +38,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "Providers", description: "List available speech-to-text providers and service types", actions: ["list_stt_providers"] },
   ],
   "📠 Fax": [
-    { name: "Fax", description: "Send faxes programmatically", actions: ["send_fax"] },
+    { name: "Fax", description: "Send and manage inbound and outbound faxes", actions: ["send_fax", "check_fax_status", "cancel_fax", "refresh_fax_media_url"] },
   ],
   "📡 IoT": [
     { name: "SIM Cards", description: "List, inspect, enable, and disable IoT SIM cards", actions: ["list_sim_cards", "retrieve_sim_card", "enable_sim_card", "disable_sim_card"] },
@@ -87,6 +87,9 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent update-messaging-profile", description: "Update one or more fields on a messaging profile" },
   { name: "telnyx-agent delete-messaging-profile", description: "Delete a messaging profile by ID with explicit confirmation" },
   { name: "telnyx-agent fax-send", description: "Send a fax using a fax application connection and a media URL or uploaded media name" },
+  { name: "telnyx-agent fax-status", description: "Retrieve the latest status and useful details for one fax" },
+  { name: "telnyx-agent fax-cancel", description: "Cancel an outbound fax that is queued, processed, originated, or sending" },
+  { name: "telnyx-agent fax-refresh", description: "Refresh the expired temporary media URL for an inbound fax" },
   { name: "telnyx-agent send-group-mms", description: "Send a group MMS to multiple recipients (--to comma-separated E.164 numbers)" },
   { name: "telnyx-agent schedule-sms", description: "Schedule an SMS for future delivery at a given ISO 8601 time" },
   { name: "telnyx-agent sms-status", description: "Check SMS delivery status, or cancel a scheduled message with --cancel" },

--- a/cli/src/commands/fax-lifecycle.ts
+++ b/cli/src/commands/fax-lifecycle.ts
@@ -1,0 +1,215 @@
+/**
+ * Fax lifecycle commands backed by the Stainless-generated Go CLI.
+ *
+ * These are direct wrappers over `faxes retrieve` and the
+ * `faxes:actions cancel|refresh` action group.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { outputJson, printError, printSuccess } from "../utils/output.ts";
+
+type Flags = Record<string, string | boolean>;
+type JsonRecord = Record<string, unknown>;
+
+export interface FaxStatusResult {
+  fax_id: string;
+  status: string;
+  direction?: string;
+  connection_id?: string;
+  from?: string;
+  to?: string;
+  page_count?: number;
+  created_at?: string;
+  updated_at?: string;
+  completed_at?: string;
+  failure_reason?: string;
+  media_url?: string;
+}
+
+export interface FaxCancelResult {
+  fax_id: string;
+  result: string;
+  cancelled: true;
+}
+
+export interface FaxRefreshResult {
+  fax_id: string;
+  result: string;
+  media_url?: string;
+  refreshed: true;
+}
+
+/** Retrieve the latest server-side state for one fax. */
+export async function faxStatusCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const id = requireFaxId(flags, jsonOutput);
+
+  try {
+    const response = await telnyxCli(["faxes", "retrieve", "--id", id]);
+    const data = responseData(response);
+    const result = normalizeFaxStatus(data, id);
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      const details: Record<string, string | number | boolean> = {
+        "Fax ID": result.fax_id,
+        Status: result.status,
+      };
+      addDetail(details, "Direction", result.direction);
+      addDetail(details, "Connection ID", result.connection_id);
+      addDetail(details, "From", result.from);
+      addDetail(details, "To", result.to);
+      addDetail(details, "Pages", result.page_count);
+      addDetail(details, "Created At", result.created_at);
+      addDetail(details, "Updated At", result.updated_at);
+      addDetail(details, "Completed At", result.completed_at);
+      addDetail(details, "Failure Reason", result.failure_reason);
+      addDetail(details, "Media URL", result.media_url);
+      printSuccess("Fax status retrieved!", details);
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+/** Request cancellation of an outbound fax that is still in a cancellable state. */
+export async function faxCancelCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const id = requireFaxId(flags, jsonOutput);
+
+  try {
+    const response = await telnyxCli(["faxes:actions", "cancel", "--id", id]);
+    const data = responseData(response);
+    const result: FaxCancelResult = {
+      fax_id: stringValue(data.id) || id,
+      result: stringValue(data.result) || "cancel_requested",
+      cancelled: true,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("Fax cancellation requested!", {
+        "Fax ID": result.fax_id,
+        Result: result.result,
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+/** Refresh an expired temporary media URL for an inbound fax. */
+export async function faxRefreshCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const id = requireFaxId(flags, jsonOutput);
+
+  try {
+    const response = await telnyxCli(["faxes:actions", "refresh", "--id", id]);
+    const data = responseData(response);
+    const mediaUrl = stringValue(data.media_url) || undefined;
+    const result: FaxRefreshResult = {
+      fax_id: stringValue(data.id) || id,
+      result: stringValue(data.result) || "refresh_requested",
+      ...(mediaUrl ? { media_url: mediaUrl } : {}),
+      refreshed: true,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      const details: Record<string, string | number | boolean> = {
+        "Fax ID": result.fax_id,
+        Result: result.result,
+      };
+      addDetail(details, "Media URL", result.media_url);
+      printSuccess("Fax media URL refreshed!", details);
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function normalizeFaxStatus(data: JsonRecord, fallbackId: string): FaxStatusResult {
+  const direction = optionalString(data.direction);
+  const connectionId = optionalString(data.connection_id);
+  const from = optionalString(data.from);
+  const to = optionalString(data.to);
+  const pageCount = numberValue(data.page_count);
+  const createdAt = optionalString(data.created_at);
+  const updatedAt = optionalString(data.updated_at);
+  const completedAt = optionalString(data.completed_at);
+  const failureReason = optionalString(data.failure_reason);
+  const mediaUrl = optionalString(data.media_url);
+
+  return {
+    fax_id: stringValue(data.id) || fallbackId,
+    status: stringValue(data.status) || "unknown",
+    ...(direction ? { direction } : {}),
+    ...(connectionId ? { connection_id: connectionId } : {}),
+    ...(from ? { from } : {}),
+    ...(to ? { to } : {}),
+    ...(pageCount !== undefined ? { page_count: pageCount } : {}),
+    ...(createdAt ? { created_at: createdAt } : {}),
+    ...(updatedAt ? { updated_at: updatedAt } : {}),
+    ...(completedAt ? { completed_at: completedAt } : {}),
+    ...(failureReason ? { failure_reason: failureReason } : {}),
+    ...(mediaUrl ? { media_url: mediaUrl } : {}),
+  };
+}
+
+function requireFaxId(flags: Flags, jsonOutput: boolean): string {
+  const value = flags.id;
+  if (typeof value !== "string" || value.length === 0) {
+    fail("--id is required (fax ID)", jsonOutput);
+  }
+  return value;
+}
+
+function responseData(response: unknown): JsonRecord {
+  const envelope = asRecord(response);
+  return asRecord(envelope.data ?? response);
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonRecord : {};
+}
+
+function optionalString(value: unknown): string | undefined {
+  const text = stringValue(value);
+  return text || undefined;
+}
+
+function stringValue(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value);
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function addDetail(
+  details: Record<string, string | number | boolean>,
+  label: string,
+  value: string | number | undefined,
+): void {
+  if (value !== undefined && value !== "") details[label] = value;
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) outputJson({ error: message });
+  else printError(message);
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -41,6 +41,11 @@ import {
   updateMessagingProfileCommand,
 } from "./commands/messaging-profiles.ts";
 import { faxSendCommand } from "./commands/fax-send.ts";
+import {
+  faxCancelCommand,
+  faxRefreshCommand,
+  faxStatusCommand,
+} from "./commands/fax-lifecycle.ts";
 import { sendGroupMmsCommand } from "./commands/send-group-mms.ts";
 import { scheduleSmsCommand } from "./commands/schedule-sms.ts";
 import { smsStatusCommand } from "./commands/sms-status.ts";
@@ -130,6 +135,9 @@ Commands:
   update-messaging-profile Update a messaging profile by ID
   delete-messaging-profile Delete a messaging profile by ID (requires --confirm)
   fax-send          Send a fax from a URL or uploaded media file
+  fax-status        Retrieve the latest status and details for a fax
+  fax-cancel        Cancel an outbound fax that is still in progress
+  fax-refresh       Refresh an expired media URL for an inbound fax
   send-group-mms    Send a group MMS to multiple recipients (--to comma-separated)
   schedule-sms      Schedule an SMS for future delivery (--send-at ISO 8601)
   sms-status        Check SMS delivery status, or cancel a scheduled message (--cancel)
@@ -294,6 +302,7 @@ Messaging Profile Flags:
   --confirm              Required safety confirmation (delete-messaging-profile)
 
 Fax Action Flags:
+  --id <fax-id>          Fax ID (fax-status, fax-cancel, fax-refresh; required)
   --connection-id <id>   Fax application connection ID (fax-send, required)
   --from <e164>          Sender number, E.164 (fax-send, required)
   --to <e164|sip-uri>    Destination number or SIP URI (fax-send, required)
@@ -561,6 +570,9 @@ Examples:
   telnyx-agent update-messaging-profile --id <profile-id> --name "Updated SMS" --enabled true --json
   telnyx-agent delete-messaging-profile --id <profile-id> --confirm --json
   telnyx-agent fax-send --connection-id <id> --from +131****0000 --to +131****0001 --media-url https://example.com/document.pdf
+  telnyx-agent fax-status --id <fax-id> --json
+  telnyx-agent fax-cancel --id <fax-id> --json
+  telnyx-agent fax-refresh --id <fax-id> --json
   telnyx-agent send-group-mms --from +131****0000 --to +131****0001,+131****0002,+131****0003 --text "Group hi!"
   telnyx-agent send-group-mms --from +131****0000 --to +131****0001,+131****0002 --media-url https://example.com/cat.png
   telnyx-agent schedule-sms --from +131****0000 --to +131****0001 --text "Later" --send-at 2024-12-31T00:00:00Z
@@ -668,6 +680,9 @@ const COMMANDS: Record<string, (
   "update-messaging-profile": updateMessagingProfileCommand,
   "delete-messaging-profile": deleteMessagingProfileCommand,
   "fax-send": faxSendCommand,
+  "fax-status": faxStatusCommand,
+  "fax-cancel": faxCancelCommand,
+  "fax-refresh": faxRefreshCommand,
   "send-group-mms": sendGroupMmsCommand,
   "schedule-sms": scheduleSmsCommand,
   "sms-status": smsStatusCommand,

--- a/cli/tests/fax.test.ts
+++ b/cli/tests/fax.test.ts
@@ -41,6 +41,26 @@ if (command[0] === "faxes" && command[1] === "create") {
       created_at: "2026-07-20T00:00:00Z"
     }
   }));
+} else if (command[0] === "faxes" && command[1] === "retrieve") {
+  console.log(JSON.stringify({
+    data: {
+      id: "fax-123",
+      record_type: "fax",
+      status: "delivered",
+      direction: "outbound",
+      connection_id: "conn-123",
+      from: "+131****0000",
+      to: "+131****0001",
+      page_count: 3,
+      created_at: "2026-07-20T00:00:00Z",
+      updated_at: "2026-07-20T00:01:00Z",
+      media_url: "https://api.example.test/faxes/fax-123.pdf"
+    }
+  }));
+} else if (command[0] === "faxes:actions" && command[1] === "cancel") {
+  console.log(JSON.stringify({ data: { result: "success" } }));
+} else if (command[0] === "faxes:actions" && command[1] === "refresh") {
+  console.log(JSON.stringify({ data: { result: "success" } }));
 } else {
   console.error("unexpected command: " + command.join(" "));
   process.exit(2);
@@ -276,18 +296,76 @@ describe("fax-send command", () => {
     assert.deepEqual(readLoggedArgs(fake.logPath), []);
   });
 
+  it("wraps fax retrieve, cancel, and refresh with newline-delimited mock invocations", () => {
+    const fake = setupFakeTelnyx();
+
+    const status = JSON.parse(runCli(["fax-status", "--id", "fax-123", "--json"], fake.env));
+    const cancel = JSON.parse(runCli(["fax-cancel", "--id", "fax-123", "--json"], fake.env));
+    const refresh = JSON.parse(runCli(["fax-refresh", "--id", "fax-123", "--json"], fake.env));
+
+    assert.deepEqual(status, {
+      fax_id: "fax-123",
+      status: "delivered",
+      direction: "outbound",
+      connection_id: "conn-123",
+      from: "+131****0000",
+      to: "+131****0001",
+      page_count: 3,
+      created_at: "2026-07-20T00:00:00Z",
+      updated_at: "2026-07-20T00:01:00Z",
+      media_url: "https://api.example.test/faxes/fax-123.pdf",
+    });
+    assert.deepEqual(cancel, {
+      fax_id: "fax-123",
+      result: "success",
+      cancelled: true,
+    });
+    assert.deepEqual(refresh, {
+      fax_id: "fax-123",
+      result: "success",
+      refreshed: true,
+    });
+
+    // The fake appends one genuine newline-terminated JSON record per process.
+    // Reading all three records verifies the fixture is JSONL, not a literal backslash-n string.
+    assert.equal(readFileSync(fake.logPath, "utf8").match(/\n/g)?.length, 3);
+    assert.deepEqual(readLoggedArgs(fake.logPath), [
+      ["faxes", "retrieve", "--id", "fax-123", "--format", "json"],
+      ["faxes:actions", "cancel", "--id", "fax-123", "--format", "json"],
+      ["faxes:actions", "refresh", "--id", "fax-123", "--format", "json"],
+    ]);
+  });
+
+  for (const command of ["fax-status", "fax-cancel", "fax-refresh"]) {
+    it(`${command} requires --id before invoking telnyx`, () => {
+      const fake = setupFakeTelnyx();
+      expectFailure([command, "--json"], fake.env, /--id is required \(fax ID\)/);
+      assert.deepEqual(readLoggedArgs(fake.logPath), []);
+    });
+  }
+
   it("is wired into help and capabilities", () => {
     const help = runCli(["help"]);
     assert.match(help, /fax-send\s+Send a fax/);
     assert.match(help, /Fax Action Flags:/);
     assert.match(help, /--connection-id <id>/);
+    assert.match(help, /fax-status\s+Retrieve the latest status/);
+    assert.match(help, /fax-cancel\s+Cancel an outbound fax/);
+    assert.match(help, /fax-refresh\s+Refresh an expired media URL/);
+    assert.match(help, /--id <fax-id>/);
 
     const capabilities = JSON.parse(runCli(["capabilities", "--json"]));
     const faxCapability = capabilities.api_capabilities["📠 Fax"][0];
-    assert.ok(faxCapability.actions.includes("send_fax"));
-    assert.ok(
-      capabilities.composite_commands.some((command: { name: string }) => command.name === "telnyx-agent fax-send"),
-      "capabilities should advertise the executable fax-send command",
-    );
+    for (const action of ["send_fax", "check_fax_status", "cancel_fax", "refresh_fax_media_url"]) {
+      assert.ok(faxCapability.actions.includes(action), `fax capabilities should include ${action}`);
+    }
+    for (const command of ["fax-send", "fax-status", "fax-cancel", "fax-refresh"]) {
+      assert.ok(
+        capabilities.composite_commands.some(
+          (entry: { name: string }) => entry.name === `telnyx-agent ${command}`,
+        ),
+        `capabilities should advertise the executable ${command} command`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Audit finding
The agent CLI could send faxes but could not inspect, cancel, or refresh them, leaving fax workflows fire-and-forget.

## Scope
- add `fax-status`, `fax-cancel`, and `fax-refresh`
- provide stable JSON and human output
- update help, capabilities, validation, and mock-binary tests

## Validation
- fax tests: 14/14 passed
- `npm run typecheck` passed
- `git diff --check` passed