### PR TITLE
Update auto-generated Telnyx skills

### DIFF
--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-inference-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-inference-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-hosted-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-hosted-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-profiles-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-profiles-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-compliance-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-compliance-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-config-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-config-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-services-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-services-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-porting-in-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-porting-in-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-porting-out-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-porting-out-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-account-access-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-account-access-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-account-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-account-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-account-management-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-account-management-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-account-notifications-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-account-notifications-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-account-reports-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-account-reports-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-fax-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-fax-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-iot-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-iot-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-missions-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-missions-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-networking-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-networking-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-oauth-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-oauth-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-sip-integrations-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-sip-integrations-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-sip-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-sip-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-storage-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-storage-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-texml-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-texml-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account-access.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account-access.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account-management.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account-management.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account-notifications.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account-notifications.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account-reports.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account-reports.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/account.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/ai-inference.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/ai-inference.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/fax.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/fax.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/iot.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/iot.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging-hosted.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging-hosted.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging-profiles.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging-profiles.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/missions.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/missions.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/networking.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/networking.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers-compliance.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers-compliance.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers-config.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers-config.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers-services.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers-services.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/oauth.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/oauth.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/porting-in.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/porting-in.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/porting-out.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/porting-out.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/sip-integrations.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/sip-integrations.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/sip.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/sip.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/storage.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/storage.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/texml.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/texml.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/verify.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/verify.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/video.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/video.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-advanced.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-advanced.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-conferencing.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-conferencing.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-gather.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-gather.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-media.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-media.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-streaming.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice-streaming.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/webrtc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/webrtc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-verify/skills/telnyx-verify-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-verify/skills/telnyx-verify-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-advanced-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-advanced-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-conferencing-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-conferencing-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-gather-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-gather-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-media-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-media-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-streaming-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-streaming-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-webrtc/skills/telnyx-video-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-webrtc/skills/telnyx-video-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-webrtc/skills/telnyx-webrtc-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-webrtc/skills/telnyx-webrtc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-account-access-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-account-access-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-account-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-account-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-account-management-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-account-management-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-account-notifications-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-account-notifications-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-account-reports-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-account-reports-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-ai-inference-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-inference-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-fax-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-fax-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-iot-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-iot-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-messaging-hosted-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-hosted-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-messaging-profiles-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-profiles-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-missions-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-missions-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-networking-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-networking-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-numbers-compliance-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-compliance-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-numbers-config-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-config-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-numbers-services-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-services-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-oauth-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-oauth-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-porting-in-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-porting-in-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-porting-out-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-porting-out-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-sip-integrations-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-sip-integrations-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-sip-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-sip-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-storage-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-storage-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-texml-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-texml-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account-access.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account-access.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account-management.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account-management.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account-notifications.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account-notifications.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account-reports.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account-reports.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/account.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-inference.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-inference.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/fax.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/fax.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/iot.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/iot.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging-hosted.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging-hosted.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging-profiles.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging-profiles.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/missions.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/missions.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/networking.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/networking.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers-compliance.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers-compliance.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers-config.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers-config.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers-services.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers-services.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/oauth.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/oauth.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/porting-in.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/porting-in.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/porting-out.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/porting-out.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/sip-integrations.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/sip-integrations.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/sip.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/sip.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/storage.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/storage.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/texml.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/texml.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/verify.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/verify.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/video.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/video.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-advanced.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-advanced.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-conferencing.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-conferencing.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-gather.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-gather.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-media.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-media.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-streaming.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice-streaming.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/webrtc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/webrtc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-verify-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-verify-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-video-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-video-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-advanced-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-advanced-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-conferencing-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-conferencing-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-gather-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-gather-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-media-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-media-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-streaming-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-streaming-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-webrtc-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-webrtc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-account-access-java/SKILL.md
+++ b/skills/telnyx-account-access-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-account-java/SKILL.md
+++ b/skills/telnyx-account-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-account-management-java/SKILL.md
+++ b/skills/telnyx-account-management-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-account-notifications-java/SKILL.md
+++ b/skills/telnyx-account-notifications-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-account-reports-java/SKILL.md
+++ b/skills/telnyx-account-reports-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-ai-inference-java/SKILL.md
+++ b/skills/telnyx-ai-inference-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-fax-java/SKILL.md
+++ b/skills/telnyx-fax-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-iot-java/SKILL.md
+++ b/skills/telnyx-iot-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-messaging-hosted-java/SKILL.md
+++ b/skills/telnyx-messaging-hosted-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-messaging-profiles-java/SKILL.md
+++ b/skills/telnyx-messaging-profiles-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-missions-java/SKILL.md
+++ b/skills/telnyx-missions-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-networking-java/SKILL.md
+++ b/skills/telnyx-networking-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-numbers-compliance-java/SKILL.md
+++ b/skills/telnyx-numbers-compliance-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-numbers-config-java/SKILL.md
+++ b/skills/telnyx-numbers-config-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-numbers-services-java/SKILL.md
+++ b/skills/telnyx-numbers-services-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-oauth-java/SKILL.md
+++ b/skills/telnyx-oauth-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-porting-in-java/SKILL.md
+++ b/skills/telnyx-porting-in-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-porting-out-java/SKILL.md
+++ b/skills/telnyx-porting-out-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-sip-integrations-java/SKILL.md
+++ b/skills/telnyx-sip-integrations-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-sip-java/SKILL.md
+++ b/skills/telnyx-sip-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-storage-java/SKILL.md
+++ b/skills/telnyx-storage-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-texml-java/SKILL.md
+++ b/skills/telnyx-texml-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/account-access.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/account-access.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/account-management.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/account-management.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/account-notifications.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/account-notifications.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/account-reports.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/account-reports.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/account.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/account.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/ai-inference.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/ai-inference.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/fax.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/fax.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/iot.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/iot.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/messaging-hosted.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/messaging-hosted.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/messaging-profiles.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/messaging-profiles.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/missions.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/missions.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/networking.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/networking.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/numbers-compliance.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/numbers-compliance.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/numbers-config.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/numbers-config.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/numbers-services.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/numbers-services.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/oauth.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/oauth.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/porting-in.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/porting-in.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/porting-out.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/porting-out.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/sip-integrations.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/sip-integrations.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/sip.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/sip.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/storage.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/storage.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/texml.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/texml.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/verify.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/verify.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/video.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/video.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice-advanced.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice-advanced.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice-conferencing.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice-conferencing.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice-gather.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice-gather.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice-media.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice-media.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice-streaming.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice-streaming.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/webrtc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/webrtc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-verify-java/SKILL.md
+++ b/skills/telnyx-verify-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-video-java/SKILL.md
+++ b/skills/telnyx-video-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-advanced-java/SKILL.md
+++ b/skills/telnyx-voice-advanced-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-conferencing-java/SKILL.md
+++ b/skills/telnyx-voice-conferencing-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-gather-java/SKILL.md
+++ b/skills/telnyx-voice-gather-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-media-java/SKILL.md
+++ b/skills/telnyx-voice-media-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-streaming-java/SKILL.md
+++ b/skills/telnyx-voice-streaming-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup

--- a/skills/telnyx-webrtc-java/SKILL.md
+++ b/skills/telnyx-webrtc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.84.0</version>
+    <version>6.88.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.84.0")
+implementation("com.telnyx.sdk:telnyx:6.88.0")
 ```
 
 ## Setup


### PR DESCRIPTION
## Auto-generated Telnyx skills update

Updates canonical `skills/` in `team-telnyx/ai` from the OpenAPI skill-generation pipeline and runs `./scripts/sync-skills.sh` to refresh Claude/Cursor provider copies.

- Generated canonical skills copied: 180
- Manual/non-target skills preserved: 56
- Canonical skills total: 236
