### PR TITLE
chore: remove stray .claude/worktrees gitlink from #382

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 
 # MCP configuration with secrets
 .mcp.json
+
+# Local Claude Code worktrees
+.claude/worktrees/


### PR DESCRIPTION
#382 accidentally included `.claude/worktrees/agent-plugins-manifest` as an empty gitlink (submodule pointer, no content) via `git add -A` on a machine with a local Claude Code worktree. This removes it and adds `.claude/worktrees/` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUvgBc85drrrYnWQKCzfMG