### PR TITLE
fix(ci): use a Telnyx-hosted model in chat-completion read-only probes

### DIFF
--- a/tools/python/tests/test_integration_ci.py
+++ b/tools/python/tests/test_integration_ci.py
@@ -23,7 +23,9 @@ RESOURCE_PREFIX = "ci-integration-test-"  # Easy to identify and cleanup
 
 pytestmark = pytest.mark.skipif(not TELNYX_API_KEY, reason="TELNYX_API_KEY not set")
 
-TRANSIENT_STATUSES = (500, 502, 503, 504)
+# 408 included: the API has historically returned it for /ai/chat/completions from
+# GH runners (an upstream timeout, not a problem with this repo).
+TRANSIENT_STATUSES = (408, 500, 502, 503, 504)
 READONLY_TIMEOUT = 30
 
 # Set after the first *connection-level* failure (cannot reach api.telnyx.com

--- a/tools/python/tests/test_integration_ci.py
+++ b/tools/python/tests/test_integration_ci.py
@@ -181,11 +181,6 @@ class TestReadonly:
             assert "data" in data
             assert isinstance(data["data"], list)
 
-    @pytest.mark.xfail(
-        reason="Telnyx /ai/chat/completions returns 408 consistently from GH runners; "
-        "tracked separately — remove xfail once upstream is stable",
-        strict=False,
-    )
     def test_readonly_ai_chat_completion(self):
         """POST /v2/ai/chat/completions works with a tiny request."""
         r = _readonly_post(

--- a/tools/typescript/tests/integration-ci.test.ts
+++ b/tools/typescript/tests/integration-ci.test.ts
@@ -23,7 +23,9 @@ if (!API_KEY) {
   process.exit(0);
 }
 
-const TRANSIENT_STATUSES = [500, 502, 503, 504];
+// 408 included: the API has historically returned it for /ai/chat/completions from
+// GH runners (an upstream timeout, not a problem with this repo).
+const TRANSIENT_STATUSES = [408, 500, 502, 503, 504];
 const READONLY_TIMEOUT_MS = 30_000;
 
 // Set after the first connection-level failure (runner cannot reach

--- a/tools/typescript/tests/integration-ci.test.ts
+++ b/tools/typescript/tests/integration-ci.test.ts
@@ -165,19 +165,15 @@ describe("TypeScript SDK — Read-Only API", () => {
     const r = await readonlyFetch(t, "ai chat completion", `${BASE}/ai/chat/completions`, {
       method: "POST",
       body: JSON.stringify({
-        model: "openai/gpt-4o",
+        // OpenAI models now require a customer-provided key on the public
+        // endpoint (error 10015); use a Telnyx-hosted model, as the Python suite does.
+        model: "meta-llama/Meta-Llama-3.1-8B-Instruct",
         messages: [{ role: "user", content: "Say OK" }],
         max_tokens: 3,
       }),
     });
     if (!r) return;
-    if (r.status !== 200) {
-      // Known-unstable upstream (the Python suite xfails this too). Log the
-      // body so the cause is visible in CI without failing the job.
-      const text = await r.text();
-      t.skip(`/ai/chat/completions returned ${r.status} (known-unstable upstream): ${text.slice(0, 300)}`);
-      return;
-    }
+    assert.equal(r.status, 200, await r.clone().text());
     const body = (await r.json()) as any;
     assert.ok(body.choices.length > 0);
   });


### PR DESCRIPTION
Follow-up to #408, which got the Read-Only job green but left `ai_chat_completion` as a skip-with-body. The body turned out to be a stable error, not an outage:

> code 10015: `openai/gpt-4o requires a customer-provided API key on public endpoints.`

- **TS:** switch the model to `meta-llama/Meta-Llama-3.1-8B-Instruct` (what the Python suite uses) and restore the plain `assert 200`, with the response body as the assertion message so any future failure is self-explaining.
- **Python:** drop the `xfail` on `test_readonly_ai_chat_completion`. Its reason cited 408s from GH runners, but the test has XPASSed on every recent run ([main 2026-08-21](https://github.com/team-telnyx/ai/actions/runs/32491677622/job/96802175897), [#408 2026-08-23](https://github.com/team-telnyx/ai/actions/runs/32653921025/job/97230434705)). The `_readonly_post` helper still covers genuine 5xx/timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ahbFhuAjqG52Zsi3NBjss