### PR TITLE
docs(payments): fix dead agent.json links, state the two-x402-flavors distinction, apply payments-owner fact-check

### DIFF
--- a/agent.json
+++ b/agent.json
@@ -160,10 +160,10 @@
     {
       "id": "payments",
       "name": "x402 Crypto Payments",
-      "description": "Fund account with USDC on Base blockchain via x402 protocol.",
+      "description": "Fund account with USDC on Base blockchain via x402 protocol (authenticated; distinct from Telnyx's keyless pay-per-call x402 endpoints at x402.telnyx.com).",
       "guide": "/guides/x402-payments.md",
       "api": "POST /v2/x402/credit_account/quote",
-      "docs": "https://developers.telnyx.com/docs/account/billing",
+      "docs": "https://telnyx.com/.well-known/agent-skills/telnyx-x402-payment/SKILL.md",
       "requires": []
     },
     {
@@ -172,7 +172,7 @@
       "description": "Fund account via Machine Payment Protocol (HTTP 402) with Stripe Link or Tempo USDC.",
       "guide": "/guides/mpp-payments.md",
       "api": "POST /v2/machine-payments/account-credit",
-      "docs": "https://developers.telnyx.com/docs/account/billing",
+      "docs": "https://telnyx.com/.well-known/agent-skills/telnyx-mpp-payment/SKILL.md",
       "requires": []
     },
     {

--- a/guides/mpp-payments.md
+++ b/guides/mpp-payments.md
@@ -2,6 +2,8 @@
 
 > Fund your Telnyx account through an HTTP `402 Payment Required` flow, paying with a Stripe Link agent wallet or USDC from a Tempo wallet.
 
+This is **authenticated account funding**: every call carries your Telnyx API key, and the credit lands on the account that owns the key. A funded balance pays for any Telnyx product. For paying per request without any Telnyx account (inference/TTS/STT only), use the keyless x402 endpoints at [x402.telnyx.com](https://x402.telnyx.com/) instead; for funding with USDC on Base rather than Link/Tempo, see [x402-payments.md](./x402-payments.md).
+
 ## Prerequisites
 
 - Telnyx API key ([get one free](https://telnyx.com/agent-signup.md)) for the account you want to credit

--- a/guides/mpp-payments.md
+++ b/guides/mpp-payments.md
@@ -9,7 +9,7 @@ This is **authenticated account funding**: every call carries your Telnyx API ke
 - Telnyx API key ([get one free](https://telnyx.com/agent-signup.md)) for the account you want to credit
 - Node.js, npm, and `curl`
 - One of:
-  - **Stripe Link** — an eligible card issued in the United States or Canada, paid via `@stripe/link-cli`
+  - **Stripe Link** — an eligible card in a supported region (currently cards issued in the United States or Canada), paid via `@stripe/link-cli`
   - **Tempo** — a funded mainnet USDC wallet, paid via `mppx`
 - Account must be active and eligible for machine payments (a `403` means it isn't — contact Telnyx Support)
 
@@ -40,7 +40,7 @@ curl -sS -X POST "$MPP_ENDPOINT" \
 ### Pay with Stripe Link
 
 ```bash
-# Sign in and pick a card marked eligible for agentic payments (US/CA-issued only)
+# Sign in and pick a card marked eligible for agentic payments (supported regions — currently US/CA)
 npx --yes @stripe/link-cli@0.11.0 auth login --client-name 'Telnyx MPP payer' --timeout 600
 npx --yes @stripe/link-cli@0.11.0 payment-methods list --format json
 export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'

--- a/guides/x402-payments.md
+++ b/guides/x402-payments.md
@@ -37,7 +37,7 @@ curl -X POST "https://api.telnyx.com/v2/x402/credit_account" \
 
 **`POST /v2/x402/credit_account/quote`**
 
-Request a quote for the USD amount to fund. Minimum $5.00, maximum $10,000.00. Quotes expire after 5 minutes.
+Request a quote for the USD amount to fund. Per-payment minimum and maximum limits apply; they are configurable and may change, and the API's 422 error messages state the current values. Quotes expire after 5 minutes.
 
 ```bash
 curl -X POST "https://api.telnyx.com/v2/x402/credit_account/quote" \
@@ -280,8 +280,8 @@ print(f"USDC amount: {int(quote['data']['amount_crypto']) / 1_000_000}")
 
 | Error | HTTP Status | Resolution |
 |-------|-------------|------------|
-| `amount_usd must be at least 5.00` | 422 | Minimum is $5.00 |
-| `amount_usd must not exceed 10000.00` | 422 | Maximum is $10,000 |
+| `amount_usd must be at least <min>` | 422 | Retry with the minimum the error states |
+| `amount_usd must not exceed <max>` | 422 | Retry with the maximum the error states |
 | `insufficient_balance` | 422 | Wallet lacks USDC |
 | `expired_authorization` | 400 | Quote expired — get new one |
 | `invalid_signature` | 400 | Verify EIP-712 signing parameters |

--- a/guides/x402-payments.md
+++ b/guides/x402-payments.md
@@ -2,6 +2,8 @@
 
 > Fund your Telnyx account with USDC on the Base blockchain using the x402 payment protocol.
 
+Telnyx supports x402 two ways. This guide covers **authenticated account funding**: you hold a Telnyx API key and top up the account balance, which then pays for any Telnyx product (SMS, numbers, voice, inference). The separate **keyless pay-per-call** endpoints at [x402.telnyx.com](https://x402.telnyx.com/) sell inference/TTS/STT per request with no account at all — if that's all you need, use those directly and skip this guide.
+
 ## Prerequisites
 
 - Telnyx API key ([get one free](https://telnyx.com/agent-signup.md))

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-mpp-payment/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-mpp-payment/SKILL.md
@@ -42,7 +42,7 @@ The first request returns HTTP `402 Payment Required`. This is an expected part 
 - Your Telnyx account must be active and eligible for machine payments.
 - The payment is tied to the account and amount in the challenge. Do not change either after you approve or sign it.
 - Never reuse a Link spend request, Shared Payment Token, Tempo payment credential, or completed challenge.
-- Only cards issued in the United States or Canada are currently accepted for MPP payments through Link.
+- Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 - Never print, commit, or send your API key, Link access token, Shared Payment Token, wallet private key, or `Authorization: Payment` value.
 
 ## Setup
@@ -91,7 +91,7 @@ npx --yes @stripe/link-cli@0.11.0 auth status
 npx --yes @stripe/link-cli@0.11.0 payment-methods list --format json
 ```
 
-Choose a card marked as eligible for agentic payments. Only cards issued in the United States or Canada are currently accepted for MPP payments through Link.
+Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 
 ```sh
 export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-x402-payment/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-x402-payment/SKILL.md
@@ -34,7 +34,7 @@ Fund a Telnyx account with USDC on the Base blockchain using the x402 payment pr
 
 ## Step 1: Get a Quote
 
-Request a quote for the USD amount to fund. Minimum $5.00, maximum $10,000.00. Quotes expire after 5 minutes.
+Request a quote for the USD amount to fund. Per-payment minimum and maximum limits apply; they are configurable and may change, and the API's 422 error messages state the current values. Quotes expire after 5 minutes.
 
 ```bash
 curl -s -X POST "https://api.telnyx.com/v2/x402/credit_account/quote" \
@@ -336,8 +336,8 @@ Settlement is nearly instant (~2 seconds on Base L2). Platform credit is applied
 
 | Error Code | HTTP Status | Meaning | Resolution |
 |------------|-------------|---------|------------|
-| `amount_usd must be at least 5.00` | 422 | Below minimum | Use $5.00 or more |
-| `amount_usd must not exceed 10000.00` | 422 | Above maximum | Use $10,000.00 or less |
+| `amount_usd must be at least <min>` | 422 | Below the current minimum | Retry with an amount at or above the minimum the error states |
+| `amount_usd must not exceed <max>` | 422 | Above the current maximum | Retry with an amount at or below the maximum the error states |
 | `insufficient_balance` | 422 | Wallet lacks USDC | Fund the wallet with USDC on Base |
 | `insufficient_funds` | 422 | Wallet lacks USDC (alias) | Fund the wallet with USDC on Base |
 | `insufficient_allowance` | 422 | USDC token allowance insufficient | Approve USDC spending for the facilitator contract |

--- a/providers/cursor/plugin/skills/telnyx-mpp-payment/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-mpp-payment/SKILL.md
@@ -42,7 +42,7 @@ The first request returns HTTP `402 Payment Required`. This is an expected part 
 - Your Telnyx account must be active and eligible for machine payments.
 - The payment is tied to the account and amount in the challenge. Do not change either after you approve or sign it.
 - Never reuse a Link spend request, Shared Payment Token, Tempo payment credential, or completed challenge.
-- Only cards issued in the United States or Canada are currently accepted for MPP payments through Link.
+- Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 - Never print, commit, or send your API key, Link access token, Shared Payment Token, wallet private key, or `Authorization: Payment` value.
 
 ## Setup
@@ -91,7 +91,7 @@ npx --yes @stripe/link-cli@0.11.0 auth status
 npx --yes @stripe/link-cli@0.11.0 payment-methods list --format json
 ```
 
-Choose a card marked as eligible for agentic payments. Only cards issued in the United States or Canada are currently accepted for MPP payments through Link.
+Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 
 ```sh
 export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'

--- a/providers/cursor/plugin/skills/telnyx-x402-payment/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-x402-payment/SKILL.md
@@ -34,7 +34,7 @@ Fund a Telnyx account with USDC on the Base blockchain using the x402 payment pr
 
 ## Step 1: Get a Quote
 
-Request a quote for the USD amount to fund. Minimum $5.00, maximum $10,000.00. Quotes expire after 5 minutes.
+Request a quote for the USD amount to fund. Per-payment minimum and maximum limits apply; they are configurable and may change, and the API's 422 error messages state the current values. Quotes expire after 5 minutes.
 
 ```bash
 curl -s -X POST "https://api.telnyx.com/v2/x402/credit_account/quote" \
@@ -336,8 +336,8 @@ Settlement is nearly instant (~2 seconds on Base L2). Platform credit is applied
 
 | Error Code | HTTP Status | Meaning | Resolution |
 |------------|-------------|---------|------------|
-| `amount_usd must be at least 5.00` | 422 | Below minimum | Use $5.00 or more |
-| `amount_usd must not exceed 10000.00` | 422 | Above maximum | Use $10,000.00 or less |
+| `amount_usd must be at least <min>` | 422 | Below the current minimum | Retry with an amount at or above the minimum the error states |
+| `amount_usd must not exceed <max>` | 422 | Above the current maximum | Retry with an amount at or below the maximum the error states |
 | `insufficient_balance` | 422 | Wallet lacks USDC | Fund the wallet with USDC on Base |
 | `insufficient_funds` | 422 | Wallet lacks USDC (alias) | Fund the wallet with USDC on Base |
 | `insufficient_allowance` | 422 | USDC token allowance insufficient | Approve USDC spending for the facilitator contract |

--- a/skills/telnyx-mpp-payment/SKILL.md
+++ b/skills/telnyx-mpp-payment/SKILL.md
@@ -42,7 +42,7 @@ The first request returns HTTP `402 Payment Required`. This is an expected part 
 - Your Telnyx account must be active and eligible for machine payments.
 - The payment is tied to the account and amount in the challenge. Do not change either after you approve or sign it.
 - Never reuse a Link spend request, Shared Payment Token, Tempo payment credential, or completed challenge.
-- Only cards issued in the United States or Canada are currently accepted for MPP payments through Link.
+- Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 - Never print, commit, or send your API key, Link access token, Shared Payment Token, wallet private key, or `Authorization: Payment` value.
 
 ## Setup
@@ -91,7 +91,7 @@ npx --yes @stripe/link-cli@0.11.0 auth status
 npx --yes @stripe/link-cli@0.11.0 payment-methods list --format json
 ```
 
-Choose a card marked as eligible for agentic payments. Only cards issued in the United States or Canada are currently accepted for MPP payments through Link.
+Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 
 ```sh
 export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'

--- a/skills/telnyx-x402-payment/SKILL.md
+++ b/skills/telnyx-x402-payment/SKILL.md
@@ -34,7 +34,7 @@ Fund a Telnyx account with USDC on the Base blockchain using the x402 payment pr
 
 ## Step 1: Get a Quote
 
-Request a quote for the USD amount to fund. Minimum $5.00, maximum $10,000.00. Quotes expire after 5 minutes.
+Request a quote for the USD amount to fund. Per-payment minimum and maximum limits apply; they are configurable and may change, and the API's 422 error messages state the current values. Quotes expire after 5 minutes.
 
 ```bash
 curl -s -X POST "https://api.telnyx.com/v2/x402/credit_account/quote" \
@@ -336,8 +336,8 @@ Settlement is nearly instant (~2 seconds on Base L2). Platform credit is applied
 
 | Error Code | HTTP Status | Meaning | Resolution |
 |------------|-------------|---------|------------|
-| `amount_usd must be at least 5.00` | 422 | Below minimum | Use $5.00 or more |
-| `amount_usd must not exceed 10000.00` | 422 | Above maximum | Use $10,000.00 or less |
+| `amount_usd must be at least <min>` | 422 | Below the current minimum | Retry with an amount at or above the minimum the error states |
+| `amount_usd must not exceed <max>` | 422 | Above the current maximum | Retry with an amount at or below the maximum the error states |
 | `insufficient_balance` | 422 | Wallet lacks USDC | Fund the wallet with USDC on Base |
 | `insufficient_funds` | 422 | Wallet lacks USDC (alias) | Fund the wallet with USDC on Base |
 | `insufficient_allowance` | 422 | USDC token allowance insufficient | Approve USDC spending for the facilitator contract |


### PR DESCRIPTION
Follow-up to the agentic-payments docs audit (why zero bots have tried x402/MPP), now in two parts:

## 1. Discoverability (original scope)
- **agent.json**: both payment capabilities pointed `docs` at `developers.telnyx.com/docs/account/billing`, which **404s**. They now point at the live public runbooks (`telnyx.com/.well-known/agent-skills/telnyx-{x402,mpp}-payment/SKILL.md`), and the x402 capability description states it is authenticated funding, distinct from the keyless pay-per-call endpoints.
- **guides/x402-payments.md + guides/mpp-payments.md**: open with the keyless-vs-authenticated distinction and cross-link each other and the keyless gateway.

## 2. Payments-owner fact-check (added after DRI review in Slack)
- **Funding limits unpublished**: the $5/$10,000 min/max are configurable anti-abuse values — the x402 skill + guide now say limits apply and the API's 422 error messages state current values (error-table rows use `<min>`/`<max>` placeholders instead of hard-coded amounts).
- **Stripe Link wording**: "only US/CA-issued cards" → "eligible cards in supported regions — currently US/Canada", per the DRI's suggested phrasing.
- Provider copies regenerated (`sync-skills.sh`); `check-skills-sync.sh` passes.

## Release coupling
Both payment SKILL.md bodies changed → the published copies on telnyx.com and their sha256 digests in the agent-skills index must ship together. The companion commit on **team-telnyx/dotcom-monorepo#3222** updates the public copies + digests, and that PR's new digest spec enforces the match in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJUz4xwgxbQFjFvUFFfSv2