### PR TITLE
chore(deps): add dependabot.yml with grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,113 @@
+# Dependabot configuration.
+#
+# Before this file existed Dependabot only opened security-update PRs, one per
+# package per directory (e.g. #285/#402/#410/#411). Grouping collapses those
+# into one PR per directory per week, and adds scheduled minor/patch version
+# updates so we are not only ever reacting to CVEs. Majors are left ungrouped
+# so they get individual review.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/cli"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/plugins/opencode"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/tools/mcp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/tools/mcp-apps"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directory: "/tools/typescript"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+  - package-ecosystem: "uv"
+    directory: "/tools/python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      uv-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      uv-security:
+        applies-to: security-updates
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github_actions-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      github_actions-security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
There was no `.github/dependabot.yml`, so Dependabot has only ever opened **security** PRs, one per package per directory (#285, #402, #410, #411 today alone). This adds a config that:

- groups security updates into one PR per directory
- adds weekly (Monday) **minor/patch** version updates, grouped per directory; majors stay individual
- covers every manifest with a lockfile: npm × 6 (`/`, `/cli`, `/plugins/opencode`, `/tools/mcp`, `/tools/mcp-apps` workspace, `/tools/typescript`), `uv` for `/tools/python`, and `github-actions`
- caps each at 5 open PRs

Not covered: `tools/ffl-cli` (no lockfile, and on hold per the 08-05 standup) and the `push-notification-tester` script `package.json`s (no lockfile, vendored into 3 copies by sync-skills).

Note: this does not touch the 85 existing vulnerability alerts; it only changes how future PRs for them are batched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ahbFhuAjqG52Zsi3NBjss