### PR TITLE
feat: add Agent Plugins manifest (plugin.json + mcp.json)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,6 +84,7 @@ out of sync. CI will catch drift.
 - `inference/` — Telnyx inference docs
 - `guides/` — operational guides
 - `agent.json` — top-level agent manifest
+- `plugin.json` / `mcp.json` — Agent Plugins (agent-plugins.org) manifest: bundles `skills/` + hosted MCP
 - `.claude-plugin/` — Claude Code marketplace metadata
 - `.cursor-plugin/` — Cursor marketplace metadata
 - `gemini-extension.json` — Gemini CLI extension manifest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ Run the relevant package's test suite before declaring a task done. Don't run al
 | `guides/`               | Step-by-step operational guides.                                          |
 | `scripts/sync-skills.sh`| Syncs `skills/` → `providers/{claude,cursor}/plugin/skills/`.             |
 | `agent.json`            | Top-level agent manifest (capabilities, auth, endpoints).                 |
+| `plugin.json`, `mcp.json` | Agent Plugins (agent-plugins.org) manifest bundling `skills/` + the hosted MCP server. |
 | `.claude-plugin/`       | Claude Code marketplace metadata.                                         |
 | `.cursor-plugin/`       | Cursor marketplace metadata.                                              |
 | `gemini-extension.json` | Gemini CLI extension manifest.                                            |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Add the Telnyx MCP server to your project's `.cursor/mcp.json`:
   }
 ```
 
+### Agent Plugins manifest (any compatible client)
+
+The repo root also carries an [Agent Plugins](https://agent-plugins.org/specification) manifest — [`plugin.json`](/plugin.json) + [`mcp.json`](/mcp.json) — so clients that speak that format can install the whole repo as one plugin: every `skills/*/SKILL.md` is bundled automatically and `mcp.json` declares the hosted Telnyx MCP server (`https://api.telnyx.com/v2/mcp`, Streamable HTTP).
+
+**Authentication.** Agent Plugins v1 has no portable credential mechanism — the spec forbids embedding secrets in `headers`/`env` and leaves authorization to the client — so `mcp.json` ships no credentials. Discovery calls (`initialize`, `tools/list`, `resources/*`) work unauthenticated; `tools/call` requires `Authorization: Bearer <TELNYX_API_KEY>`. Supply the key through your client's own credential/header settings for the `telnyx` server, or, if your client cannot attach headers to plugin-provided servers, run the [`@telnyx/mcp`](/tools/mcp) proxy (`npx -y @telnyx/mcp --api-key=YOUR_TELNYX_API_KEY`) which adds the header for you. Get a key via the portal or [`telnyx.com/agent-signup.md`](https://telnyx.com/agent-signup.md).
+
 ### Harnesses
 
 Finalized Telnyx harness plugin repositories for OpenClaw and Hermes integrations:

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "telnyx": {
+      "type": "streamable-http",
+      "url": "https://api.telnyx.com/v2/mcp"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "telnyx",
+  "version": "0.4.0",
+  "description": "Telnyx Agent Plugin — Agent Skills for voice, messaging, email, numbers, verify, TTS/STT, AI inference and platform services, plus the hosted Telnyx MCP server.",
+  "author": {
+    "name": "Telnyx",
+    "url": "https://telnyx.com"
+  },
+  "homepage": "https://developers.telnyx.com",
+  "repository": "https://github.com/team-telnyx/ai",
+  "license": "MIT",
+  "keywords": [
+    "telnyx",
+    "telecom",
+    "voice",
+    "messaging",
+    "mcp",
+    "agent-skills"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a root-level **Agent Plugins** manifest (https://agent-plugins.org/specification) so this repo can be installed as a single plugin by any client that supports the format, and to close the orank `agent-plugins-repo` check ("No Agent Plugins manifest (plugin.json) found in discovered repos") from the CEO-shared telnyx.com scan — `team-telnyx/ai` is the repo orank discovers via `AGENTS.md`.

- `plugin.json` — required `$schema` + `name` (`telnyx`), plus the same version/author/homepage/repository/license metadata used by the existing per-provider `providers/claude/plugins/*/.claude-plugin/plugin.json` files. Version pinned to `0.4.0` to match `.claude-plugin/marketplace.json`.
- `mcp.json` — the spec forbids inline MCP config in `plugin.json`; this declares the hosted server `https://api.telnyx.com/v2/mcp` as `streamable-http`.
- Skills need no config: the spec auto-discovers every `skills/*/SKILL.md` as a bundled skill, which is exactly this repo's canonical `skills/` layout.
- One-line entries added to `AGENTS.md` and `.claude/CLAUDE.md` "Where things live".

No changes to existing Claude/Cursor/Gemini manifests — this is additive.

## Testing

Both files validate against the published schemas:

```
npx ajv-cli@5 validate --spec=draft2020 -s plugin.schema.json -d plugin.json   # valid
npx ajv-cli@5 validate --spec=draft2020 -s mcp.schema.json    -d mcp.json      # valid
```

After merge: rescan `POST https://ora.ai/api/scan {"url":"telnyx.com"}` and confirm `agent-plugins-repo` reports 1/1.

## Not included

- No `extensions` block; the spec's optional extension mechanism isn't needed for skills + MCP.
- No bump to `.claude-plugin/marketplace.json` — separate concern.
