### PR TITLE
chore(deps): collapse dependabot to one grouped PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,4 +56,8 @@ updates:
     open-pull-requests-limit: 1
     groups:
       actions-all:
+        applies-to: version-updates
+        patterns: ["*"]
+      actions-security:
+        applies-to: security-updates
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,113 +1,59 @@
 # Dependabot configuration.
 #
-# Before this file existed Dependabot only opened security-update PRs, one per
-# package per directory (e.g. #285/#402/#410/#411). Grouping collapses those
-# into one PR per directory per week, and adds scheduled minor/patch version
-# updates so we are not only ever reacting to CVEs. Majors are left ungrouped
-# so they get individual review.
+# Goal: as few PRs as possible. Each ecosystem is ONE entry covering every
+# directory, with a single group that spans directories and all update
+# types, so a weekly sweep is at most one PR for npm, one for uv and one for
+# GitHub Actions (plus one grouped security PR per ecosystem if needed).
+#
+# Majors of typescript / @types/node are ignored: bump those deliberately in
+# one hand-made PR when the repo is ready, not whenever upstream tags one.
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/cli"
+      - "/plugins/opencode"
+      - "/tools/mcp"
+      - "/tools/mcp-apps"
+      - "/tools/typescript"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     groups:
-      npm-minor-patch:
+      npm-all:
         applies-to: version-updates
-        update-types: ["minor", "patch"]
+        patterns: ["*"]
       npm-security:
         applies-to: security-updates
         patterns: ["*"]
-  - package-ecosystem: "npm"
-    directory: "/cli"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    groups:
-      npm-minor-patch:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      npm-security:
-        applies-to: security-updates
-        patterns: ["*"]
-  - package-ecosystem: "npm"
-    directory: "/plugins/opencode"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    groups:
-      npm-minor-patch:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      npm-security:
-        applies-to: security-updates
-        patterns: ["*"]
-  - package-ecosystem: "npm"
-    directory: "/tools/mcp"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    groups:
-      npm-minor-patch:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      npm-security:
-        applies-to: security-updates
-        patterns: ["*"]
-  - package-ecosystem: "npm"
-    directory: "/tools/mcp-apps"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    groups:
-      npm-minor-patch:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      npm-security:
-        applies-to: security-updates
-        patterns: ["*"]
-  - package-ecosystem: "npm"
-    directory: "/tools/typescript"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    groups:
-      npm-minor-patch:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      npm-security:
-        applies-to: security-updates
-        patterns: ["*"]
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "uv"
     directory: "/tools/python"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     groups:
-      uv-minor-patch:
+      uv-all:
         applies-to: version-updates
-        update-types: ["minor", "patch"]
+        patterns: ["*"]
       uv-security:
         applies-to: security-updates
         patterns: ["*"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
-      github_actions-minor-patch:
-        applies-to: version-updates
-        update-types: ["minor", "patch"]
-      github_actions-security:
-        applies-to: security-updates
+      actions-all:
         patterns: ["*"]


### PR DESCRIPTION
Follow-up to #412, whose first run opened 21 PRs (#413–#433): grouping only covered minor/patch, so majors came through one-per-package-per-directory — `typescript` 7.0 ×5, `@types/node` 26 ×5, four Actions majors.

This collapses the config to one entry per ecosystem:
- **npm:** one entry listing all six directories, one group spanning directories *and* all update types → at most **one** npm PR per week
- **uv** (`/tools/python`) and **github-actions**: same, one grouped PR each
- security updates keep their own group per ecosystem
- `typescript` and `@types/node` **majors are ignored** — those get bumped deliberately in one hand-made PR, not whenever upstream tags one
- `open-pull-requests-limit` lowered to 2/2/1

Expected on merge: Dependabot re-runs, closes the superseded individual PRs from #412's sweep itself, and opens the grouped replacements. No manual mass-close needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ahbFhuAjqG52Zsi3NBjss