### PR TITLE
feat: Add porting order activation to agent CLI

### DIFF
--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -88,7 +88,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "x402 Crypto Payments", description: "Fund account with USDC on Base blockchain via x402 protocol", actions: ["get_payment_quote", "submit_payment"] },
   ],
   "🔄 Porting": [
-    { name: "Number Porting", description: "Check portability, create and manage port-in orders, track requirements and documents", actions: ["check_portability", "list_porting_orders", "create_porting_order", "get_porting_order", "update_porting_order", "submit_porting_order", "cancel_porting_order", "list_porting_phone_numbers", "attach_porting_document", "list_porting_documents", "list_porting_requirements"] },
+    { name: "Number Porting", description: "Check portability, create and manage port-in orders, track requirements and documents", actions: ["check_portability", "list_porting_orders", "create_porting_order", "get_porting_order", "update_porting_order", "submit_porting_order", "cancel_porting_order", "activate_porting_order", "list_porting_phone_numbers", "attach_porting_document", "list_porting_documents", "list_porting_requirements"] },
     { name: "Port-Out", description: "List and inspect port-out activity, reject or comment on port-out orders", actions: ["list_portout_orders", "get_portout_order", "list_portout_rejection_codes"] },
   ],
   "💬 WhatsApp": [
@@ -161,6 +161,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent update-porting-order", description: "Update references, FOC settings, documents, messaging, and post-port number configuration" },
   { name: "telnyx-agent submit-porting-order", description: "Confirm and submit a draft porting order" },
   { name: "telnyx-agent cancel-porting-order", description: "Cancel a porting order after explicit --confirm acknowledgement" },
+  { name: "telnyx-agent activate-porting-order", description: "Activate all numbers in a US FastPort order asynchronously" },
   { name: "telnyx-agent attach-porting-document", description: "Attach an existing Telnyx document resource to a porting order" },
   { name: "telnyx-agent list-porting-documents", description: "List documents attached to a porting order with type filters and pagination" },
   { name: "telnyx-agent tts", description: "Generate speech from text (text-to-speech) across multiple providers, returning base64-encoded audio data" },

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -161,7 +161,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent update-porting-order", description: "Update references, FOC settings, documents, messaging, and post-port number configuration" },
   { name: "telnyx-agent submit-porting-order", description: "Confirm and submit a draft porting order" },
   { name: "telnyx-agent cancel-porting-order", description: "Cancel a porting order after explicit --confirm acknowledgement" },
-  { name: "telnyx-agent activate-porting-order", description: "Activate all numbers in a US FastPort order asynchronously" },
+  { name: "telnyx-agent activate-porting-order", description: "Activate all numbers in a US FastPort order after explicit --confirm acknowledgement (irreversible)" },
   { name: "telnyx-agent attach-porting-document", description: "Attach an existing Telnyx document resource to a porting order" },
   { name: "telnyx-agent list-porting-documents", description: "List documents attached to a porting order with type filters and pagination" },
   { name: "telnyx-agent tts", description: "Generate speech from text (text-to-speech) across multiple providers, returning base64-encoded audio data" },

--- a/cli/src/commands/porting-orders.ts
+++ b/cli/src/commands/porting-orders.ts
@@ -191,6 +191,11 @@ export async function cancelPortingOrderCommand(flags: Flags): Promise<void> {
 
 export async function activatePortingOrderCommand(flags: Flags): Promise<void> {
   const jsonOutput = flags.json === true;
+  // Activation triggers the actual port of every number in the order and
+  // cannot be undone, so require the same explicit acknowledgement as cancel.
+  if (flags.confirm !== true) {
+    fail("activate-porting-order is irreversible; pass --confirm to continue", jsonOutput);
+  }
   const portingOrderId = requireId(flags, jsonOutput);
   try {
     const response = await telnyxCli(["porting-orders:actions", "activate", "--id", portingOrderId]);
@@ -198,7 +203,7 @@ export async function activatePortingOrderCommand(flags: Flags): Promise<void> {
     const result: ActivatePortingOrderResult = {
       porting_order_id: portingOrderId,
       action: "activate",
-      status: statusValue(activationJob.status) || "created",
+      status: statusValue(activationJob.status) || "unknown",
       activation_job_id: stringValue(activationJob.id),
       activation_job: activationJob,
     };

--- a/cli/src/commands/porting-orders.ts
+++ b/cli/src/commands/porting-orders.ts
@@ -33,6 +33,14 @@ interface PortingActionResult extends PortingOrderResult {
   status: string;
 }
 
+interface ActivatePortingOrderResult {
+  porting_order_id: string;
+  action: "activate";
+  status: string;
+  activation_job_id: string;
+  activation_job: JsonRecord;
+}
+
 interface PortingDocumentListResult {
   porting_order_id: string;
   count: number;
@@ -179,6 +187,34 @@ export async function cancelPortingOrderCommand(flags: Flags): Promise<void> {
     fail("cancel-porting-order is destructive; pass --confirm to continue", jsonOutput);
   }
   await runPortingAction("cancel", "cancel", flags);
+}
+
+export async function activatePortingOrderCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const portingOrderId = requireId(flags, jsonOutput);
+  try {
+    const response = await telnyxCli(["porting-orders:actions", "activate", "--id", portingOrderId]);
+    const activationJob = responseDataRecord(response);
+    const result: ActivatePortingOrderResult = {
+      porting_order_id: portingOrderId,
+      action: "activate",
+      status: statusValue(activationJob.status) || "created",
+      activation_job_id: stringValue(activationJob.id),
+      activation_job: activationJob,
+    };
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("Porting order activation requested!", {
+        "Porting Order ID": result.porting_order_id,
+        "Activation Job ID": result.activation_job_id || "(not returned)",
+        Action: result.action,
+        Status: result.status,
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
 }
 
 export async function attachPortingDocumentCommand(flags: Flags): Promise<void> {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,6 +13,7 @@ import { verifyCheckCommand } from "./commands/verify-check.ts";
 import { setup10dlcCommand } from "./commands/setup-10dlc.ts";
 import { setupPortingCommand } from "./commands/setup-porting.ts";
 import {
+  activatePortingOrderCommand,
   attachPortingDocumentCommand,
   cancelPortingOrderCommand,
   getPortingOrderCommand,
@@ -170,6 +171,7 @@ Commands:
   update-porting-order Update porting order details and number configuration
   submit-porting-order Confirm and submit a draft porting order
   cancel-porting-order Cancel a porting order (requires --confirm)
+  activate-porting-order Activate all numbers in a US FastPort order asynchronously
   attach-porting-document Attach an existing Telnyx document to a porting order
   list-porting-documents List documents attached to a porting order
   edge-doctor       Validate Edge Compute prerequisites and handoff readiness
@@ -315,7 +317,7 @@ Verify Flags:
   --submit          Submit the newly created porting order immediately (setup-porting)
 
 Porting Order Action Flags:
-  --id <id>         Porting order ID (get, update, submit, cancel, attach/list documents — required)
+  --id <id>         Porting order ID (get, update, submit, cancel, activate, attach/list documents — required)
   --customer-reference Customer bookkeeping reference (list, update)
   --customer-group-reference Customer group reference (list, update)
   --parent-support-key Parent support key filter (list-porting-orders)
@@ -810,6 +812,7 @@ Examples:
   telnyx-agent update-porting-order --id <porting-order-id> --connection-id <connection-id> --enable-messaging true --json
   telnyx-agent submit-porting-order --id <porting-order-id> --json
   telnyx-agent cancel-porting-order --id <porting-order-id> --confirm --json
+  telnyx-agent activate-porting-order --id <porting-order-id> --json
   telnyx-agent attach-porting-document --id <porting-order-id> --document-id <document-id> --document-type loa --json
   telnyx-agent list-porting-documents --id <porting-order-id> --document-type loa,invoice --json
   telnyx-agent verify-send --phone-number +131****0001 --verify-profile-id prof_xxx --method sms
@@ -984,6 +987,7 @@ const COMMANDS: Record<string, (
   "update-porting-order": updatePortingOrderCommand,
   "submit-porting-order": submitPortingOrderCommand,
   "cancel-porting-order": cancelPortingOrderCommand,
+  "activate-porting-order": activatePortingOrderCommand,
   "attach-porting-document": attachPortingDocumentCommand,
   "list-porting-documents": listPortingDocumentsCommand,
   "edge-doctor": edgeDoctorCommand,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -171,7 +171,7 @@ Commands:
   update-porting-order Update porting order details and number configuration
   submit-porting-order Confirm and submit a draft porting order
   cancel-porting-order Cancel a porting order (requires --confirm)
-  activate-porting-order Activate all numbers in a US FastPort order asynchronously
+  activate-porting-order Activate all numbers in a US FastPort order (irreversible; requires --confirm)
   attach-porting-document Attach an existing Telnyx document to a porting order
   list-porting-documents List documents attached to a porting order
   edge-doctor       Validate Edge Compute prerequisites and handoff readiness
@@ -340,7 +340,7 @@ Porting Order Action Flags:
   --webhook-url     Porting order webhook URL (update)
   --remaining-numbers-action keep|disconnect (partial-port update)
   --new-billing-phone-number Required when keeping remaining numbers (update)
-  --confirm         Required safety acknowledgement (cancel-porting-order)
+  --confirm         Required safety acknowledgement (cancel-porting-order, activate-porting-order)
   --document-id     Existing Telnyx document ID (attach-porting-document — required)
   --document-type   loa|invoice|csr|other (attach required; comma-separated list filter)
 
@@ -812,7 +812,7 @@ Examples:
   telnyx-agent update-porting-order --id <porting-order-id> --connection-id <connection-id> --enable-messaging true --json
   telnyx-agent submit-porting-order --id <porting-order-id> --json
   telnyx-agent cancel-porting-order --id <porting-order-id> --confirm --json
-  telnyx-agent activate-porting-order --id <porting-order-id> --json
+  telnyx-agent activate-porting-order --id <porting-order-id> --confirm --json
   telnyx-agent attach-porting-document --id <porting-order-id> --document-id <document-id> --document-type loa --json
   telnyx-agent list-porting-documents --id <porting-order-id> --document-type loa,invoice --json
   telnyx-agent verify-send --phone-number +131****0001 --verify-profile-id prof_xxx --method sms

--- a/cli/tests/porting.test.ts
+++ b/cli/tests/porting.test.ts
@@ -438,7 +438,7 @@ describe("Porting-order management commands", () => {
 
   it("activates a US FastPort order through the generated asynchronous action", () => {
     const fake = setupFakeTelnyx();
-    const output = runAgent(["activate-porting-order", "--id", "po-fastport-1", "--json"], fake.env);
+    const output = runAgent(["activate-porting-order", "--id", "po-fastport-1", "--confirm", "--json"], fake.env);
 
     assert.deepEqual(JSON.parse(output), {
       porting_order_id: "po-fastport-1",
@@ -513,7 +513,8 @@ describe("Porting-order management commands", () => {
   it("validates IDs, updates, dates, pagination, booleans, and document types before invoking telnyx", () => {
     const invalidCommands = [
       ["get-porting-order", "--json"],
-      ["activate-porting-order", "--json"],
+      ["activate-porting-order", "--confirm", "--json"],
+      ["activate-porting-order", "--id", "po-fastport-1", "--json"],
       ["update-porting-order", "--id", "po-1", "--json"],
       ["update-porting-order", "--id", "po-1", "--foc-datetime-requested", "tomorrow", "--json"],
       ["update-porting-order", "--id", "po-1", "--enable-messaging", "maybe", "--json"],

--- a/cli/tests/porting.test.ts
+++ b/cli/tests/porting.test.ts
@@ -53,6 +53,10 @@ if (args[0] === "porting-orders" && args[1] === "list") {
     phone_numbers_count: 2,
     end_user: { admin: { pinPasscode: "update-pin-8274", name: "Updated Admin" } }
   } }));
+} else if (args[0] === "porting-orders:actions" && args[1] === "activate") {
+  console.log(JSON.stringify({ data: {
+    id: "activation-job-1", status: "in-process", activation_type: "on-demand"
+  } }));
 } else if (args[0] === "porting-orders:actions" && (args[1] === "confirm" || args[1] === "cancel")) {
   console.log(JSON.stringify({ data: {
     id: flag("--id"), status: args[1] === "confirm" ? "submitted" : { value: "cancel-pending" }
@@ -432,6 +436,23 @@ describe("Porting-order management commands", () => {
     assertFlag(args, "--id", "po-1");
   });
 
+  it("activates a US FastPort order through the generated asynchronous action", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["activate-porting-order", "--id", "po-fastport-1", "--json"], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      porting_order_id: "po-fastport-1",
+      action: "activate",
+      status: "in-process",
+      activation_job_id: "activation-job-1",
+      activation_job: { id: "activation-job-1", status: "in-process", activation_type: "on-demand" },
+    });
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["porting-orders:actions", "activate"]);
+    assertFlag(args, "--id", "po-fastport-1");
+    assertFlag(args, "--format", "json");
+  });
+
   it("attaches an existing Telnyx document using exact additional-document inner flags", () => {
     const fake = setupFakeTelnyx();
     const output = runAgent([
@@ -492,6 +513,7 @@ describe("Porting-order management commands", () => {
   it("validates IDs, updates, dates, pagination, booleans, and document types before invoking telnyx", () => {
     const invalidCommands = [
       ["get-porting-order", "--json"],
+      ["activate-porting-order", "--json"],
       ["update-porting-order", "--id", "po-1", "--json"],
       ["update-porting-order", "--id", "po-1", "--foc-datetime-requested", "tomorrow", "--json"],
       ["update-porting-order", "--id", "po-1", "--enable-messaging", "maybe", "--json"],
@@ -518,6 +540,7 @@ describe("Porting-order management commands", () => {
       "update-porting-order",
       "submit-porting-order",
       "cancel-porting-order",
+      "activate-porting-order",
       "attach-porting-document",
       "list-porting-documents",
     ];
@@ -536,6 +559,7 @@ describe("Porting-order management commands", () => {
       "update_porting_order",
       "submit_porting_order",
       "cancel_porting_order",
+      "activate_porting_order",
       "attach_porting_document",
       "list_porting_documents",
     ]) {


### PR DESCRIPTION
## Audit finding
The agent CLI wrapped porting confirm/cancel but omitted the upstream FastPort activation action.

## Scope
- add `activate-porting-order --id` over `porting-orders:actions activate`
- preserve requested order ID and returned activation-job details
- update help, capabilities, output, and mock-binary tests

## Validation
- porting tests: 18/18 passed
- `npx tsc --noEmit` passed
- `git diff --check` passed