### PR TITLE
feat(migration): isolate static correctness analyzer

### DIFF
--- a/.github/workflows/twilio-migration-tests.yml
+++ b/.github/workflows/twilio-migration-tests.yml
@@ -1,0 +1,37 @@
+name: Twilio migration analyzer contracts
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/twilio-migration-tests.yml'
+      - 'skills/telnyx-twilio-migration/**'
+      - 'providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/**'
+      - 'providers/cursor/plugin/skills/telnyx-twilio-migration/**'
+      - 'tests/test_twilio_migration_analyzer.py'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/twilio-migration-tests.yml'
+      - 'skills/telnyx-twilio-migration/**'
+      - 'providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/**'
+      - 'providers/cursor/plugin/skills/telnyx-twilio-migration/**'
+      - 'tests/test_twilio_migration_analyzer.py'
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    name: Analyzer contracts (no network)
+    runs-on: ubuntu-latest
+    # Observed job duration on this branch: 142-206s across runs, trending up
+    # as contract cases are added. 20 minutes keeps headroom for that growth
+    # and for runner variance without letting a hung run burn a full hour.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+      - run: python3 tests/test_twilio_migration_analyzer.py -v

--- a/.github/workflows/twilio-migration-tests.yml
+++ b/.github/workflows/twilio-migration-tests.yml
@@ -25,10 +25,11 @@ jobs:
   contracts:
     name: Analyzer contracts (no network)
     runs-on: ubuntu-latest
-    # Observed job duration on this branch: 142-206s across runs, trending up
-    # as contract cases are added. 20 minutes keeps headroom for that growth
-    # and for runner variance without letting a hung run burn a full hour.
-    timeout-minutes: 20
+    # Exact-head CI reached the previous 20-minute ceiling, while the same
+    # supported-Python suite completed locally in about 36 minutes. Keep enough
+    # runner-variance headroom for the generated contract matrices without
+    # turning a normal run into a cancelled required check.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/SKILL.md
@@ -10,7 +10,7 @@ user_invocable: true
 metadata:
   author: telnyx
   product: migration
-  compatibility: "Requires bash 4+, jq, curl, python3. macOS ships bash 3.2 — scripts auto-upgrade via Homebrew bash if available (brew install bash). python3 is mandatory: the scanners and the correctness linter exit 2 without it."
+  compatibility: "Requires bash 4+, Python 3.10+, jq, curl. macOS ships bash 3.2 — scripts auto-upgrade via Homebrew bash if available (brew install bash)."
 ---
 
 # Twilio to Telnyx Migration

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Filter ``grep -nH`` matches through the migration source lexer.
+
+The shell validators use grep for breadth, but grep cannot distinguish live
+syntax from comments or quoted prose.  This adapter keeps the shell tools on
+the same lexical contract as the messaging-profile analyzer while preserving
+the familiar ``path:line:text`` output used in reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+MATCH_RE = re.compile(r"^(.*?):([0-9]+):(.*)$")
+
+
+def load_analyzer(path: Path):
+    spec = importlib.util.spec_from_file_location("telnyx_source_contract", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("comments", "code"), default="comments")
+    parser.add_argument("--analyzer", type=Path, required=True)
+    parser.add_argument("--pattern", required=True)
+    args = parser.parse_args()
+
+    analyzer = load_analyzer(args.analyzer)
+    cache: dict[Path, object] = {}
+    for raw in sys.stdin:
+        raw = raw.rstrip("\n")
+        match = MATCH_RE.match(raw)
+        if not match:
+            continue
+        filename, line_number, original = match.groups()
+        path = Path(filename)
+        try:
+            if path not in cache:
+                source = path.read_text(encoding="utf-8", errors="replace")
+                suffix = analyzer.canonical_suffix(path)
+                if (
+                    path.name == ".env"
+                    or path.name.startswith(".env.")
+                    or path.suffix.lower() in {
+                        ".conf",
+                        ".env",
+                        ".ini",
+                        ".properties",
+                        ".toml",
+                        ".yaml",
+                        ".yml",
+                    }
+                ):
+                    suffix = ".sh"
+                cache[path] = analyzer.lex_source(source, suffix)
+            lexed = cache[path]
+            view = lexed.code if args.mode == "code" else lexed.without_comments
+            lines = view.splitlines()
+            index = int(line_number) - 1
+            filtered = lines[index] if 0 <= index < len(lines) else ""
+        except OSError:
+            filtered = original
+        live_match = subprocess.run(
+            ["grep", "-E", "-q", args.pattern],
+            input=filtered,
+            text=True,
+            check=False,
+        ).returncode == 0
+        if filtered.strip() and live_match:
+            print(f"{filename}:{line_number}:{filtered}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -35,6 +35,7 @@ def main() -> int:
     parser.add_argument("--mode", choices=("comments", "code"), default="comments")
     parser.add_argument("--analyzer", type=Path, required=True)
     parser.add_argument("--pattern", required=True)
+    parser.add_argument("--region", choices=("all", "backend"), default="all")
     args = parser.parse_args()
 
     analyzer = load_analyzer(args.analyzer)
@@ -49,6 +50,10 @@ def main() -> int:
         try:
             if path not in cache:
                 source = path.read_text(encoding="utf-8", errors="replace")
+                if args.region == "backend":
+                    source = analyzer.backend_executable_source(path, source)
+                else:
+                    source = analyzer.executable_source(path, source)
                 suffix = analyzer.canonical_suffix(path)
                 if (
                     path.name == ".env"

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -47,7 +47,12 @@ def grep_records(data: bytes) -> Iterator[tuple[Path, int]]:
 def display_path(path: Path) -> str:
     """Keep one finding per output line even for control characters in paths."""
 
-    return str(path).replace("\r", "\\r").replace("\n", "\\n")
+    return (
+        str(path)
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
 
 
 def load_analyzer(path: Path):

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -83,7 +83,13 @@ def main() -> int:
             continue
         try:
             if path not in cache:
-                source = path.read_text(encoding="utf-8", errors="replace")
+                # Preserve physical newlines exactly. grep -n counts LF bytes;
+                # universal-newline translation would turn a preceding bare CR
+                # into a synthetic LF and make the lexer index a different row.
+                with path.open(
+                    "r", encoding="utf-8", errors="replace", newline=""
+                ) as source_file:
+                    source = source_file.read()
                 if args.region == "backend":
                     source = analyzer.backend_executable_source(path, source)
                 else:

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -11,13 +11,43 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import re
+import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterator
 
 
-MATCH_RE = re.compile(r"^(.*?):([0-9]+):(.*)$")
+def grep_records(data: bytes) -> Iterator[tuple[Path, int]]:
+    """Parse ``grep -nH --null`` records without interpreting path bytes.
+
+    Grep terminates the filename with NUL, then writes ``line:text\n``.  A
+    filename may legally contain colons or newlines on POSIX, so neither can be
+    used to find the filename boundary.  Match text cannot contain a newline;
+    grep removes that source delimiter from each emitted record.
+    """
+
+    cursor = 0
+    while cursor < len(data):
+        nul = data.find(b"\0", cursor)
+        if nul < 0:
+            raise ValueError("grep record has no NUL filename delimiter")
+        newline = data.find(b"\n", nul + 1)
+        if newline < 0:
+            newline = len(data)
+        locator = data[nul + 1 : newline]
+        colon = locator.find(b":")
+        if colon <= 0 or not locator[:colon].isdigit():
+            raise ValueError("grep record has no numeric line field")
+        filename = os.fsdecode(data[cursor:nul])
+        yield Path(filename), int(locator[:colon])
+        cursor = newline + 1
+
+
+def display_path(path: Path) -> str:
+    """Keep one finding per output line even for control characters in paths."""
+
+    return str(path).replace("\r", "\\r").replace("\n", "\\n")
 
 
 def load_analyzer(path: Path):
@@ -36,17 +66,21 @@ def main() -> int:
     parser.add_argument("--analyzer", type=Path, required=True)
     parser.add_argument("--pattern", required=True)
     parser.add_argument("--region", choices=("all", "backend"), default="all")
+    parser.add_argument("--exclude-suffix", action="append", default=[])
     args = parser.parse_args()
 
     analyzer = load_analyzer(args.analyzer)
+    try:
+        records = list(grep_records(sys.stdin.buffer.read()))
+    except ValueError as error:
+        print(f"Error: malformed NUL-delimited grep input: {error}", file=sys.stderr)
+        return 2
+
     cache: dict[Path, object] = {}
-    for raw in sys.stdin:
-        raw = raw.rstrip("\n")
-        match = MATCH_RE.match(raw)
-        if not match:
+    excluded_suffixes = {suffix.lower() for suffix in args.exclude_suffix}
+    for path, line_number in records:
+        if path.suffix.lower() in excluded_suffixes:
             continue
-        filename, line_number, original = match.groups()
-        path = Path(filename)
         try:
             if path not in cache:
                 source = path.read_text(encoding="utf-8", errors="replace")
@@ -72,19 +106,27 @@ def main() -> int:
                 cache[path] = analyzer.lex_source(source, suffix)
             lexed = cache[path]
             view = lexed.code if args.mode == "code" else lexed.without_comments
-            lines = view.splitlines()
-            index = int(line_number) - 1
-            filtered = lines[index] if 0 <= index < len(lines) else ""
-        except OSError:
-            filtered = original
-        live_match = subprocess.run(
+            lines = view.split("\n")
+            index = line_number - 1
+            if not 0 <= index < len(lines):
+                raise ValueError(
+                    f"grep line {line_number} is outside the lexed source"
+                )
+            filtered = lines[index]
+        except (OSError, ValueError) as error:
+            print(f"Error: could not filter {display_path(path)}: {error}", file=sys.stderr)
+            return 2
+        match_result = subprocess.run(
             ["grep", "-E", "-q", args.pattern],
             input=filtered,
             text=True,
             check=False,
-        ).returncode == 0
-        if filtered.strip() and live_match:
-            print(f"{filename}:{line_number}:{filtered}")
+        )
+        if match_result.returncode > 1:
+            print("Error: grep could not evaluate the filter pattern", file=sys.stderr)
+            return 2
+        if filtered.strip() and match_result.returncode == 0:
+            print(f"{display_path(path)}:{line_number}:{filtered}")
     return 0
 
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Read local dependency declarations; never resolve packages over the network.
+
+Exit zero only for positive evidence. Unresolved external Maven parents,
+properties, and unsupported Gradle expressions deliberately remain warnings.
+Gradle version catalogs use stdlib tomllib on Python 3.11+; older Python still
+supports Maven, Composer and literal Gradle coordinates without extra packages.
+"""
+from __future__ import annotations
+
+import json
+import importlib.util
+import os
+from pathlib import Path
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+try:
+    import tomllib
+except ImportError:
+    tomllib = None
+
+JVM_ARTIFACTS = {"telnyx", "telnyx-core", "telnyx-client-okhttp"}
+
+
+def version_is_constrained(value: object) -> bool:
+    return isinstance(value, str) and bool(re.fullmatch(
+        r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?", value.strip()
+    ))
+
+
+def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    try:
+        data = json.loads((root / "composer.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and any(
+        isinstance(data.get(section), dict)
+        and isinstance(data[section].get(package), str)
+        and bool(data[section][package].strip())
+        for section in ("require", "require-dev")
+    )
+
+
+def maven_dependencies(path: Path) -> list[tuple[str, str, str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+        # Manifests need no entities. Avoid entity expansion on untrusted input.
+        if "<!DOCTYPE" in text or "<!ENTITY" in text:
+            return []
+        project = ET.fromstring(text)
+    except (OSError, ValueError, ET.ParseError):
+        return []
+    for node in project.iter():
+        node.tag = node.tag.rsplit("}", 1)[-1]
+    if project.tag != "project":
+        return []
+    properties = {node.tag: (node.text or "").strip()
+                  for node in project.findall("./properties/*")}
+
+    def resolve(value: str) -> str:
+        seen = set()
+        while re.fullmatch(r"\$\{[^}]+\}", value) and value not in seen:
+            seen.add(value)
+            value = properties.get(value[2:-1], "")
+        return value
+
+    def field(node: ET.Element, name: str) -> str:
+        return resolve((node.findtext(name) or "").strip())
+
+    managed = {
+        (field(dep, "groupId"), field(dep, "artifactId")): field(dep, "version")
+        for dep in project.findall("./dependencyManagement/dependencies/dependency")
+    }
+    dependencies = []
+    for dep in project.findall("./dependencies/dependency"):
+        group, artifact = field(dep, "groupId"), field(dep, "artifactId")
+        # An explicit unresolved version must not fall back to management.
+        version = (field(dep, "version") if dep.find("version") is not None
+                   else managed.get((group, artifact), ""))
+        dependencies.append((group, artifact, version))
+    return dependencies
+
+
+def maven_pinned(path: Path) -> bool:
+    return any(group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS
+               and version_is_constrained(version)
+               for group, artifact, version in maven_dependencies(path))
+
+
+def groovy_slashy_ranges(source: str, code: str) -> list[tuple[int, int]]:
+    """Exclude Groovy's additional string delimiters from declaration evidence.
+
+    Ordinary quotes/comments are already masked by the shared lexer. Slashy
+    strings are expressions, so a division operator after an operand isn't an
+    opener. This does not evaluate interpolation or arbitrary build programs.
+    """
+    ranges = []
+    end = 0
+    for match in re.finditer(r"\$/|/(?![/*])", code):
+        start = match.start()
+        if start < end:
+            continue
+        dollar = match[0] == "$/"
+        prefix = code[:start].rstrip()
+        if not dollar and prefix and prefix[-1] not in "=(:,[!?{" and not re.search(r"\breturn$", prefix):
+            continue
+        cursor = match.end()
+        while cursor < len(source):
+            if dollar and source.startswith("/$", cursor):
+                cursor += 2
+                break
+            if not dollar and source[cursor] == "/":
+                cursor += 1
+                break
+            if (dollar and source[cursor] == "$" and cursor + 1 < len(source)
+                    and source[cursor + 1] in "$/") or (not dollar and source[cursor] == "\\"):
+                cursor += 2
+            else:
+                cursor += 1
+        end = cursor
+        ranges.append((start, end))
+    return ranges
+
+
+def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tuple[str, str, object]]:
+    spec = importlib.util.spec_from_file_location(
+        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+    ownership = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ownership)
+    analyzer = ownership.load_script("lint-required-messaging-profile")
+    dependencies = []
+    accessors = set()
+    for name in ("build.gradle", "build.gradle.kts"):
+        try:
+            source = (root / name).read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        # Reuse source masking: inline comments and help strings aren't code.
+        lexed = ownership.lexed_source(source, ".kt" if name.endswith(".kts") else ".java")
+        strings = {token.start: token for token in lexed.strings}
+        inert_ranges = groovy_slashy_ranges(source, lexed.code) if name == "build.gradle" else []
+        declaration = r"\b(?:implementation|api|compileOnly|runtimeOnly|testImplementation)\b"
+        for match in re.finditer(declaration, lexed.code):
+            if any(start <= match.start() < end for start, end in inert_ranges):
+                continue
+            prefix = re.match(r"\s*\(?\s*", lexed.without_comments[match.end():])
+            start = match.end() + prefix.end()
+            token = strings.get(start)
+            if token:
+                parts = token.contents.split(":")
+                if len(parts) in {2, 3}:
+                    dependencies.append((parts[0], parts[1], parts[2] if len(parts) == 3 else ""))
+            else:
+                accessor = re.match(r"libs\.([\w.]+)", lexed.code[start:])
+                if accessor:
+                    accessors.add(accessor[1])
+                    continue
+                # Groovy also accepts named-map dependency notation:
+                # implementation group: 'g', name: 'a', version: '1.2.3'
+                # and the equivalent parenthesized call. Read only string
+                # tokens belonging to this declaration, so comments and prose
+                # cannot contribute coordinates.
+                cursor = match.end()
+                while (cursor < len(lexed.code)
+                       and lexed.code[cursor] in " \t\r"):
+                    cursor += 1
+                parenthesized = (cursor < len(lexed.code)
+                                 and lexed.code[cursor] == "(")
+                if parenthesized:
+                    closing = analyzer.matching_delimiter(
+                        lexed.code, cursor, "(", ")")
+                    if closing is None:
+                        continue
+                    argument_start, argument_end = cursor + 1, closing
+                else:
+                    argument_start, argument_end = cursor, len(lexed.code)
+                fields = {}
+                cursor = argument_start
+                continued = parenthesized
+                while cursor < argument_end:
+                    while (cursor < argument_end
+                           and lexed.code[cursor].isspace()
+                           and (continued or lexed.code[cursor] != "\n")):
+                        cursor += 1
+                    field = re.match(r"(group|name|version)\s*:",
+                                     lexed.code[cursor:argument_end])
+                    if field is None:
+                        break
+                    value_start = cursor + field.end()
+                    while (value_start < argument_end
+                           and lexed.without_comments[value_start].isspace()):
+                        value_start += 1
+                    token = strings.get(value_start)
+                    if token and token.end <= argument_end:
+                        fields[field[1]] = token.contents
+                        cursor = token.end
+                    else:
+                        # Dynamic/unsupported values invalidate an earlier
+                        # duplicate literal instead of leaving stale evidence.
+                        fields[field[1]] = None
+                        boundary = re.search(r"[,;\n})]",
+                                             lexed.code[value_start:argument_end])
+                        cursor = (argument_end if boundary is None else
+                                  value_start + boundary.start())
+                    while (cursor < argument_end
+                           and lexed.code[cursor] in " \t\r"):
+                        cursor += 1
+                    if cursor >= argument_end or lexed.code[cursor] != ",":
+                        break
+                    cursor += 1
+                    continued = True
+                if "group" in fields and "name" in fields:
+                    dependencies.append((fields["group"], fields["name"],
+                                         fields.get("version", "")))
+    if tomllib is None:
+        return dependencies
+    try:
+        catalog = tomllib.loads(((catalog_root or root) / "gradle/libs.versions.toml").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return dependencies
+    libraries, versions = catalog.get("libraries", {}), catalog.get("versions", {})
+    if not isinstance(libraries, dict) or not isinstance(versions, dict):
+        return dependencies
+    for alias, entry in libraries.items():
+        accessor = re.sub(r"[-_]", ".", alias)
+        if accessor not in accessors:
+            continue
+        if isinstance(entry, str):
+            parts = entry.split(":")
+            if len(parts) != 3:
+                continue
+            group, artifact, version = parts
+        elif isinstance(entry, dict):
+            module = entry.get("module")
+            if isinstance(module, str) and module.count(":") == 1:
+                group, artifact = module.split(":")
+            else:
+                group, artifact = entry.get("group"), entry.get("name")
+            version = entry.get("version")
+            if isinstance(version, dict):
+                reference = version.get("ref")
+                version = versions.get(reference) if isinstance(reference, str) else None
+        else:
+            continue
+        dependencies.append((group, artifact, version))
+    return dependencies
+
+
+def gradle_pinned(root: Path) -> bool:
+    return any(group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS
+               and version_is_constrained(version)
+               for group, artifact, version in gradle_dependencies(root))
+
+
+def jvm_declared(root: Path, vendor: str) -> bool:
+    for directory, dirs, names in os.walk(root):
+        relative = Path(directory).relative_to(root)
+        dirs[:] = [name for name in dirs if name not in {
+            ".git", "node_modules", "build", "vendor", ".gradle", ".venv"}
+            and len(relative.parts) < 3]
+        path = Path(directory)
+        dependencies = maven_dependencies(path / "pom.xml") if "pom.xml" in names else []
+        if "build.gradle" in names or "build.gradle.kts" in names:
+            dependencies.extend(gradle_dependencies(path, root))
+        if any((group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS)
+               if vendor == "telnyx" else (group == "com.twilio.sdk" and artifact == "twilio")
+               for group, artifact, _ in dependencies):
+            return True
+    return False
+
+
+def main() -> int:
+    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "jvm-pinned", "jvm-declared", "twilio-jvm-declared"}:
+        return 2
+    root = Path(sys.argv[2])
+    mode = sys.argv[1]
+    if mode == "composer":
+        found = composer_declared(root)
+    elif mode.endswith("declared"):
+        found = jvm_declared(root, "twilio" if mode.startswith("twilio") else "telnyx")
+    else:
+        found = maven_pinned(root / "pom.xml") or gradle_pinned(root)
+    return 0 if found else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -9,6 +9,7 @@ on older Python. Gradle catalogs still require tomllib; no packages are installe
 from __future__ import annotations
 
 import ast
+import codecs
 import configparser
 from functools import lru_cache
 import json
@@ -17,6 +18,7 @@ import os
 from pathlib import Path
 import re
 import sys
+import tokenize
 import xml.etree.ElementTree as ET
 
 try:
@@ -43,8 +45,26 @@ def version_is_constrained(value: object) -> bool:
 
 def read_text(path: Path) -> str:
     try:
-        return path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError):
+        # Python source and pip requirements honor PEP 263 declarations. npm's
+        # JSON reader accepts a leading UTF-8 BOM; TOML does not share that rule.
+        if path.name == "setup.py":
+            with tokenize.open(path) as source:
+                return source.read()
+        if path.name == "requirements.txt":
+            data = path.read_bytes()
+            # pip checks BOMs before coding comments, and UTF-32 before UTF-16.
+            for boms, encoding in (((codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE), "utf-32"),
+                                   ((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE), "utf-16"),
+                                   ((codecs.BOM_UTF8,), "utf-8-sig")):
+                if data.startswith(boms):
+                    return data.decode(encoding)
+            for line in data.split(b"\n")[:2]:
+                cookie = re.search(br"coding[:=]\s*([-\w.]+)", line) if line.startswith(b"#") else None
+                if cookie:
+                    return data.decode(cookie[1].decode("ascii"))
+            return data.decode("utf-8")
+        return path.read_text(encoding="utf-8-sig" if path.name == "package.json" else "utf-8")
+    except (OSError, UnicodeError, SyntaxError, LookupError):
         return ""
 
 
@@ -252,6 +272,36 @@ def python_requirement(value: object) -> list[str]:
     return [suffix.split(";", 1)[0].strip().strip("() ")]
 
 
+_SETUP_FUNCTION = object()
+
+
+class _SetupModule:
+    """Static import identity, never an imported or executed Python module."""
+
+
+_SETUP_MODULE = _SetupModule()
+
+
+def setup_import_bindings(statement: ast.Import | ast.ImportFrom) -> dict:
+    """Names replaced by an import; None denotes an unrecognized owner."""
+    result = {}
+    for alias in statement.names:
+        name = alias.asname or alias.name.split(".")[0]
+        result[name] = None
+        if isinstance(statement, ast.Import):
+            if alias.name == "setuptools" or (not alias.asname and alias.name.startswith("setuptools.")):
+                result[name] = _SETUP_MODULE
+        elif not statement.level and statement.module in {"setuptools", "distutils.core"} and alias.name == "setup":
+            result[name] = _SETUP_FUNCTION
+        elif not statement.level and statement.module == "setuptools" and alias.name == "*":
+            # setuptools explicitly exports these names through __all__. Do
+            # not erase unrelated local requirements or aliases on this import.
+            result = dict.fromkeys(("Command", "Distribution", "Extension", "Require",
+                                    "SetuptoolsDeprecationWarning", "find_namespace_packages", "find_packages"))
+            result["setup"] = _SETUP_FUNCTION
+    return result
+
+
 def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
     """Resolve only local literal data, never execute setup code or imports."""
     if depth > 20:
@@ -259,6 +309,8 @@ def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
     resolve = lambda child: setup_literal(child, bindings, depth + 1)
     if isinstance(node, ast.Name):
         return bindings[node.id]
+    if isinstance(node, ast.Attribute) and node.attr == "setup" and isinstance(resolve(node.value), _SetupModule):
+        return _SETUP_FUNCTION
     if isinstance(node, (ast.List, ast.Tuple)):
         values = [resolve(child) for child in node.elts]
         return tuple(values) if isinstance(node, ast.Tuple) else values
@@ -293,29 +345,72 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
         for child in ast.iter_child_nodes(node):
             yield from local_nodes(child)
 
-    def invalidate(names):
+    def invalidate(names, mutation=False):
         # Containers can own aliases too, e.g. config={"requires": requirements}.
         def mutable_objects(value):
-            objects = {id(value)} if isinstance(value, (list, dict)) else set()
+            objects = {id(value)} if isinstance(value, (list, dict, _SetupModule)) else set()
             children = value.values() if isinstance(value, dict) else value if isinstance(value, (list, tuple)) else ()
             for child in children:
                 objects.update(mutable_objects(child))
             return objects
 
         objects = set().union(*(mutable_objects(bindings[name]) for name in names if name in bindings))
+        if mutation and class_outer is not None:
+            # Class-local rebinding stays local; mutating a shared outer module
+            # or container does not. Never restore its stale entry snapshot.
+            for name in list(class_outer):
+                if mutable_objects(class_outer[name]) & objects:
+                    del class_outer[name]
         for name in list(bindings):
             if name in names or mutable_objects(bindings[name]) & objects:
                 del bindings[name]
 
     def preceding(statement):
+        nonlocal bindings
+        common_imports = {}
+        if isinstance(statement, (ast.If, ast.Try)):
+            # Reuse the same statement handling on each alternative, but merge
+            # only import identity -- never conditional literal requirements.
+            paths = []
+            if isinstance(statement, ast.If):
+                paths = [(statement.body, None, []), (statement.orelse, None, [])]
+                headers = [statement.test]
+            else:
+                paths = [(statement.body + statement.orelse, None, statement.finalbody)]
+                paths += [(handler.body, handler.name, statement.finalbody) for handler in statement.handlers]
+                headers = [handler.type for handler in statement.handlers if handler.type is not None]
+            if not any(isinstance(node, (ast.Call, ast.NamedExpr)) for header in headers for node in ast.walk(header)):
+                incoming, alternatives = bindings, []
+                try:
+                    for body, exception_name, finalbody in paths:
+                        bindings = incoming.copy()
+                        if exception_name:
+                            bindings.pop(exception_name, None)
+                        for item in body:
+                            preceding(item)
+                        if exception_name:
+                            bindings.pop(exception_name, None)
+                        for item in finalbody:
+                            preceding(item)
+                        alternatives.append({name: value for name, value in bindings.items()
+                                             if value is _SETUP_FUNCTION or value is _SETUP_MODULE})
+                finally:
+                    bindings = incoming
+                common_imports = {name: value for name, value in alternatives[0].items()
+                                  if all(other.get(name) is value for other in alternatives[1:])}
         nodes = list(local_nodes(statement))
         mutated = set()
         for node in nodes:
             if isinstance(node, ast.Call):
-                mutated.update(item.id for item in ast.walk(node) if isinstance(item, ast.Name))
+                try:
+                    known_setup = setup_literal(node.func, bindings) is _SETUP_FUNCTION
+                except (KeyError, ValueError, TypeError, SyntaxError):
+                    known_setup = False
+                operands = [*node.args, *(kw.value for kw in node.keywords)] if known_setup else [node]
+                mutated.update(item.id for operand in operands for item in ast.walk(operand) if isinstance(item, ast.Name))
             elif isinstance(node, (ast.Attribute, ast.Subscript)) and isinstance(node.ctx, (ast.Store, ast.Del)):
                 mutated.update(item.id for item in ast.walk(node.value) if isinstance(item, ast.Name))
-        invalidate(mutated)
+        invalidate(mutated, mutation=True)
         if isinstance(statement, (ast.Assign, ast.AnnAssign)):
             targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
             try:
@@ -333,13 +428,36 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
             return
         invalidate({node.id for node in nodes if isinstance(node, ast.Name)
                     and isinstance(node.ctx, (ast.Store, ast.Del))})
-        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            bindings.pop(statement.name, None)
+        # Conditional imports/definitions also replace names, even though the
+        # AST represents them without Name(Store) nodes.
+        for node in nodes:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                effects = setup_import_bindings(node)
+                if "*" in effects:
+                    bindings.clear()
+                invalidate(set(effects))
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                bindings.pop(node.name, None)
         if isinstance(statement, (ast.Import, ast.ImportFrom)):
-            for alias in statement.names:
-                bindings.pop(alias.asname or alias.name.split(".")[0], None)
+            bindings.update({name: value for name, value in setup_import_bindings(statement).items() if value is not None})
+        bindings.update(common_imports)
 
+    class_outer = None
     for parent, child in reversed(path):
+        if class_outer is not None and isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            # Only the outermost iterator is evaluated in the class namespace;
+            # the comprehension body has its own enclosing lexical scope.
+            if not any(node is call for node in ast.walk(parent.generators[0].iter)):
+                bindings = class_outer
+                class_outer = None
+        if isinstance(parent, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            # A class body executes with its own locals, but is not a closure
+            # for methods or nested classes. Preserve the outer lexical scope.
+            if class_outer is not None:
+                bindings = class_outer
+                class_outer = None
+            if isinstance(parent, ast.ClassDef):
+                class_outer = bindings.copy()
         if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             # Python locals shadow outer names throughout the function, including
             # before their assignment. Parameters are unknown, not outer literals.
@@ -348,6 +466,12 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
                        for node in local_nodes(statement) if isinstance(node, ast.Name)
                        and isinstance(node.ctx, (ast.Store, ast.Del))}
             locals_.update(node.arg for node in ast.walk(parent.args) if isinstance(node, ast.arg))
+            for statement in statements:
+                for node in local_nodes(statement):
+                    if isinstance(node, (ast.Import, ast.ImportFrom)):
+                        locals_.update(alias.asname or alias.name.split(".")[0] for alias in node.names)
+                    elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                        locals_.add(node.name)
             for name in locals_:
                 bindings.pop(name, None)
         if isinstance(parent, (ast.For, ast.AsyncFor, ast.With, ast.AsyncWith,
@@ -356,13 +480,23 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
             targets = [parent.target] if isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension)) else (
                 [item.optional_vars for item in parent.items if item.optional_vars is not None]
                 if isinstance(parent, (ast.With, ast.AsyncWith)) else [])
+            if isinstance(parent, ast.comprehension) and child is parent.iter:
+                targets = []
             names = {node.id for target in targets for node in ast.walk(target) if isinstance(node, ast.Name)}
             if isinstance(parent, ast.ExceptHandler) and parent.name:
                 names.add(parent.name)
             for name in names:
                 bindings.pop(name, None)
         if isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
-            for generator in parent.generators:
+            visible = parent.generators
+            for index, generator in enumerate(parent.generators):
+                if any(node is call for node in ast.walk(generator.iter)):
+                    visible = parent.generators[:index]
+                    break
+                if any(node is call for condition in generator.ifs for node in ast.walk(condition)):
+                    visible = parent.generators[:index + 1]
+                    break
+            for generator in visible:
                 for node in ast.walk(generator.target):
                     if isinstance(node, ast.Name):
                         bindings.pop(node.id, None)
@@ -372,7 +506,7 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
                 [parent.iter] if isinstance(parent, (ast.For, ast.AsyncFor)) else
                 [item.context_expr for item in parent.items])
             invalidate({name.id for header in headers for node in ast.walk(header)
-                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)})
+                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)}, mutation=True)
         for _, children in ast.iter_fields(parent):
             if isinstance(children, list) and child in children and isinstance(child, ast.stmt):
                 for previous in children[:children.index(child)]:
@@ -439,17 +573,19 @@ def python_dependencies(root: Path) -> list[tuple[str, bool]]:
     try:
         tree = ast.parse(read_text(root / "setup.py"))
         for call in ast.walk(tree):
-            if not isinstance(call, ast.Call) or not (
-                isinstance(call.func, ast.Name) and call.func.id == "setup"
-                or isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name)
-                and call.func.value.id == "setuptools" and call.func.attr == "setup"
-            ):
+            if not isinstance(call, ast.Call):
+                continue
+            bindings = setup_bindings(tree, call)
+            try:
+                if setup_literal(call.func, bindings) is not _SETUP_FUNCTION:
+                    continue
+            except (KeyError, ValueError, TypeError, SyntaxError):
                 continue
             for keyword in call.keywords:
                 if keyword.arg not in {"install_requires", "extras_require"}:
                     continue
                 try:
-                    value = setup_literal(keyword.value, setup_bindings(tree, call))
+                    value = setup_literal(keyword.value, bindings)
                 except (KeyError, ValueError, TypeError, SyntaxError):
                     continue
                 if keyword.arg == "extras_require" and isinstance(value, dict):

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -3,11 +3,14 @@
 
 Exit zero only for positive evidence. Unresolved external Maven parents,
 properties, and unsupported Gradle expressions deliberately remain warnings.
-Gradle version catalogs use stdlib tomllib on Python 3.11+; older Python still
-supports Maven, Composer and literal Gradle coordinates without extra packages.
+TOML manifests use stdlib tomllib on Python 3.11+ and a bounded literal fallback
+on older Python. Gradle catalogs still require tomllib; no packages are installed.
 """
 from __future__ import annotations
 
+import ast
+import configparser
+from functools import lru_cache
 import json
 import importlib.util
 import os
@@ -25,22 +28,650 @@ JVM_ARTIFACTS = {"telnyx", "telnyx-core", "telnyx-client-okhttp"}
 
 
 def version_is_constrained(value: object) -> bool:
-    return isinstance(value, str) and bool(re.fullmatch(
-        r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?", value.strip()
+    """Literal JVM releases and numeric hard requirements, not dynamic selectors."""
+    if not isinstance(value, str):
+        return False
+    release = r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?"
+    value = value.strip()
+    if re.fullmatch(release, value) or re.fullmatch(r"\[" + release + r"\]", value):
+        return True
+    interval = re.fullmatch(r"[\[(]\s*(.*?)\s*,\s*(.*?)\s*[\])]", value)
+    return bool(interval and any(interval.groups()) and all(
+        not bound or re.fullmatch(release, bound) for bound in interval.groups()
     ))
 
 
-def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+
+
+def toml_string(raw: str) -> str:
+    """Decode TOML 1.0 string escapes without Python's extra escape forms."""
+    quote = raw[0]
+    width = 3 if raw.startswith(quote * 3) else 1
+    if not raw.endswith(quote * width):
+        raise ValueError("unterminated TOML string")
+    value = raw[width:-width]
+    if width == 3:
+        value = re.sub(r"^\r?\n", "", value)
+    if re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", value):
+        raise ValueError("control character in TOML string")
+    if width == 1 and ("\n" in value or "\r" in value):
+        raise ValueError("newline in single-line TOML string")
+    if quote == "'":
+        return value
+    escapes = {'b': '\b', 't': '\t', 'n': '\n', 'f': '\f', 'r': '\r', '"': '"', '\\': '\\'}
+
+    def decode(match):
+        escaped = match[0][1:]
+        if escaped in escapes:
+            return escapes[escaped]
+        if re.fullmatch(r"u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}", escaped):
+            number = int(escaped[1:], 16)
+            if number <= 0x10ffff and not 0xd800 <= number <= 0xdfff:
+                return chr(number)
+        if width == 3 and re.fullmatch(r"[ \t]*\r?\n[ \t\r\n]*", escaped):
+            return ""
+        raise ValueError("invalid TOML escape")
+
+    return re.sub(r'\\(?:u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|[ \t]*\r?\n[ \t\r\n]*|.|$)',
+                  decode, value)
+
+
+def literal_toml_mapping(source: str) -> dict:
+    """Python 3.10 fallback: tables, literal strings, arrays and inline tables.
+
+    This is intentionally not a general TOML implementation. It accepts the
+    dependency forms used below without evaluating code. Unsupported
+    values remain unresolved; masked strings cannot introduce table headers.
+    """
+    ownership = source_ownership()
+    analyzer = ownership.load_script("lint-required-messaging-profile")
+    lexed = ownership.lexed_source(source, ".py")
+    strings = {token.start: token for token in lexed.strings}
+    key = r'''(?:[A-Za-z0-9_-]+|"(?:[^"\\\n]|\\.)*"|'[^'\n]*')'''
+    data, cursor = {}, 0
+    table = data
+    headers = set()
+
+    def table_at(parts: list[str]) -> dict | None:
+        target = data
+        for part in parts:
+            if not isinstance(target.setdefault(part, {}), dict):
+                return None
+            target = target[part]
+        return target
+
+    while cursor < len(source):
+        whitespace = re.match(r"\s*", lexed.without_comments[cursor:])
+        cursor += whitespace.end()
+        if cursor >= len(source):
+            break
+        end = source.find("\n", cursor)
+        end = len(source) if end < 0 else end
+        line = lexed.without_comments[cursor:end].strip()
+        if lexed.code[cursor:cursor + 1] == "[":
+            header = re.fullmatch(r"\[\s*(" + key + r"(?:\s*\.\s*" + key + r")*)\s*\]", line)
+            if header:
+                try:
+                    parts = tuple(toml_string(part) if part.startswith(('"', "'")) else part
+                                  for part in re.findall(key, header[1]))
+                except ValueError:
+                    return {}
+                if parts in headers:
+                    return {}
+                headers.add(parts)
+                table = table_at(list(parts))
+            else:
+                table = None
+            cursor = end
+            continue
+        assignment = re.match(r"(" + key + r"(?:\s*\.\s*" + key + r")*)\s*=\s*", lexed.without_comments[cursor:])
+        if assignment is None:
+            cursor = end
+            continue
+        try:
+            parts = [toml_string(part) if part.startswith(('"', "'")) else part
+                     for part in re.findall(key, assignment[1])]
+        except ValueError:
+            return {}
+        start = cursor + assignment.end()
+        token = strings.get(start)
+        if token:
+            end = token.end
+        elif source[start:start + 1] in {"[", "{"}:
+            opening = source[start]
+            closing = analyzer.matching_delimiter(lexed.code, start, opening, "]" if opening == "[" else "}")
+            if closing is None:
+                return {}  # Cannot safely find the next declaration.
+            end = closing + 1
+        expression = lexed.without_comments[start:end]
+        replacements = []
+        supported = True
+        for token in lexed.strings:
+            if start <= token.start < end:
+                try:
+                    decoded = toml_string(source[token.start:token.end])
+                except ValueError:
+                    supported = False
+                    decoded = ""
+                replacements.append((token.start - start, token.end - start, repr(decoded)))
+        code = lexed.code[start:end]
+        if any(character in code for character in "():"):
+            return {}  # Python tuples and JSON colon maps are not TOML.
+        for field in re.finditer(r"\b([A-Za-z_][\w-]*)\s*(?==)", code):
+            replacements.append((field.start(1), field.end(1), repr(field[1])))
+        for equal in re.finditer("=", code):
+            replacements.append((equal.start(), equal.end(), ":"))
+        for boolean in re.finditer(r"\b(true|false)\b", code):
+            replacements.append((boolean.start(), boolean.end(), boolean[1].title()))
+        for first, last, replacement in sorted(replacements, reverse=True):
+            expression = expression[:first] + replacement + expression[last:]
+        cursor = end
+        line_end = source.find("\n", end)
+        line_end = len(source) if line_end < 0 else line_end
+        if lexed.without_comments[end:line_end].strip():
+            cursor = line_end
+            continue  # Do not certify a prefix of an unsupported expression.
+        if table is None or not supported:
+            continue
+        try:
+            tree = ast.parse(expression.strip(), mode="eval")
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Dict):
+                    keys = [ast.literal_eval(key) for key in node.keys]
+                    if not all(isinstance(key, str) for key in keys) or len(keys) != len(set(keys)):
+                        return {}
+            value = ast.literal_eval(tree)
+        except (ValueError, SyntaxError):
+            continue
+        target = table
+        for part in parts[:-1]:
+            target = target.setdefault(part, {})
+            if not isinstance(target, dict):
+                break
+        if isinstance(target, dict):
+            if parts[-1] in target:
+                return {}  # Duplicate keys are invalid TOML, not extra evidence.
+            target[parts[-1]] = value
+    return data
+
+
+def read_mapping(path: Path, toml: bool = False) -> dict:
+    try:
+        if toml:
+            source = read_text(path)
+            data = tomllib.loads(source) if tomllib else literal_toml_mapping(source)
+        else:
+            data = json.loads(read_text(path))
+    except ValueError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def node_dependencies(root: Path) -> list[tuple[str, str]]:
+    data = read_mapping(root / "package.json")
+    return [(name, value.strip())
+            for section in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies")
+            if isinstance(data.get(section), dict)
+            for name, value in data[section].items()
+            if (name == "telnyx" or name.startswith("@telnyx/"))
+            and isinstance(value, str)]
+
+
+def node_version_is_constrained(value: str) -> bool:
+    # Registry versions/ranges only; tags, URLs and workspace expressions stay
+    # warnings. Every OR branch must provide numeric version evidence.
+    release = r"v?\d+(?:\.\d+){0,2}(?:-[A-Za-z0-9.-]+)?(?:\+[A-Za-z0-9.-]+)?"
+    wildcard = r"\d+(?:\.\d+)?\.[xX*]"
+    for branch in value.split("||"):
+        branch = re.sub(r"([~^<>=]+)\s+", r"\1", branch.strip())
+        if re.fullmatch(release + r"\s+-\s+" + release, branch):
+            continue
+        if not branch or not all(re.fullmatch(
+            r"(?:\^|~|>=|<=|>|<|=)?(?:" + release + "|" + wildcard + ")", token)
+            for token in branch.split()):
+            return False
+    return True
+
+
+def python_requirement(value: object) -> list[str]:
+    if not isinstance(value, str):
+        return []
+    requirement = re.fullmatch(r"telnyx\s*(?:\[[\w, -]+\])?\s*(.*)",
+                               value.strip(), re.IGNORECASE)
+    if not requirement:
+        return []
+    suffix = requirement[1]
+    # Do not mistake a different distribution, e.g. telnyx-tools, for Telnyx.
+    if suffix and suffix[0] not in "<>=~!(@;":
+        return []
+    return [suffix.split(";", 1)[0].strip().strip("() ")]
+
+
+def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
+    """Resolve only local literal data, never execute setup code or imports."""
+    if depth > 20:
+        raise ValueError("literal binding depth")
+    resolve = lambda child: setup_literal(child, bindings, depth + 1)
+    if isinstance(node, ast.Name):
+        return bindings[node.id]
+    if isinstance(node, (ast.List, ast.Tuple)):
+        values = [resolve(child) for child in node.elts]
+        return tuple(values) if isinstance(node, ast.Tuple) else values
+    if isinstance(node, ast.Dict) and all(key is not None for key in node.keys):
+        return {resolve(key): resolve(value) for key, value in zip(node.keys, node.values)}
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left, right = resolve(node.left), resolve(node.right)
+        if type(left) is type(right) and isinstance(left, (str, list, tuple)):
+            return left + right
+        raise ValueError("nonliteral concatenation")
+    return ast.literal_eval(node)
+
+
+def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
+    """Snapshot preceding straight-line assignments in the call's own scopes.
+
+    Conditional writes and unknown mutations invalidate evidence. In particular,
+    never borrow a later assignment or a binding from an unrelated function.
+    """
+    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
+    path, child = [], call
+    while child in parents:
+        parent = parents[child]
+        path.append((parent, child))
+        child = parent
+    bindings = {}
+
+    def local_nodes(node):
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            return
+        for child in ast.iter_child_nodes(node):
+            yield from local_nodes(child)
+
+    def invalidate(names):
+        # Containers can own aliases too, e.g. config={"requires": requirements}.
+        def mutable_objects(value):
+            objects = {id(value)} if isinstance(value, (list, dict)) else set()
+            children = value.values() if isinstance(value, dict) else value if isinstance(value, (list, tuple)) else ()
+            for child in children:
+                objects.update(mutable_objects(child))
+            return objects
+
+        objects = set().union(*(mutable_objects(bindings[name]) for name in names if name in bindings))
+        for name in list(bindings):
+            if name in names or mutable_objects(bindings[name]) & objects:
+                del bindings[name]
+
+    def preceding(statement):
+        nodes = list(local_nodes(statement))
+        mutated = set()
+        for node in nodes:
+            if isinstance(node, ast.Call):
+                mutated.update(item.id for item in ast.walk(node) if isinstance(item, ast.Name))
+            elif isinstance(node, (ast.Attribute, ast.Subscript)) and isinstance(node.ctx, (ast.Store, ast.Del)):
+                mutated.update(item.id for item in ast.walk(node.value) if isinstance(item, ast.Name))
+        invalidate(mutated)
+        if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+            try:
+                value = setup_literal(statement.value, bindings)
+                resolved = True
+            except (KeyError, ValueError, TypeError, SyntaxError):
+                resolved = False
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    bindings.pop(target.id, None)
+                    if resolved:
+                        bindings[target.id] = value
+                else:
+                    invalidate({node.id for node in ast.walk(target) if isinstance(node, ast.Name)})
+            return
+        invalidate({node.id for node in nodes if isinstance(node, ast.Name)
+                    and isinstance(node.ctx, (ast.Store, ast.Del))})
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bindings.pop(statement.name, None)
+        if isinstance(statement, (ast.Import, ast.ImportFrom)):
+            for alias in statement.names:
+                bindings.pop(alias.asname or alias.name.split(".")[0], None)
+
+    for parent, child in reversed(path):
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            # Python locals shadow outer names throughout the function, including
+            # before their assignment. Parameters are unknown, not outer literals.
+            statements = parent.body if isinstance(parent.body, list) else []
+            locals_ = {node.id for statement in statements
+                       for node in local_nodes(statement) if isinstance(node, ast.Name)
+                       and isinstance(node.ctx, (ast.Store, ast.Del))}
+            locals_.update(node.arg for node in ast.walk(parent.args) if isinstance(node, ast.arg))
+            for name in locals_:
+                bindings.pop(name, None)
+        if isinstance(parent, (ast.For, ast.AsyncFor, ast.With, ast.AsyncWith,
+                               ast.ExceptHandler, ast.comprehension)):
+            # These names are rebound by the header, before its body executes.
+            targets = [parent.target] if isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension)) else (
+                [item.optional_vars for item in parent.items if item.optional_vars is not None]
+                if isinstance(parent, (ast.With, ast.AsyncWith)) else [])
+            names = {node.id for target in targets for node in ast.walk(target) if isinstance(node, ast.Name)}
+            if isinstance(parent, ast.ExceptHandler) and parent.name:
+                names.add(parent.name)
+            for name in names:
+                bindings.pop(name, None)
+        if isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            for generator in parent.generators:
+                for node in ast.walk(generator.target):
+                    if isinstance(node, ast.Name):
+                        bindings.pop(node.id, None)
+        if isinstance(parent, (ast.If, ast.While, ast.For, ast.AsyncFor, ast.With, ast.AsyncWith)):
+            # Calls in a control-flow header may mutate the incoming data.
+            headers = [parent.test] if isinstance(parent, (ast.If, ast.While)) else (
+                [parent.iter] if isinstance(parent, (ast.For, ast.AsyncFor)) else
+                [item.context_expr for item in parent.items])
+            invalidate({name.id for header in headers for node in ast.walk(header)
+                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)})
+        for _, children in ast.iter_fields(parent):
+            if isinstance(children, list) and child in children and isinstance(child, ast.stmt):
+                for previous in children[:children.index(child)]:
+                    if isinstance(previous, ast.stmt):
+                        preceding(previous)
+    return bindings
+
+
+def python_dependencies(root: Path) -> list[tuple[str, bool]]:
+    """Read declared literal requirements; never execute setup.py or imports."""
+    result = []
+
+    def requirements(values: object) -> None:
+        if isinstance(values, (list, tuple)):
+            for value in values:
+                result.extend((constraint, False) for constraint in python_requirement(value))
+
+    def package_table(table: object, poetry: bool = False) -> None:
+        if not isinstance(table, dict):
+            return
+        for name, value in table.items():
+            if name.lower() == "telnyx":
+                if isinstance(value, dict):
+                    value = value.get("version", "")
+                if isinstance(value, str):
+                    result.append((value.strip(), poetry))
+
+    # pip joins physical lines before removing comments. Per-requirement options
+    # belong to pip, not to the PEP 440 version constraint (nor another package).
+    source = re.sub(r"\\\r?\n", "", read_text(root / "requirements.txt"))
+    requirements([re.split(r"\s+--(?:hash|config-settings)(?==|\s|$)",
+                          re.sub(r"(^|\s+)#.*", "", line), maxsplit=1)[0]
+                  for line in source.splitlines()])
+    pipfile = read_mapping(root / "Pipfile", toml=True)
+    for section in ("packages", "dev-packages"):
+        package_table(pipfile.get(section))
+    project = read_mapping(root / "pyproject.toml", toml=True)
+    metadata = project.get("project", {})
+    if isinstance(metadata, dict):
+        requirements(metadata.get("dependencies"))
+        optional = metadata.get("optional-dependencies", {})
+        if isinstance(optional, dict):
+            for values in optional.values():
+                requirements(values)
+    tool = project.get("tool", {})
+    poetry = tool.get("poetry", {}) if isinstance(tool, dict) else {}
+    if isinstance(poetry, dict):
+        for section in ("dependencies", "dev-dependencies"):
+            package_table(poetry.get(section), poetry=True)
+        groups = poetry.get("group", {})
+        if isinstance(groups, dict):
+            for group in groups.values():
+                if isinstance(group, dict):
+                    package_table(group.get("dependencies"), poetry=True)
+    config = configparser.ConfigParser(interpolation=None)
+    try:
+        config.read_string(read_text(root / "setup.cfg"))
+        requirements(config.get("options", "install_requires", fallback="").splitlines())
+        if config.has_section("options.extras_require"):
+            for _, values in config.items("options.extras_require"):
+                requirements(values.splitlines())
+    except configparser.Error:
+        pass
+    try:
+        tree = ast.parse(read_text(root / "setup.py"))
+        for call in ast.walk(tree):
+            if not isinstance(call, ast.Call) or not (
+                isinstance(call.func, ast.Name) and call.func.id == "setup"
+                or isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "setuptools" and call.func.attr == "setup"
+            ):
+                continue
+            for keyword in call.keywords:
+                if keyword.arg not in {"install_requires", "extras_require"}:
+                    continue
+                try:
+                    value = setup_literal(keyword.value, setup_bindings(tree, call))
+                except (KeyError, ValueError, TypeError, SyntaxError):
+                    continue
+                if keyword.arg == "extras_require" and isinstance(value, dict):
+                    for values in value.values():
+                        requirements(values)
+                elif keyword.arg == "install_requires":
+                    requirements(value)
+    except (ValueError, SyntaxError):
+        pass
+    return result
+
+
+def python_version_is_constrained(value: str, poetry: bool = False) -> bool:
+    """Bounded PEP 440 specifiers, with Poetry's table-only caret/tilde syntax."""
+    numeric = r"(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*"
+    release = (r"v?" + numeric
+               + r"(?:[-_.]?(?:a|b|c|rc|alpha|beta|pre|preview)[-_.]?[0-9]*)?"
+               + r"(?:-[0-9]+|[-_.]?(?:post|rev|r)[-_.]?[0-9]*)?"
+               + r"(?:[-_.]?dev[-_.]?[0-9]*)?")
+    local = r"(?:\+[a-z0-9]+(?:[-_.][a-z0-9]+)*)?"
+    for token in value.split(","):
+        match = re.fullmatch(r"(===|==|~=|>=|<=|!=|>|<|\^|~)?\s*(\S+)", token.strip())
+        if not match:
+            return False
+        operator, version = match.groups()
+        if operator == "===":
+            continue  # PEP 440 explicitly permits arbitrary equality strings.
+        if operator in {None, "^", "~"} and not poetry:
+            return False
+        if re.fullmatch(numeric + r"\.\*", version):
+            if operator not in ({None, "==", "!="} if poetry else {"==", "!="}):
+                return False
+            continue
+        if not re.fullmatch(release + local, version, re.IGNORECASE):
+            return False
+        if "+" in version and operator not in {None, "==", "!="}:
+            return False
+        if operator == "~=" and not re.match(r"v?(?:[0-9]+!)?[0-9]+\.[0-9]+", version):
+            return False
+    return True
+
+
+@lru_cache(maxsize=1)
+def source_ownership():
+    spec = importlib.util.spec_from_file_location(
+        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+    ownership = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ownership)
+    return ownership
+
+
+def ruby_dependencies(root: Path) -> list[str]:
+    """Literal gem calls, bounded by arguments rather than whole source lines."""
+    source = read_text(root / "Gemfile")
+    if not source:
+        return []
+    ownership = source_ownership()
+    lexed = ownership.lexed_source(source, ".rb")
+    strings = {token.start: token for token in lexed.strings}
+    result = []
+
+    def literal(token) -> bool:
+        raw = source[token.start:token.end]
+        return (raw.startswith(("'", '"', "%q", "%Q"))
+                and "#{" not in token.contents and "\\" not in token.contents)
+
+    def skip_space(cursor: int) -> int:
+        # The shared lexer masks percent strings even in without_comments.
+        # Stop at their token boundary rather than eating the literal as space.
+        while cursor < len(source) and cursor not in strings and lexed.without_comments[cursor].isspace():
+            cursor += 1
+        return cursor
+
+    for call in re.finditer(r"(?<![\w.:])gem\b", lexed.code):
+        cursor = skip_space(call.end())
+        if source[cursor:cursor + 1] == "(":
+            cursor = skip_space(cursor + 1)
+        token = strings.get(cursor)
+        if token is None or not literal(token) or token.contents != "telnyx":
+            continue
+        if not re.match(r"[ \t]*(?=[,;\n)]|(?:if|unless)\b|$)", lexed.without_comments[token.end:]):
+            continue  # The package name is an expression, not this literal.
+        cursor, constraints = token.end, []
+        while True:
+            comma = re.match(r"[ \t]*(?:\r?\n[ \t]*)?,", lexed.without_comments[cursor:])
+            if comma is None:
+                break
+            token = strings.get(skip_space(cursor + comma.end()))
+            if token is None or not literal(token):
+                break
+            if not re.match(r"[ \t]*(?=[,;\n)]|(?:if|unless)\b|$)", lexed.without_comments[token.end:]):
+                break
+            constraints.append(token.contents)
+            cursor = token.end
+        result.append(",".join(constraints))
+    return result
+
+
+def ruby_version_is_constrained(value: str) -> bool:
+    return bool(value and all(re.fullmatch(
+        r"(?:~>|>=|<=|!=|>|<|=)?\s*\d+(?:\.[0-9A-Za-z]+)*(?:-[0-9A-Za-z.-]+)?",
+        token.strip()) for token in value.split(",")))
+
+
+def go_dependencies(root: Path) -> list[str]:
+    source = read_text(root / "go.mod")
+    result, block = [], False
+    for line in source.splitlines():
+        line = line.split("//", 1)[0].strip()
+        if re.fullmatch(r"require\s*\(", line):
+            block = True
+            continue
+        if line == ")":
+            block = False
+            continue
+        if not block:
+            match = re.match(r"require\s+(.+)", line)
+            if not match:
+                continue
+            line = match[1]
+        dependency = re.fullmatch(
+            r'"?github\.com/team-telnyx/telnyx-go(?:/v[0-9]+)?"?\s+"?(v[^"\s]+)"?', line)
+        if dependency:
+            result.append(dependency[1])
+    return result
+
+
+def other_declared(root: Path) -> bool:
+    # Match the validator's existing root + two directory levels for these
+    # manifests. Version checking remains root-scoped, as before.
+    for directory, dirs, _ in os.walk(root):
+        path = Path(directory)
+        dirs[:] = [name for name in dirs if name not in {
+            ".git", "node_modules", "vendor", ".venv", "build"}
+            and len(path.relative_to(root).parts) < 2]
+        if python_dependencies(path) or node_dependencies(path) or ruby_dependencies(path):
+            return True
+    return bool(go_dependencies(root))
+
+
+def other_pinned(root: Path) -> bool:
+    return (any(python_version_is_constrained(value, poetry) for value, poetry in python_dependencies(root))
+            or any(name == "telnyx" and node_version_is_constrained(value)
+                   for name, value in node_dependencies(root))
+            or any(ruby_version_is_constrained(value) for value in ruby_dependencies(root))
+            or any(re.fullmatch(r"v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?", value)
+                   for value in go_dependencies(root)))
+
+
+def composer_constraints(root: Path, package: str = "telnyx/telnyx-php") -> list[str]:
+    """Read only real dependency links, shared by presence and version checks."""
     try:
         data = json.loads((root / "composer.json").read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return False
-    return isinstance(data, dict) and any(
-        isinstance(data.get(section), dict)
+        return []
+    if not isinstance(data, dict):
+        return []
+    return [
+        data[section][package].strip()
+        for section in ("require", "require-dev")
+        if isinstance(data.get(section), dict)
         and isinstance(data[section].get(package), str)
         and bool(data[section][package].strip())
-        for section in ("require", "require-dev")
-    )
+    ]
+
+
+def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    return bool(composer_constraints(root, package))
+
+
+def composer_version_is_constrained(value: object) -> bool:
+    """Recognize common Composer constraints, not resolve or solve them.
+
+    Exact releases, numeric ranges/wildcards, and explicit dev branches supply
+    version evidence. Bare wildcards and stability-only flags do not. Every OR
+    alternative must constrain a version; an AND may contain a neutral wildcard.
+    Unsupported syntax (including inline aliases) conservatively stays a warning.
+    A constraint is not a lockfile or a guarantee against breaking upgrades.
+    See https://getcomposer.org/doc/articles/versions.md and the schema's links.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return False
+    release = (r"v?[0-9]+(?:\.[0-9]+){0,3}"
+               r"(?:[._-]?(?:stable|alpha|a|beta|b|RC|patch|pl|p)"
+               r"(?:[.-]?[0-9]+(?:[.-][0-9]+)*)?)?(?:[.-]?dev)?"
+               r"(?:\+[A-Za-z0-9.-]+)?")
+    wildcard = r"v?[0-9]+(?:\.[0-9]+){0,2}(?:\.[x*]){1,3}"
+    stability = r"@(dev|stable|alpha|beta|RC)$"
+
+    def atom(token: str) -> bool | None:
+        if not token:
+            return None
+        token = re.sub(stability, "", token, flags=re.IGNORECASE)
+        if not token or re.fullmatch(r"[x*](?:\.[x*])*", token, re.IGNORECASE):
+            return False
+        if re.fullmatch(r"(?:dev-[A-Za-z0-9_][A-Za-z0-9_./-]*|"
+                        + wildcard + r"-dev)(?:#[A-Za-z0-9]+)?",
+                        token, re.IGNORECASE):
+            return True
+        if re.fullmatch(r"(?:\^|~|>=|<=|!=|<>|==|=|>|<)?" + release,
+                        token, re.IGNORECASE):
+            return True
+        if re.fullmatch(wildcard, token, re.IGNORECASE):
+            return True
+        return None
+
+    for alternative in re.split(r"\|\|?", value.strip()):
+        alternative = alternative.strip()
+        if re.fullmatch(release + r"\s+-\s+" + release,
+                        alternative, re.IGNORECASE):
+            continue
+        # Whitespace after an operator belongs to that atom, not to an AND.
+        alternative = re.sub(r"([~^<>=!]+)\s+", r"\1", alternative)
+        atoms = [atom(token) for token in re.split(r"\s*,\s*|\s+", alternative)]
+        if None in atoms or not any(atoms):
+            return False
+    return True
+
+
+def composer_pinned(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    return any(composer_version_is_constrained(value)
+               for value in composer_constraints(root, package))
 
 
 def maven_dependencies(path: Path) -> list[tuple[str, str, str]]:
@@ -125,10 +756,7 @@ def groovy_slashy_ranges(source: str, code: str) -> list[tuple[int, int]]:
 
 
 def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tuple[str, str, object]]:
-    spec = importlib.util.spec_from_file_location(
-        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
-    ownership = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(ownership)
+    ownership = source_ownership()
     analyzer = ownership.load_script("lint-required-messaging-profile")
     dependencies = []
     accessors = set()
@@ -241,7 +869,12 @@ def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tu
             version = entry.get("version")
             if isinstance(version, dict):
                 reference = version.get("ref")
-                version = versions.get(reference) if isinstance(reference, str) else None
+                if isinstance(reference, str):
+                    version = versions.get(reference)
+                if isinstance(version, dict):
+                    # Rich catalog versions are still attached to the consumed
+                    # library. Preferences alone are not a hard requirement.
+                    version = version.get("strictly", version.get("require"))
         else:
             continue
         dependencies.append((group, artifact, version))
@@ -272,12 +905,18 @@ def jvm_declared(root: Path, vendor: str) -> bool:
 
 
 def main() -> int:
-    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "jvm-pinned", "jvm-declared", "twilio-jvm-declared"}:
+    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "composer-pinned", "jvm-pinned", "jvm-declared", "twilio-jvm-declared", "other-declared", "other-pinned"}:
         return 2
     root = Path(sys.argv[2])
     mode = sys.argv[1]
-    if mode == "composer":
+    if mode == "other-declared":
+        found = other_declared(root)
+    elif mode == "other-pinned":
+        found = other_pinned(root)
+    elif mode == "composer":
         found = composer_declared(root)
+    elif mode == "composer-pinned":
+        found = composer_pinned(root)
     elif mode.endswith("declared"):
         found = jvm_declared(root, "twilio" if mode.startswith("twilio") else "telnyx")
     else:

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -14552,6 +14552,7 @@ def csharp_twilio_message_calls(
 def csharp_twilio_resource_calls(
     lexed: LexedSource, target: str, methods: tuple[str, ...],
     source: SourceEndpointResolver | None = None,
+    global_using_code: str = "",
 ) -> list[Call]:
     """Resolve the SDK resource's C# using/alias forms before checking its body.
 
@@ -14567,27 +14568,54 @@ def csharp_twilio_resource_calls(
         return max((span for span in namespaces if span[0] < offset < span[1]),
                    key=lambda span: span[0], default=None)
 
-    imports = []
-    for match in re.finditer(
+    using_pattern = re.compile(
         r"\b(?:global\s+)?using\s+(?:(?P<static>static)\s+)?"
         r"(?:(?P<alias>\w+)\s*=\s*)?(?:global\s*::\s*)?"
-        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;", code
-    ):
+        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;"
+    )
+    global_imports = [(match, re.sub(r"\s+", "", match.group("target")))
+                      for match in using_pattern.finditer(global_using_code)]
+    imports = []
+    for match in using_pattern.finditer(code):
         imports.append((match, re.sub(r"\s+", "", match.group("target")),
                         namespace_at(match.start())))
     candidates = calls_matching(lexed, re.compile(
         r"(?<![\w$.])(?:global\s*::\s*)?(?:\w+\s*\.\s*)*(?:"
         + "|".join(re.escape(method) for method in methods) + r")\s*\("
     ))
+    # Unqualified static imports lose to local methods/delegates. Keep method
+    # declarations out of call evidence and retain their enclosing scope.
+    local_methods = []
+    for candidate in candidates:
+        if not re.fullmatch(r"\w+", code[candidate.start:candidate.open_paren].strip()):
+            continue
+        closing = matching_delimiter(code, candidate.open_paren, "(", ")")
+        if closing is None:
+            continue
+        tail = code[closing + 1:]
+        prefix = code[max(0, candidate.start - 100):candidate.start]
+        if (re.match(r"\s*(?:\{|=>)", tail)
+                and re.search(r"\b[\w<>?\[\].]+\s+$", prefix)
+                and not re.search(r"\bnew\s+$", prefix)):
+            local_methods.append(candidate)
     result = []
     for call in candidates:
         head = re.sub(r"\s+", "", code[call.start:call.open_paren])
         receiver = head.rsplit(".", 1)[0] if "." in head else ""
+        if not receiver:
+            if re.search(r"\bnew\s+$", code[max(0, call.start - 100):call.start]):
+                continue
+            if any(code[item.start:item.open_paren].strip() == head
+                   and scope_contains(code, item.start, call.start)
+                   for item in local_methods):
+                continue
+            if source.graph.visible_binding(head, source.scope_at(call.start), call.start) is not None:
+                continue
         if receiver.startswith("global::"):
             if receiver.removeprefix("global::") == target:
                 result.append(call)
             continue
-        visible = [(match, name) for match, name, scope in imports
+        visible = global_imports + [(match, name) for match, name, scope in imports
                    if scope is None or scope[0] < call.start < scope[1]]
         aliases = {match.group("alias"): name for match, name in visible
                    if match.group("alias")}

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1520,33 +1520,6 @@ _HEREDOC_OPENER_RE = re.compile(
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
-_SHELL_HEREDOC_REDIRECTION_RE = re.compile(
-    r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
-    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"\\])*\"|"
-    r"(?:\\.|[^\\ \t\r\n;<>&|])+)",
-)
-
-
-def _shell_heredoc_redirection_tail(tail: str) -> bool:
-    """Accept only shell redirections after a heredoc delimiter.
-
-    A delimiter need not end the physical command: `cat <<EOF >out 2>&1` is
-    valid shell.  The lexer must mask that body, while still rejecting an
-    arbitrary expression containing `<< WORD`.  Consuming a sequence of
-    concrete redirections keeps that boundary explicit.
-    """
-
-    position = 0
-    while position < len(tail):
-        if tail[position:].strip() == "":
-            return True
-        if tail[position:].lstrip().startswith("#"):
-            return True
-        match = _SHELL_HEREDOC_REDIRECTION_RE.match(tail, position)
-        if match is None or match.end() == position:
-            return False
-        position = match.end()
-    return True
 
 
 def _heredoc_opener_at(
@@ -1561,15 +1534,19 @@ def _heredoc_opener_at(
     match = _HEREDOC_OPENER_RE.match(source, index)
     if match is None:
         return None
+    # In shell, three opening angle brackets introduce an inline here-string,
+    # not a multiline heredoc body. Treating `<<<WORD` as an opener can mask
+    # every request below it when no line contains the pseudo terminator.
+    if suffix == ".sh" and (
+        source.startswith("<<<", index)
+        or (index > 0 and source[index - 1] == "<")
+    ):
+        return None
     line_start = source.rfind("\n", 0, index) + 1
     line_end = source.find("\n", match.end())
     if line_end < 0:
         line_end = len(source)
-    tail = source[match.end():line_end]
-    if suffix == ".sh":
-        if not _shell_heredoc_redirection_tail(tail):
-            return None
-    elif tail.strip():
+    if suffix != ".sh" and source[match.end():line_end].strip():
         return None
     if suffix == ".rb":
         if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
@@ -1578,7 +1555,139 @@ def _heredoc_opener_at(
 
 
 def _heredoc_langs(suffix: str) -> bool:
-    return suffix in {".sh", ".php", ".rb"}
+    return suffix in {".php", ".rb"}
+
+
+def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
+    """Return shell heredoc body ranges in one command-aware linear pass.
+
+    The scan follows quotes, arithmetic contexts and backslash continuations,
+    collects every delimiter in one logical command, then consumes their
+    bodies in declaration order. It intentionally does not parse shell
+    expressions beyond the boundaries needed to distinguish heredocs from
+    arithmetic shifts and here-strings.
+    """
+
+    ranges: list[tuple[int, int]] = []
+    pending: list[tuple[str, bool]] = []
+    quote = ""
+    escaped = False
+    parenthesis_depth = 0
+    bracket_depth = 0
+    comment_start: int | None = None
+    command_start = 0
+    index = 0
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif quote == '"' and character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if parenthesis_depth:
+            if character == "(":
+                parenthesis_depth += 1
+            elif character == ")":
+                parenthesis_depth -= 1
+            index += 1
+            continue
+        if bracket_depth:
+            if character == "[":
+                bracket_depth += 1
+            elif character == "]":
+                bracket_depth -= 1
+            index += 1
+            continue
+        if source.startswith("$((", index):
+            parenthesis_depth = 2
+            index += 3
+            continue
+        if source.startswith("((", index):
+            parenthesis_depth = 2
+            index += 2
+            continue
+        if source.startswith("$[", index):
+            bracket_depth = 1
+            index += 2
+            continue
+        if character == "\\":
+            if index + 1 < len(source) and source[index + 1] == "\n":
+                index += 2
+            else:
+                index += 2
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            index += 1
+            continue
+        if character == "#" and (
+            index == command_start or source[index - 1].isspace()
+        ):
+            comment_start = index
+            newline = source.find("\n", index + 1)
+            index = len(source) if newline < 0 else newline
+            continue
+        if source.startswith("<<<", index):
+            index += 3
+            continue
+        opener = _HEREDOC_OPENER_RE.match(source, index)
+        if opener is not None and (
+            index == 0 or source[index - 1] != "<"
+        ):
+            pending.append((opener.group("tag"), "<<-" in opener.group(0)))
+            index = opener.end()
+            continue
+        if character != "\n":
+            index += 1
+            continue
+
+        command_end = index if comment_start is None else comment_start
+        command = source[command_start:command_end].rstrip()
+        comment_start = None
+        if command.endswith(("|", "&&")):
+            index += 1
+            continue
+        if not pending:
+            index += 1
+            command_start = index
+            continue
+
+        body_start = index + 1
+        for tag, strips_tabs in pending:
+            cursor = body_start
+            terminator_start: int | None = None
+            terminator_end: int | None = None
+            while cursor <= len(source):
+                line_end = source.find("\n", cursor)
+                line_end = len(source) if line_end < 0 else line_end
+                line = source[cursor:line_end].removesuffix("\r")
+                delimiter = line.lstrip("\t") if strips_tabs else line
+                if delimiter == tag:
+                    terminator_start = cursor
+                    terminator_end = line_end
+                    break
+                if line_end == len(source):
+                    break
+                cursor = line_end + 1
+            body_end = len(source) if terminator_start is None else terminator_start
+            if body_start < body_end:
+                ranges.append((body_start, body_end))
+            if terminator_end is None:
+                body_start = len(source)
+                break
+            body_start = (
+                len(source)
+                if terminator_end == len(source)
+                else terminator_end + 1
+            )
+        pending.clear()
+        index = body_start
+        command_start = index
+    return ranges
 
 
 _JS_REGEX_PREFIX_WORDS = {
@@ -1762,10 +1871,29 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     c_line_comments = suffix in JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
     c_block_comments = c_line_comments
     hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
+    shell_heredoc_ranges = _shell_heredoc_ranges(source) if suffix == ".sh" else []
+    shell_heredoc_index = 0
     index = 0
     last_js_opaque_end = 0
 
     while index < len(source):
+        while (
+            shell_heredoc_index < len(shell_heredoc_ranges)
+            and shell_heredoc_ranges[shell_heredoc_index][1] <= index
+        ):
+            shell_heredoc_index += 1
+        if shell_heredoc_index < len(shell_heredoc_ranges):
+            body_start, body_end = shell_heredoc_ranges[shell_heredoc_index]
+            if body_start <= index < body_end:
+                _blank(code, body_start, body_end)
+                strings.append(
+                    StringToken(
+                        body_start, body_end, source[body_start:body_end]
+                    )
+                )
+                index = body_end
+                shell_heredoc_index += 1
+                continue
         if (
             suffix in JS_TS_SUFFIXES
             and source[index] == "/"
@@ -1879,21 +2007,35 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         # and masked the send that followed.
         heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
         if heredoc is not None:
-            tag = heredoc.group("tag")
             body_start = source.find("\n", heredoc.end())
             if body_start < 0:
                 index = heredoc.end()
                 continue
             body_start += 1
-            terminator = re.compile(rf"^[ \t]*{re.escape(tag)}\b", re.M).search(
-                source, body_start
-            )
-            body_end = len(source) if terminator is None else terminator.start()
-            _blank(code, body_start, body_end)
-            strings.append(
-                StringToken(body_start, body_end, source[body_start:body_end])
-            )
-            index = body_end
+            openers = [heredoc]
+            for opener in openers:
+                tag = opener.group("tag")
+                terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
+                terminator = re.compile(terminator_pattern, re.M).search(
+                    source, body_start
+                )
+                body_end = (
+                    len(source) if terminator is None else terminator.start()
+                )
+                _blank(code, body_start, body_end)
+                strings.append(
+                    StringToken(
+                        body_start, body_end, source[body_start:body_end]
+                    )
+                )
+                if terminator is None:
+                    body_start = len(source)
+                    break
+                terminator_end = source.find("\n", terminator.end())
+                body_start = (
+                    len(source) if terminator_end < 0 else terminator_end + 1
+                )
+            index = body_start
             continue
 
         quote = source[index]
@@ -4220,22 +4362,41 @@ def request_object_is_executed(
     tail = lexed.code[call.end:]
     ruby_spans = _ruby_function_spans(lexed.code) if suffix == ".rb" else []
     for name in names:
-        execution = re.search(pattern.format(name=re.escape(name)), tail)
-        if execution is None:
-            continue
-        execution_offset = call.end + execution.start()
-        if suffix == ".rb" and not _same_ruby_function_scope(
-            lexed.code, call.start, execution_offset, ruby_spans
-        ):
-            continue
-        # A new reaching definition supersedes this request object. A later
-        # execution of the same variable must not retroactively execute the
-        # discarded constructor.
-        rebound = re.search(
-            rf"(?<![\w@$]){re.escape(name)}\s*=(?!=)", tail[:execution.start()]
+        execution_pattern = pattern.format(name=re.escape(name))
+        # Ruby member assignments such as `self.req = ...` do not rebind the
+        # local `req`. Include member/namespace separators in the boundary so
+        # a suffix match cannot discard the local request object.
+        binding_boundary = (
+            r"(?<![\w@$.])(?<!::)" if suffix == ".rb" else r"(?<![\w@$])"
         )
-        if rebound is None:
-            return True
+        rebound_pattern = re.compile(
+            rf"{binding_boundary}{re.escape(name)}\s*=(?!=)"
+        )
+        for execution in re.finditer(execution_pattern, tail):
+            execution_offset = call.end + execution.start()
+            # Ruby locals belong to one method/top-level scope. Instance,
+            # class and global variables retain their identity across methods.
+            local_ruby_binding = suffix == ".rb" and not name.startswith(
+                ("@", "$")
+            )
+            if local_ruby_binding and not _same_ruby_function_scope(
+                lexed.code, call.start, execution_offset, ruby_spans
+            ):
+                continue
+            # A new reaching definition supersedes this request object. Check
+            # every exact-binding assignment before THIS execution; for Ruby
+            # locals, assignments in unrelated methods do not rebind it.
+            rebound = False
+            for candidate in rebound_pattern.finditer(tail, 0, execution.start()):
+                candidate_offset = call.end + candidate.start()
+                if local_ruby_binding and not _same_ruby_function_scope(
+                    lexed.code, call.start, candidate_offset, ruby_spans
+                ):
+                    continue
+                rebound = True
+                break
+            if not rebound:
+                return True
     return False
 
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -2644,8 +2644,14 @@ def finding_row(path: Path, line: int, detail: str) -> str:
     # The analyzer-to-shell protocol is LF-delimited. POSIX permits CR and LF
     # in filenames, so emitting a raw path can turn one finding into several
     # records and inflate both counts and details.files. Escape only the record
-    # delimiters; keep the rest of the path byte-for-byte displayable.
-    display_path = str(path).replace("\r", "\\r").replace("\n", "\\n")
+    # delimiters. Escape backslashes first so a literal `\n` path segment and
+    # an actual newline cannot collapse to the same display identity.
+    display_path = (
+        str(path)
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
     return f"{display_path}:{line}:{detail}"
 
 
@@ -11365,12 +11371,53 @@ def external_static_values(
     return resolved
 
 
-def external_reference_names(source: str, suffix: str) -> set[str]:
+def _matches_js_alias_key(module: str, key: str) -> bool:
+    pattern = re.escape(key).replace(r"\*", ".*")
+    return re.fullmatch(pattern, module) is not None
+
+
+def _js_module_has_local_provenance(module: str, project_root: Path) -> bool:
+    """Return whether a JS module spelling denotes project-controlled code."""
+
+    if module.startswith((".", "@/", "~/", "#")):
+        return True
+    for filename in ("tsconfig.json", "jsconfig.json"):
+        try:
+            config = json.loads((project_root / filename).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(config, dict):
+            continue
+        compiler_options = config.get("compilerOptions", {})
+        if not isinstance(compiler_options, dict):
+            continue
+        paths = compiler_options.get("paths", {})
+        if isinstance(paths, dict) and any(
+            isinstance(key, str) and _matches_js_alias_key(module, key)
+            for key in paths
+        ):
+            return True
+    try:
+        package = json.loads((project_root / "package.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        package = {}
+    imports = package.get("imports", {}) if isinstance(package, dict) else {}
+    return isinstance(imports, dict) and any(
+        isinstance(key, str) and _matches_js_alias_key(module, key)
+        for key in imports
+    )
+
+
+def external_reference_names(
+    source: str, suffix: str, project_root: Path
+) -> set[str]:
     """Return local names whose values originate outside the current file.
 
-    Exact static exports are resolved separately. This index covers the wider
-    language-level import boundary so an unresolved mutating request fails
-    closed instead of silently passing. Sentinels are intentionally narrow:
+    Exact relative static exports are resolved separately. This index covers
+    the wider language-level import boundary—including configured aliases
+    such as ``@/``, ``~/``, tsconfig paths, and package
+    ``imports``—so an unresolved mutating request fails closed instead of
+    silently passing. Sentinels are intentionally narrow:
     uppercase constants after require/include, qualified package/class members,
     and shell variables only when a source command is present.
     """
@@ -11383,16 +11430,23 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
             for match in re.finditer(
                 r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
                 r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
-                r"from\s*(['\"])\.[^'\"]*\2",
+                r"from\s*(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         for match in re.finditer(
             r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
             r"\{(?P<members>[^{}]*)\}\s*from\s*"
-            r"(['\"])\.[^'\"]*\2",
+            r"(['\"])(?P<module>[^'\"]+)\2",
             visible,
         ):
+            if not _js_module_has_local_provenance(
+                match.group("module"), project_root
+            ):
+                continue
             for member in match.group("members").split(","):
                 parsed = re.fullmatch(
                     r"\s*([A-Za-z_$]\w*)(?:\s+as\s+([A-Za-z_$]\w*))?\s*",
@@ -11405,23 +11459,33 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
             for match in re.finditer(
                 r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
                 r"\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
-                r"(['\"])\.[^'\"]*\2",
+                r"(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         names.update(
             match.group(1)
             for match in re.finditer(
                 r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
-                r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+                r"require\s*\(\s*(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         for match in re.finditer(
             r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
-            r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+            r"require\s*\(\s*(['\"])(?P<module>[^'\"]+)\2",
             visible,
         ):
+            if not _js_module_has_local_provenance(
+                match.group("module"), project_root
+            ):
+                continue
             for member in match.group("members").split(","):
                 parsed = re.fullmatch(
                     r"\s*([A-Za-z_$]\w*)(?:\s*:\s*([A-Za-z_$]\w*))?\s*",
@@ -11499,7 +11563,7 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
         lexed,
         suffix,
         external_static_values(path, project_root, source, suffix),
-        external_reference_names(source, suffix),
+        external_reference_names(source, suffix, project_root),
     )
     profile_resolver = PayloadStateResolver(
         lexed,

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1,0 +1,10277 @@
+#!/usr/bin/env python3
+"""Find required-profile messaging calls whose own payload omits the profile.
+
+This is intentionally a small lexer, not a language parser. It preserves byte
+offsets while masking comments and string literals, which is enough to match
+call/assignment boundaries without confusing URLs, comment markers, or
+semicolons inside strings for source syntax. Payload variables are resolved to
+their nearest real assignment in the same file.
+"""
+
+from __future__ import annotations
+
+import bisect
+import json
+import os
+import posixpath
+import re
+import shlex
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, TypeAlias
+from urllib.parse import urljoin, urlsplit
+
+
+# Node module-system extensions (.cjs/.mjs) and the TypeScript equivalents
+# (.cts/.mts) are the same language as .js/.ts. SKILL.md documents a CommonJS
+# flow, and scan-twilio-deep.py already treats them as JavaScript, so omitting
+# them here made the two tools disagree about what counts as source.
+JS_TS_SUFFIXES = {
+    ".cjs",
+    ".cts",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".mts",
+    ".ts",
+    ".tsx",
+}
+TYPESCRIPT_SUFFIXES = {".ts", ".tsx", ".mts", ".cts"}
+# Keys a request-style config object may carry its URL under. Shared so the
+# named-argument path and the config-object path cannot recognise different
+# spellings, which is how `uri` came to work as a named argument but not as
+# an object member.
+URL_MEMBER_NAMES = ("url", "uri", "requestUri", "request_uri")
+# Extensions that are aliases of a language this linter already analyses, not
+# new languages. A `.bash` file is a shell script and a `.phtml` file is PHP,
+# but every downstream check compares against the canonical suffix, so an
+# alias was read as an unknown language and silently produced no findings.
+# Normalising in one place beats widening each comparison: there are dozens.
+SUFFIX_LANGUAGE_ALIASES = {
+    ".bash": ".sh",
+    ".ksh": ".sh",
+    ".zsh": ".sh",
+    ".phtml": ".php",
+    ".pyw": ".py",
+    ".rake": ".rb",
+    ".cshtml": ".cs",
+    ".scala": ".java",
+    # Kotlin shares Java's grammar for everything this linter models - the
+    # OkHttp/java.net.http builder chains, the braced control-flow arms, the
+    # execution links. Three branches already name `.kt`/`.kts` explicitly, but
+    # the discovery layer never yielded such a file, so a Kotlin migration was
+    # scanned as zero files and passed silently no matter what it contained.
+    ".kt": ".java",
+    ".kts": ".java",
+    # Single-file components and server templates embed the SAME JS/Ruby a
+    # sibling .js/.rb file would hold, but the allow-list excluded the whole
+    # file type, so a number-pool send inside a Vue/Svelte/Astro component or
+    # an ERB view was never opened at all. The lexer already stops a single
+    # quote at end of line for JS, so surrounding markup prose does not mask
+    # the script blocks.
+    ".vue": ".js",
+    ".svelte": ".js",
+    ".astro": ".js",
+    ".erb": ".rb",
+}
+INCLUDED_SUFFIXES = {
+    ".cs",
+    ".go",
+    ".java",
+    ".php",
+    ".py",
+    ".rb",
+    ".sh",
+} | JS_TS_SUFFIXES | set(SUFFIX_LANGUAGE_ALIASES)
+
+
+# package.json "bin" entry points and repo CLIs are extensionless; the
+# shebang is their file identity. The Phase-1 scanner greps without include
+# filters and reports them, so refusing to open them here let the pipeline
+# contradict itself on the same tree.
+SHEBANG_LANGUAGE_SUFFIXES = (
+    ("node", ".js"),
+    ("python", ".py"),
+    ("ruby", ".rb"),
+    ("bash", ".sh"),
+    ("zsh", ".sh"),
+    ("ksh", ".sh"),
+    ("sh", ".sh"),
+)
+
+
+def shebang_suffix(path: Path) -> str | None:
+    """Return the canonical suffix an extensionless executable maps to."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            first_line = handle.readline(200)
+    except OSError:
+        return None
+    if not first_line.startswith("#!"):
+        return None
+    for token, suffix in SHEBANG_LANGUAGE_SUFFIXES:
+        if token in first_line:
+            return suffix
+    return None
+
+
+def canonical_suffix(path: Path) -> str:
+    """Return the language suffix a file should be analysed as."""
+    suffix = path.suffix.lower()
+    if not suffix:
+        return shebang_suffix(path) or ""
+    return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
+# Kept in step with the EXCLUDE_DIRS list in scan-twilio-usage.sh. Generated
+# output belongs here as much as node_modules: a stale compiled bundle under
+# .next carrying a pre-fix number-pool send would fail Phase 4 after the
+# source had already been corrected, and the scanner that produced the plan
+# never looked at it.
+EXCLUDED_DIRS = {
+    ".git",
+    ".next",
+    ".nuxt",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "vendor",
+    "venv",
+}
+EXCLUDED_FILES = {
+    "Gemfile.lock",
+    "Pipfile.lock",
+    "migration-state.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "twilio-deep-scan.json",
+    "twilio-scan.json",
+    "yarn.lock",
+}
+
+PROFILE_NAMES = (
+    "messaging_profile_id",
+    "messagingProfileId",
+    "messagingProfileID",
+    "MessagingProfileId",
+    "MessagingProfileID",
+)
+PROFILE_NAME_PATTERN = "|".join(map(re.escape, PROFILE_NAMES))
+PROFILE_IDENTIFIER_RE = re.compile(
+    rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
+)
+PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
+SDK_CALL_RE = re.compile(
+    r"(?:\?\.|\.|->)\s*(?:"
+    r"sendNumberPool|send_number_pool|SendNumberPool|"
+    r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
+    r"SendWithAlphanumericSender"
+    r")\s*(?:\?\.)?\s*\("
+)
+FETCH_CALL_RE = re.compile(
+    r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
+    # curl_init($url) is the documented one-liner that sets CURLOPT_URL
+    # directly. Listing only the setopt spellings made that whole shape
+    # invisible: no endpoint resolved, so the send was never counted and the
+    # fail-safe could not fire - the linter reported "no number-pool call sites
+    # detected" on a number-pool POST.
+    # Net::HTTP::Post.new(uri) is the ONLY Net::HTTP form that can set request
+    # headers (an Authorization header, for instance), so it is what real
+    # migrated Ruby uses. Modelling only Net::HTTP.post made the whole shape
+    # invisible: zero sends detected, so the fail-safe could not fire either.
+    r"Net::HTTP::(?:Post|Put|Patch)\s*\.\s*new|"
+    r"NewRequest|curl_setopt_array|curl_setopt|curl_init|"
+    r"HttpRequestMessage|RestRequest|Request|open|file_get_contents|"
+    r"axios\s*\.\s*post|axios)\s*\("
+)
+TWILIO_MESSAGE_CREATE_RE = re.compile(
+    r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
+    r"create\s*(?:\?\.)?\s*\("
+)
+MESSAGE_BODY_CALL_RE = re.compile(
+    r"(?:"
+    r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
+    r"(?:create|send|send_)\s*(?:\?\.)?\s*\("
+    r"|(?:\?\.|\.|->)\s*Messages\s*(?:\?\.|\.|->)\s*"
+    r"Send\s*\("
+    r"|(?:\?\.|\.|->)\s*messages\s*\(\s*\)\s*"
+    r"(?:\?\.|\.|->)\s*send\s*\("
+    r")"
+)
+SIMPLE_VARIABLE_RE = re.compile(r"(?:\.\.\.|\*\*|[&*])?\s*(\$?[A-Za-z_]\w*)\s*$")
+STRINGIFIED_VARIABLE_RE = re.compile(
+    r"(?:JSON\s*\.\s*stringify|json\s*\.\s*dumps|json\s*\.\s*Marshal|"
+    r"json_encode|JsonSerializer\s*\.\s*Serialize|"
+    r"JsonConvert\s*\.\s*SerializeObject)\s*\(\s*"
+    r"(\$?[A-Za-z_]\w*)\s*\)"
+)
+NAMED_PAYLOAD_VARIABLE_RE = re.compile(
+    r"(?:\bbody|\bdata|\bjson|\bpayload)\s*[:=]\s*(\$?[A-Za-z_]\w*)"
+)
+SOURCE_IDENTIFIER_RE = re.compile(r"(?<![\w$.])(\$?[A-Za-z_]\w*)(?!\w)")
+SPREAD_VARIABLE_RE = re.compile(r"\.\.\.\s*(\$?[A-Za-z_]\w*)")
+# Matched against RAW source offsets, so it has to tolerate the leading
+# whitespace a member span keeps after `{ a, ...base }` is split.
+SPREAD_MEMBER_RE = re.compile(r"\s*(?:\.\.\.|\*\*)\s*")
+VARIABLE_ASSIGNMENT_RE = re.compile(
+    r"(?<![\w$.>])(\$?[A-Za-z_]\w*)(?!\w)"
+    r"(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+)
+SHELL_VARIABLE_RE = re.compile(r"^\$(?:\{([A-Za-z_]\w*)\}|([A-Za-z_]\w*))$")
+SHELL_STATIC_REFERENCE_RE = re.compile(
+    r"\$(?:\{([A-Za-z_]\w*)(?:\[([^\]]+)\])?\}|([A-Za-z_]\w*))"
+)
+SHELL_CURL_RE = re.compile(r"(?<![\w-])(curl)(?=\s|$)")
+SHELL_DATA_OPTIONS = {
+    "-d",
+    "--data",
+    "--data-ascii",
+    "--data-binary",
+    "--data-raw",
+    "--data-urlencode",
+    "--json",
+}
+SHELL_FORM_OPTIONS = {"-F", "--form", "--form-string"}
+SHELL_UPLOAD_OPTIONS = {"-T", "--upload-file"}
+SHELL_CURL_URL_OPTIONS = {"--url"}
+SHELL_CURL_SHORT_VALUE_OPTIONS = set("AbcCdDeEFHKmoPqrtTuUwXxyzY")
+SHELL_CURL_VALUE_OPTIONS = (
+    SHELL_DATA_OPTIONS
+    | SHELL_FORM_OPTIONS
+    | SHELL_UPLOAD_OPTIONS
+    | SHELL_CURL_URL_OPTIONS
+    | {
+        "-A",
+        "--cacert",
+        "--cert",
+        "--connect-timeout",
+        "-H",
+        "--header",
+        "--key",
+        "--max-time",
+        "-o",
+        "--output",
+        "--proxy",
+        "--resolve",
+        "--retry",
+        "--retry-delay",
+        "-u",
+        "--user",
+        "-w",
+        "--write-out",
+        "-X",
+        "--request",
+    }
+)
+SHELL_ASSIGNMENT_TOKEN_RE = re.compile(r"[A-Za-z_]\w*=.*")
+MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH"})
+
+
+@dataclass(frozen=True)
+class StringToken:
+    start: int
+    end: int
+    contents: str
+
+
+@dataclass(frozen=True)
+class LexedSource:
+    original: str
+    code: str
+    without_comments: str
+    strings: tuple[StringToken, ...]
+
+
+@dataclass(frozen=True)
+class Call:
+    start: int
+    open_paren: int
+    end: int
+    parenthesized: bool = True
+
+
+EndpointReference = tuple[str, ...]
+
+
+REQUIRED = "required"
+SAFE = "safe"
+UNKNOWN = "unknown"
+MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class EndpointValue:
+    kind: str
+    exact: str | None = None
+
+
+UNKNOWN_VALUE = EndpointValue(UNKNOWN)
+MISSING_VALUE = EndpointValue(MISSING)
+
+
+@dataclass(frozen=True)
+class EndpointLiteral:
+    value: str
+
+
+@dataclass(frozen=True)
+class EndpointUnknown:
+    reason: str = "unsupported"
+
+
+@dataclass(frozen=True)
+class EndpointRef:
+    binding_id: int
+    members: EndpointReference = ()
+
+
+@dataclass(frozen=True)
+class EndpointObject:
+    entries: tuple[tuple[str, "EndpointExpression"], ...]
+
+
+@dataclass(frozen=True)
+class EndpointArray:
+    items: tuple["EndpointExpression", ...]
+
+
+@dataclass(frozen=True)
+class EndpointDefault:
+    primary: "EndpointExpression"
+    fallback: "EndpointExpression"
+
+
+@dataclass(frozen=True)
+class EndpointConcat:
+    parts: tuple["EndpointExpression", ...]
+
+
+@dataclass(frozen=True)
+class EndpointProjected:
+    expression: "EndpointExpression"
+    members: EndpointReference
+
+
+EndpointExpression: TypeAlias = (
+    EndpointLiteral
+    | EndpointUnknown
+    | EndpointRef
+    | EndpointObject
+    | EndpointArray
+    | EndpointDefault
+    | EndpointConcat
+    | EndpointProjected
+)
+
+
+@dataclass(frozen=True)
+class IndexedScope:
+    id: int
+    parent: int | None
+    start: int
+    end: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class IndexedBinding:
+    id: int
+    name: str
+    scope_id: int
+    declaration_start: int
+    visibility_start: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class IndexedDefinition:
+    binding_id: int
+    member_path: EndpointReference
+    start: int
+    expression: EndpointExpression
+    scope_id: int
+    execution_scope: int
+    kind: str
+    guarded: bool = False
+
+
+@dataclass(frozen=True)
+class EndpointAccessState:
+    binding_id: int
+    path: EndpointReference
+    before: int
+    use_scope: int
+
+
+@dataclass(frozen=True)
+class EndpointExpressionState:
+    expression: EndpointExpression
+    projection: EndpointReference
+    before: int
+    use_scope: int
+
+
+EndpointState: TypeAlias = EndpointAccessState | EndpointExpressionState
+
+
+@dataclass
+class EndpointExpansion:
+    dependencies: tuple[EndpointState, ...] = ()
+    combine: Callable[[tuple[EndpointValue, ...]], EndpointValue] | None = None
+    immediate: EndpointValue | None = None
+
+
+@dataclass
+class EndpointFrame:
+    state: EndpointState
+    expansion: EndpointExpansion | None = None
+    next_dependency: int = 0
+    values: list[EndpointValue] = field(default_factory=list)
+
+
+def _blank(buffer: list[str], start: int, end: int) -> None:
+    for index in range(start, end):
+        if buffer[index] != "\n":
+            buffer[index] = " "
+
+
+# Heredoc openers: shell/ruby `<<TAG`, `<<-TAG`, `<<~TAG`, `<<'TAG'`; PHP
+# `<<<TAG` / `<<<'TAG'`. The body is data and must be masked like a string.
+# NO whitespace is permitted between `<<`/`<<<` and the tag in any of these
+# languages. Allowing it made Ruby's append operator (`audit_log << recipient`),
+# PHP's left shift (`1 << OFFSET`) and shell arithmetic (`$((1 << SHIFT))`) parse
+# as heredoc openers, and since no later line matched the pseudo-tag the "body"
+# ran to EOF and blanked every send below it - a silent pass.
+_HEREDOC_OPENER_RE = re.compile(
+    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)[ \t]*(?=\r?\n|$)"
+)
+# Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
+# singleton-class syntax `class <<self` also puts a bare word straight after
+# `<<` at end of line, so it parsed as a heredoc opening a body that never
+# closed - blanking the rest of the file and silently passing every send below
+# it. That is the same defect the end-of-line anchor was added to fix, one
+# spelling sideways, so the opener needs its LEFT context checked too.
+_NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+
+
+def _heredoc_opener_at(
+    source: str, index: int, suffix: str
+) -> "re.Match[str] | None":
+    """Match a heredoc opener at `index`, rejecting Ruby's `class <<self`.
+
+    Scoped to Ruby: `class` is not a keyword before `<<` in shell or PHP, so
+    applying the rejection there would disable heredoc masking on any opener
+    line that merely ENDS with the word `class` (`echo class <<EOT`).
+    """
+    match = _HEREDOC_OPENER_RE.match(source, index)
+    if match is None:
+        return None
+    if suffix == ".rb":
+        line_start = source.rfind("\n", 0, index) + 1
+        if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
+            return None
+    return match
+
+
+def _heredoc_langs(suffix: str) -> bool:
+    return suffix in {".sh", ".php", ".rb"}
+
+
+def lex_source(source: str, suffix: str) -> LexedSource:
+    """Mask comments and strings while preserving offsets and newlines."""
+
+    code = list(source)
+    without_comments = list(source)
+    strings: list[StringToken] = []
+    c_line_comments = suffix in JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
+    c_block_comments = c_line_comments
+    hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
+    index = 0
+
+    while index < len(source):
+        if c_block_comments and source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            end = len(source) if end < 0 else end + 2
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        if c_line_comments and source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            end = len(source) if end < 0 else end
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        if hash_comments and source[index] == "#":
+            if suffix == ".sh" and index == 0 and source.startswith("#!", index):
+                end = source.find("\n", index + 2)
+                index = len(source) if end < 0 else end
+                continue
+            end = source.find("\n", index + 1)
+            end = len(source) if end < 0 else end
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        # Ruby block comments. Without this, `=begin ... =end` prose was lexed
+        # as code, so one apostrophe in it opened a string that swallowed the
+        # sends below (the fail-safe above cannot help when the stray quote
+        # finds a LATER quote to pair with).
+        if (
+            suffix == ".rb"
+            and source.startswith("=begin", index)
+            and (index == 0 or source[index - 1] == "\n")
+        ):
+            terminator = re.search(r"^=end\b.*$", source[index:], re.M)
+            end = (
+                len(source)
+                if terminator is None
+                else index + terminator.end()
+            )
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        # Heredoc bodies are DATA, not code. They were lexed as code, so an
+        # apostrophe inside one ("Don't edit by hand") paired with a later quote
+        # and masked the send that followed.
+        heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
+        if heredoc is not None:
+            tag = heredoc.group("tag")
+            body_start = source.find("\n", heredoc.end())
+            if body_start < 0:
+                index = heredoc.end()
+                continue
+            body_start += 1
+            terminator = re.compile(rf"^[ \t]*{re.escape(tag)}\b", re.M).search(
+                source, body_start
+            )
+            body_end = len(source) if terminator is None else terminator.start()
+            _blank(code, body_start, body_end)
+            strings.append(
+                StringToken(body_start, body_end, source[body_start:body_end])
+            )
+            index = body_end
+            continue
+
+        quote = source[index]
+        if quote not in {"'", '"', "`"}:
+            index += 1
+            continue
+
+        delimiter = quote
+        if quote in {"'", '"'} and source.startswith(quote * 3, index):
+            delimiter = quote * 3
+        string_start = index
+        index += len(delimiter)
+        contents_start = index
+        # A backtick delimits a Go RAW string, which has no escape sequences, so
+        # a literal `\` inside one previously consumed the closing backtick and
+        # ran the "string" to end of file.
+        honours_escapes = not (suffix == ".go" and delimiter == "`")
+        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
+            JS_TS_SUFFIXES | {".py"}
+        )
+        terminated = False
+        while index < len(source):
+            if source.startswith(delimiter, index):
+                contents_end = index
+                index += len(delimiter)
+                terminated = True
+                break
+            if honours_escapes and source[index] == "\\":
+                index = min(len(source), index + 2)
+                continue
+            if source[index] == "\n" and line_bounded:
+                # A single/double-quoted JS/TS or Python literal cannot contain a
+                # raw newline, so hitting one means the quote never opened a
+                # string at all (an apostrophe in JSX text, prose, or a comment).
+                # Stop here rather than pairing it with some LATER quote, which
+                # masked every send in between.
+                break
+            index += 1
+        else:
+            contents_end = len(source)
+
+        if not terminated:
+            # FAIL SAFE. An unterminated quote used to blank everything to EOF,
+            # so a single apostrophe in JSX text, a heredoc body, or a Ruby
+            # =begin comment deleted every send below it and the file was
+            # reported clean. Treat the lone quote as ordinary code and resume
+            # immediately after it: the damage is one character, not the file.
+            index = string_start + 1
+            continue
+
+        _blank(code, string_start, index)
+        strings.append(
+            StringToken(string_start, index, source[contents_start:contents_end])
+        )
+
+    return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
+
+
+def matching_delimiter(code: str, opening: int, left: str, right: str) -> int | None:
+    depth = 0
+    for index in range(opening, len(code)):
+        character = code[index]
+        if character == left:
+            depth += 1
+        elif character == right:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def calls_matching(lexed: LexedSource, pattern: re.Pattern[str]) -> list[Call]:
+    calls: list[Call] = []
+    for match in pattern.finditer(lexed.code):
+        opening = lexed.code.rfind("(", match.start(), match.end())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None:
+            closing = lexed.code.find("\n", opening)
+            closing = len(lexed.code) - 1 if closing < 0 else closing
+        calls.append(Call(match.start(), opening, closing + 1))
+    return calls
+
+
+def serialized_payload_string(
+    lexed: LexedSource, token: StringToken, region_start: int
+) -> bool:
+    prefix_start = max(region_start, token.start - 120)
+    code_prefix = lexed.code[prefix_start : token.start]
+    source_prefix = lexed.without_comments[prefix_start : token.start]
+    return bool(
+        re.search(r"(?:\bbody|\bdata)\s*[:=]\s*$", code_prefix)
+        or re.search(
+            r"(?:^|\s)(?:-d|--data(?:-raw|-binary)?)\s*$", source_prefix
+        )
+    )
+
+
+def structural_depth(code: str, start: int, offset: int) -> tuple[int, int, int]:
+    round_depth = square_depth = curly_depth = 0
+    for character in code[start:offset]:
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+    return round_depth, square_depth, curly_depth
+
+
+def curly_ancestry(code: str, offset: int) -> tuple[int, ...]:
+    """Return the unmatched opening-brace positions containing offset."""
+
+    ancestry: list[int] = []
+    for index, character in enumerate(code[:offset]):
+        if character == "{":
+            ancestry.append(index)
+        elif character == "}" and ancestry:
+            ancestry.pop()
+    return tuple(ancestry)
+
+
+def scope_contains(code: str, binding: int, use: int) -> bool:
+    """Return true when binding's lexical brace path contains use."""
+
+    binding_scope = curly_ancestry(code, binding)
+    use_scope = curly_ancestry(code, use)
+    return use_scope[: len(binding_scope)] == binding_scope
+
+
+def payload_root_depth(code: str, start: int, end: int) -> tuple[int, int, int]:
+    """Return the direct-member depth for an object payload or argument list."""
+
+    round_depth = square_depth = curly_depth = 0
+    named_value = False
+    for character in code[start:end]:
+        at_argument_root = round_depth == square_depth == curly_depth == 0
+        if at_argument_root and character == ",":
+            return 0, 0, 0
+        if at_argument_root and character in {":", "="}:
+            named_value = True
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+            if not named_value:
+                return round_depth, square_depth, curly_depth
+            return 0, 0, 0
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+            if not named_value:
+                return round_depth, square_depth, curly_depth
+            return 0, 0, 0
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+    return 0, 0, 0
+
+
+def at_payload_root(
+    code: str,
+    start: int,
+    end: int,
+    offset: int,
+) -> bool:
+    return structural_depth(code, start, offset) == payload_root_depth(code, start, end)
+
+
+def serialized_json_has_profile(value: str) -> bool:
+    candidates = [value]
+    try:
+        decoded_literal = json.loads(f'"{value}"')
+    except (TypeError, ValueError):
+        pass
+    else:
+        if decoded_literal != value:
+            candidates.append(decoded_literal)
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict) and any(
+            _is_usable_profile_value(payload.get(name))
+            for name in PROFILE_NAMES
+            if name in payload
+        ):
+            return True
+    return False
+
+
+def _is_usable_profile_value(value: Any) -> bool:
+    """Return whether a decoded JSON profile value is usable.
+
+    `value not in {None, ""}` raised TypeError on a dict or list value, and
+    nothing between here and main() caught it, so ONE payload carrying
+    `"messaging_profile_id": {...}` aborted the entire scan - every other file
+    in the project went unanalysed and the run reported nothing at all.
+    A non-scalar is also not a usable profile id, so it is simply False.
+    """
+    return isinstance(value, (str, int)) and not isinstance(value, bool) and str(value).strip() != ""
+
+
+def token_is_entire_expression(
+    lexed: LexedSource, token: StringToken, start: int, end: int
+) -> bool:
+    """Return true when a string token is the assignment value, not nested data."""
+
+    return not (
+        lexed.code[start:token.start].strip()
+        or lexed.code[token.end:end].strip()
+    )
+
+
+def region_has_profile(
+    lexed: LexedSource,
+    start: int,
+    end: int,
+    *,
+    serialized_assignment: bool = False,
+    allow_js_shorthand: bool = False,
+) -> bool:
+    code_region = lexed.code[start:end]
+    if PROFILE_CLI_RE.search(code_region):
+        return True
+    for match in PROFILE_IDENTIFIER_RE.finditer(lexed.code, start, end):
+        if not at_payload_root(lexed.code, start, end, match.start()):
+            continue
+        after = lexed.code[match.end():end]
+        if re.match(r"\s*(?::|=(?!=)|\()", after):
+            return True
+        if allow_js_shorthand and re.match(r"\s*(?=[,}])", after):
+            return True
+
+    for token in lexed.strings:
+        if token.start < start or token.end > end:
+            continue
+        after = lexed.without_comments[token.end:end]
+        if (
+            token.contents in PROFILE_NAMES
+            and at_payload_root(lexed.code, start, end, token.start)
+            and re.match(r"\s*(?::|=>|=(?!=))", after)
+        ):
+            return True
+        serialized_value = serialized_payload_string(lexed, token, start) or (
+            serialized_assignment
+            and token_is_entire_expression(lexed, token, start, end)
+        )
+        if serialized_value and serialized_json_has_profile(token.contents):
+            return True
+    return False
+
+
+def split_arguments(code: str, start: int, end: int) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    segment_start = start
+    round_depth = square_depth = curly_depth = 0
+    for index in range(start, end):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == "," and not (round_depth or square_depth or curly_depth):
+            spans.append((segment_start, index))
+            segment_start = index + 1
+    spans.append((segment_start, end))
+    return spans
+
+
+def entry_value_end(code: str, start: int, limit: int) -> int:
+    """End of one `key => value` entry inside an enclosing literal.
+
+    The entry stops at its own top-level `,`/`;` or at the first closer that
+    belongs to the CONTAINER rather than to the value, so a nested literal
+    value is kept whole while a trailing `]]);` is not swallowed.
+    """
+    depth = 0
+    for index in range(start, limit):
+        character = code[index]
+        if character in "([{":
+            depth += 1
+        elif character in ")]}":
+            if depth == 0:
+                return index
+            depth -= 1
+        elif depth == 0 and character in ",;":
+            return index
+    return limit
+
+
+def named_payload_spans(
+    code: str,
+    spans: list[tuple[int, int]],
+    *,
+    allow_js_shorthand: bool = False,
+) -> list[tuple[int, int]]:
+    """Return only body/data/json/payload values from argument/object spans."""
+
+    payloads: list[tuple[int, int]] = []
+    name_pattern = re.compile(r"\s*(?:body|data|json|payload)\s*[:=](?!=)")
+    shorthand_pattern = re.compile(r"\s*(?:body|data|json|payload)\s*$")
+    for start, end in spans:
+        match = name_pattern.match(code, start, end)
+        if match is not None:
+            payloads.append((match.end(), end))
+            continue
+        if allow_js_shorthand and shorthand_pattern.fullmatch(code, start, end):
+            payloads.append((start, end))
+            continue
+        opening = code.find("{", start, end)
+        if opening < 0:
+            continue
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is None or closing >= end:
+            continue
+        for member_start, member_end in split_arguments(code, opening + 1, closing):
+            member_match = name_pattern.match(code, member_start, member_end)
+            if member_match is not None:
+                payloads.append((member_match.end(), member_end))
+            elif allow_js_shorthand and shorthand_pattern.fullmatch(
+                code, member_start, member_end
+            ):
+                payloads.append((member_start, member_end))
+    return payloads
+
+
+def assigned_payload_member_span(
+    lexed: LexedSource,
+    variable: str,
+    after: int,
+    before: int,
+    suffix: str,
+) -> list[tuple[int, int]]:
+    """Return the latest body-like property assigned to an options variable."""
+
+    escaped = re.escape(variable)
+    pattern = re.compile(
+        rf"(?<![\w$.>]){escaped}(?!\w)\s*(?:\.|->)\s*"
+        r"(?:body|data|json|payload)\s*(?::=|=(?!=|>))"
+    )
+    matches = list(pattern.finditer(lexed.code, after, before))
+    if not matches:
+        return []
+    latest = matches[-1]
+    return [(latest.end(), assignment_end(lexed, latest.end(), suffix))]
+
+
+def assigned_named_payload_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> list[tuple[int, int]]:
+    """Resolve an options variable and return only its request-body member."""
+
+    candidate = lexed.code[span[0] : span[1]].strip()
+    variable_match = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+    if variable_match is None:
+        return []
+    variable = variable_match.group(1)
+    if variable in seen:
+        return []
+    matches = assignment_matches(lexed.code, variable, before)
+    if not matches:
+        return []
+    assignment = matches[-1]
+    rhs_start = assignment.end()
+    rhs_end = assignment_end(lexed, rhs_start, suffix)
+    named = named_payload_spans(
+        lexed.code,
+        [(rhs_start, rhs_end)],
+        allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+    )
+    mutation = assigned_payload_member_span(
+        lexed, variable, rhs_end, before, suffix
+    )
+    if mutation:
+        return mutation
+    if named:
+        return named
+    return assigned_named_payload_spans(
+        lexed,
+        (rhs_start, rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def argument_string_value(
+    lexed: LexedSource, span: tuple[int, int]
+) -> str | None:
+    """Return a sole string literal argument's value."""
+
+    tokens = [
+        token
+        for token in lexed.strings
+        if span[0] <= token.start and token.end <= span[1]
+    ]
+    if len(tokens) != 1 or lexed.code[span[0] : span[1]].strip():
+        return None
+    return tokens[0].contents
+
+
+_KTOR_BODY_LINK_RE = re.compile(r"\b(?:setBody|body)\s*(?:\(|=)")
+
+
+def _trailing_lambda_span(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Span of a Kotlin trailing lambda immediately following `call`."""
+    tail = lexed.code[call.end:call.end + 40]
+    brace = re.match(r"\s*\{", tail)
+    if brace is None:
+        return None
+    opening = call.end + brace.end() - 1
+    closing = matching_delimiter(lexed.code, opening, "{", "}")
+    return None if closing is None else (opening, closing)
+
+
+def ktor_trailing_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Body attached inside a Ktor builder lambda: `post(url) { setBody(x) }`.
+
+    Ktor's send takes the ENDPOINT as its only argument and configures the body
+    in the trailing lambda, so neither the argument list nor any earlier chain
+    link carries the payload.
+    """
+    block = _trailing_lambda_span(lexed, call)
+    if block is None:
+        return None
+    inner_text = lexed.code[block[0]:block[1]]
+    link = _KTOR_BODY_LINK_RE.search(inner_text)
+    if link is None:
+        return None
+    base = block[0] + link.end()
+    if inner_text[link.end() - 1] == "(":
+        closing = matching_delimiter(lexed.code, base - 1, "(", ")")
+        if closing is None:
+            return None
+        arguments = split_arguments(lexed.code, base, closing)
+        span = payload_argument(lexed, arguments) if arguments else None
+    else:
+        end = lexed.code.find("\n", base)
+        span = (base, end if end > 0 else block[1])
+    if span is None:
+        return None
+    return resolve_wrapped_payload(lexed, span, span[0], suffix)
+
+
+def ruby_request_body_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Body assigned to a Ruby request object after construction.
+
+    `req = Net::HTTP::Post.new(uri)` carries only the endpoint; the payload
+    arrives in a later statement as `req.body = ...`, so the constructor's own
+    arguments never reveal it.
+    """
+    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    binding = re.search(
+        r"([A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+    )
+    if binding is None:
+        return []
+    name = re.escape(binding.group(1))
+    match = re.search(
+        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*", lexed.code[call.end:]
+    )
+    if match is None:
+        return []
+    start = call.end + match.end()
+    end = lexed.code.find("\n", start)
+    span = (start, end if end > 0 else len(lexed.code))
+    return [resolve_wrapped_payload(lexed, span, span[0], suffix)]
+
+
+def rest_payload_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select request-body expressions without accepting query/config fields."""
+
+    args_start = call.open_paren + 1
+    args_end = max(args_start, call.end - 1)
+    arguments = split_arguments(lexed.code, args_start, args_end)
+    if not arguments:
+        return []
+
+    # Guzzle's canonical body shape is an options array with a quoted `json`
+    # key: `$client->post($url, ['json' => ['messaging_profile_id' => $mp]])`.
+    # Quoted keys are blanked in `lexed.code`, so the generic named-member
+    # regex cannot recover them. Project the literal container through the
+    # lexer's token-aware key resolver instead.
+    if suffix == ".php":
+        for argument in arguments[1:]:
+            projected = literal_value_span(
+                lexed, argument[0], argument[1], ("json",), suffix
+            )
+            if projected is not None:
+                return [projected]
+
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    if suffix == ".php" and callee == "file_get_contents":
+        region = php_stream_context_region(lexed, call, suffix)
+        if region is None:
+            return []
+        key = re.search(
+            r"[\'\"]content[\'\"]\s*=>", lexed.original[region[0]:region[1]]
+        )
+        if key is None:
+            return []
+        start = region[0] + key.end()
+        # `region[1]` is the end of the whole stream_context_create(...)
+        # statement, so an unbounded span reads `$json]]);` rather than the
+        # entry's value: no variable is recognised, the hop to the body is lost
+        # and a compliant send is reported as missing the profile. Bound the
+        # value at the entry's own `,`/`]` first.
+        end = entry_value_end(lexed.code, start, region[1])
+        return [resolve_wrapped_payload(lexed, (start, end), start, suffix)]
+    if suffix in JS_TS_SUFFIXES and callee.split(".")[-1] == "open":
+        body = xhr_send_body_span(lexed, call, suffix)
+        return [body] if body else []
+    if suffix == ".py" and callee.split(".")[-1] == "Request":
+        data = named_argument_spans(lexed, arguments, "data")
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in data[-1:]
+        ]
+    if callee in {"HttpRequestMessage", "RestRequest"}:
+        body = csharp_request_body_span(lexed, call, suffix)
+        return [body] if body else []
+    if suffix == ".go" and callee in {"Post", "Put", "Patch"} and len(arguments) == 1:
+        body = builder_body_span(lexed, call, "SetBody|SetJSONBody|SetFormData")
+        return [resolve_wrapped_payload(lexed, body, body[0], suffix)] if body else []
+    if suffix == ".go" and callee == "Post" and len(arguments) >= 3:
+        # net/http.Post(url, contentType, body) carries the request body in
+        # its third argument, unlike the common post(url, body, config) form.
+        # Gating on the receiver being literally "http" missed every
+        # (*http.Client).Post call — client.Post(...), httpClient.Post(...),
+        # http.DefaultClient.Post(...) — which fell through to the generic
+        # rule and had its content-type string inspected as the payload,
+        # reporting a compliant body as missing messaging_profile_id.
+        receiver = (call_receiver(lexed, call) or "").lower()
+        second = lexed.code[arguments[1][0]:arguments[1][1]].strip()
+        looks_like_content_type = bool(
+            re.fullmatch(r"""["'][A-Za-z0-9.+-]+/[A-Za-z0-9.+;=\s-]+["']""", second)
+        )
+        if (
+            receiver == "http"
+            or receiver.endswith("client")
+            or looks_like_content_type
+        ):
+            # Follow reader/stringifier wrappers to the literal, as the curl
+            # branch does. Returning the raw span only worked when the literal
+            # sat textually inside it: the idiomatic
+            # `body := []byte(...); http.Post(url, ct, bytes.NewBuffer(body))`
+            # left the span at the wrapper, so a compliant body was reported as
+            # missing messaging_profile_id.
+            return [
+                resolve_wrapped_payload(
+                    lexed, arguments[2], arguments[2][0], suffix
+                )
+            ]
+    if callee == "fetch":
+        inline = named_payload_spans(
+            lexed.code,
+            arguments[1:2],
+            allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+        )
+        if inline:
+            return inline
+        if len(arguments) > 1:
+            return assigned_named_payload_spans(
+                lexed, arguments[1], call.start, suffix
+            )
+        return []
+    if callee == "axios.post":
+        return arguments[1:2]
+    if callee == "axios":
+        inline = named_payload_spans(
+            lexed.code,
+            arguments[:1],
+            allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+        )
+        if inline:
+            return inline
+        return assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+    named = named_payload_spans(
+        lexed.code,
+        arguments,
+        allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+    )
+    if named:
+        return named
+    if callee == "request" and len(arguments) >= 3:
+        method = argument_string_value(lexed, arguments[0])
+        if method is None or method.upper() in MUTATING_HTTP_METHODS:
+            return arguments[2:3]
+
+    if callee == "NewRequest" and len(arguments) >= 3:
+        # http.NewRequest(method, url, body): the body is the third argument,
+        # normally wrapped (bytes.NewBuffer(json.Marshal output)).
+        return [
+            resolve_wrapped_payload(lexed, arguments[2], call.start, suffix)
+        ]
+    if callee.split(".")[-1] == "post_form":
+        # Net::HTTP.post_form(uri, k => v, ...): every pair after the URI is
+        # form data. Returning only the first pair would report a compliant
+        # send whose profile arrives in a later pair.
+        return arguments[1:]
+    if callee.endswith("new") and "Net::HTTP::" in callee:
+        # The endpoint is this call's argument (handled in request_url_spans);
+        # the BODY arrives later as `req.body = ...` on the binding, exactly
+        # like the C# `req.Content = ...` shape.
+        return ruby_request_body_spans(lexed, call, suffix)
+    if callee == "curl_init":
+        # `$ch = curl_init($url)` names its handle on the LEFT of the
+        # assignment, not in the argument list, so the sibling
+        # CURLOPT_POSTFIELDS lookup needs the binding. Without it the endpoint
+        # resolved but the body never did, and a COMPLIANT send was reported as
+        # missing the profile.
+        line_start = lexed.code.rfind("\n", 0, call.start) + 1
+        binding = re.search(
+            r"(\$[A-Za-z_]\w*)\s*=\s*$",
+            lexed.code[line_start:call.start].rstrip()[-120:] + "=",
+        ) or re.search(
+            r"(\$[A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+        )
+        if binding is None:
+            return []
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in curl_postfields_spans(
+                lexed, binding.group(1), call.start, suffix
+            )
+        ]
+    if callee == "curl_setopt" and len(arguments) >= 3:
+        option = lexed.code[arguments[1][0]:arguments[1][1]].strip()
+        if option != "CURLOPT_URL":
+            return []
+        handle = lexed.code[arguments[0][0]:arguments[0][1]].strip()
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in curl_postfields_spans(
+                lexed, handle, call.start, suffix
+            )
+        ]
+    if callee == "curl_setopt_array" and len(arguments) >= 2:
+        # The array form carries the body in the SAME literal as the URL, and
+        # may also have been set by earlier per-option calls on the handle.
+        handle = lexed.code[arguments[0][0]:arguments[0][1]].strip()
+        spans = curl_option_array_value_spans(
+            lexed, arguments[1], suffix, "CURLOPT_POSTFIELDS"
+        ) or curl_postfields_spans(lexed, handle, call.start, suffix)
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in spans
+        ]
+    # `.kt`/`.kts` are CANONICALISED to `.java` before reaching here, so this
+    # must test the canonical suffix - keying on ".kt" meant the branch never
+    # ran. Gating on the trailing lambda keeps it Kotlin-only in practice:
+    # Java has no trailing-lambda call syntax for this shape.
+    if suffix in {".java", ".kt", ".kts", ".scala"} and callee.lower() in {
+        "post", "put", "patch", "request", "submitform"
+    }:
+        ktor_body = ktor_trailing_body_span(lexed, call, suffix)
+        if ktor_body is not None:
+            return [ktor_body]
+    if (
+        callee.lower() == "post"
+        and suffix in {".java", ".kt", ".kts", ".scala"}
+        # ONE argument only. Both idioms below pass the body alone, because the
+        # endpoint came from an earlier `.uri(...)`/`.url(...)` link. A
+        # positional two-argument `post(url, body)` - the shape used by Ktor and
+        # by most thin JVM wrappers - puts the ENDPOINT first, so taking
+        # argument 0 as the payload read the URL as the body and reported
+        # compliant code as missing the profile. Matching on the case-insensitive
+        # verb widened this branch to exactly those calls, so it must now check
+        # the arity the branch actually assumes.
+        and len(arguments) == 1
+        # Ktor spells the send `client.post(url) { setBody(json) }` - ONE
+        # argument, but that argument is the ENDPOINT and the body lives in the
+        # trailing lambda. The arity gate alone still read the URL as the
+        # payload, so a compliant Kotlin send was flagged. A trailing lambda
+        # means the single argument is not the body.
+        and _trailing_lambda_span(lexed, call) is None
+    ):
+        # .POST(HttpRequest.BodyPublishers.ofString(json)) for java.net.http and
+        # .post(RequestBody.create(json, TYPE)) for OkHttp — in both the payload
+        # is the wrapper's inner argument, not the wrapper itself.
+        # The canonical OkHttp idiom binds the body first — `RequestBody body =
+        # RequestBody.create(json, MediaType.parse(...)); ....post(body)` — and
+        # `unwrap_body_publisher` returns a bare variable untouched, leaving the
+        # whole `create(json, mediaType)` right-hand side to be inspected as the
+        # payload, where the media-type string won and a compliant send was
+        # reported as missing the profile. Resolve the variable hop first.
+        return [
+            unwrap_body_publisher(
+                lexed, resolve_wrapped_payload(lexed, span, span[0], suffix)
+            )
+            for span in arguments[:1]
+        ]
+    if callee == "request" and len(arguments) == 1:
+        resolved = assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+        if resolved:
+            return resolved
+        # Node core http(s).request: the body never rides in the options
+        # object — it is written afterwards via <handle>.write(payload).
+        written = request_write_payload_spans(lexed, call)
+        if written:
+            return written
+        return []
+
+    if callee.split(".")[-1].lower() in {"post", "postasync"}:
+        # Request-style config object held in a variable:
+        #   const cfg = {url: ..., json: {...}}; request.post(cfg)
+        # The inline form is already covered by named_payload_spans above,
+        # which reads json/body/data straight out of the literal. Once the URL
+        # side learned to resolve the variable, this side had to as well —
+        # otherwise the call was recognised as targeting the endpoint but its
+        # body could never be proven compliant, turning a silent miss into a
+        # false report on exactly the shape that was just fixed.
+        #
+        # Only returned when a body member is actually found. For
+        # post(urlVariable, bodyVariable) the first argument resolves to a
+        # string with no body member, so this yields nothing and the
+        # positional rule below still applies.
+        resolved = assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+        if resolved:
+            return resolved
+
+    # For post(url, payload, config)-style clients, only the second positional
+    # argument is request data. Later arguments are transport/query options.
+    return arguments[1:2]
+
+
+def payload_variables(
+    lexed: LexedSource, start: int, end: int, *, sdk_call: bool = False
+) -> list[str]:
+    variables: list[str] = []
+    for arg_start, arg_end in reversed(split_arguments(lexed.code, start, end)):
+        argument = lexed.code[arg_start:arg_end].strip()
+        match = SIMPLE_VARIABLE_RE.fullmatch(argument)
+        if match:
+            variables.append(match.group(1))
+        for nested in STRINGIFIED_VARIABLE_RE.finditer(argument):
+            variables.append(nested.group(1))
+        if not sdk_call:
+            for named in NAMED_PAYLOAD_VARIABLE_RE.finditer(argument):
+                variables.append(named.group(1))
+    for spread in SPREAD_VARIABLE_RE.finditer(lexed.code, start, end):
+        depth = structural_depth(lexed.code, start, spread.start())
+        if depth[2] and depth == payload_root_depth(lexed.code, start, end):
+            variables.append(spread.group(1))
+    variables = list(dict.fromkeys(variables))
+    if not sdk_call:
+        return variables
+
+    non_payload_names = {
+        "cancellationToken",
+        "context",
+        "ctx",
+        "options",
+        "requestOptions",
+    }
+    return [
+        variable
+        for variable in variables
+        if variable.lstrip("$") not in non_payload_names
+    ][:1]
+
+
+def assignment_matches(code: str, variable: str, before: int) -> list[re.Match[str]]:
+    escaped = re.escape(variable)
+    # The optional annotation covers TypeScript/Python declarations without
+    # allowing the search to cross a statement boundary.
+    pattern = re.compile(
+        rf"(?<![\w$.>]){escaped}(?!\w)(?:\s*,\s*\$?[A-Za-z_]\w*)*"
+        rf"(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+    )
+    return list(pattern.finditer(code, 0, before))
+
+
+def assignment_end(lexed: LexedSource, rhs_start: int, suffix: str) -> int:
+    code = lexed.code
+    round_depth = square_depth = curly_depth = 0
+    c_style = suffix in JS_TS_SUFFIXES | {".cs", ".java", ".php"}
+    for index in range(rhs_start, len(code)):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == "}" and not (round_depth or square_depth or curly_depth):
+            return index
+        elif character == ";" and not (round_depth or square_depth or curly_depth):
+            return index
+        elif character == "\n" and not (round_depth or square_depth or curly_depth):
+            if c_style:
+                next_line = code[index + 1 :].lstrip(" \t")
+                if next_line.startswith((".", "?")):
+                    continue
+            return index
+    return len(code)
+
+
+def shell_jq_assignment_has_profile(
+    lexed: LexedSource, start: int, end: int
+) -> bool:
+    """Recognize a top-level profile key emitted by a jq command substitution."""
+
+    try:
+        shell_source = re.sub(
+            r"\\\r?\n", "", lexed.original[start:end]
+        )
+        tokens = shlex.split(
+            shell_source, comments=True, posix=True
+        )
+    except ValueError:
+        return False
+
+    jq_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if token.lstrip("$(").rsplit("/", 1)[-1] == "jq"
+        ),
+        None,
+    )
+    if jq_index is None:
+        return False
+
+    two_value_options = {
+        "--arg",
+        "--argjson",
+        "--slurpfile",
+        "--rawfile",
+    }
+    one_value_options = {
+        "-f",
+        "--from-file",
+        "-L",
+        "--library-path",
+        "--indent",
+    }
+    index = jq_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in two_value_options:
+            index += 3
+            continue
+        if token in one_value_options:
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    if index >= len(tokens):
+        return False
+
+    program = tokens[index]
+    program_lexed = lex_source(program, ".sh")
+    return region_has_profile(program_lexed, 0, len(program))
+
+
+def shell_curl_get_mode(tokens: list[str]) -> bool:
+    """Return curl's final -G/--get state without reading option values as flags."""
+
+    enabled = False
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        option, separator, _ = token.partition("=")
+        if separator and option in SHELL_CURL_VALUE_OPTIONS:
+            index += 1
+            continue
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            index += 2
+            continue
+        if token == "--get":
+            enabled = True
+        elif token == "--no-get":
+            enabled = False
+        elif token.startswith("-") and not token.startswith("--"):
+            for short_option in token[1:]:
+                if short_option == "G":
+                    enabled = True
+                if short_option in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                    break
+        index += 1
+    return enabled
+
+
+def shell_curl_http_method(lexed: LexedSource, call: Call) -> str | None:
+    """Return curl's effective HTTP method, or None when it is dynamic.
+
+    curl defaults to GET, switches to POST for data/form options and PUT for
+    uploads, while an explicit request method wins.  A dynamic -X value stays
+    unresolved so callers can conservatively keep the request in scope.
+    """
+
+    try:
+        tokens = shlex.split(
+            lexed.original[call.start:call.end], comments=True, posix=True
+        )
+    except ValueError:
+        return None
+    curl_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if re.search(r"(?:^|[/$(])curl$", token)
+        ),
+        None,
+    )
+    if curl_index is None:
+        return None
+
+    explicit: str | None = None
+    inferred = "GET"
+    index = curl_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"-X", "--request"}:
+            if index + 1 >= len(tokens):
+                return None
+            explicit = tokens[index + 1]
+            index += 2
+            continue
+        if token.startswith("--request="):
+            explicit = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token.startswith("-X") and len(token) > 2:
+            explicit = token[2:]
+            index += 1
+            continue
+        option = token.split("=", 1)[0]
+        if (
+            option in SHELL_DATA_OPTIONS | SHELL_FORM_OPTIONS
+            or token.startswith("-d") and len(token) > 2
+            or token.startswith("-F") and len(token) > 2
+        ):
+            inferred = "POST"
+        elif (
+            option in SHELL_UPLOAD_OPTIONS
+            or token.startswith("-T") and len(token) > 2
+        ):
+            inferred = "PUT"
+        elif option in {"-I", "--head"}:
+            inferred = "HEAD"
+        elif option in {"-G", "--get"}:
+            inferred = "GET"
+        elif (
+            token.startswith("-")
+            and not token.startswith("--")
+            and len(token) > 1
+        ):
+            # BUNDLED short options: `curl -fsSd '<json>' <url>` means -f -s -S
+            # -d. Only a bare or `-d<value>` form was inferred as POST, so a
+            # clustered -d left the method at GET and the send was dropped
+            # from the scan entirely.
+            for short_option in token[1:]:
+                if short_option not in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                    continue
+                if short_option == "d":
+                    inferred = "POST"
+                elif short_option == "F":
+                    inferred = "POST"
+                elif short_option == "T":
+                    inferred = "PUT"
+                break
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            index += 2
+        else:
+            index += 1
+
+    if explicit is None:
+        return "GET" if shell_curl_get_mode(tokens[curl_index + 1:]) else inferred
+    if re.search(r"[$`{}()]", explicit):
+        return None
+    return explicit.upper()
+
+
+def shell_payload_values(source: str, start: int, end: int) -> list[str]:
+    """Return curl request-body arguments without executing shell syntax."""
+
+    try:
+        tokens = shlex.split(source[start:end], comments=True, posix=True)
+    except ValueError:
+        return []
+    if shell_curl_get_mode(tokens):
+        return []
+
+    values: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in SHELL_DATA_OPTIONS:
+            if index + 1 < len(tokens):
+                values.append(tokens[index + 1])
+                index += 2
+                continue
+        for option in sorted(SHELL_DATA_OPTIONS, key=len, reverse=True):
+            separator = "=" if token.startswith(f"{option}=") else ""
+            if separator:
+                values.append(token[len(option) + 1 :])
+                break
+            if option == "-d" and token.startswith("-d") and len(token) > 2:
+                values.append(token[2:])
+                break
+        else:
+            # BUNDLED short options: `curl -fsSd '<json>' <url>` is the same as
+            # `-f -s -S -d '<json>'`. Only a bare `-d` or a `-d<value>` prefix
+            # was recognised, so a clustered -d hid the body entirely and the
+            # send was never treated as carrying a payload.
+            if (
+                token.startswith("-")
+                and not token.startswith("--")
+                and len(token) > 1
+            ):
+                for position, short_option in enumerate(token[1:], start=1):
+                    if short_option not in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                        continue
+                    if short_option == "d":
+                        inline = token[position + 1:]
+                        if inline:
+                            values.append(inline)
+                        elif index + 1 < len(tokens):
+                            values.append(tokens[index + 1])
+                            index += 1
+                    break  # a value-taking option consumes the rest
+        index += 1
+    return values
+
+
+def shell_payload_variable(value: str) -> str | None:
+    candidate = value[1:] if value.startswith("@") else value
+    match = SHELL_VARIABLE_RE.fullmatch(candidate)
+    if match is None:
+        return None
+    return match.group(1) or match.group(2)
+
+
+def shell_payload_file_has_profile(
+    value: str, source_path: Path, project_root: Path
+) -> bool:
+    if not value.startswith("@") or "$" in value or value == "@-":
+        return False
+    relative = Path(value[1:])
+    candidates = (
+        relative if relative.is_absolute() else source_path.parent / relative,
+        project_root / relative,
+    )
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+            resolved.relative_to(project_root)
+        except (OSError, ValueError):
+            continue
+        if not resolved.is_file():
+            continue
+        try:
+            payload = resolved.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if serialized_json_has_profile(payload[:1_000_000]):
+            return True
+    return False
+
+
+def _parses_as_json_object(value: str) -> bool:
+    """Return whether the text is a complete JSON object we can judge by value."""
+    try:
+        return isinstance(json.loads(value), dict)
+    except (TypeError, ValueError):
+        return False
+
+
+def shell_inline_payload_has_profile(value: str) -> bool:
+    """Recognize a literal JSON object passed through a curl data option."""
+    return serialized_json_has_profile(value)
+
+
+def payload_spans(
+    lexed: LexedSource,
+    call: Call,
+    suffix: str,
+    mode: str,
+) -> list[tuple[int, int]]:
+    """Select the payload for each supported official request signature."""
+
+    start = call.open_paren + 1
+    end = max(start, call.end - 1 if call.parenthesized else call.end)
+    if mode == "rest":
+        return rest_payload_spans(lexed, call, suffix)
+    arguments = split_arguments(lexed.code, start, end)
+    if suffix == ".go":
+        # Idiomatic Go passes a context first, so the payload is the second
+        # argument - but a single-argument send has its payload in the ONLY
+        # argument. Reading argument 1 there yields no span at all, and a
+        # compliant send is reported missing.
+        return arguments[1:2] or arguments[:1]
+    if suffix in {".py", ".rb", ".php"}:
+        spans = [(start, end)]
+        if mode == "body" and suffix == ".php" and len(arguments) > 1:
+            # twilio-php declares `create(string $to, array $options = [])`
+            # (twilio/twilio-php MessageList::create), so the canonical send
+            # keeps `body` inside the trailing options array - one level below
+            # the argument list this region covers.
+            spans.append(arguments[-1])
+        return spans
+    return arguments[:1]
+
+
+def call_has_profile(
+    lexed: LexedSource,
+    call: Call,
+    suffix: str,
+    source_path: Path,
+    project_root: Path,
+    *,
+    sdk_call: bool,
+    resolver: PayloadStateResolver | None = None,
+) -> bool:
+    resolver = resolver or PayloadStateResolver(
+        lexed, suffix, PROFILE_NAMES, require_value=True
+    )
+    if suffix == ".sh" and not sdk_call:
+        for value in shell_payload_values(lexed.original, call.start, call.end):
+            variable = shell_payload_variable(value)
+            if variable is not None and resolver.presence_for_name(
+                variable, call.start
+            ).state == PRESENT:
+                return True
+            if shell_payload_file_has_profile(value, source_path, project_root):
+                return True
+            # When the body is parseable JSON its VALUE can be checked, so that
+            # verdict is authoritative. text_presence only sees the key, so a
+            # structurally-present but unusable value - `"messaging_profile_id":
+            # {"id": "x"}` - was accepted and the send certified.
+            if _parses_as_json_object(value):
+                if serialized_json_has_profile(value):
+                    return True
+                continue
+            if resolver.text_presence(value).state == PRESENT:
+                return True
+        return False
+    return any(
+        resolver.span_presence(start, end, call.start).state == PRESENT
+        for start, end in payload_spans(
+            lexed, call, suffix, "sdk" if sdk_call else "rest"
+        )
+    )
+
+
+def line_number(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def line_bounds(source: str, offset: int) -> tuple[int, int]:
+    start = source.rfind("\n", 0, offset) + 1
+    end = source.find("\n", offset)
+    return start, len(source) if end < 0 else end
+
+
+def finding_row(path: Path, line: int, detail: str) -> str:
+    """Format ONE findings row - the single site that decides the path shape.
+
+    Every row the analyzer prints goes through here, so the whole run uses one
+    path convention: the path exactly as `iter_source_files` yielded it. Callers
+    depend on that - lint-telnyx-correctness.sh copies these strings verbatim
+    into both `details.files[]` and the printed bullets, so mixing conventions
+    in one run leaves a consumer unable to group, dedupe or open by file.
+    """
+
+    return f"{path}:{line}:{detail}"
+
+
+def call_detail(path: Path, lexed: LexedSource, call: Call) -> str:
+    line_start, line_end = line_bounds(lexed.original, call.start)
+    code_line = lexed.code[line_start:line_end]
+    relative = call.start - line_start
+    statement_start = code_line.rfind(";", 0, relative) + 1
+    statement_end = code_line.find(";", relative)
+    statement_end = len(code_line) if statement_end < 0 else statement_end + 1
+    detail = " ".join(
+        lexed.original[line_start + statement_start : line_start + statement_end].split()
+    )
+    return finding_row(path, line_number(lexed.original, call.start), detail)
+
+
+def static_references(
+    lexed: LexedSource, start: int, end: int
+) -> list[EndpointReference]:
+    """Return identifier/member chains whose property names are static."""
+
+    references: list[EndpointReference] = []
+    strings = {token.start: token for token in lexed.strings}
+    for match in SOURCE_IDENTIFIER_RE.finditer(lexed.code, start, end):
+        if re.search(r"(?:\.|->)\s*$", lexed.code[start:match.start()]):
+            continue
+        parts = [match.group(1)]
+        cursor = match.end()
+        while cursor < end:
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            bracket = False
+            if lexed.code.startswith("?.", cursor):
+                cursor += 2
+                while cursor < end and lexed.code[cursor].isspace():
+                    cursor += 1
+                bracket = cursor < end and lexed.code[cursor] == "["
+            elif lexed.code.startswith("->", cursor):
+                cursor += 2
+            elif cursor < end and lexed.code[cursor] == ".":
+                cursor += 1
+            elif cursor < end and lexed.code[cursor] == "[":
+                bracket = True
+            else:
+                break
+
+            if bracket:
+                cursor += 1
+                while (
+                    cursor < end
+                    and cursor not in strings
+                    and lexed.code[cursor].isspace()
+                ):
+                    cursor += 1
+                token = strings.get(cursor)
+                if token is not None:
+                    key = token.contents
+                    cursor = token.end
+                else:
+                    numeric = re.match(r"\d+", lexed.code[cursor:end])
+                    symbol = re.match(
+                        r":\s*([A-Za-z_]\w*)", lexed.code[cursor:end]
+                    )
+                    if numeric is not None:
+                        key = numeric.group(0)
+                        cursor += len(numeric.group(0))
+                    elif symbol is not None:
+                        key = symbol.group(1)
+                        cursor += len(symbol.group(0))
+                    else:
+                        break
+                while cursor < end and lexed.code[cursor].isspace():
+                    cursor += 1
+                if cursor >= end or lexed.code[cursor] != "]":
+                    break
+                parts.append(key)
+                cursor += 1
+                continue
+
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            member = re.match(r"[A-Za-z_]\w*", lexed.code[cursor:end])
+            if member is None:
+                break
+            member_name = member.group(0)
+            cursor += len(member_name)
+            lookup_cursor = cursor
+            while lookup_cursor < end and lexed.code[lookup_cursor].isspace():
+                lookup_cursor += 1
+            if (
+                member_name in {"fetch", "get", "Get"}
+                and lookup_cursor < end
+                and lexed.code[lookup_cursor] == "("
+            ):
+                closing = matching_delimiter(
+                    lexed.code, lookup_cursor, "(", ")"
+                )
+                if closing is None or closing >= end:
+                    break
+                key = static_lookup_key(
+                    lexed, lookup_cursor + 1, closing
+                )
+                if key is None:
+                    break
+                parts.append(key)
+                cursor = closing + 1
+            else:
+                parts.append(member_name)
+        references.append(tuple(parts))
+
+    for token in lexed.strings:
+        if (
+            token.start < start
+            or token.end > end
+            or lexed.original[token.start] != "`"
+        ):
+            continue
+        for interpolation in re.finditer(r"\$\{([^{}]+)\}", token.contents):
+            expression = interpolation.group(1).strip()
+            root = re.match(r"(\$?[A-Za-z_]\w*)", expression)
+            if root is None:
+                continue
+            parts = [root.group(1)]
+            cursor = root.end()
+            valid = True
+            while cursor < len(expression):
+                whitespace = re.match(r"\s*", expression[cursor:])
+                cursor += len(whitespace.group(0)) if whitespace else 0
+                dot = re.match(
+                    r"(?:\?\.|\.)\s*([A-Za-z_]\w*)",
+                    expression[cursor:],
+                )
+                bracket = re.match(
+                    r"\[\s*(?:['\"]([^'\"]+)['\"]|(\d+))\s*\]",
+                    expression[cursor:],
+                )
+                if dot is not None:
+                    parts.append(dot.group(1))
+                    cursor += len(dot.group(0))
+                elif bracket is not None:
+                    parts.append(bracket.group(1) or bracket.group(2))
+                    cursor += len(bracket.group(0))
+                else:
+                    valid = False
+                    break
+            if valid:
+                references.append(tuple(parts))
+    return references
+
+
+def direct_member_assignments(
+    lexed: LexedSource, before: int, suffix: str
+) -> list[tuple[EndpointReference, int, int, int]]:
+    """Return assignments to static dot/bracket member chains."""
+
+    target = (
+        r"(\$?[A-Za-z_]\w*(?:(?:\s*(?:\.|->)\s*[A-Za-z_]\w*)|"
+        r"(?:\s*\[\s*(?:\"[^\"]*\"|'[^']*'|`[^`]*`|"
+        r":\s*[A-Za-z_]\w*|\d+)\s*\]))+)"
+    )
+    pattern = re.compile(target + r"\s*(?::=|=(?!=|>))")
+    assignments: list[tuple[EndpointReference, int, int, int]] = []
+    for match in pattern.finditer(lexed.without_comments, 0, before):
+        if lexed.code[match.start(1)].isspace():
+            continue
+        references = static_references(lexed, match.start(1), match.end(1))
+        if not references:
+            continue
+        rhs_start = match.end()
+        assignments.append(
+            (
+                references[0],
+                match.start(),
+                rhs_start,
+                assignment_end(lexed, rhs_start, suffix),
+            )
+        )
+    return assignments
+
+
+def top_level_colon(code: str, start: int, end: int) -> int | None:
+    round_depth = square_depth = curly_depth = 0
+    for index in range(start, end):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == ":" and not (round_depth or square_depth or curly_depth):
+            return index
+    return None
+
+
+def static_object_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    code = lexed.code[start:end].strip()
+    if re.fullmatch(r"[A-Za-z_]\w*", code):
+        return code
+    if re.fullmatch(r"\d+", code):
+        return code
+    symbol = re.fullmatch(r":\s*([A-Za-z_]\w*)", code)
+    if symbol is not None:
+        return symbol.group(1)
+    tokens = [
+        token for token in lexed.strings
+        if start <= token.start and token.end <= end
+    ]
+    if len(tokens) != 1:
+        return None
+    residual = (
+        lexed.code[start:tokens[0].start] + lexed.code[tokens[0].end:end]
+    ).strip()
+    return tokens[0].contents if residual in {"", "[]"} else None
+
+
+def static_lookup_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    """Return only literal lookup keys, never a runtime identifier."""
+
+    code = lexed.code[start:end].strip()
+    if re.fullmatch(r"\d+", code):
+        return code
+    symbol = re.fullmatch(r":\s*([A-Za-z_]\w*)", code)
+    if symbol is not None:
+        return symbol.group(1)
+    tokens = [
+        token for token in lexed.strings
+        if start <= token.start and token.end <= end
+    ]
+    if len(tokens) != 1:
+        return None
+    residual = (
+        lexed.code[start:tokens[0].start] + lexed.code[tokens[0].end:end]
+    ).strip()
+    return tokens[0].contents if not residual else None
+
+
+def top_level_assignment_separator(
+    code: str, start: int, end: int
+) -> tuple[int, int] | None:
+    round_depth = square_depth = curly_depth = 0
+    index = start
+    while index < end:
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif not (round_depth or square_depth or curly_depth):
+            if code.startswith("=>", index):
+                return index, index + 2
+            if (
+                character == "="
+                and not code.startswith(("==", "=>"), index)
+                and (index == start or code[index - 1] not in "!<>=")
+            ):
+                return index, index + 1
+        index += 1
+    return None
+
+
+def matching_opening(
+    code: str, closing: int, left: str, right: str
+) -> int | None:
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == right:
+            depth += 1
+        elif code[index] == left:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def first_argument_is_object(
+    lexed: LexedSource, span: tuple[int, int]
+) -> bool:
+    """Return whether an argument span is an object/dict literal."""
+    text = lexed.code[span[0]:span[1]].strip()
+    return text.startswith("{")
+
+
+def resolved_config_object_span(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> tuple[int, int] | None:
+    """Return the object literal behind an inline or local config alias."""
+
+    if first_argument_is_object(lexed, span):
+        return span
+
+    candidate = lexed.code[span[0]:span[1]].strip()
+    variable_match = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+    if variable_match is None:
+        return None
+    variable = variable_match.group(1)
+    if variable in seen:
+        return None
+    matches = assignment_matches(lexed.code, variable, before)
+    if not matches:
+        return None
+    assignment = matches[-1]
+    rhs_start = assignment.end()
+    rhs_end = assignment_end(lexed, rhs_start, suffix)
+    return resolved_config_object_span(
+        lexed,
+        (rhs_start, rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def config_object_member_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    names: tuple[str, ...],
+) -> list[tuple[int, int]]:
+    """Return selected members of an inline or aliased config object."""
+
+    resolved = resolved_config_object_span(
+        lexed, span, before, suffix
+    )
+    return (
+        named_object_member_spans(lexed, resolved, names)
+        if resolved is not None
+        else []
+    )
+
+
+def config_object_url_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> list[tuple[int, int]]:
+    """Return the URL member of a request-style config object."""
+
+    return config_object_member_spans(
+        lexed, span, before, suffix, URL_MEMBER_NAMES
+    )
+
+
+def named_object_member_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    name: str | tuple[str, ...],
+) -> list[tuple[int, int]]:
+    names = (name,) if isinstance(name, str) else name
+    opening = lexed.code.find("{", span[0], span[1])
+    if opening < 0:
+        return []
+    closing = matching_delimiter(lexed.code, opening, "{", "}")
+    if closing is None or closing >= span[1]:
+        return []
+    values: list[tuple[int, int]] = []
+    for member_start, member_end in split_arguments(
+        lexed.code, opening + 1, closing
+    ):
+        colon = top_level_colon(lexed.code, member_start, member_end)
+        if colon is None:
+            shorthand = lexed.code[member_start:member_end].strip()
+            if shorthand in names:
+                values.append((member_start, member_end))
+            continue
+        if (
+            static_object_key(lexed, member_start, colon) in names
+        ):
+            values.append((colon + 1, member_end))
+    return values
+
+
+def named_argument_spans(
+    lexed: LexedSource,
+    spans: list[tuple[int, int]],
+    name: str,
+) -> list[tuple[int, int]]:
+    """Return top-level keyword/named-argument value spans."""
+
+    values: list[tuple[int, int]] = []
+    for start, end in spans:
+        separator = top_level_assignment_separator(lexed.code, start, end)
+        if separator is None:
+            colon = top_level_colon(lexed.code, start, end)
+            separator = (colon, colon + 1) if colon is not None else None
+        if separator is None:
+            continue
+        separator_start, value_start = separator
+        if lexed.code[start:separator_start].strip().lstrip("$") == name:
+            values.append((value_start, end))
+    return values
+
+
+def call_receiver(lexed: LexedSource, call: Call) -> str | None:
+    # The optional `?` covers optional chaining - JS `client?.post(...)` and
+    # PHP nullsafe `$client?->post(...)`. Without it the receiver reads as
+    # anonymous and the send is discarded by the anonymous-receiver guard,
+    # which is a false negative on a defensive but perfectly ordinary send.
+    match = re.search(
+        r"(\$?[A-Za-z_]\w*)\s*\??\s*(?:\.|->|::)\s*$",
+        lexed.code[max(0, call.start - 120):call.start],
+    )
+    return match.group(1).lstrip("$") if match is not None else None
+
+
+# Factory methods that build an HTTP client which then sends. A `.post()` on
+# such a factory (requests.Session().post, httpx.Client().post,
+# axios.create(...).post) is a real send; a `.post()` on a mock/assertion
+# factory (nock, expect) is not. Distinguishing on the factory method keeps
+# the mocks out of scope without dropping the clients.
+HTTP_CLIENT_FACTORY_METHODS = frozenset(
+    {
+        "Session",
+        "session",  # requests.session() is the documented lowercase alias
+        "Client",
+        "AsyncClient",
+        # aiohttp's client class is named ClientSession, not Client or
+        # Session, so `aiohttp.ClientSession().post(url, json=...)` fell
+        # through the allowlist and the send was discarded entirely.
+        "ClientSession",
+        "create",
+        "Http",
+        "HTTP",
+        # resty builds the request through a chain - client.R().SetBody(x).Post(url)
+        # - so the IMMEDIATE receiver of the send is the last builder link, not
+        # the client. Each link must be recognised or the send is discarded by
+        # the anonymous-receiver guard.
+        "R",
+        "SetBody",
+        "SetJSONBody",
+        "SetFormData",
+        "SetHeader",
+        "SetHeaders",
+        "SetQueryParam",
+        "SetResult",
+    }
+)
+
+
+def factory_receiver_method(lexed: LexedSource, call: Call) -> str | None:
+    """Return the method name of a factory-call receiver, or None.
+
+    For `axios.create(...).post(...)` the receiver is the call `create(...)`,
+    so `call_receiver` returns None; this recovers `create`. For a receiver
+    that is not a call (`foo.post`) it returns None.
+    """
+    prefix = lexed.code[:call.start]
+    accessor = re.search(r"(?:\.|->|::)\s*$", prefix)
+    if accessor is None:
+        return None
+    before = prefix[: accessor.start()].rstrip()
+    if not before.endswith(")"):
+        return None
+    # Walk back to the matching '(' of the factory call.
+    depth = 0
+    index = len(before) - 1
+    while index >= 0:
+        char = before[index]
+        if char == ")":
+            depth += 1
+        elif char == "(":
+            depth -= 1
+            if depth == 0:
+                break
+        index -= 1
+    if index < 0:
+        return None
+    # The factory method sits immediately before the call parens:
+    # requests.Session() -> "Session", axios.create(...) -> "create",
+    # new Client() -> "Client". A receiver wrapped in an extra paren group,
+    # e.g. PHP `(new Client())`, is not recovered here and stays skipped
+    # rather than risking a misread; that shape is left to a future change.
+    name = re.search(r"([A-Za-z_]\w*)\s*$", before[:index])
+    return name.group(1) if name is not None else None
+
+
+def static_method_value(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> str | None:
+    value = argument_string_value(lexed, span)
+    if value is not None:
+        return value.upper()
+    member_constant = re.fullmatch(
+        r"\s*(?:[A-Za-z_]\w*\s*\.\s*)*(?:Http|Request)?Method"
+        r"\s*\.?\s*(Get|Head|Options|Delete|Post|Put|Patch)\s*",
+        lexed.code[slice(*span)],
+        re.IGNORECASE,
+    )
+    if member_constant is not None:
+        return member_constant.group(1).upper()
+    symbol = re.fullmatch(r"\s*:\s*([A-Za-z_]\w*)\s*", lexed.code[slice(*span)])
+    if symbol is not None:
+        return symbol.group(1).upper()
+    variable_match = re.fullmatch(
+        r"\s*(\$?[A-Za-z_]\w*)\s*", lexed.code[slice(*span)]
+    )
+    if variable_match is None or variable_match.group(1) in seen:
+        return None
+    variable = variable_match.group(1)
+    assignments = assignment_matches(lexed.code, variable, before)
+    if not assignments:
+        return None
+    assignment = assignments[-1]
+    rhs_end = assignment_end(lexed, assignment.end(), suffix)
+    return static_method_value(
+        lexed,
+        (assignment.end(), rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def static_string_value(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> str | None:
+    """Resolve a string literal through a bounded local alias chain."""
+
+    value = argument_string_value(lexed, span)
+    if value is not None:
+        return value
+    variable_match = re.fullmatch(
+        r"\s*(\$?[A-Za-z_]\w*)\s*", lexed.code[slice(*span)]
+    )
+    if variable_match is None or variable_match.group(1) in seen:
+        return None
+    variable = variable_match.group(1)
+    assignments = assignment_matches(lexed.code, variable, before)
+    if not assignments:
+        return None
+    assignment = assignments[-1]
+    rhs_end = assignment_end(lexed, assignment.end(), suffix)
+    return static_string_value(
+        lexed,
+        (assignment.end(), rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+_CSHARP_BODY_RE = re.compile(
+    r"\.\s*(?:Content\s*=|AddJsonBody\s*\(|AddStringBody\s*\(|AddBody\s*\()"
+)
+
+
+# A request OBJECT is not a request. Each client has an explicit execution step;
+# without it the object is constructed and discarded (a builder in a factory, a
+# test fixture, dead code), and reporting it is a false positive.
+_EXECUTION_LINK_RE = {
+    # OkHttp executes via newCall(req).execute()/.enqueue(); java.net.http via
+    # client.send(req, ...) / sendAsync(req, ...).
+    # `\??\s*\.` accepts Kotlin's null-safe call: the .kt/.kts files that now
+    # reach this table spell the same link `client?.newCall(req)?.execute()`,
+    # and requiring a plain dot dropped the send entirely - a silent pass on
+    # idiomatic Kotlin.
+    # `(?:\?|!!)?` accepts both Kotlin null-handling spellings between the call
+    # and the link - `client?.newCall(req)?.execute()` and the non-null
+    # assertion `client!!.newCall(req)!!.execute()`. Requiring a plain dot
+    # dropped the send entirely on idiomatic Kotlin, a silent pass.
+    ".java": (
+        r"newCall\s*\(\s*{name}\s*\)\s*(?:\?|!!)?\s*\.\s*(?:execute|enqueue)\s*\("
+        r"|(?:send|sendAsync)\s*\(\s*{name}\b"
+    ),
+    ".cs": (
+        r"(?:SendAsync|Send)\s*\(\s*{name}\b"
+        r"|Execute\w*\s*(?:<[^>()]*>)?\s*\(\s*(?:[A-Za-z_]\w*\s*,\s*)?{name}\b"
+    ),
+    ".py": r"urlopen\s*\(\s*{name}\b",
+    ".go": r"\.\s*Do\s*\(\s*{name}\b",
+}
+_INLINE_EXECUTION_RE = re.compile(
+    # The constructor may be namespaced inside the execution call, as in
+    # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
+    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do)\s*\(\s*"
+    r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
+)
+
+
+def request_object_is_executed(
+    lexed: LexedSource, call: Call, suffix: str
+) -> bool:
+    """Return whether a constructed request object is actually sent.
+
+    OkHttp needs newCall(req).execute()/.enqueue(), HttpRequestMessage needs
+    SendAsync(req), RestSharp needs Execute*/ExecuteAsync*, urllib needs
+    urlopen(req) and net/http needs client.Do(req). Construction alone is not a
+    send.
+    """
+    canonical = ".java" if suffix in {".kt", ".kts", ".scala"} else suffix
+    pattern = _EXECUTION_LINK_RE.get(canonical)
+    if pattern is None:
+        return True
+
+    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)).
+    prefix = lexed.code[max(0, call.start - 160):call.start]
+    if _INLINE_EXECUTION_RE.search(prefix):
+        return True
+
+    # Otherwise the object must be bound and that binding executed. The bound
+    # name is searched for SPECIFICALLY so two request objects in one scope
+    # cannot borrow each other's execution.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        chain_newline_boundary(lexed.code, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    ) + 1
+    head = lexed.code[statement_start:call.start]
+    assignment = re.search(r"^(.*?)(?::=|=(?!=))", head, re.S)
+    if assignment is None:
+        # An UNBOUND chain can still be executed inline:
+        #   client.send(HttpRequest.newBuilder()...build(), handler)
+        return re.search(
+            r"(?:send|sendAsync|newCall|execute|enqueue|urlopen|Do)\s*\(", head
+        ) is not None
+    # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
+    # never the one executed, so every candidate must be tried.
+    names = [
+        name
+        for name in re.findall(r"[A-Za-z_]\w*", assignment.group(1))
+        if name != "_"
+    ]
+    return any(
+        re.search(pattern.format(name=re.escape(name)), lexed.code[statement_start:])
+        for name in names
+    )
+
+
+def php_stream_context_region(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the stream-context array backing a file_get_contents() call.
+
+    `$ctx = stream_context_create(["http" => ["method" => "POST", "content" =>
+    $json]]); file_get_contents($url, false, $ctx);` - the verb and the body live
+    in the CONTEXT, not in the call, so the call alone looks like a plain read.
+    """
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    if len(args) < 3:
+        return None
+    text = lexed.code[args[2][0]:args[2][1]].strip()
+    if "stream_context_create" in text:
+        return args[2]
+    name = re.fullmatch(r"\$?([A-Za-z_]\w*)", text)
+    if name is None:
+        return None
+    # A PHP variable is written `$ctx`, and assignment_matches' lookbehind
+    # rejects a leading `$`, so the bare name alone never resolves.
+    candidates = [
+        match
+        for form in (text, name.group(1))
+        for match in assignment_matches(lexed.code, form, call.start)
+    ]
+    for assignment in sorted(candidates, key=lambda m: m.start(), reverse=True):
+        start = assignment.end()
+        end = assignment_end(lexed, start, suffix)
+        if "stream_context_create" in lexed.code[start:end]:
+            return (start, end)
+    return None
+
+
+def xhr_send_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the body passed to `.send(...)` after an XHR `.open(...)`.
+
+    XMLHttpRequest splits one request across two calls on the same object:
+    `x.open('POST', url)` carries the endpoint and method, `x.send(body)` the
+    payload. Neither call alone describes the send.
+    """
+    receiver = call_receiver(lexed, call)
+    if receiver is None:
+        return None
+    # `call_receiver` strips a leading `$` (PHP/JS sigil), so the name is
+    # searched back into source that still spells it `$xhr`. Keeping `$` in the
+    # lookbehind without allowing the sigil made every `$`-prefixed JS
+    # identifier ($xhr, $http) unmatchable, losing the `.send(...)` body and
+    # reporting a compliant send as missing the profile.
+    match = re.search(
+        rf"(?<![\w$])\$?{re.escape(receiver)}\s*(?:\?\.|\.)\s*send\s*\(",
+        lexed.code[call.end:],
+    )
+    if match is None:
+        return None
+    open_paren = call.end + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    if not inner:
+        return None
+    return resolve_wrapped_payload(lexed, inner[0], inner[0][0], suffix)
+
+
+def csharp_request_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the body attached to a C# request object after construction.
+
+    `new HttpRequestMessage(HttpMethod.Post, url)` and `new RestRequest(url,
+    Method.Post)` carry only the endpoint; the body arrives in a LATER statement
+    (`req.Content = new StringContent(json)`, `req.AddJsonBody(...)`), so the
+    constructor's own arguments never reveal it.
+    """
+    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    assigned = re.search(
+        r"([A-Za-z_][\w]*)\s*=\s*$", lexed.code[line_start:call.start].rstrip()[:200]
+    ) or re.search(
+        r"(?:var|[A-Za-z_][\w<>\[\]]*)\s+([A-Za-z_][\w]*)\s*=",
+        lexed.code[line_start:call.start],
+    )
+    if assigned is None:
+        return None
+    name = assigned.group(1)
+    for match in re.finditer(
+        rf"(?<![\w]){re.escape(name)}\s*(?=\.)", lexed.code[call.end:]
+    ):
+        tail = lexed.code[call.end + match.end():]
+        body = _CSHARP_BODY_RE.match(tail)
+        if body is None:
+            continue
+        base = call.end + match.end() + body.end()
+        if tail[body.end() - 1] == "(":
+            closing = matching_delimiter(lexed.code, base - 1, "(", ")")
+            if closing is None:
+                continue
+            inner = split_arguments(lexed.code, base, closing)
+            span = inner[0] if inner else None
+        else:
+            end = lexed.code.find(";", base)
+            span = (base, end if end > 0 else len(lexed.code))
+        if span is not None:
+            return resolve_wrapped_payload(lexed, span, span[0], suffix)
+    return None
+
+
+# A wrapped fluent chain is ONE statement written two ways. Go (and Python
+# inside brackets) puts the dot at the END of the previous line; Java, Kotlin,
+# C#, JavaScript and TypeScript put it at the START of the next one, which is
+# by far the more common formatting:
+#
+#     Request r = new Request.Builder().url(URL)
+#         .post(body).build();
+#
+# Only the trailing-dot half used to be recognised, so every window bounded by
+# a newline was truncated at the first wrap. That cost the chain its own
+# binding (`Request r =`), which is what the execution-link check searches for
+# - so a multi-line OkHttp builder was unresolvable while the byte-identical
+# single-line spelling resolved fine, and the fail-safe backstop then reported
+# a correct send as "could not verify".
+#
+# The leading-dot form requires the identifier to touch the dot (`.post`, never
+# `. post`). That is how fluent chains are written, and it keeps shell's `.`
+# source command (`. env.sh`) from reading as a continuation.
+_LEADING_CHAIN_LINK_RE = re.compile(r"\.[A-Za-z_]")
+
+
+def newline_continues_chain(code: str, newline: int) -> bool:
+    """Whether the newline at `newline` is a chain wrap rather than a boundary.
+
+    Both halves look only at the text either side of the newline itself. An
+    earlier draft bounded the lookahead at the CALLER's position, which for the
+    leading-dot form is the dot itself - so the identifier that proves it is a
+    chain link sat outside the window and the test could never fire.
+    """
+    if code[max(0, newline - 200):newline].rstrip().endswith("."):
+        return True
+    following = code[newline:newline + 200].lstrip()
+    return bool(_LEADING_CHAIN_LINK_RE.match(following))
+
+
+def chain_newline_boundary(code: str, position: int) -> int:
+    """Index of the newline that really ends the statement before `position`.
+
+    Walks back over newlines that only wrap a fluent chain. Callers combine
+    this with `rfind(";")`/`rfind("{")` under `max()`, so a genuine terminator
+    on an earlier line still wins and the widened window cannot swallow a
+    preceding statement.
+    """
+    index = code.rfind("\n", 0, position)
+    while index > 0 and newline_continues_chain(code, index):
+        index = code.rfind("\n", 0, index)
+    return index
+
+
+def _go_block_brace(code: str, start: int) -> int:
+    """Index of the `{` that opens a Go statement BODY, scanning from `start`.
+
+    Go headers are brace-ambiguous: a composite literal (`cfg{A: 1}`,
+    `map[string]int{...}`, `[]T{...}`) puts a brace in the header that does not
+    open the block. A literal's brace is always preceded by a type expression -
+    an identifier, or the `]` closing a slice/map type - whereas a block's brace
+    follows an operator, a paren, or nothing. Balanced runs of `()`/`[]` are
+    skipped so a brace nested inside them is never mistaken for either.
+
+    Returns -1 when no body brace is found before the statement ends.
+    """
+    index, depth = start, 0
+    while index < len(code):
+        char = code[index]
+        if char in "([":
+            depth += 1
+        elif char in ")]":
+            depth -= 1
+            if depth < 0:
+                return -1
+        elif char == "}" and depth == 0:
+            return -1
+        elif char == "{" and depth == 0:
+            # ADJACENCY is the discriminator, not the preceding token class:
+            # `switch mode {` also puts an identifier before the brace, so
+            # testing the token alone classified every ordinary switch as a
+            # composite literal. Go composite literals are written with the
+            # brace touching the type (`cfg{`, `map[string]int{`), and a block
+            # brace is always separated by whitespace.
+            prefix = code[max(0, index - 200):index]
+            if prefix and (prefix[-1].isalnum() or prefix[-1] in "_]"):
+                # A composite literal: skip its balanced body and keep looking.
+                closing = matching_delimiter(code, index, "{", "}")
+                if closing is None:
+                    return -1
+                index = closing
+            else:
+                return index
+        index += 1
+    return -1
+
+
+def _top_level_ternary(
+    code: str, start: int, end: int
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    """Split `cond ? a : b` into its two arms, or None if this is not a ternary.
+
+    Skips balanced brackets so a `?` inside an argument list is not mistaken for
+    the operator, and ignores JS optional chaining (`?.`) and nullish
+    coalescing (`??`).
+    """
+    depth = question = -1
+    depth = 0
+    for index in range(start, end):
+        char = code[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "?" and depth == 0:
+            if code[index + 1:index + 2] in (".", "?"):
+                continue
+            question = index
+            break
+    if question < 0:
+        return None
+    depth = 0
+    for index in range(question + 1, end):
+        char = code[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == ":" and depth == 0:
+            return (question + 1, index), (index + 1, end)
+    return None
+
+
+def chain_statement_start(code: str, position: int) -> int:
+    """Index of the statement boundary preceding a chained call.
+
+    A raw `rfind` for `;`/`{`/newline stops inside the chain's own arguments:
+    `SetBody(map[string]string{...}).Post(url)` puts a `{` between the body
+    link and the send, so the search window began AFTER the very link being
+    looked for. Scan backwards instead, skipping balanced `()`/`{}`/`[]` runs,
+    and treat a newline as a boundary only when it is not a chain wrap in
+    either of the two spellings above.
+    """
+    depth = 0
+    index = position - 1
+    while index >= 0:
+        char = code[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth == 0:
+                return index
+            depth -= 1
+        elif depth == 0 and char in ";\n":
+            if char == "\n" and newline_continues_chain(code, index):
+                index -= 1
+                continue
+            return index
+        index -= 1
+    return -1
+
+
+def builder_body_span(
+    lexed: LexedSource, call: Call, methods: str
+) -> tuple[int, int] | None:
+    """Return the body argument set by an earlier link of the same chain.
+
+    resty spells it `client.R().SetBody(payload).Post(url)`: the endpoint is the
+    send call's argument while the BODY was attached upstream, the mirror image
+    of the java/OkHttp builders.
+    """
+    statement_start = chain_statement_start(lexed.code, call.start)
+    window = lexed.code[statement_start + 1:call.start]
+    last = None
+    for match in re.finditer(rf"\.\s*(?:{methods})\s*\(", window):
+        last = match
+    if last is None:
+        return None
+    open_paren = statement_start + 1 + last.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > call.start:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else None
+
+
+def builder_uri_span(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Return the .uri(...)/.url(...) argument preceding a builder send call.
+
+    java.net.http uses `.uri(URI.create(URL))`; OkHttp uses `.url(URL)`. Both
+    put the endpoint in an EARLIER link of the same chain than the call that
+    performs the send, so the send argument alone never reveals the endpoint.
+    """
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    )
+    window = lexed.code[statement_start + 1:call.start]
+    last = None
+    matched_link = None
+    for match in re.finditer(r"\.\s*(?:uri|url)\s*\(", window):
+        last = match
+        matched_link = "url" if "url" in match.group(0) else "uri"
+    if last is None:
+        return None
+    open_paren = statement_start + 1 + last.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > call.start:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    if not inner:
+        return None
+    _BUILDER_LINK_KIND[(id(lexed), call.start)] = matched_link
+    return inner[0]
+
+
+# Which builder link supplied the endpoint for a given call: "uri" for
+# java.net.http, "url" for OkHttp. Recorded rather than re-sniffed, because a
+# substring search for ".url" in the preceding source also matches an unrelated
+# `this.url` / `cfg.url` and silently rerouted java.net.http chains into the
+# OkHttp branch, where the execution-link requirement then discarded the send.
+_BUILDER_LINK_KIND: dict[tuple[int, int], str | None] = {}
+
+
+PAYLOAD_WRAPPER_RE = re.compile(
+    # `new` is optional so the C# constructor forms below match the same way
+    # the static factories above do.
+    r"^\s*(?:new\s+)?(?:bytes\s*\.\s*NewBuffer|bytes\s*\.\s*NewReader|"
+    r"strings\s*\.\s*NewReader|json\s*\.\s*Marshal|json_encode|"
+    r"RequestBody\s*\.\s*create|okhttp3\s*\.\s*RequestBody\s*\.\s*create|"
+    # C# attaches the body as `req.Content = new StringContent(json, ...)`.
+    # `csharp_request_body_span` already resolved that span, but without the
+    # wrapper listed here the presence check ran against the CONSTRUCTOR text
+    # rather than the JSON inside it - so a compliant HttpRequestMessage send
+    # was reported as missing the profile, and a non-compliant one was flagged
+    # for the wrong reason.
+    r"StringContent|JsonContent\s*\.\s*Create|"
+    # .NET serializers. Without these the resolver stopped at
+    # `JsonSerializer.Serialize(payload)` and never reached the payload
+    # variable, so every field written via Dictionary.Add was invisible and a
+    # compliant C# send was reported as missing the profile.
+    r"JsonSerializer\s*\.\s*Serialize|JsonConvert\s*\.\s*SerializeObject)"
+    r"\s*\("
+)
+
+
+# A wrapper's payload is not always its FIRST argument. OkHttp ships both
+# `RequestBody.create(body, mediaType)` and the deprecated
+# `RequestBody.create(mediaType, body)` - and Kotlin code overwhelmingly uses
+# the latter. Taking argument 0 unconditionally resolved the MEDIA TYPE as the
+# payload, so `messaging_profile_id` was invisible and a compliant send was
+# reported as missing it.
+#
+# Selection is POSITIVE - identify the argument that looks like a BODY - rather
+# than a deny-list of media-type spellings. An earlier draft enumerated the
+# media-type factories instead, and each spelling it did not list reopened the
+# same false positive: a bound `static final MediaType JSON` constant (the
+# spelling in OkHttp's own README), and Kotlin's `"application/json"
+# .toMediaType()`. Enumerating producers cannot terminate; asking what a
+# payload looks like can.
+_MEDIA_TYPE_FACTORY_RE = re.compile(
+    r"(?:[\w.]*\bMediaType\s*\.\s*(?:parse|get)\s*\(|\bContentType\s*\.|"
+    r"\.\s*toMediaTypeOrNull\s*\(|\.\s*toMediaType\s*\(|"
+    r"\bMediaTypeHeaderValue\s*\()"
+)
+# A MIME literal is `type/subtype` with an optional parameter tail, and nothing
+# else. A JSON body is never shaped like that, so a real payload cannot be
+# skipped by this test.
+_MIME_LITERAL_RE = re.compile(
+    r"""^\s*(["'])[\w.+-]+/[\w.+-]+(?:\s*;[^"']*)?\1\s*$"""
+)
+# A body announces itself: a quoted literal whose content opens a JSON object or
+# array, or an inline object/array/map literal.
+_BODY_LITERAL_RE = re.compile(r"""^\s*(?:["'`]\s*[\{\[]|[\{\[])""")
+# Last-resort tiebreak only (see payload_argument). Names that read as a content
+# type rather than a payload. Deliberately narrow: it must not match a name a
+# real body would plausibly carry, so `body`, `payload`, `data` and `content`
+# are absent - `content` in particular appears in `StringContent`, a body.
+_CONTENT_TYPE_NAME_RE = re.compile(
+    r"(?i)(?:\bmedia[_]?type|\bmime\b|\bcontent[_]?type|\bJSON_TYPE\b|\bTYPE\b)"
+)
+# Postfix wrapper: the payload is the RECEIVER. Kotlin/OkHttp 4 spells body
+# construction this way (`json.toRequestBody(contentType)`), the mirror image of
+# every prefix wrapper above.
+# Anchored on the CALL, with the receiver taken as everything before it. A
+# pattern that tried to capture the receiver directly matched the blanks inside
+# a masked string literal instead: lex_source blanks the quotes as well as the
+# content, so on `"{...}".toRequestBody(...)` the receiver is indistinguishable
+# from whitespace in `lexed.code` and must be delimited by offset, not by shape.
+_POSTFIX_PAYLOAD_WRAPPER_RE = re.compile(
+    r"\.\s*(?:toRequestBody|toResponseBody)\s*\("
+)
+# `new X(...)` is NOT evidence of a body: `new MediaTypeHeaderValue("application
+# /json")` and `new StringContent(...)` are both spelled that way, so accepting
+# every constructor let a CONTENT-TYPE argument win the positive body test and
+# outrank the real payload. Only composite literals - Go maps and struct/object
+# literals, which are brace-initialised - count here; a constructor has to earn
+# it through PAYLOAD_WRAPPER_RE like every other wrapper.
+_MAP_LITERAL_RE = re.compile(r"^\s*(?:map\[|new\s+\w[\w.<>\[\]]*\s*\{|\w+\s*\{)")
+
+
+def _is_media_type_argument(
+    lexed: LexedSource, span: tuple[int, int], before: int
+) -> bool:
+    """Whether an argument denotes a CONTENT TYPE rather than a payload."""
+    code_text = lexed.code[span[0]:span[1]]
+    if _MEDIA_TYPE_FACTORY_RE.search(code_text):
+        return True
+    if _MIME_LITERAL_RE.match(lexed.original[span[0]:span[1]]):
+        return True
+    # An identifier reveals nothing by itself; resolve what it was assigned.
+    # `static final MediaType JSON = MediaType.parse(...)` is the OkHttp README
+    # spelling, and without this hop the constant read as the payload. The name
+    # may be QUALIFIED (`HttpConstants.JSON`, `this.jsonType`, `Companion.JSON`)
+    # - resolving only the bare form left every qualified constant unclassified,
+    # so it fell through as "not a media type" and won the argument.
+    bare = code_text.strip().rsplit(".", 1)[-1].strip()
+    variable = SIMPLE_VARIABLE_RE.fullmatch(bare)
+    if variable is None:
+        return False
+    # Searched across the WHOLE file, not just above the send. A media-type
+    # constant is conventionally declared at the BOTTOM of the class in Kotlin
+    # (`companion object { val JSON = ... }`) and in Java, so bounding the
+    # lookup at the call site left those unclassified and the media type won the
+    # argument. Safe here because the result only decides which argument is the
+    # CONTENT TYPE - it never decides whether a profile value is present.
+    matches = assignment_matches(lexed.code, variable.group(1), len(lexed.code))
+    if not matches:
+        matches = assignment_matches(lexed.code, variable.group(1), before)
+    if not matches:
+        return False
+    rhs_start = matches[-1].end()
+    rhs_code = lexed.code[rhs_start:rhs_start + 200]
+    if _MEDIA_TYPE_FACTORY_RE.search(rhs_code.split("\n")[0]):
+        return True
+    rhs_original = lexed.original[rhs_start:rhs_start + 200].split("\n")[0]
+    return bool(_MIME_LITERAL_RE.match(rhs_original.strip().rstrip(";,")))
+
+
+def _is_body_argument(lexed: LexedSource, span: tuple[int, int]) -> bool:
+    """Whether an argument positively looks like a request payload."""
+    if _BODY_LITERAL_RE.match(lexed.original[span[0]:span[1]]):
+        return True
+    code_text = lexed.code[span[0]:span[1]]
+    if _BODY_LITERAL_RE.match(code_text) or _MAP_LITERAL_RE.match(code_text):
+        return True
+    return bool(PAYLOAD_WRAPPER_RE.match(code_text) or
+                STRINGIFIED_VARIABLE_RE.search(code_text))
+
+
+def payload_argument(
+    lexed: LexedSource, inner: list[tuple[int, int]]
+) -> tuple[int, int] | None:
+    """Pick the argument carrying the BODY, skipping content-type arguments."""
+    if len(inner) <= 1:
+        return inner[0] if inner else None
+    before = inner[0][0]
+    bodies = [span for span in inner if _is_body_argument(lexed, span)]
+    if bodies:
+        return bodies[0]
+    for span in inner:
+        if not _is_media_type_argument(lexed, span, before):
+            return span
+    # Nothing was positively identified either way. That happens when both
+    # arguments are plain identifiers and the media-type constant could not be
+    # resolved - a qualified name whose last segment collides with an unrelated
+    # variable, or a declaration in another file. Falling through to argument 0
+    # then picked the MEDIA TYPE for the deprecated
+    # `RequestBody.create(mediaType, body)` order. As a last resort only, prefer
+    # the argument whose NAME does not read as a content type. This is a
+    # tiebreak, never an override: any positively identified body above wins.
+    named = [
+        span for span in inner
+        if not _CONTENT_TYPE_NAME_RE.search(lexed.code[span[0]:span[1]])
+    ]
+    if named:
+        return named[0]
+    return inner[0]
+
+
+def resolve_wrapped_payload(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> tuple[int, int]:
+    """Follow reader/stringifier wrappers and variables to the payload.
+
+    bytes.NewBuffer(body) -> body -> json.Marshal(payload) -> payload -> the
+    map literal. The literal is where messaging_profile_id is provably
+    present or absent; stopping at any earlier hop reports compliant code as
+    missing the profile.
+    """
+    for _ in range(6):
+        text = lexed.code[span[0]:span[1]]
+        # Kotlin/OkHttp 4 wraps the body as an EXTENSION on it -
+        # `body.toRequestBody(mediaType)` - so the payload is the receiver, not
+        # an argument. Every wrapper above is prefix-shaped, so without this the
+        # whole expression was treated as the payload and the JSON inside it was
+        # never inspected.
+        postfix = _POSTFIX_PAYLOAD_WRAPPER_RE.search(text)
+        if postfix is not None and postfix.start() > 0:
+            start, end = span[0], span[0] + postfix.start()
+            # Trim against the ORIGINAL: a masked literal is blank in `code`,
+            # so trimming there would consume the payload itself.
+            while start < end and lexed.original[start].isspace():
+                start += 1
+            while end > start and lexed.original[end - 1].isspace():
+                end -= 1
+            if end > start:
+                span = (start, end)
+                continue
+        wrapper = PAYLOAD_WRAPPER_RE.match(text)
+        if wrapper is not None:
+            open_paren = span[0] + wrapper.end() - 1
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None or closing > span[1]:
+                return span
+            inner = split_arguments(lexed.code, open_paren + 1, closing)
+            if not inner:
+                return span
+            chosen = payload_argument(lexed, inner)
+            if chosen is None:
+                return span
+            span = chosen
+            continue
+        candidate = text.strip()
+        variable = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+        if variable is None:
+            return span
+        matches = assignment_matches(lexed.code, variable.group(1), before)
+        if not matches:
+            return span
+        assignment = matches[-1]
+        rhs_start = assignment.end()
+        rhs = (rhs_start, assignment_end(lexed, rhs_start, suffix))
+        rhs_text = lexed.code[rhs[0]:rhs[1]]
+        # The postfix wrapper counts as a wrapper hop too. Kotlin binds the body
+        # first as often as it inlines it (`val body = json.toRequestBody(type)`
+        # then `.post(body)`), and recognising only prefix wrappers here left the
+        # variable unresolved, so a compliant Kotlin/OkHttp-4 send was always
+        # reported as missing the profile.
+        if (
+            PAYLOAD_WRAPPER_RE.match(rhs_text) is None
+            and _POSTFIX_PAYLOAD_WRAPPER_RE.search(rhs_text) is None
+        ):
+            # Only serializer/reader hops need chasing: the resolver cannot see
+            # through json.Marshal/json_encode. Collapsing a plain variable to
+            # its declaration literal instead DISCARDS every later mutation
+            # (`payload["messaging_profile_id"] = ""`), certifying a send whose
+            # profile was emptied. Stop here and let the mutation-aware
+            # resolver evaluate the variable itself.
+            return span
+        span = rhs
+        before = assignment.start()
+    return span
+
+
+BODY_PUBLISHER_RE = re.compile(
+    r"^\s*(?:(?:HttpRequest\s*\.\s*)?BodyPublishers\s*\.\s*of\w+"
+    r"|(?:okhttp3\s*\.\s*)?RequestBody\s*\.\s*create)\s*\("
+)
+
+
+def unwrap_body_publisher(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel BodyPublishers.ofString(...) down to the payload expression."""
+    text = lexed.code[span[0]:span[1]]
+    match = BODY_PUBLISHER_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else span
+
+
+def php_curl_transaction_bounds(
+    lexed: LexedSource, handle: str, anchor: int
+) -> tuple[int, int]:
+    """Bound the handle transaction containing a URL-setting call."""
+
+    exec_pattern = re.compile(
+        r"curl_exec\s*\(\s*" + re.escape(handle) + r"\s*\)"
+    )
+    previous_exec = list(exec_pattern.finditer(lexed.code, 0, anchor))
+    start = previous_exec[-1].end() if previous_exec else 0
+    next_exec = exec_pattern.search(lexed.code, anchor)
+    return start, next_exec.start() if next_exec is not None else len(lexed.code)
+
+
+def curl_postfields_spans(
+    lexed: LexedSource, handle: str, anchor: int, suffix: str
+) -> list[tuple[int, int]]:
+    """Return POSTFIELDS spans from the same curl handle transaction."""
+
+    transaction_start, transaction_end = php_curl_transaction_bounds(
+        lexed, handle, anchor
+    )
+    pattern = re.compile(
+        r"curl_setopt\s*\(\s*" + re.escape(handle)
+        + r"\s*,\s*CURLOPT_POSTFIELDS\s*,"
+    )
+    # The two curl option forms mix freely on one handle. Reading only the
+    # per-option form here made the body invisible whenever the URL arrived
+    # through curl_setopt(CURLOPT_URL) but the body through
+    # curl_setopt_array() - a compliant send was then reported as missing its
+    # profile. Spans are ordered by position so the last write still wins.
+    array_pattern = re.compile(
+        r"curl_setopt_array\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+
+    def collect(start: int, end: int) -> list[tuple[int, int]]:
+        found: list[tuple[int, tuple[int, int]]] = []
+        for match in pattern.finditer(lexed.code, start, end):
+            open_paren = lexed.code.index("(", match.start())
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None:
+                continue
+            arguments = split_arguments(lexed.code, open_paren + 1, closing)
+            if len(arguments) >= 3:
+                found.append((open_paren, arguments[2]))
+        for match in array_pattern.finditer(lexed.code, start, end):
+            open_paren = lexed.code.index("(", match.start())
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None:
+                continue
+            arguments = split_arguments(lexed.code, open_paren + 1, closing)
+            if len(arguments) >= 2:
+                found.extend(
+                    (open_paren, span)
+                    for span in curl_option_array_value_spans(
+                        lexed, arguments[1], suffix, "CURLOPT_POSTFIELDS"
+                    )
+                )
+        return [span for _, span in sorted(found)]
+
+    spans = collect(transaction_start, transaction_end)
+    if not spans:
+        # POSTFIELDS persists on the handle across exec until overwritten or
+        # reset, so a transaction that only changes CURLOPT_URL still sends the
+        # body set earlier. Fall back to the most recent carried value.
+        state_start = php_curl_handle_state_start(lexed, handle, anchor)
+        carried = collect(state_start, transaction_start)
+        if carried:
+            spans = carried[-1:]
+    return spans
+
+
+_CURL_ARRAY_OPTION_RE = re.compile(
+    r"\s*['\"]?(CURLOPT_[A-Z_]+)['\"]?\s*=>"
+)
+
+
+def curl_option_array_value_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    suffix: str,
+    option: str,
+) -> list[tuple[int, int]]:
+    """Return the value spans for one option inside a curl option ARRAY.
+
+    curl_setopt_array($ch, [CURLOPT_URL => ..., CURLOPT_POSTFIELDS => ...]) is
+    as idiomatic as repeated curl_setopt() calls, but only the per-option call
+    form was recognized, so a number-pool send configured this way was never
+    visited at all. Keys are read from the ORIGINAL source (the masked view
+    blanks string contents); values stay offset-accurate for the resolvers.
+    """
+    container = root_literal_container(lexed, span[0], span[1], suffix)
+    if container is None:
+        return []
+    _, opening, closing = container
+    spans: list[tuple[int, int]] = []
+    for element in split_arguments(lexed.code, opening + 1, closing):
+        match = _CURL_ARRAY_OPTION_RE.match(
+            lexed.original, element[0], element[1]
+        )
+        if match is not None and match.group(1) == option:
+            spans.append((match.end(), element[1]))
+    return spans
+
+
+def php_curl_handle_state_start(
+    lexed: LexedSource, handle: str, anchor: int
+) -> int:
+    """Return where the handle's CARRIED option state begins.
+
+    ext-curl options persist on a handle across curl_exec() until they are
+    overwritten or curl_reset() is called — they are NOT cleared by the exec.
+    State therefore begins at the last curl_reset()/curl_init() before the
+    anchor, not after the previous exec.
+    """
+    latest = 0
+    for pattern in (
+        r"curl_reset\s*\(\s*" + re.escape(handle) + r"\s*\)",
+        re.escape(handle) + r"\s*=\s*curl_init\s*\(",
+    ):
+        matches = list(re.finditer(pattern, lexed.code, 0))
+        for match in matches:
+            if match.end() <= anchor and match.end() > latest:
+                latest = match.end()
+    return latest
+
+
+def php_curl_handle_method(
+    lexed: LexedSource, handle: str, url_call_start: int, suffix: str
+) -> str | None:
+    """Return the method used by the handle's next curl_exec transaction."""
+
+    transaction_start, transaction_end = php_curl_transaction_bounds(
+        lexed, handle, url_call_start
+    )
+    # Options set before an earlier exec are STILL IN EFFECT unless overwritten
+    # or reset, so a handle that posted once and then only changes CURLOPT_URL
+    # is still POSTing. Scanning from the previous exec made that second
+    # transaction look like a fresh GET, and the required send escaped.
+    state_start = php_curl_handle_state_start(lexed, handle, url_call_start)
+    if state_start < transaction_start:
+        transaction_start = state_start
+    setter_pattern = re.compile(
+        r"curl_setopt\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+    array_pattern = re.compile(
+        r"curl_setopt_array\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+
+    # Both option forms must be applied in SOURCE ORDER so that later settings
+    # win. Scanning only curl_setopt() left the array form's method invisible,
+    # so an array-configured GET looked like a required send.
+    events: list[tuple[int, str, tuple[int, int]]] = []
+    for match in setter_pattern.finditer(
+        lexed.code, transaction_start, transaction_end
+    ):
+        opening = lexed.code.index("(", match.start())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None or closing > transaction_end:
+            continue
+        arguments = split_arguments(lexed.code, opening + 1, closing)
+        if len(arguments) < 3:
+            continue
+        events.append(
+            (match.start(), lexed.code[slice(*arguments[1])].strip(), arguments[2])
+        )
+    for match in array_pattern.finditer(
+        lexed.code, transaction_start, transaction_end
+    ):
+        opening = lexed.code.index("(", match.start())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None or closing > transaction_end:
+            continue
+        arguments = split_arguments(lexed.code, opening + 1, closing)
+        if len(arguments) < 2:
+            continue
+        container = root_literal_container(
+            lexed, arguments[1][0], arguments[1][1], suffix
+        )
+        if container is None:
+            continue
+        _, array_open, array_close = container
+        for element in split_arguments(lexed.code, array_open + 1, array_close):
+            key = _CURL_ARRAY_OPTION_RE.match(
+                lexed.original, element[0], element[1]
+            )
+            if key is not None:
+                events.append(
+                    (element[0], key.group(1), (key.end(), element[1]))
+                )
+
+    method = "GET"
+    custom_method: str | None = None
+    for position, option, value_span in sorted(events, key=lambda event: event[0]):
+        value = lexed.code[slice(*value_span)].strip().lower()
+        if option == "CURLOPT_CUSTOMREQUEST":
+            resolved = static_method_value(
+                lexed, value_span, position, suffix
+            )
+            if resolved is None:
+                return None
+            custom_method = resolved
+        elif option == "CURLOPT_POSTFIELDS":
+            method = "POST"
+        elif option == "CURLOPT_POST":
+            if value in {"true", "1"}:
+                method = "POST"
+            elif value in {"false", "0"}:
+                method = "GET"
+            else:
+                return None
+        elif option == "CURLOPT_HTTPGET" and value in {"true", "1"}:
+            method = "GET"
+        elif option == "CURLOPT_NOBODY" and value in {"true", "1"}:
+            method = "HEAD"
+        elif option in {"CURLOPT_UPLOAD", "CURLOPT_PUT"}:
+            if value in {"true", "1"}:
+                method = "PUT"
+            elif value not in {"false", "0"}:
+                return None
+    return custom_method or method
+
+
+ASSIGNED_HANDLE_RE = re.compile(
+    r"([A-Za-z_$][\w$]*)\s*=\s*(?:new\s+)?(?:[A-Za-z_$][\w$]*\s*\.\s*)?$"
+)
+
+
+def request_write_payload_spans(
+    lexed: LexedSource, call: Call
+) -> list[tuple[int, int]]:
+    """Return <handle>.write(...) payload spans after a request(...) call."""
+    prefix = lexed.code[max(0, call.start - 160):call.start]
+    match = ASSIGNED_HANDLE_RE.search(prefix)
+    if match is None:
+        return []
+    handle = match.group(1)
+    write_re = re.compile(
+        r"(?<![\w$])" + re.escape(handle) + r"\s*\.\s*write\s*\("
+    )
+    spans: list[tuple[int, int]] = []
+    for found in write_re.finditer(lexed.code, call.end):
+        open_paren = lexed.code.index("(", found.end() - 1)
+        closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+        if closing is None:
+            continue
+        arguments = split_arguments(lexed.code, open_paren + 1, closing)
+        if arguments:
+            spans.append(arguments[0])
+    return spans
+
+
+URL_CONSTRUCTOR_RE = re.compile(
+    r"^\s*(?:new\s+)?(?:URI|URL)(?:\s*\.\s*(?:create|parse|join))?\s*\("
+)
+
+
+def unwrap_url_constructor(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel URI(...) / URI.create(...) / new URL(...) down to the URL itself.
+
+    Ruby's Net::HTTP and Java's HttpRequest REQUIRE the wrapped form, so a
+    resolver that only reads bare strings treated the mandatory spelling as
+    an unknown expression and dropped the call entirely.
+    """
+    text = lexed.code[span[0]:span[1]]
+    match = URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else span
+
+
+def unwrap_bound_url_constructor(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel a URI/URL constructor held in a BINDING's right-hand side.
+
+    `uri = URI(URL); Net::HTTP.post(uri, body)` is as idiomatic as the inline
+    spelling, but unwrapping only ran on the call-argument span, so the binding
+    stayed an unknown expression and the send resolved to nothing.
+
+    Narrower than `unwrap_url_constructor` on purpose: a binding carries no
+    companion base lookup, so the two-argument `new URL(path, base)` form must
+    stay unresolved rather than collapse to its (safe-looking) path, and a
+    trailing member call (`URI.create(u).resolve(x)`) must not be discarded.
+    """
+    text = lexed.code[span[0]:span[1]]
+    match = URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing >= span[1]:
+        return span
+    if lexed.code[closing + 1:span[1]].strip():
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if len(inner) == 1 else span
+
+
+# Only JS/TS `new URL(path, base)` — the WHATWG constructor whose second
+# argument is a base. Java/Python `URI(...)` multi-argument constructors have
+# different semantics (Java's two-arg form is (scheme, ssp), NOT (path, base)),
+# so combining their arguments would misclassify unrelated calls.
+_JS_URL_CONSTRUCTOR_RE = re.compile(r"^\s*(?:new\s+)?URL\s*\(")
+
+
+def url_constructor_base(
+    lexed: LexedSource, span: tuple[int, int], suffix: str
+) -> str | None:
+    """Return the static base of a JS/TS `new URL(path, base)` span."""
+    if suffix not in JS_TS_SUFFIXES:
+        return None
+    text = lexed.code[span[0]:span[1]]
+    match = _JS_URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return None
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return None
+    arguments = split_arguments(lexed.code, open_paren + 1, closing)
+    if len(arguments) < 2:
+        return None
+    base_start, base_end = arguments[1]
+    for token in lexed.strings:
+        if base_start <= token.start and token.end <= base_end:
+            return token.contents
+    # `new URL(path, BASE)` with the base held in a constant is the idiomatic
+    # spelling; reading only a raw string token left the whole send
+    # unresolvable. Resolve the alias chain the same way every other base does.
+    return static_string_value(lexed, arguments[1], span[0], suffix)
+
+
+# A base URL carried by a client factory: axios.create({baseURL: '...'}),
+# httpx.Client(base_url='...'). The request path is then relative, so the
+# effective endpoint is base + path. The KEY name is code (preserved), but the
+# value is a string whose contents the lexer masks, so it is read from the
+# string token rather than from the masked code.
+# Stops at the separator: the lexer masks the value string to blanks, so a
+# trailing \s* would run past it and miss the token.
+# The left boundary excludes `\w` and `-` so the bare `url` alternative cannot
+# match the TAIL of an unrelated key (`callback_url:`, `'X-Callback-Url' =>`),
+# whose value would otherwise be read as the client's base. `$` is deliberately
+# NOT excluded: PHP's `$base_url =` must still match.
+_BASE_URL_KEY_RE = re.compile(
+    r"(?<![\w\-])(?:base[_]?url|base_uri|BaseAddress|url)['\"]?\s*(?::|=>|=)",
+    re.I,
+)
+_CLIENT_FACTORY_CALL_RE = re.compile(
+    r"(?:\.\s*create|\bClient|\bAsyncClient|\bHttpClient|\bSession|"
+    r"\bsession|\bFaraday\s*\.\s*new)\s*\("
+)
+
+
+def _paren_group_span_before_accessor(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Return the offset span inside the receiver's trailing call parens."""
+    accessor = re.search(r"(?:\.|->|::)\s*$", lexed.code[: call.start])
+    if accessor is None:
+        return None
+    end = len(lexed.code[: accessor.start()].rstrip())
+    if end == 0 or lexed.code[end - 1] != ")":
+        return None
+    depth = 0
+    index = end - 1
+    while index >= 0:
+        if lexed.code[index] == ")":
+            depth += 1
+        elif lexed.code[index] == "(":
+            depth -= 1
+            if depth == 0:
+                break
+        index -= 1
+    if index < 0:
+        return None
+    return index + 1, end - 1
+
+
+def _base_url_in_region(
+    lexed: LexedSource, region: tuple[int, int]
+) -> str | None:
+    """Return the base URL string literal declared within an offset region."""
+    start, end = region
+    # Some languages commonly quote option keys (`'base_uri' =>` in PHP),
+    # which the masked-code view deliberately blanks. Key syntax is safe to
+    # inspect in the original source here; the value still comes from the
+    # lexer's string-token table rather than from regex parsing.
+    key = _BASE_URL_KEY_RE.search(lexed.original, start, end)
+    if key is None:
+        return None
+    value_start = key.end()
+    value_end = _option_value_end(lexed, value_start, end)
+    following = [
+        token
+        for token in lexed.strings
+        if value_start <= token.start and token.end <= value_end
+    ]
+    if not following:
+        return None
+    return min(following, key=lambda token: token.start).contents
+
+
+def _option_value_end(lexed: LexedSource, start: int, limit: int) -> int:
+    """End of ONE option's value: the next separator at its own nesting depth.
+
+    Without this bound the scan took the first string ANYWHERE after the key,
+    so a non-literal base (`url: base`, `baseURL: process.env.X`) silently
+    adopted the next option's value - `headers: {'X-Doc' => '<base>'}` became
+    the base URL and a relative path was joined against it.
+    """
+    depth = 0
+    cursor = start
+    while cursor < limit:
+        char = lexed.code[cursor]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            if depth == 0:
+                return cursor
+            depth -= 1
+        elif char in ",;" and depth == 0:
+            return cursor
+        cursor += 1
+    return limit
+
+
+# An Axios METHOD HELPER takes a per-request config whose baseURL overrides the
+# instance one (axios.post(url, data, {baseURL}) / api.post(url, data, {baseURL})).
+# Body-carrying helpers put that config third; the rest put it second.
+_AXIOS_HELPER_CONFIG_INDEX = {
+    "post": 2,
+    "put": 2,
+    "patch": 2,
+    "get": 1,
+    "delete": 1,
+    "head": 1,
+    "options": 1,
+}
+
+
+def config_object_base_url(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> str | None:
+    """Resolve a static baseURL/base_uri from an inline or aliased config."""
+
+    base_spans = config_object_member_spans(
+        lexed, span, before, suffix, ("baseURL", "baseUrl", "base_uri")
+    )
+    if not base_spans:
+        return None
+    return static_string_value(
+        lexed, base_spans[-1], before, suffix
+    )
+
+
+def client_base_url(lexed: LexedSource, call: Call, suffix: str) -> str | None:
+    """Return the static base URL of the client a `.post()` is sent through.
+
+    Handles the client created inline —
+    axios.create({baseURL: '...'}).post(path) — and bound to a variable —
+    const api = axios.create({baseURL: '...'}); api.post(path). The idiomatic
+    variable form is as common as the inline one, so both must resolve or a
+    base-URL send is silently classified as safe.
+    """
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren]).lower()
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    receiver = call_receiver(lexed, call)
+    if (
+        callee in {"axios", "axios.request"}
+        or (callee == "request" and receiver == "axios")
+    ) and args:
+        return config_object_base_url(
+            lexed, args[0], call.start, suffix
+        )
+
+    # A per-request config on a method helper — axios.post(url, data, {baseURL})
+    # or api.post(url, data, {baseURL}) — sets the effective base and OVERRIDES
+    # the instance baseURL. Only the one-shot axios(config) form was read, so a
+    # required send addressed this way resolved to the bare path and was
+    # silently classified as safe. Checked first for that precedence.
+    # Member access differs by language (obj.post, $obj->post, Obj::post).
+    method_name = re.split(r"->|::|\.", callee)[-1]
+    config_index = _AXIOS_HELPER_CONFIG_INDEX.get(method_name)
+    if config_index is not None and len(args) > config_index:
+        base = config_object_base_url(
+            lexed, args[config_index], call.start, suffix
+        )
+        if base is not None:
+            return base
+
+    if receiver is None:
+        region = _paren_group_span_before_accessor(lexed, call)
+        return _base_url_in_region(lexed, region) if region is not None else None
+
+    # C# commonly configures HttpClient in a separate member assignment:
+    # `client.BaseAddress = new Uri("..."); client.PostAsync(path, ...)`.
+    member_base_pattern = re.compile(
+        rf"\b{re.escape(receiver)}\s*\.\s*BaseAddress\s*="
+    )
+    member_base = list(
+        member_base_pattern.finditer(lexed.code, 0, call.start)
+    )
+    if member_base:
+        start = member_base[-1].end()
+        end = assignment_end(lexed, start, suffix)
+        values = [
+            token.contents
+            for token in lexed.strings
+            if start <= token.start and token.end <= end
+        ]
+        if values:
+            return values[0]
+
+    for assignment in reversed(assignment_matches(lexed.code, receiver, call.start)):
+        rhs_start = assignment.end()
+        rhs_end = assignment_end(lexed, rhs_start, suffix)
+        if _CLIENT_FACTORY_CALL_RE.search(lexed.code, rhs_start, rhs_end):
+            base = _base_url_in_region(lexed, (rhs_start, rhs_end))
+            if base is not None:
+                return base
+    return None
+
+
+def join_base_and_path(base: str, path: str) -> str:
+    return base.rstrip("/") + "/" + path.lstrip("/")
+
+
+def request_url_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select URL expressions, unwrapping URI/URL constructor spellings."""
+    return [
+        unwrap_url_constructor(lexed, span)
+        for span in _request_url_spans(lexed, call, suffix)
+    ]
+
+
+def _request_url_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select URL expressions for the supported REST client signatures."""
+
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    if not args:
+        return []
+    callee = re.sub(
+        r"\s+", "", lexed.code[call.start:call.open_paren]
+    )
+    callee_lower = callee.lower()
+    receiver = call_receiver(lexed, call)
+    explicit_receiver = bool(
+        re.search(r"(?:\.|->|::)\s*$", lexed.code[:call.start])
+    )
+    if callee_lower == "post" and suffix in {".java", ".kt", ".kts", ".scala"}:
+        # Builder chain: the endpoint is set by an EARLIER link in the same
+        # statement — .uri(URI.create(url)) for java.net.http, .url(url) for
+        # OkHttp — so the send call's own arguments never carry it. The chain
+        # has no simple receiver, so this must run before the anonymous-receiver
+        # guard below or the call is discarded exactly because it is a builder.
+        # Keyed on the PRESENCE of that link rather than on the method's case,
+        # since java.net.http spells it .POST and OkHttp spells it .post.
+        uri_span = builder_uri_span(lexed, call)
+        if uri_span is not None:
+            # The execution-link requirement applies to OkHttp (`.url(...)` +
+            # newCall/enqueue), which is newly modelled here. java.net.http
+            # (`.uri(...)`) keeps its existing contract, where the builder chain
+            # itself is treated as the send - changing that is out of scope for
+            # this fix and its behaviour is pinned by existing tests.
+            okhttp_style = _BUILDER_LINK_KIND.get((id(lexed), call.start)) == "url"
+            if not okhttp_style or request_object_is_executed(
+                lexed, call, suffix
+            ):
+                return [uri_span]
+            return []
+        if callee == "POST":
+            return []
+    # A `.post()` whose receiver is not a simple identifier is a factory call.
+    # Two kinds exist: HTTP-client factories that DO send —
+    # requests.Session().post(...), httpx.Client().post(...),
+    # axios.create(...).post(...) — and mock/assertion factories that do NOT —
+    # nock(API).post(...), expect(x)... . Skipping every anonymous receiver
+    # missed the real clients (a common shape); analysing every one flags the
+    # mocks. Discriminate on the factory METHOD name: analyse only the known
+    # client factories, keep skipping the rest.
+    if (
+        callee_lower in {"post", "postasync", "request"}
+        and explicit_receiver
+        and receiver is None
+        and factory_receiver_method(lexed, call) not in HTTP_CLIENT_FACTORY_METHODS
+    ):
+        return []
+    if callee_lower in {"post", "postasync"} and receiver in {
+        "app", "console", "expect", "nock", "router"
+    }:
+        return []
+    if callee_lower in {"axios", "axios.request"}:
+        return config_object_url_spans(
+            lexed, args[0], call.start, suffix
+        )
+    named_method = named_argument_spans(lexed, args, "method")
+    named_url = [
+        span
+        for name in URL_MEMBER_NAMES
+        for span in named_argument_spans(lexed, args, name)
+    ]
+    if callee_lower in {"post", "postasync"} and named_url:
+        return named_url[-1:]
+    if suffix == ".php" and callee == "file_get_contents" and args:
+        region = php_stream_context_region(lexed, call, suffix)
+        if region is None:
+            return []
+        blob = lexed.original[region[0]:region[1]]
+        verb = re.search(r"[\'\"]method[\'\"]\s*=>\s*[\'\"](\w+)[\'\"]", blob)
+        if verb is None or verb.group(1).upper() not in MUTATING_HTTP_METHODS:
+            return []
+        return args[0:1]
+    if (
+        suffix in JS_TS_SUFFIXES
+        and callee.split(".")[-1] == "open"
+        and len(args) >= 2
+    ):
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        if method is None or method.upper() not in MUTATING_HTTP_METHODS:
+            return []
+        return args[1:2]
+    if suffix == ".py" and callee.split(".")[-1] == "Request" and args:
+        # urllib.request.Request(url, data=..., method="POST") - the stdlib
+        # client. Default method is GET unless data= is present or method=
+        # names a mutating verb.
+        blob = lexed.original[call.start:call.end]
+        method = re.search(r"method\s*=\s*[\'\"](\w+)[\'\"]", blob)
+        if method is not None:
+            if method.group(1).upper() not in MUTATING_HTTP_METHODS:
+                return []
+        elif not re.search(r"(?<![\w])data\s*=", blob):
+            return []
+        if not request_object_is_executed(lexed, call, suffix):
+            return []
+        return args[0:1]
+    if callee in {"HttpRequestMessage", "RestRequest"} and args:
+        # HttpRequestMessage(HttpMethod.Post, url) puts the endpoint SECOND;
+        # RestRequest(url, Method.Post) puts it FIRST. Only a mutating method
+        # makes the request a send.
+        blob = lexed.original[call.start:call.end]
+        mutating = re.search(
+            r"(?:HttpMethod|Method)\s*\.\s*(?:Post|Put|Patch)", blob
+        ) is not None
+        if not mutating:
+            # The verb may be assigned AFTER construction:
+            #   var req = new RestRequest(url);  req.Method = Method.Post;
+            # Treating the constructor alone as authoritative made that a
+            # silent pass.
+            statement_start = max(
+                lexed.code.rfind(";", 0, call.start),
+                chain_newline_boundary(lexed.code, call.start),
+            ) + 1
+            binding = re.search(
+                r"([A-Za-z_]\w*)\s*=(?!=)", lexed.code[statement_start:call.start]
+            )
+            if binding is None:
+                return []
+            mutating = re.search(
+                rf"(?<![\w]){re.escape(binding.group(1))}\s*\.\s*Method\s*="
+                r"\s*(?:HttpMethod|Method)\s*\.\s*(?:Post|Put|Patch)\b",
+                lexed.code[call.end:],
+            ) is not None
+            if not mutating:
+                return []
+        if not request_object_is_executed(lexed, call, suffix):
+            return []
+        return args[1:2] if callee == "HttpRequestMessage" else args[0:1]
+    if suffix == ".go" and callee in {"Post", "Put", "Patch"} and len(args) == 1:
+        # resty: client.R().SetBody(...).Post(url) - a single argument is the
+        # ENDPOINT, unlike net/http.Post(url, contentType, body). Without this
+        # the whole send was invisible.
+        return args[0:1]
+    if callee == "NewRequest" and len(args) >= 2:
+        # Go net/http: http.NewRequest(method, url, body) + client.Do(req).
+        # The idiomatic non-shortcut form; only mutating methods matter here.
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return []
+        # NOTE: http.NewRequest is NOT gated on a client.Do(req) execution link.
+        # An existing contract (test_http_method_gate_is_consistent_across_
+        # transports, fixture go-method-post.go) pins the behaviour that
+        # NewRequest alone counts as a required send. Adding the gate here was a
+        # behaviour change beyond the scope of this work, so it is left as-is;
+        # the execution requirement applies only to the clients newly modelled
+        # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
+        return args[1:2]
+    if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
+        return args[0:1]
+    if callee == "curl_init" and len(args) >= 1:
+        # `curl_init($url)` sets CURLOPT_URL directly - it is the documented
+        # one-liner form and is at least as common as the setopt spelling.
+        # Modelling only curl_setopt(CURLOPT_URL) made the whole send invisible:
+        # the endpoint was never resolved, so the call was not counted as a send
+        # and the fail-safe could not fire either. The linter reported "no
+        # number-pool call sites detected" on a number-pool POST.
+        return args[0:1]
+    if callee == "curl_setopt" and len(args) >= 3:
+        # PHP ext-curl is stateful: the URL and the payload arrive in
+        # separate curl_setopt calls on the same handle. The CURLOPT_URL call
+        # carries the endpoint; rest_payload_spans finds the sibling
+        # CURLOPT_POSTFIELDS for the same handle. Every other option is not
+        # an HTTP send and is skipped outright.
+        option = lexed.code[args[1][0]:args[1][1]].strip()
+        return args[2:3] if option == "CURLOPT_URL" else []
+    if callee == "curl_setopt_array" and len(args) >= 2:
+        # Same statefulness, one literal: curl_setopt_array($ch, [CURLOPT_URL
+        # => ..., CURLOPT_POSTFIELDS => ...]). The URL comes from the array,
+        # and the same method gate applies — an array that configures a GET is
+        # not a send and must not be reported.
+        url_spans = curl_option_array_value_spans(
+            lexed, args[1], suffix, "CURLOPT_URL"
+        )[-1:]
+        if not url_spans:
+            return []
+        handle = lexed.code[args[0][0]:args[0][1]].strip()
+        method = php_curl_handle_method(lexed, handle, call.start, suffix)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return []
+        return url_spans
+    if callee_lower in {"post", "postasync"} and not named_url:
+        # Request-style config object: post({url: ..., json: {...}}), with or
+        # without a trailing callback — request.post(options, cb) is the
+        # library's classic form. The URL lives in a member rather than a
+        # named argument, so named_url stays empty and the fallback below
+        # evaluated the whole object, meaning a number-pool send missing
+        # messaging_profile_id was never seen as a required call at all.
+        #
+        # Resolved from the FIRST argument only, never from any argument
+        # carrying a url-ish key: in post(url, {callback_url: ...}) the
+        # endpoint is the positional string and a url-shaped key inside the
+        # body must not displace it. A base-URL client passing only a body
+        # object has no URL member and keeps its existing treatment.
+        object_url = config_object_url_spans(
+            lexed, args[0], call.start, suffix
+        )
+        if object_url:
+            return object_url[-1:]
+    if callee_lower == "request" and named_method and named_url:
+        method = static_method_value(
+            lexed, named_method[-1], call.start, suffix
+        )
+        return (
+            []
+            if method is not None and method not in MUTATING_HTTP_METHODS
+            else named_url[-1:]
+        )
+    if callee_lower == "request":
+        first_config = resolved_config_object_span(
+            lexed, args[0], call.start, suffix
+        )
+        if first_config is not None:
+            members = config_object_url_spans(
+                lexed, args[0], call.start, suffix
+            )
+            if members:
+                return members[-1:]
+            path_members = named_object_member_spans(
+                lexed, first_config, ("path",)
+            )
+            host_members = named_object_member_spans(
+                lexed, first_config, ("hostname", "host")
+            )
+            return path_members[-1:] if path_members and host_members else []
+        if len(args) > 1 and resolved_config_object_span(
+            lexed, args[1], call.start, suffix
+        ) is not None:
+            # request(url, options[, callback]) is URL-first. Method gating
+            # is binding-aware in SourceEndpointResolver.
+            return args[:1]
+    if callee_lower == "request" and len(args) > 1:
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        return (
+            []
+            if method is not None and method not in MUTATING_HTTP_METHODS
+            else args[1:2]
+        )
+    if callee_lower == "request" and len(args) == 1:
+        members = config_object_url_spans(lexed, args[0], call.start, suffix)
+        if members:
+            return members[-1:]
+        # Node core http(s).request splits the endpoint into hostname + path.
+        # The path alone identifies the required endpoint (the normalizer
+        # accepts relative "/v2/messages/number_pool"), so a host member plus
+        # a path member is enough to place the call.
+        path_members = named_object_member_spans(lexed, args[0], ("path",))
+        host_members = named_object_member_spans(
+            lexed, args[0], ("hostname", "host")
+        )
+        if path_members and host_members:
+            return path_members[-1:]
+        return []
+    return args[:1]
+
+
+def selected_members_after_container(
+    lexed: LexedSource, closing: int, end: int
+) -> EndpointReference | None:
+    """Return a static selection chain, or None for a dynamic selector."""
+
+    members: list[str] = []
+    strings = {token.start: token for token in lexed.strings}
+    cursor = closing + 1
+    while cursor < end:
+        while cursor < end and (
+            lexed.code[cursor].isspace() or lexed.code[cursor] == ")"
+        ):
+            cursor += 1
+        bracket = False
+        if lexed.code.startswith("?.", cursor):
+            cursor += 2
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            bracket = cursor < end and lexed.code[cursor] == "["
+        elif cursor < end and lexed.code[cursor] == ".":
+            cursor += 1
+        elif lexed.code.startswith("->", cursor):
+            cursor += 2
+        elif cursor < end and lexed.code[cursor] == "[":
+            bracket = True
+        else:
+            break
+
+        if bracket:
+            cursor += 1
+            while (
+                cursor < end
+                and cursor not in strings
+                and lexed.code[cursor].isspace()
+            ):
+                cursor += 1
+            token = strings.get(cursor)
+            if token is not None:
+                key = token.contents
+                cursor = token.end
+            else:
+                numeric = re.match(r"\d+", lexed.code[cursor:end])
+                symbol = re.match(
+                    r":\s*([A-Za-z_]\w*)", lexed.code[cursor:end]
+                )
+                if numeric is not None:
+                    key = numeric.group(0)
+                    cursor += len(numeric.group(0))
+                elif symbol is not None:
+                    key = symbol.group(1)
+                    cursor += len(symbol.group(0))
+                else:
+                    return None
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            if cursor >= end or lexed.code[cursor] != "]":
+                return None
+            members.append(key)
+            cursor += 1
+            continue
+
+        while cursor < end and lexed.code[cursor].isspace():
+            cursor += 1
+        member = re.match(r"[A-Za-z_]\w*", lexed.code[cursor:end])
+        if member is None:
+            return None
+        member_name = member.group(0)
+        cursor += len(member_name)
+        lookup_cursor = cursor
+        while lookup_cursor < end and lexed.code[lookup_cursor].isspace():
+            lookup_cursor += 1
+        if (
+            member_name in {"fetch", "get", "Get"}
+            and lookup_cursor < end
+            and lexed.code[lookup_cursor] == "("
+        ):
+            lookup_closing = matching_delimiter(
+                lexed.code, lookup_cursor, "(", ")"
+            )
+            if lookup_closing is None or lookup_closing >= end:
+                return None
+            key = static_lookup_key(
+                lexed, lookup_cursor + 1, lookup_closing
+            )
+            if key is None:
+                return None
+            members.append(key)
+            cursor = lookup_closing + 1
+        else:
+            members.append(member_name)
+    return tuple(members)
+
+
+STATIC_REFERENCE_EXPRESSION_RE = re.compile(
+    r"\s*\$?[A-Za-z_]\w*"
+    r"(?:\s*(?:"
+    r"(?:\?\.|\.|->)\s*[A-Za-z_]\w*"
+    r"|(?:\?\.)?\s*\[\s*(?:\"[^\"]*\"|'[^']*'|`[^`]*`|"
+    r":\s*[A-Za-z_]\w*|\d+)\s*\]"
+    r"|(?:\.|->)\s*(?:get|Get|fetch)\s*\(\s*"
+    r"(?:\"[^\"]*\"|'[^']*'|`[^`]*`|:\s*[A-Za-z_]\w*|\d+)"
+    r"\s*\)"
+    r"))*\s*"
+)
+
+
+def strip_expression_parentheses(
+    lexed: LexedSource, start: int, end: int
+) -> tuple[int, int]:
+    while True:
+        while start < end and lexed.original[start].isspace():
+            start += 1
+        while end > start and lexed.original[end - 1].isspace():
+            end -= 1
+        if start >= end or lexed.code[start] != "(":
+            return start, end
+        closing = matching_delimiter(lexed.code, start, "(", ")")
+        if closing != end - 1:
+            return start, end
+        start += 1
+        end -= 1
+
+
+def static_reference_expression(
+    lexed: LexedSource, start: int, end: int
+) -> EndpointReference | None:
+    start, end = strip_expression_parentheses(lexed, start, end)
+    if not STATIC_REFERENCE_EXPRESSION_RE.fullmatch(
+        lexed.original[start:end]
+    ):
+        return None
+    references = static_references(lexed, start, end)
+    return references[0] if references else None
+
+
+def root_literal_container(
+    lexed: LexedSource, start: int, end: int, suffix: str
+) -> tuple[str, int, int] | None:
+    """Return a literal container rooted in one bounded expression."""
+
+    start, end = strip_expression_parentheses(lexed, start, end)
+    call_forms: tuple[tuple[str, str], ...] = ()
+    if suffix == ".java":
+        call_forms = (
+            (r"\bMap\s*\.\s*of\s*\(", "pairs"),
+            (r"\b(?:List\s*\.\s*of|Arrays\s*\.\s*asList)\s*\(", "array"),
+        )
+    elif suffix == ".php":
+        call_forms = ((r"\barray\s*\(", "members"),)
+    for pattern, kind in call_forms:
+        match = re.search(pattern, lexed.code[start:end])
+        if match is None:
+            continue
+        absolute_end = start + match.end()
+        opening = lexed.code.rfind("(", start, absolute_end)
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is not None and closing < end:
+            return kind, opening, closing
+
+    delimiters = "{" if suffix in {".cs", ".go", ".java"} else "[{"
+    candidates: list[int] = []
+    for index in range(start, end):
+        if lexed.code[index] not in delimiters:
+            continue
+        prefix = lexed.code[start:index].strip()
+        prefix = prefix.strip("() \t\r\n")
+        if not prefix or (
+            suffix in {".cs", ".go", ".java"}
+            and re.fullmatch(
+                r"(?:new\s+)?(?:[A-Za-z_]\w*(?:\s*<[^{}]+>)?"
+                r"(?:\s*\[[^{}]*\])?|map\s*\[[^{}]*\]\s*[A-Za-z_]\w*"
+                r"|\[[^{}]*\]\s*[A-Za-z_]\w*)",
+                prefix,
+            )
+        ):
+            candidates.append(index)
+    if not candidates:
+        return None
+    opening = candidates[0]
+    left = lexed.code[opening]
+    right = "}" if left == "{" else "]"
+    closing = matching_delimiter(lexed.code, opening, left, right)
+    return (
+        ("members", opening, closing)
+        if closing is not None and closing < end
+        else None
+    )
+
+
+def literal_value_span(
+    lexed: LexedSource,
+    start: int,
+    end: int,
+    path: EndpointReference,
+    suffix: str,
+) -> tuple[int, int] | None:
+    """Project a static key/index through nested bounded literals."""
+
+    current_start, current_end = start, end
+    for selected_key in path:
+        container = root_literal_container(
+            lexed, current_start, current_end, suffix
+        )
+        if container is None:
+            return None
+        kind, opening, closing = container
+        members = split_arguments(lexed.code, opening + 1, closing)
+        candidates: list[tuple[str, tuple[int, int]]] = []
+        if kind == "pairs":
+            for index in range(1, len(members), 2):
+                key = static_object_key(lexed, *members[index - 1])
+                if key is not None:
+                    candidates.append((key, members[index]))
+        else:
+            separators = [
+                (
+                    (colon, colon + 1)
+                    if (colon := top_level_colon(
+                        lexed.code, member_start, member_end
+                    )) is not None
+                    else top_level_assignment_separator(
+                        lexed.code, member_start, member_end
+                    )
+                )
+                for member_start, member_end in members
+            ]
+            keyed = any(
+                separator is not None for separator in separators
+            )
+            for index, ((member_start, member_end), separator) in enumerate(
+                zip(members, separators)
+            ):
+                if keyed:
+                    if separator is None:
+                        key = static_object_key(
+                            lexed, member_start, member_end
+                        )
+                        if key is not None:
+                            candidates.append(
+                                (key, (member_start, member_end))
+                            )
+                        continue
+                    separator_start, value_start = separator
+                    key = static_object_key(
+                        lexed, member_start, separator_start
+                    )
+                    if key is not None:
+                        candidates.append(
+                            (key, (value_start, member_end))
+                        )
+                else:
+                    candidates.append(
+                        (str(index), (member_start, member_end))
+                    )
+        # Object/hash duplicate keys use their last value.
+        selected = next(
+            (
+                span
+                for key, span in reversed(candidates)
+                if key == selected_key
+            ),
+            None,
+        )
+        if selected is None:
+            return None
+        current_start, current_end = selected
+    return strip_expression_parentheses(lexed, current_start, current_end)
+
+
+def class_field_regions(
+    lexed: LexedSource, suffix: str
+) -> list[tuple[int, int]]:
+    """Top-level regions of JS/TS class BODIES - where fields are declared.
+
+    A class field (`class S { payload = {…} }`) declares a MEMBER, not a
+    reassignment of a same-named outer variable, but the assignment pattern
+    cannot tell them apart. The field's value overwrote an outer `payload`
+    that already carried messaging_profile_id, and the send that used the outer
+    one was reported as missing the profile. Method bodies sit at depth > 0 and
+    are deliberately excluded, so real locals inside them still bind.
+    """
+
+    if suffix not in JS_TS_SUFFIXES:
+        return []
+    code = lexed.code
+    regions: list[tuple[int, int]] = []
+    for match in re.finditer(r"\bclass\b[^{};()]*\{", code):
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is None:
+            continue
+        depth = 0
+        span_start = opening + 1
+        for index in range(opening + 1, closing):
+            character = code[index]
+            if character in "([{":
+                if depth == 0:
+                    regions.append((span_start, index))
+                depth += 1
+            elif character in ")]}" and depth:
+                depth -= 1
+                if depth == 0:
+                    span_start = index + 1
+        regions.append((span_start, closing))
+    return regions
+
+
+def c_function_headers(
+    lexed: LexedSource, suffix: str
+) -> dict[int, tuple[int, int]]:
+    """Index common C-family function/method/closure braces and parameters."""
+
+    supported = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
+    if suffix not in supported:
+        return {}
+    headers: dict[int, tuple[int, int]] = {}
+    controls = {
+        "catch", "checked", "fixed", "for", "foreach", "if", "lock",
+        "switch", "synchronized", "try", "unchecked", "using", "while",
+        "with",
+    }
+    for opening in (index for index, char in enumerate(lexed.code) if char == "{"):
+        statement_start = max(
+            lexed.code.rfind(";", 0, opening),
+            lexed.code.rfind("{", 0, opening),
+            lexed.code.rfind("}", 0, opening),
+            lexed.code.rfind("\n", 0, opening),
+        ) + 1
+        statement_start = max(statement_start, opening - 512)
+        header = lexed.code[statement_start:opening]
+        trimmed = header.rstrip()
+
+        arrow_token = None
+        if suffix in JS_TS_SUFFIXES | {".cs"}:
+            arrow_token = "=>"
+        elif suffix == ".java":
+            arrow_token = "->"
+        if arrow_token and trimmed.endswith(arrow_token):
+            arrow_start = statement_start + len(trimmed) - 2
+            cursor = arrow_start - 1
+            while cursor >= statement_start and lexed.code[cursor].isspace():
+                cursor -= 1
+            if cursor >= statement_start and lexed.code[cursor] == ")":
+                params_open = matching_opening(
+                    lexed.code, cursor, "(", ")"
+                )
+                if params_open is not None and params_open >= statement_start:
+                    headers[opening] = (params_open + 1, cursor)
+                continue
+            parameter = re.search(
+                r"(?:^|[^\w$])([$A-Za-z_]\w*)\s*$",
+                lexed.code[statement_start:arrow_start],
+            )
+            if parameter is not None:
+                headers[opening] = (
+                    statement_start + parameter.start(1),
+                    statement_start + parameter.end(1),
+                )
+            continue
+
+        pairs: list[tuple[int, int]] = []
+        depth = 0
+        params_open = -1
+        for index in range(statement_start, opening):
+            if lexed.code[index] == "(":
+                if depth == 0:
+                    params_open = index
+                depth += 1
+            elif lexed.code[index] == ")" and depth:
+                depth -= 1
+                if depth == 0:
+                    pairs.append((params_open, index))
+        if not pairs:
+            continue
+
+        keyword = re.search(r"\b(function|func)\b", header)
+        if keyword is not None:
+            keyword_end = statement_start + keyword.end()
+            candidates = [pair for pair in pairs if pair[0] >= keyword_end]
+            if not candidates:
+                continue
+            selected = candidates[0]
+            if suffix == ".go" and len(candidates) > 1:
+                before_first = lexed.code[keyword_end:selected[0]].strip()
+                between = lexed.code[selected[1] + 1:candidates[1][0]].strip()
+                if not before_first and re.fullmatch(
+                    r"[A-Za-z_]\w*", between
+                ):
+                    selected = candidates[1]
+            headers[opening] = (selected[0] + 1, selected[1])
+            continue
+        if suffix in {".go", ".php"}:
+            continue
+
+        for candidate_open, candidate_close in pairs:
+            prefix = lexed.code[statement_start:candidate_open]
+            name_match = re.search(r"([A-Za-z_]\w*)\s*$", prefix)
+            if name_match is None:
+                continue
+            name = name_match.group(1)
+            if name in controls:
+                continue
+            before_name = prefix[:name_match.start(1)]
+            if re.search(
+                rf"\b(?:{'|'.join(sorted(controls))})\b[^{{}};]*$",
+                before_name,
+            ):
+                continue
+            if re.search(r"(?:\.|->|::)\s*$", before_name):
+                continue
+            if re.search(
+                r"\b(?:new|return|throw)\b[^{};]*$", before_name
+            ) or re.search(r"\bclass\b[^{};]*\bextends\b", before_name):
+                continue
+            tail = lexed.code[candidate_close + 1:opening].strip()
+            if suffix == ".java" and tail and not tail.startswith("throws"):
+                continue
+            if suffix == ".cs" and tail and not re.fullmatch(
+                r":\s*(?:base|this)\s*\([\s\S]*\)", tail
+            ):
+                continue
+            if suffix in JS_TS_SUFFIXES and tail:
+                if not tail.startswith(":"):
+                    continue
+            if suffix == ".sh":
+                if lexed.code[candidate_open + 1:candidate_close].strip():
+                    continue
+                shell_prefix = prefix.strip()
+                if not re.fullmatch(
+                    rf"(?:function\s+)?{re.escape(name)}\s*", shell_prefix
+                ):
+                    continue
+            headers[opening] = (candidate_open + 1, candidate_close)
+            break
+    return headers
+
+
+def conditional_curly_scopes(code: str) -> set[int]:
+    # The prefix runs back to the previous brace, not a fixed 160 characters:
+    # `[^{}]*` already bounds the search there, and a LONG condition pushed its
+    # `if` outside the window, so the block opened no scope at all and a
+    # block-scoped `const payload` inside it leaked into the enclosing scope -
+    # shadowing the outer payload the send actually uses.
+    guarded: set[int] = set()
+    head = re.compile(
+        r"(?:\b(?:if|else|for|foreach|while|switch|case|catch|try)\b[^{}]*)$"
+    )
+    boundary = 0
+    for index, character in enumerate(code):
+        if character not in "{}":
+            continue
+        if character == "{" and head.search(code[boundary:index]):
+            guarded.add(index)
+        boundary = index + 1
+    return guarded
+
+
+def required_endpoint(value: str) -> bool:
+    # urlsplit RAISES on a malformed authority (an unclosed IPv6 bracket, an
+    # invalid port), and this runs on every endpoint-shaped literal in the tree
+    # - including ones inside test fixtures and documentation. An exception here
+    # aborted the whole FILE, so one unparsable string turned every send in it
+    # into "could not verify". Fall back to plain string handling instead.
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        parsed = None
+    path = (
+        (parsed.path if parsed is not None else "")
+        or value.split("?", 1)[0].split("#", 1)[0]
+    )
+    # Clients configured with a base URL (axios baseURL, requests Session
+    # mounts) pass RELATIVE paths such as "messages/number_pool"; a trailing-
+    # slash base joined with a relative path also leaves INTERIOR "." / ".."
+    # segments, because axios combineURLs does no normalization (baseURL
+    # ".../v2/messages/" + "./number_pool" -> ".../v2/messages/./number_pool",
+    # and ".../v2/messages/foo/" + "../number_pool" -> "...foo/../number_pool").
+    # Resolve all dot segments the way the HTTP layer does before comparing, so
+    # neither the base-URL form nor an interior dot segment is silently missed.
+    if not path.startswith("/"):
+        path = "/" + path
+    path = posixpath.normpath(path)
+    # posixpath.normpath PRESERVES a leading "//" (POSIX reserves it), so
+    # "https://api.telnyx.com//v2/messages/number_pool" kept a "//v2/..." path
+    # and matched nothing. Interior runs are already collapsed by normpath;
+    # collapse the leading run the same way an HTTP router does.
+    path = "/" + path.lstrip("/")
+    if path.startswith("/v2/") or path == "/v2":
+        path = path[3:] or "/"
+    return path.rstrip("/") in {
+        "/messages/number_pool",
+        "/messages/alphanumeric_sender_id",
+    }
+
+
+def required_endpoint_literal_signal(value: str) -> bool:
+    """Whether a URL-expression literal proves a required endpoint suffix.
+
+    Format strings often carry an unknown host prefix (`%s/v2/...`) that is
+    not itself a valid URL/path, but their static suffix is still definitive.
+    Keep this separate from `required_endpoint`, whose exact-path contract is
+    intentionally stricter for fully resolved URLs.
+    """
+    clean = value.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+    return bool(
+        re.search(
+            r"(?:^|/)messages/(?:number_pool|alphanumeric_sender_id)$",
+            clean,
+        )
+    )
+
+
+def endpoint_literal_value(value: str) -> EndpointValue:
+    return EndpointValue(REQUIRED if required_endpoint(value) else SAFE, value)
+
+
+def _default_endpoint_value(
+    values: tuple[EndpointValue, ...]
+) -> EndpointValue:
+    """Combine a `primary, fallback` pair (`get(k, d)`, `{a = d} = o`).
+
+    Only a MISSING primary selects the fallback - that is the one case where the
+    default is provably taken. EVERY other primary, UNRESOLVABLE included, is
+    returned as-is, so a dynamic lookup does NOT promote a REQUIRED literal
+    default. See the comment below for why that stays out of scope here.
+    """
+    primary, fallback = values[0], values[1]
+    if primary.kind == MISSING:
+        return fallback
+    # An UNRESOLVABLE primary deliberately does NOT promote a REQUIRED default.
+    # Treating it as required was tried and reverted: the documented contract
+    # (test_endpoint_resolver_common_static_syntax_corpus, fixture
+    # runtime-primary-default.js) places fail-closed dynamic lookups OUTSIDE
+    # this non-parser's finite grammar, so `const {pool: e = REQUIRED} = r`
+    # with a dynamic `r` is not provably a required send. Changing that is a
+    # behaviour change that needs its own justification, not a side effect.
+    return primary
+
+
+def join_endpoint_values(values: Iterable[EndpointValue]) -> EndpointValue:
+    values = tuple(values)
+    if not values:
+        return UNKNOWN_VALUE
+    kinds = {value.kind for value in values}
+    exacts = {value.exact for value in values}
+    # A JOIN is over branches that may ALL execute (a conditional reassignment,
+    # a guarded arm). If ANY branch reaches the required endpoint the send can
+    # reach it at runtime, so the join must stay REQUIRED. Collapsing the mixed
+    # case to UNKNOWN silently dropped conditionally-assigned number_pool sends:
+    # the surrounding call was still recognised, so the fail-safe backstop had
+    # nothing left to report either.
+    if REQUIRED in kinds:
+        return EndpointValue(
+            REQUIRED, exacts.pop() if len(exacts) == 1 else None
+        )
+    if len(kinds) != 1 or UNKNOWN in kinds:
+        return UNKNOWN_VALUE
+    return EndpointValue(
+        values[0].kind, exacts.pop() if len(exacts) == 1 else None
+    )
+
+
+class EndpointGraph:
+    """Iterative abstract interpreter over pre-indexed endpoint definitions."""
+
+    def __init__(self, source_length: int, state_budget: int = 10_000) -> None:
+        self.scopes: dict[int, IndexedScope] = {
+            0: IndexedScope(0, None, 0, source_length, "module")
+        }
+        self.bindings: dict[int, IndexedBinding] = {}
+        self.bindings_by_name: dict[str, list[int]] = {}
+        self.definitions: dict[int, list[IndexedDefinition]] = {}
+        self.definition_offsets: dict[int, list[int]] = {}
+        self._next_scope = 1
+        self._next_binding = 1
+        self.state_budget = state_budget
+        self._memo: dict[EndpointState, EndpointValue] = {}
+
+    def add_scope(
+        self, parent: int, start: int, end: int, kind: str
+    ) -> int:
+        scope_id = self._next_scope
+        self._next_scope += 1
+        self.scopes[scope_id] = IndexedScope(
+            scope_id, parent, start, end, kind
+        )
+        return scope_id
+
+    def ancestors(self, scope_id: int) -> tuple[int, ...]:
+        result: list[int] = []
+        current: int | None = scope_id
+        while current is not None:
+            result.append(current)
+            current = self.scopes[current].parent
+        return tuple(result)
+
+    def execution_scope(self, scope_id: int) -> int:
+        for candidate in self.ancestors(scope_id):
+            if self.scopes[candidate].kind in {"function", "module"}:
+                return candidate
+        return 0
+
+    def visible_binding(
+        self, name: str, use_scope: int, before: int
+    ) -> int | None:
+        ancestry = self.ancestors(use_scope)
+        depth = {scope_id: index for index, scope_id in enumerate(ancestry)}
+        candidates = [
+            self.bindings[binding_id]
+            for binding_id in self.bindings_by_name.get(name, ())
+            if self.bindings[binding_id].scope_id in depth
+            and self.bindings[binding_id].visibility_start <= before
+        ]
+        if not candidates:
+            return None
+        candidates.sort(
+            key=lambda binding: (
+                depth[binding.scope_id],
+                -binding.declaration_start,
+            )
+        )
+        return candidates[0].id
+
+    def add_binding(
+        self,
+        name: str,
+        scope_id: int,
+        declaration_start: int,
+        visibility_start: int,
+        kind: str,
+    ) -> int:
+        binding_id = self._next_binding
+        self._next_binding += 1
+        binding = IndexedBinding(
+            binding_id,
+            name,
+            scope_id,
+            declaration_start,
+            visibility_start,
+            kind,
+        )
+        self.bindings[binding_id] = binding
+        self.bindings_by_name.setdefault(name, []).append(binding_id)
+        return binding_id
+
+    def add_definition(
+        self,
+        binding_id: int,
+        path: EndpointReference,
+        expression: EndpointExpression,
+        offset: int,
+        scope_id: int,
+        kind: str,
+        guarded: bool = False,
+    ) -> None:
+        self._memo.clear()
+        definition = IndexedDefinition(
+            binding_id,
+            path,
+            offset,
+            expression,
+            scope_id,
+            self.execution_scope(scope_id),
+            kind,
+            guarded,
+        )
+        offsets = self.definition_offsets.setdefault(binding_id, [])
+        definitions = self.definitions.setdefault(binding_id, [])
+        index = bisect.bisect_right(offsets, offset)
+        offsets.insert(index, offset)
+        definitions.insert(index, definition)
+
+    def _definition_reaches(
+        self, definition: IndexedDefinition, state: EndpointAccessState
+    ) -> bool:
+        if definition.kind in {"declaration", "parameter"}:
+            return definition.scope_id in self.ancestors(state.use_scope)
+        return definition.execution_scope == self.execution_scope(
+            state.use_scope
+        )
+
+    def _matching_definitions(
+        self, state: EndpointAccessState
+    ) -> list[IndexedDefinition]:
+        offsets = self.definition_offsets.get(state.binding_id, ())
+        stop = bisect.bisect_left(offsets, state.before)
+        return [
+            definition
+            for definition in self.definitions.get(state.binding_id, ())[:stop]
+            if state.path[: len(definition.member_path)]
+            == definition.member_path
+            and self._definition_reaches(definition, state)
+        ]
+
+    @staticmethod
+    def _concat(values: tuple[EndpointValue, ...]) -> EndpointValue:
+        if not values:
+            return UNKNOWN_VALUE
+        if all(value.exact is not None for value in values):
+            return endpoint_literal_value(
+                "".join(value.exact or "" for value in values)
+            )
+        suffix_parts: list[str] = []
+        for value in reversed(values):
+            if value.exact is None:
+                break
+            suffix_parts.append(value.exact)
+        suffix = "".join(reversed(suffix_parts))
+        if required_endpoint(suffix):
+            return EndpointValue(REQUIRED)
+        # A dynamic QUERY STRING (".../messages/number_pool?ref=" + id) leaves
+        # no exact trailing run at all, so the suffix scan above saw nothing and
+        # the send was silently classified as safe. Once the exact PREFIX has
+        # reached a "?" or "#" the path is already closed: whatever follows is
+        # query or fragment and cannot change the endpoint.
+        prefix_parts: list[str] = []
+        for value in values:
+            if value.exact is None:
+                break
+            prefix_parts.append(value.exact)
+        prefix = "".join(prefix_parts)
+        if ("?" in prefix or "#" in prefix) and required_endpoint(prefix):
+            return EndpointValue(REQUIRED)
+        return UNKNOWN_VALUE
+
+    def _definition_dependency(
+        self,
+        definition: IndexedDefinition,
+        state: EndpointAccessState,
+    ) -> EndpointExpressionState:
+        remainder = state.path[len(definition.member_path):]
+        live_container_alias = (
+            bool(remainder)
+            and isinstance(definition.expression, EndpointRef)
+            and not definition.expression.members
+        )
+        return EndpointExpressionState(
+            definition.expression,
+            remainder,
+            state.before if live_container_alias else definition.start,
+            state.use_scope if live_container_alias else definition.scope_id,
+        )
+
+    def _expand_access(
+        self, state: EndpointAccessState
+    ) -> EndpointExpansion:
+        definitions = self._matching_definitions(state)
+        if not definitions:
+            return EndpointExpansion(immediate=UNKNOWN_VALUE)
+        last_unguarded = -1
+        use_ancestry = set(self.ancestors(state.use_scope))
+        for index, definition in enumerate(definitions):
+            if not definition.guarded or definition.scope_id in use_ancestry:
+                last_unguarded = index
+        if last_unguarded < 0:
+            selected = definitions
+            baseline = (UNKNOWN_VALUE,)
+        else:
+            selected = [definitions[last_unguarded]] + [
+                definition
+                for definition in definitions[last_unguarded + 1:]
+                if definition.guarded
+                and definition.scope_id not in use_ancestry
+            ]
+            baseline = ()
+        dependencies = tuple(
+            self._definition_dependency(definition, state)
+            for definition in selected
+        )
+        return EndpointExpansion(
+            dependencies,
+            lambda values: join_endpoint_values(baseline + values),
+        )
+
+    def _expand_expression(
+        self, state: EndpointExpressionState
+    ) -> EndpointExpansion:
+        expression = state.expression
+        if isinstance(expression, EndpointUnknown):
+            return EndpointExpansion(immediate=UNKNOWN_VALUE)
+        if isinstance(expression, EndpointLiteral):
+            return EndpointExpansion(
+                immediate=(
+                    UNKNOWN_VALUE
+                    if state.projection
+                    else endpoint_literal_value(expression.value)
+                )
+            )
+        if isinstance(expression, EndpointRef):
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointAccessState(
+                        expression.binding_id,
+                        expression.members + state.projection,
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointObject):
+            if not state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            key, remainder = state.projection[0], state.projection[1:]
+            candidates = [
+                value for entry_key, value in expression.entries
+                if entry_key == key
+            ]
+            if not candidates:
+                return EndpointExpansion(immediate=MISSING_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        candidates[-1], remainder, state.before, state.use_scope
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointArray):
+            if not state.projection or not state.projection[0].isdigit():
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            index = int(state.projection[0])
+            if index >= len(expression.items):
+                return EndpointExpansion(immediate=MISSING_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.items[index],
+                        state.projection[1:],
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointDefault):
+            if state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.primary, (), state.before, state.use_scope
+                    ),
+                    EndpointExpressionState(
+                        expression.fallback, (), state.before, state.use_scope
+                    ),
+                ),
+                combine=_default_endpoint_value,
+            )
+        if isinstance(expression, EndpointConcat):
+            if state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            return EndpointExpansion(
+                dependencies=tuple(
+                    EndpointExpressionState(
+                        part, (), state.before, state.use_scope
+                    )
+                    for part in expression.parts
+                ),
+                combine=self._concat,
+            )
+        if isinstance(expression, EndpointProjected):
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.expression,
+                        expression.members + state.projection,
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        return EndpointExpansion(immediate=UNKNOWN_VALUE)
+
+    def _expand(self, state: EndpointState) -> EndpointExpansion:
+        return (
+            self._expand_access(state)
+            if isinstance(state, EndpointAccessState)
+            else self._expand_expression(state)
+        )
+
+    def evaluate(self, state: EndpointState) -> EndpointValue:
+        memo: dict[EndpointState, EndpointValue] = dict(self._memo)
+        visiting: set[EndpointState] = set()
+        stack = [EndpointFrame(state)]
+        expanded_states = 0
+        while stack:
+            frame = stack[-1]
+            if frame.state in memo:
+                value = memo[frame.state]
+                stack.pop()
+                if stack:
+                    stack[-1].values.append(value)
+                    stack[-1].next_dependency += 1
+                continue
+            if frame.expansion is None:
+                expanded_states += 1
+                if expanded_states > self.state_budget:
+                    return UNKNOWN_VALUE
+                frame.expansion = self._expand(frame.state)
+                if frame.expansion.immediate is not None:
+                    memo[frame.state] = frame.expansion.immediate
+                    continue
+                visiting.add(frame.state)
+            dependencies = frame.expansion.dependencies
+            if frame.next_dependency < len(dependencies):
+                dependency = dependencies[frame.next_dependency]
+                if dependency in visiting:
+                    frame.values.append(UNKNOWN_VALUE)
+                    frame.next_dependency += 1
+                elif dependency in memo:
+                    frame.values.append(memo[dependency])
+                    frame.next_dependency += 1
+                else:
+                    stack.append(EndpointFrame(dependency))
+                continue
+            visiting.discard(frame.state)
+            assert frame.expansion.combine is not None
+            memo[frame.state] = frame.expansion.combine(tuple(frame.values))
+        self._memo.update(memo)
+        return memo[state]
+
+
+class SourceEndpointResolver:
+    """Compile one source file into a call-centric endpoint value graph."""
+
+    JAVASCRIPT_SUFFIXES = JS_TS_SUFFIXES
+    C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
+
+    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+        self.lexed = lexed
+        self.suffix = suffix
+        self.graph = EndpointGraph(len(lexed.code))
+        self.c_headers = c_function_headers(lexed, suffix)
+        self.class_fields = class_field_regions(lexed, suffix)
+        self.conditional_openings = conditional_curly_scopes(lexed.code)
+        self.scope_ranges: list[tuple[int, int, int]] = []
+        self.scope_by_opening: dict[int, int] = {}
+        self.expression_parameters: list[tuple[int, int, int, int]] = []
+        self.assignment_bindings: dict[int, int] = {}
+        self.destructuring: list[
+            tuple[int, int, int, int, list[tuple[str, EndpointReference, tuple[int, int] | None]]]
+        ] = []
+        self.destructure_mutations: set[int] = set()
+        self._build_scopes()
+        self._find_destructuring()
+        self.root_assignments = [
+            match
+            for match in VARIABLE_ASSIGNMENT_RE.finditer(lexed.code)
+            if not self._inside_destructuring_lhs(match.start())
+            and not self._inside_parameter_list(match.start())
+            and not self._inside_class_field(match.start())
+        ]
+        self._build_bindings()
+        self._index_node_path_join_bindings()
+        self._build_definitions()
+
+    def _index_node_path_join_bindings(self) -> None:
+        """Index only live bindings that originate from Node's path.join.
+
+        The builder parser must distinguish a real destructured/imported
+        ``path.join`` from an unrelated local function with the same name.
+        Binding IDs make parameter/block shadowing explicit; origin offsets
+        let later assignments invalidate a mutable CommonJS alias.
+        """
+
+        self.node_path_join_origins: dict[int, int] = {}
+        self.node_path_join_imports: dict[str, int] = {}
+        self.node_path_module_origins: dict[int, int] = {}
+        self.node_path_module_imports: dict[str, int] = {}
+        source = self.lexed.without_comments
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?(?!\s*\.)",
+            source,
+        ):
+            name = match.group(1)
+            binding_id = self.graph.visible_binding(
+                name, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_module_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+
+        for match in re.finditer(
+            r"\bimport\s+(?:\*\s+as\s+)?([A-Za-z_$]\w*)\s+from\s*"
+            r"['\"](?:node:)?path['\"]",
+            source,
+        ):
+            self.node_path_module_imports[match.group(1)] = match.start()
+
+        commonjs = re.compile(
+            r"\b(?:const|let|var)\s*\{([^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?"
+        )
+        for match in commonjs.finditer(source):
+            opening = source.find("{", match.start(), match.end())
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*join\s*(?::\s*([A-Za-z_$]\w*))?\s*", member
+                )
+                if parsed is None:
+                    continue
+                name = parsed.group(1) or "join"
+                binding_id = self.destructure_bindings.get((opening, name))
+                if binding_id is not None:
+                    self.node_path_join_origins[binding_id] = opening
+
+        for match in re.finditer(
+            r"\bimport\s*\{([^{}]*)\}\s*from\s*"
+            r"['\"](?:node:)?path['\"]",
+            source,
+        ):
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*join\s*(?:as\s+([A-Za-z_$]\w*))?\s*", member
+                )
+                if parsed is not None:
+                    self.node_path_join_imports[parsed.group(1) or "join"] = (
+                        match.start()
+                    )
+
+        # Destructuring or copying `.join` from a previously bound path
+        # module is equivalent to destructuring it directly from require().
+        for opening, _, rhs_start, rhs_end, leaves in self.destructuring:
+            rhs = source[rhs_start:rhs_end].strip()
+            module = re.fullmatch(r"([A-Za-z_$]\w*)", rhs)
+            if module is None or not self._is_node_path_module_alias(
+                module.group(1), self.scope_at(opening), opening
+            ):
+                continue
+            for name, members, _ in leaves:
+                if members == ("join",):
+                    binding_id = self.destructure_bindings.get((opening, name))
+                    if binding_id is not None:
+                        self.node_path_join_origins[binding_id] = opening
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"([A-Za-z_$]\w*)\s*\.\s*join\b",
+            source,
+        ):
+            alias, module = match.groups()
+            if not self._is_node_path_module_alias(
+                module, self.scope_at(match.start()), match.start()
+            ):
+                continue
+            binding_id = self.graph.visible_binding(
+                alias, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_join_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?\s*\.\s*join\b",
+            source,
+        ):
+            name = match.group(1)
+            binding_id = self.graph.visible_binding(
+                name, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_join_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+            else:
+                self.node_path_join_imports[name] = match.start()
+
+    def _is_node_path_module_alias(
+        self, name: str, scope_id: int, before: int
+    ) -> bool:
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        if binding_id is None:
+            return self.node_path_module_imports.get(name, before + 1) < before
+        origin = self.node_path_module_origins.get(binding_id)
+        if origin is None:
+            return False
+        return not any(
+            origin < offset < before and assigned == binding_id
+            for offset, assigned in self.assignment_bindings.items()
+        )
+
+    def _is_node_path_join_alias(
+        self, name: str, scope_id: int, before: int
+    ) -> bool:
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        if binding_id is None:
+            return self.node_path_join_imports.get(name, before + 1) < before
+        origin = self.node_path_join_origins.get(binding_id)
+        if origin is None:
+            return False
+        # A mutable alias stops identifying path.join after any later plain
+        # or destructuring assignment that reaches the same binding.
+        if any(
+            origin < offset < before and assigned == binding_id
+            for offset, assigned in self.assignment_bindings.items()
+        ):
+            return False
+        if any(
+            origin < opening < before
+            and self.destructure_bindings.get((opening, name)) == binding_id
+            for opening in self.destructure_mutations
+        ):
+            return False
+        return True
+
+    def _build_scopes(self) -> None:
+        if self.suffix in self.C_SUFFIXES:
+            stack: list[tuple[int, int, int]] = []
+            for opening, character in enumerate(self.lexed.code):
+                if character != "{":
+                    continue
+                statement_start = max(
+                    self.lexed.code.rfind(";", 0, opening),
+                    self.lexed.code.rfind("\n", 0, opening),
+                    self.lexed.code.rfind("}", 0, opening),
+                ) + 1
+                prefix = self.lexed.code[statement_start:opening].strip()
+                code_block = (
+                    opening in self.c_headers
+                    or opening in self.conditional_openings
+                    or not prefix
+                    or bool(
+                        re.search(
+                            r"\b(?:else|try|finally|do|class|namespace|"
+                            r"interface|struct|enum|synchronized|using|lock|"
+                            r"fixed|checked|unchecked)\b[^{}]*$",
+                            prefix,
+                        )
+                    )
+                )
+                if not code_block:
+                    continue
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "{", "}"
+                )
+                if closing is None:
+                    continue
+                while stack and opening > stack[-1][1]:
+                    stack.pop()
+                parent = stack[-1][2] if stack else 0
+                kind = (
+                    "function"
+                    if opening in self.c_headers
+                    else "conditional"
+                    if opening in self.conditional_openings
+                    else "block"
+                )
+                scope_id = self.graph.add_scope(
+                    parent, opening, closing + 1, kind
+                )
+                self.scope_by_opening[opening] = scope_id
+                self.scope_ranges.append((opening, closing + 1, scope_id))
+                stack.append((opening, closing, scope_id))
+            self._build_expression_lambda_scopes()
+            return
+        if self.suffix == ".py":
+            self._build_python_scopes()
+            return
+        if self.suffix == ".rb":
+            self._build_ruby_scopes()
+
+    def _build_expression_lambda_scopes(self) -> None:
+        token = "->" if self.suffix == ".java" else "=>"
+        if self.suffix not in JS_TS_SUFFIXES | {".cs", ".java"}:
+            return
+        for arrow in re.finditer(re.escape(token), self.lexed.code):
+            body_start = arrow.end()
+            while (
+                body_start < len(self.lexed.code)
+                and self.lexed.code[body_start].isspace()
+            ):
+                body_start += 1
+            if (
+                body_start >= len(self.lexed.code)
+                or self.lexed.code[body_start] == "{"
+            ):
+                continue
+            cursor = arrow.start() - 1
+            while cursor >= 0 and self.lexed.code[cursor].isspace():
+                cursor -= 1
+            if cursor >= 0 and self.lexed.code[cursor] == ")":
+                params_open = matching_opening(
+                    self.lexed.code, cursor, "(", ")"
+                )
+                if params_open is None:
+                    continue
+                params_start, params_end = params_open + 1, cursor
+            else:
+                parameter = re.search(
+                    r"([$A-Za-z_]\w*)\s*$",
+                    self.lexed.code[:arrow.start()],
+                )
+                if parameter is None:
+                    continue
+                params_start, params_end = parameter.span(1)
+
+            round_depth = square_depth = curly_depth = 0
+            body_end = len(self.lexed.code)
+            for index in range(body_start, len(self.lexed.code)):
+                character = self.lexed.code[index]
+                if character == "(":
+                    round_depth += 1
+                elif character == "[":
+                    square_depth += 1
+                elif character == "{":
+                    curly_depth += 1
+                elif character == ")":
+                    if not round_depth:
+                        body_end = index
+                        break
+                    round_depth -= 1
+                elif character == "]":
+                    if not square_depth:
+                        body_end = index
+                        break
+                    square_depth -= 1
+                elif character == "}":
+                    if not curly_depth:
+                        body_end = index
+                        break
+                    curly_depth -= 1
+                elif (
+                    character in {";", "\n", ","}
+                    and not (round_depth or square_depth or curly_depth)
+                ):
+                    body_end = index
+                    break
+            parent = self.scope_at(arrow.start())
+            scope_id = self.graph.add_scope(
+                parent, body_start, body_end, "function"
+            )
+            self.scope_ranges.append((body_start, body_end, scope_id))
+            self.expression_parameters.append(
+                (scope_id, params_start, params_end, arrow.start())
+            )
+
+    def _build_python_scopes(self) -> None:
+        lines = self.lexed.code.splitlines(keepends=True)
+        stack: list[tuple[int, str, int, int]] = []
+        records: list[list[int | str]] = []
+        cursor = 0
+        row = 0
+        while row < len(lines):
+            line = lines[row]
+            consumed = 1
+            stripped = line.lstrip(" \t")
+            if stripped.strip():
+                indent = len(line) - len(stripped)
+                while stack and indent <= stack[-1][0]:
+                    _, _, record_index, _ = stack.pop()
+                    records[record_index][2] = cursor
+                match = None
+                if re.match(r"(?:async\s+)?(?:def|class)\b", stripped):
+                    # A def/class signature may WRAP across lines, leaving its
+                    # ':' on a continuation row. Only a one-line header was
+                    # recognised, so the function opened no scope at all and a
+                    # local `payload` reassignment inside it read as a
+                    # module-level one - hiding a send that never got the
+                    # profile. Join continuation rows until the brackets close.
+                    joined = stripped
+                    while (
+                        re.search(r":\s*$", joined) is None
+                        and row + consumed < len(lines)
+                        and sum(joined.count(character) for character in "([{")
+                        > sum(joined.count(character) for character in ")]}")
+                    ):
+                        joined += lines[row + consumed]
+                        consumed += 1
+                    match = re.fullmatch(
+                        r"(?:async\s+)?(def|class)\b[\s\S]*:\s*", joined
+                    )
+                if match is not None:
+                    kind = "function" if match.group(1) == "def" else "class"
+                    parent = stack[-1][3] if stack else 0
+                    if kind == "function" and stack and stack[-1][1] == "class":
+                        parent = 0
+                    records.append([cursor, kind, len(self.lexed.code), parent])
+                    record_index = len(records) - 1
+                    # The graph id is filled after ranges are known; retain a
+                    # temporary negative record id in the stack.
+                    stack.append((indent, kind, record_index, -(record_index + 1)))
+            cursor += sum(
+                len(lines[row + offset]) for offset in range(consumed)
+            )
+            row += consumed
+        while stack:
+            _, _, record_index, _ = stack.pop()
+            records[record_index][2] = len(self.lexed.code)
+
+        id_by_record: dict[int, int] = {}
+        for index, (start, kind, end, parent_token) in enumerate(records):
+            parent = (
+                id_by_record[-int(parent_token) - 1]
+                if int(parent_token) < 0
+                else int(parent_token)
+            )
+            scope_id = self.graph.add_scope(
+                parent, int(start), int(end), str(kind)
+            )
+            id_by_record[index] = scope_id
+            self.scope_ranges.append((int(start), int(end), scope_id))
+
+    def _build_ruby_scopes(self) -> None:
+        stack: list[tuple[str, int | None, int]] = []
+        records: list[list[int | str]] = []
+        cursor = 0
+        for line in self.lexed.code.splitlines(keepends=True):
+            stripped = line.strip()
+            if re.match(r"end\b", stripped) and stack:
+                _, record_index, _ = stack.pop()
+                if record_index is not None:
+                    records[record_index][2] = cursor + len(line)
+            else:
+                match = re.match(r"(def|class|module)\b", stripped)
+                if match is not None:
+                    kind = "function" if match.group(1) == "def" else "class"
+                    parent_token = stack[-1][2] if stack else 0
+                    if kind == "function" and stack:
+                        parent_token = 0
+                    records.append(
+                        [cursor, kind, len(self.lexed.code), parent_token]
+                    )
+                    record_index = len(records) - 1
+                    stack.append((kind, record_index, -(record_index + 1)))
+                elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
+                    parent_token = stack[-1][2] if stack else 0
+                    records.append(
+                        [cursor, "block", len(self.lexed.code), parent_token]
+                    )
+                    record_index = len(records) - 1
+                    stack.append(("block", record_index, -(record_index + 1)))
+                elif re.match(
+                    r"(?:if|unless|case|begin|for|while|until)\b", stripped
+                ):
+                    parent_token = stack[-1][2] if stack else 0
+                    stack.append(("control", None, parent_token))
+            cursor += len(line)
+        id_by_record: dict[int, int] = {}
+        for index, (start, kind, end, parent_token) in enumerate(records):
+            parent = (
+                id_by_record[-int(parent_token) - 1]
+                if int(parent_token) < 0
+                else int(parent_token)
+            )
+            scope_id = self.graph.add_scope(
+                parent, int(start), int(end), str(kind)
+            )
+            id_by_record[index] = scope_id
+            self.scope_ranges.append((int(start), int(end), scope_id))
+
+    def scope_at(self, offset: int) -> int:
+        candidates = [
+            (end - start, scope_id)
+            for start, end, scope_id in self.scope_ranges
+            if start <= offset < end
+        ]
+        return min(candidates)[1] if candidates else 0
+
+    def _inside_parameter_list(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end in self.c_headers.values())
+
+    def _inside_class_field(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end in self.class_fields)
+
+    def _inside_destructuring_lhs(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end, _, _, _ in self.destructuring)
+
+    def _destructure_leaves(
+        self,
+        start: int,
+        end: int,
+        prefix: EndpointReference = (),
+    ) -> list[tuple[str, EndpointReference, tuple[int, int] | None]]:
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end or self.lexed.code.startswith("...", start):
+            return []
+        if self.lexed.code[start] not in "[{":
+            default = top_level_assignment_separator(
+                self.lexed.code, start, end
+            )
+            leaf_end = default[0] if default is not None else end
+            leaf = self.lexed.code[start:leaf_end].strip()
+            match = re.fullmatch(r"\$?([A-Za-z_]\w*)", leaf)
+            return (
+                [(match.group(1), prefix, (default[1], end) if default else None)]
+                if match is not None
+                else []
+            )
+        left = self.lexed.code[start]
+        right = "}" if left == "{" else "]"
+        closing = matching_delimiter(self.lexed.code, start, left, right)
+        if closing is None:
+            return []
+        leaves: list[
+            tuple[str, EndpointReference, tuple[int, int] | None]
+        ] = []
+        for index, (member_start, member_end) in enumerate(
+            split_arguments(self.lexed.code, start + 1, closing)
+        ):
+            if not self.lexed.code[member_start:member_end].strip():
+                continue
+            if left == "[":
+                leaves.extend(
+                    self._destructure_leaves(
+                        member_start,
+                        member_end,
+                        prefix + (str(index),),
+                    )
+                )
+                continue
+            colon = top_level_colon(
+                self.lexed.code, member_start, member_end
+            )
+            if colon is not None:
+                key = static_object_key(
+                    self.lexed, member_start, colon
+                )
+                if key is not None:
+                    leaves.extend(
+                        self._destructure_leaves(
+                            colon + 1,
+                            member_end,
+                            prefix + (key,),
+                        )
+                    )
+                continue
+            default = top_level_assignment_separator(
+                self.lexed.code, member_start, member_end
+            )
+            key_end = default[0] if default is not None else member_end
+            key = static_object_key(
+                self.lexed, member_start, key_end
+            )
+            if key is not None:
+                leaves.append(
+                    (
+                        key,
+                        prefix + (key,),
+                        (default[1], member_end) if default else None,
+                    )
+                )
+        return leaves
+
+    def _find_destructuring(self) -> None:
+        if self.suffix not in self.JAVASCRIPT_SUFFIXES:
+            return
+        code = self.lexed.code
+        for opening, character in enumerate(code):
+            if character not in "[{":
+                continue
+            boundary = max(
+                code.rfind(";", 0, opening),
+                code.rfind("\n", 0, opening),
+            ) + 1
+            prefix = code[boundary:opening]
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            assignment = declaration is None and re.fullmatch(
+                r"\s*\(*\s*", prefix
+            )
+            if declaration is None and not assignment:
+                continue
+            right = "}" if character == "{" else "]"
+            closing = matching_delimiter(code, opening, character, right)
+            if closing is None:
+                continue
+            round_depth = square_depth = curly_depth = 0
+            equals = None
+            for cursor in range(closing + 1, len(code)):
+                current = code[cursor]
+                if current == "(":
+                    round_depth += 1
+                elif current == ")" and round_depth:
+                    round_depth -= 1
+                elif current == "[":
+                    square_depth += 1
+                elif current == "]" and square_depth:
+                    square_depth -= 1
+                elif current == "{":
+                    curly_depth += 1
+                elif current == "}" and curly_depth:
+                    curly_depth -= 1
+                elif not (round_depth or square_depth or curly_depth):
+                    if current in ";\n":
+                        break
+                    if (
+                        current == "="
+                        and not code.startswith(("==", "=>"), cursor)
+                        and (cursor == 0 or code[cursor - 1] not in "!<>=")
+                    ):
+                        equals = cursor
+                        break
+            if equals is None:
+                continue
+            residual = code[closing + 1:equals]
+            if residual.strip() and not re.fullmatch(
+                r"\s*:\s*[^=;\n]+\s*", residual
+            ):
+                continue
+            leaves = self._destructure_leaves(opening, closing + 1)
+            if not leaves:
+                continue
+            rhs_start = equals + 1
+            rhs_end = assignment_end(self.lexed, rhs_start, self.suffix)
+            if assignment:
+                wrapper = opening - 1
+                while wrapper >= boundary and code[wrapper].isspace():
+                    wrapper -= 1
+                if wrapper >= boundary and code[wrapper] == "(":
+                    wrapper_closing = matching_delimiter(
+                        code, wrapper, "(", ")"
+                    )
+                    if wrapper_closing is not None:
+                        rhs_end = min(rhs_end, wrapper_closing)
+                self.destructure_mutations.add(opening)
+            self.destructuring.append(
+                (opening, equals, rhs_start, rhs_end, leaves)
+            )
+
+    def _parameter_names(
+        self, start: int, end: int
+    ) -> list[str]:
+        names: list[str] = []
+        for span_start, span_end in split_arguments(
+            self.lexed.code, start, end
+        ):
+            source = self.lexed.code[span_start:span_end]
+            if not source.strip() or source.lstrip().startswith(("{", "[")):
+                continue
+            identifiers = re.findall(r"\$?([A-Za-z_]\w*)", source)
+            if not identifiers:
+                continue
+            if self.suffix == ".go":
+                name = identifiers[0]
+            elif self.suffix in self.JAVASCRIPT_SUFFIXES or self.suffix == ".php":
+                name = identifiers[0]
+            else:
+                name = identifiers[-1]
+            if name not in {"self", "this"}:
+                names.append(name)
+        return names
+
+    def _add_parameter_binding(
+        self, name: str, scope_id: int, offset: int
+    ) -> int:
+        existing = [
+            binding
+            for binding in self.graph.bindings.values()
+            if binding.name == name
+            and binding.scope_id == scope_id
+            and binding.kind == "parameter"
+        ]
+        if existing:
+            return existing[0].id
+        scope_start = self.graph.scopes[scope_id].start
+        binding_id = self.graph.add_binding(
+            name, scope_id, offset, scope_start, "parameter"
+        )
+        self.graph.add_definition(
+            binding_id,
+            (),
+            EndpointUnknown("parameter"),
+            scope_start,
+            scope_id,
+            "parameter",
+        )
+        return binding_id
+
+    def _build_parameter_bindings(self) -> None:
+        for opening, (start, end) in self.c_headers.items():
+            scope_id = self.scope_by_opening.get(opening)
+            if scope_id is None:
+                continue
+            for name in self._parameter_names(start, end):
+                self._add_parameter_binding(name, scope_id, opening)
+        for scope_id, start, end, offset in self.expression_parameters:
+            for name in self._parameter_names(start, end):
+                self._add_parameter_binding(name, scope_id, offset)
+        if self.suffix in self.C_SUFFIXES:
+            for match in re.finditer(
+                r"\b(catch|for|foreach)\s*\(", self.lexed.code
+            ):
+                params_open = self.lexed.code.rfind(
+                    "(", match.start(), match.end()
+                )
+                params_close = matching_delimiter(
+                    self.lexed.code, params_open, "(", ")"
+                )
+                if params_close is None:
+                    continue
+                brace = self.lexed.code.find("{", params_close)
+                if brace < 0 or self.lexed.code[params_close + 1:brace].strip():
+                    continue
+                scope_id = self.scope_by_opening.get(brace)
+                if scope_id is None:
+                    continue
+                source = self.lexed.code[params_open + 1:params_close]
+                if match.group(1) == "catch":
+                    identifiers = re.findall(r"\$?([A-Za-z_]\w*)", source)
+                    names = identifiers[-1:] if identifiers else []
+                else:
+                    declaration = re.search(
+                        r"\b(?:const|let|var|final|String|string|var)\s+"
+                        r"\$?([A-Za-z_]\w*)",
+                        source,
+                    )
+                    names = [declaration.group(1)] if declaration else []
+                for name in names:
+                    self._add_parameter_binding(name, scope_id, match.start())
+        if self.suffix == ".py":
+            pattern = re.compile(r"(?:async\s+)?def\s+\w+\s*\(")
+            for match in pattern.finditer(self.lexed.code):
+                opening = self.lexed.code.rfind("(", match.start(), match.end())
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                if closing is None:
+                    continue
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(opening + 1, closing):
+                    self._add_parameter_binding(name, scope_id, match.start())
+        if self.suffix == ".rb":
+            for match in re.finditer(
+                r"\bdef\s+\w+\s*(?:\(([^)]*)\)|([^\n]*))",
+                self.lexed.code,
+            ):
+                start, end = (
+                    match.span(1) if match.group(1) is not None else match.span(2)
+                )
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(start, end):
+                    self._add_parameter_binding(name, scope_id, match.start())
+            for match in re.finditer(
+                r"\bdo\s*\|([^|]*)\|", self.lexed.code
+            ):
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(*match.span(1)):
+                    self._add_parameter_binding(name, scope_id, match.start())
+
+    def _declaration_spec(
+        self, assignment: re.Match[str]
+    ) -> tuple[int, int, str, tuple[object, ...]] | None:
+        name = assignment.group(1).lstrip("$")
+        scope_id = self.scope_at(assignment.start())
+        execution = self.graph.execution_scope(scope_id)
+        line_start = max(
+            self.lexed.code.rfind("\n", 0, assignment.start()),
+            self.lexed.code.rfind(";", 0, assignment.start()),
+            self.lexed.code.rfind("{", 0, assignment.start()),
+        ) + 1
+        prefix = self.lexed.code[line_start:assignment.start()]
+        assignment_text = self.lexed.code[
+            assignment.start():assignment.end()
+        ]
+        if self.suffix in self.JAVASCRIPT_SUFFIXES:
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            if declaration is None:
+                return None
+            keyword = declaration.group(1)
+            owner = execution if keyword == "var" else scope_id
+            visibility = (
+                self.graph.scopes[owner].start
+                if keyword == "var"
+                else assignment.start()
+            )
+            key = ("js-var", owner, name) if keyword == "var" else (
+                "js-block", assignment.start()
+            )
+            return owner, visibility, "declaration", key
+        if self.suffix == ".go":
+            declared = ":=" in assignment_text or re.search(r"\bvar\s*$", prefix)
+            if not declared:
+                return None
+            return scope_id, assignment.start(), "declaration", (
+                "go", assignment.start()
+            )
+        if self.suffix in {".java", ".cs"}:
+            declared = re.search(
+                r"(?:^|[;{}])\s*(?:(?:public|private|protected|static|final|"
+                r"readonly|volatile)\s+)*(?:var|string|String|Uri|URI|URL|"
+                r"[A-Za-z_]\w*(?:\s*<[^;=]+>)?(?:\[\])?)\s*$",
+                prefix,
+            )
+            if declared is None:
+                return None
+            return scope_id, assignment.start(), "declaration", (
+                "c-block", assignment.start()
+            )
+        if self.suffix == ".py":
+            kind = self.graph.scopes[scope_id].kind
+            owner = scope_id if kind in {"function", "class"} else execution
+            visibility = (
+                self.graph.scopes[owner].start
+                if self.graph.scopes[owner].kind == "function"
+                else assignment.start()
+            )
+            return owner, visibility, "declaration", ("py", owner, name)
+        if self.suffix == ".rb":
+            owner = execution
+            return (
+                owner,
+                self.graph.scopes[owner].start,
+                "declaration",
+                ("rb", owner, name),
+            )
+        if self.suffix == ".php":
+            return (
+                execution,
+                self.graph.scopes[execution].start,
+                "declaration",
+                ("php", execution, name),
+            )
+        if self.suffix == ".sh":
+            return (
+                execution,
+                self.graph.scopes[execution].start,
+                "declaration",
+                ("sh", execution, name),
+            )
+        return None
+
+    def _build_bindings(self) -> None:
+        self._build_parameter_bindings()
+        grouped: dict[tuple[object, ...], int] = {}
+        for assignment in self.root_assignments:
+            name = assignment.group(1).lstrip("$")
+            spec = self._declaration_spec(assignment)
+            if spec is None:
+                continue
+            scope_id, visibility, kind, key = spec
+            binding_id = grouped.get(key)
+            if binding_id is None:
+                binding_id = self.graph.add_binding(
+                    name,
+                    scope_id,
+                    assignment.start(),
+                    visibility,
+                    kind,
+                )
+                grouped[key] = binding_id
+            self.assignment_bindings[assignment.start()] = binding_id
+
+        self.destructure_bindings: dict[tuple[int, str], int] = {}
+        for opening, _, _, _, leaves in self.destructuring:
+            prefix = self.lexed.code[
+                max(0, self.lexed.code.rfind("\n", 0, opening) + 1):opening
+            ]
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            scope_id = self.scope_at(opening)
+            if declaration is None:
+                for name, _, _ in leaves:
+                    binding_id = self.graph.visible_binding(
+                        name, scope_id, opening
+                    )
+                    if binding_id is None:
+                        candidates = list(
+                            re.compile(
+                                rf"\b(let|var|const)\s+{re.escape(name)}\b"
+                            ).finditer(self.lexed.code, 0, opening)
+                        )
+                        if candidates:
+                            candidate = candidates[-1]
+                            candidate_scope = self.scope_at(candidate.start())
+                            keyword = candidate.group(1)
+                            owner = (
+                                self.graph.execution_scope(candidate_scope)
+                                if keyword == "var"
+                                else candidate_scope
+                            )
+                            binding_id = self.graph.add_binding(
+                                name,
+                                owner,
+                                candidate.start(),
+                                (
+                                    self.graph.scopes[owner].start
+                                    if keyword == "var"
+                                    else candidate.start()
+                                ),
+                                "declaration",
+                            )
+                    if binding_id is not None:
+                        self.destructure_bindings[(opening, name)] = binding_id
+                continue
+            keyword = declaration.group(1)
+            owner = (
+                self.graph.execution_scope(scope_id)
+                if keyword == "var"
+                else scope_id
+            )
+            for name, _, _ in leaves:
+                key = (
+                    ("js-var", owner, name)
+                    if keyword == "var"
+                    else ("destructure", opening, name)
+                )
+                binding_id = grouped.get(key)
+                if binding_id is None:
+                    binding_id = self.graph.add_binding(
+                        name,
+                        owner,
+                        opening,
+                        (
+                            self.graph.scopes[owner].start
+                            if keyword == "var"
+                            else opening
+                        ),
+                        "declaration",
+                    )
+                    grouped[key] = binding_id
+                self.destructure_bindings[(opening, name)] = binding_id
+
+        # Plain assignments with no visible declaration create one bounded
+        # implicit binding in their execution scope.
+        for assignment in self.root_assignments:
+            if assignment.start() in self.assignment_bindings:
+                continue
+            name = assignment.group(1).lstrip("$")
+            scope_id = self.scope_at(assignment.start())
+            binding_id = self.graph.visible_binding(
+                name, scope_id, assignment.start()
+            )
+            if binding_id is None:
+                owner = self.graph.execution_scope(scope_id)
+                key = ("implicit", owner, name)
+                binding_id = grouped.get(key)
+                if binding_id is None:
+                    binding_id = self.graph.add_binding(
+                        name,
+                        owner,
+                        assignment.start(),
+                        self.graph.scopes[owner].start,
+                        "implicit",
+                    )
+                    grouped[key] = binding_id
+            self.assignment_bindings[assignment.start()] = binding_id
+
+    def _top_level_plus_spans(
+        self, start: int, end: int
+    ) -> list[tuple[int, int]]:
+        spans: list[tuple[int, int]] = []
+        segment = start
+        round_depth = square_depth = curly_depth = 0
+        for index in range(start, end):
+            character = self.lexed.code[index]
+            if character == "(":
+                round_depth += 1
+            elif character == ")" and round_depth:
+                round_depth -= 1
+            elif character == "[":
+                square_depth += 1
+            elif character == "]" and square_depth:
+                square_depth -= 1
+            elif character == "{":
+                curly_depth += 1
+            elif character == "}" and curly_depth:
+                curly_depth -= 1
+            elif (
+                character == "+"
+                or (
+                    # PHP concatenates with '.', and member access there is
+                    # '->' / '::', so a top-level dot is unambiguous. Guard
+                    # against decimals in a numeric literal.
+                    character == "."
+                    and self.suffix == ".php"
+                    and not (
+                        index > start
+                        and self.lexed.code[index - 1].isdigit()
+                        and index + 1 < end
+                        and self.lexed.code[index + 1].isdigit()
+                    )
+                )
+            ) and not (
+                round_depth or square_depth or curly_depth
+            ):
+                spans.append((segment, index))
+                segment = index + 1
+        if spans:
+            spans.append((segment, end))
+        return spans
+
+    def _typescript_assertion_start(
+        self, start: int, end: int
+    ) -> int | None:
+        if self.suffix not in TYPESCRIPT_SUFFIXES:
+            return None
+        round_depth = square_depth = curly_depth = 0
+        for match in re.finditer(r"\b(?:as|satisfies)\b", self.lexed.code[start:end]):
+            offset = start + match.start()
+            for character in self.lexed.code[start:offset]:
+                if character == "(":
+                    round_depth += 1
+                elif character == ")" and round_depth:
+                    round_depth -= 1
+                elif character == "[":
+                    square_depth += 1
+                elif character == "]" and square_depth:
+                    square_depth -= 1
+                elif character == "{":
+                    curly_depth += 1
+                elif character == "}" and curly_depth:
+                    curly_depth -= 1
+            if round_depth or square_depth or curly_depth:
+                round_depth = square_depth = curly_depth = 0
+                continue
+            tail = self.lexed.original[start + match.end():end].strip()
+            if tail and re.fullmatch(
+                r"(?:const|readonly\s+)?[A-Za-z_$][\w$<>.,\[\]\s|&?:]*",
+                tail,
+            ):
+                return offset
+            round_depth = square_depth = curly_depth = 0
+        return None
+
+    @staticmethod
+    def _project_expression(
+        expression: EndpointExpression, members: EndpointReference
+    ) -> EndpointExpression:
+        if not members:
+            return expression
+        if isinstance(expression, EndpointRef):
+            return EndpointRef(
+                expression.binding_id, expression.members + members
+            )
+        if isinstance(expression, EndpointProjected):
+            return EndpointProjected(
+                expression.expression, expression.members + members
+            )
+        return EndpointProjected(expression, members)
+
+    def _static_key_from_span(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> str | None:
+        literal = static_lookup_key(self.lexed, start, end)
+        if literal is not None:
+            return literal
+        source = self.lexed.original[start:end].strip()
+        if not source or re.fullmatch(r"-\d+", source):
+            return None
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is None or len(reference) != 1:
+            return None
+        binding_id = self.graph.visible_binding(
+            reference[0].lstrip("$"), scope_id, before
+        )
+        if binding_id is None:
+            return None
+        value = self.graph.evaluate(
+            EndpointAccessState(binding_id, (), before, scope_id)
+        )
+        return value.exact
+
+    def _parse_access_expression(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression | None:
+        cursor = start
+        if self.lexed.code[cursor] == "(":
+            closing = matching_delimiter(
+                self.lexed.code, cursor, "(", ")"
+            )
+            if closing is None or closing >= end:
+                return None
+            expression = self._parse_expression(
+                cursor + 1, closing, scope_id, before
+            )
+            cursor = closing + 1
+        else:
+            root = re.match(r"\$?[A-Za-z_]\w*", self.lexed.code[cursor:end])
+            if root is None:
+                return None
+            name = root.group(0).lstrip("$")
+            binding_id = self.graph.visible_binding(name, scope_id, before)
+            expression = (
+                EndpointRef(binding_id)
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{name}")
+            )
+            cursor += len(root.group(0))
+
+        default_methods = {
+            ".py": {"get"},
+            ".rb": {"fetch"},
+            ".java": {"getOrDefault"},
+            ".cs": {"GetValueOrDefault"},
+        }
+        lookup_methods = {"get", "Get", "fetch"}
+        while True:
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            if (
+                self.suffix in TYPESCRIPT_SUFFIXES
+                and cursor < end
+                and self.lexed.code[cursor] == "!"
+            ):
+                cursor += 1
+                continue
+            if cursor >= end:
+                return expression
+
+            if self.lexed.code.startswith("?.", cursor):
+                cursor += 2
+                while cursor < end and self.lexed.code[cursor].isspace():
+                    cursor += 1
+                if cursor < end and self.lexed.code[cursor] == "[":
+                    closing = matching_delimiter(
+                        self.lexed.code, cursor, "[", "]"
+                    )
+                    if closing is None or closing >= end:
+                        return EndpointUnknown("dynamic selector")
+                    key = self._static_key_from_span(
+                        cursor + 1, closing, scope_id, before
+                    )
+                    if key is None:
+                        return EndpointUnknown("dynamic selector")
+                    expression = self._project_expression(expression, (key,))
+                    cursor = closing + 1
+                    continue
+            elif self.lexed.code.startswith("->", cursor):
+                cursor += 2
+            elif self.lexed.code[cursor] == ".":
+                cursor += 1
+            elif self.lexed.code[cursor] == "[":
+                closing = matching_delimiter(
+                    self.lexed.code, cursor, "[", "]"
+                )
+                if closing is None or closing >= end:
+                    return EndpointUnknown("dynamic selector")
+                key = self._static_key_from_span(
+                    cursor + 1, closing, scope_id, before
+                )
+                if key is None:
+                    return EndpointUnknown("dynamic selector")
+                expression = self._project_expression(expression, (key,))
+                cursor = closing + 1
+                continue
+            else:
+                return None
+
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            member = re.match(r"[A-Za-z_]\w*", self.lexed.code[cursor:end])
+            if member is None:
+                return EndpointUnknown("dynamic member")
+            member_name = member.group(0)
+            cursor += len(member_name)
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            if cursor >= end or self.lexed.code[cursor] != "(":
+                expression = self._project_expression(
+                    expression, (member_name,)
+                )
+                continue
+
+            closing = matching_delimiter(
+                self.lexed.code, cursor, "(", ")"
+            )
+            if closing is None or closing >= end:
+                return EndpointUnknown("invalid lookup")
+            arguments = split_arguments(
+                self.lexed.code, cursor + 1, closing
+            )
+            if self.suffix == ".rb" and member_name == "dig":
+                keys = [
+                    self._static_key_from_span(
+                        argument_start,
+                        argument_end,
+                        scope_id,
+                        before,
+                    )
+                    for argument_start, argument_end in arguments
+                ]
+                if not keys or any(key is None for key in keys):
+                    return EndpointUnknown("dynamic dig")
+                expression = self._project_expression(
+                    expression, tuple(key for key in keys if key is not None)
+                )
+                cursor = closing + 1
+                continue
+            supported_defaults = default_methods.get(self.suffix, set())
+            if member_name not in lookup_methods | supported_defaults:
+                return EndpointUnknown("unsupported call")
+            if not arguments or len(arguments) > 2:
+                return EndpointUnknown("invalid lookup")
+            key = self._static_key_from_span(
+                arguments[0][0], arguments[0][1], scope_id, before
+            )
+            if key is None:
+                return EndpointUnknown("dynamic lookup")
+            primary = self._project_expression(expression, (key,))
+            expression = (
+                EndpointDefault(
+                    primary,
+                    self._parse_expression(
+                        arguments[1][0],
+                        arguments[1][1],
+                        scope_id,
+                        before,
+                    ),
+                )
+                if len(arguments) == 2 and member_name in supported_defaults
+                else primary
+            )
+            cursor = closing + 1
+
+    def _parse_reference_text(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        temporary = lex_source(source, self.suffix)
+        reference = static_reference_expression(
+            temporary, 0, len(temporary.code)
+        )
+        if reference is None:
+            return EndpointUnknown("dynamic interpolation")
+        name = reference[0].lstrip("$")
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        return (
+            EndpointRef(binding_id, reference[1:])
+            if binding_id is not None
+            else EndpointUnknown(f"unbound:{name}")
+        )
+
+    def _shell_text_expression(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        parts: list[EndpointExpression] = []
+        cursor = 0
+        for match in SHELL_STATIC_REFERENCE_RE.finditer(source):
+            key: str | None = None
+            if match.group(2):
+                selector = match.group(2).strip()
+                if selector.startswith("$"):
+                    temporary = lex_source(selector, ".sh")
+                    reference = static_reference_expression(
+                        temporary, 0, len(temporary.code)
+                    )
+                    if reference is None or len(reference) != 1:
+                        return EndpointUnknown("dynamic shell selector")
+                    key_binding = self.graph.visible_binding(
+                        reference[0].lstrip("$"), scope_id, before
+                    )
+                    if key_binding is None:
+                        return EndpointUnknown("dynamic shell selector")
+                    key = self.graph.evaluate(
+                        EndpointAccessState(
+                            key_binding, (), before, scope_id
+                        )
+                    ).exact
+                elif re.fullmatch(r"(?:[A-Za-z_]\w*|\d+)", selector) or (
+                    len(selector) >= 2
+                    and selector[0] == selector[-1]
+                    and selector[0] in {"'", '"'}
+                ):
+                    key = shell_static_key(selector)
+                if key is None:
+                    return EndpointUnknown("dynamic shell selector")
+            if match.start() > cursor:
+                parts.append(EndpointLiteral(source[cursor:match.start()]))
+            root = match.group(1) or match.group(3)
+            binding_id = self.graph.visible_binding(root, scope_id, before)
+            parts.append(
+                EndpointRef(binding_id, (key,) if key is not None else ())
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{root}")
+            )
+            cursor = match.end()
+        if cursor < len(source):
+            parts.append(EndpointLiteral(source[cursor:]))
+        return EndpointConcat(tuple(parts)) if parts else EndpointLiteral(source)
+
+    def _parse_shell_array(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        try:
+            tokens = shlex.split(source[1:-1], comments=True, posix=True)
+        except ValueError:
+            return EndpointUnknown("invalid shell array")
+        keyed = bool(tokens) and all(
+            re.match(r"^\[[^]]+\]=", token) for token in tokens
+        )
+        if keyed:
+            entries: list[tuple[str, EndpointExpression]] = []
+            for token in tokens:
+                match = re.match(r"^\[([^]]+)\]=(.*)$", token, re.S)
+                if match is None:
+                    return EndpointUnknown("invalid shell member")
+                key = shell_static_key(match.group(1))
+                if key is None:
+                    return EndpointUnknown("dynamic shell key")
+                entries.append(
+                    (
+                        key,
+                        self._shell_text_expression(
+                            match.group(2), scope_id, before
+                        ),
+                    )
+                )
+            return EndpointObject(tuple(entries))
+        return EndpointArray(
+            tuple(
+                self._shell_text_expression(token, scope_id, before)
+                for token in tokens
+            )
+        )
+
+    def _parse_template(
+        self,
+        token: StringToken,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        contents = token.contents
+        patterns = (
+            r"\$\{([^{}]+)\}"
+            if self.suffix in self.JAVASCRIPT_SUFFIXES
+            else r"#\{([^{}]+)\}"
+            if self.suffix == ".rb"
+            else r"\{\s*(\$[A-Za-z_]\w*)\s*\}"
+            if self.suffix == ".php"
+            else r"\{([^{}]+)\}"
+        )
+        parts: list[EndpointExpression] = []
+        cursor = 0
+        for match in re.finditer(patterns, contents):
+            if match.start() > cursor:
+                parts.append(EndpointLiteral(contents[cursor:match.start()]))
+            parts.append(
+                self._parse_reference_text(
+                    match.group(1).strip(), scope_id, before
+                )
+            )
+            cursor = match.end()
+        if cursor < len(contents):
+            parts.append(EndpointLiteral(contents[cursor:]))
+        return (
+            EndpointConcat(tuple(parts))
+            if parts
+            else EndpointLiteral(contents)
+        )
+
+    def _parse_container(
+        self,
+        kind: str,
+        opening: int,
+        closing: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        members = split_arguments(self.lexed.code, opening + 1, closing)
+        if kind == "pairs":
+            entries: list[tuple[str, EndpointExpression]] = []
+            for index in range(1, len(members), 2):
+                key = static_object_key(self.lexed, *members[index - 1])
+                if key is not None:
+                    entries.append(
+                        (
+                            key,
+                            self._parse_expression(
+                                *members[index], scope_id, before
+                            ),
+                        )
+                    )
+            return EndpointObject(tuple(entries))
+        separators = [
+            (
+                (colon, colon + 1)
+                if (colon := top_level_colon(
+                    self.lexed.code, member_start, member_end
+                )) is not None
+                else top_level_assignment_separator(
+                    self.lexed.code, member_start, member_end
+                )
+            )
+            for member_start, member_end in members
+        ]
+        declared_map = bool(
+            re.search(
+                r"(?:\bDictionary\b|\bMap\b|\bmap\s*\[)",
+                self.lexed.code[max(0, opening - 160):opening],
+            )
+        )
+        keyed = any(separator is not None for separator in separators) or (
+            self.lexed.code[opening] == "{"
+            and (
+                self.suffix not in {".cs", ".go", ".java"}
+                or declared_map
+            )
+        )
+        if not keyed:
+            return EndpointArray(
+                tuple(
+                    self._parse_expression(
+                        member_start, member_end, scope_id, before
+                    )
+                    for member_start, member_end in members
+                    if self.lexed.original[member_start:member_end].strip()
+                )
+            )
+        entries = []
+        for (member_start, member_end), separator in zip(members, separators):
+            if separator is None:
+                key = static_object_key(
+                    self.lexed, member_start, member_end
+                )
+                if key is not None:
+                    entries.append(
+                        (
+                            key,
+                            self._parse_expression(
+                                member_start, member_end, scope_id, before
+                            ),
+                        )
+                    )
+                continue
+            separator_start, value_start = separator
+            key = static_object_key(
+                self.lexed, member_start, separator_start
+            )
+            if key is not None:
+                entries.append(
+                    (
+                        key,
+                        self._parse_expression(
+                            value_start, member_end, scope_id, before
+                        ),
+                    )
+                )
+        return EndpointObject(tuple(entries))
+
+    def _parse_expression(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        raw_start, raw_end = start, end
+        while raw_start < raw_end and self.lexed.original[raw_start].isspace():
+            raw_start += 1
+        while raw_end > raw_start and self.lexed.original[raw_end - 1].isspace():
+            raw_end -= 1
+        if self.suffix == ".sh":
+            raw_source = self.lexed.original[raw_start:raw_end]
+            if raw_source.startswith("(") and raw_source.endswith(")"):
+                return self._parse_shell_array(
+                    raw_source, scope_id, before
+                )
+            if (
+                len(raw_source) >= 2
+                and raw_source[0] == raw_source[-1]
+                and raw_source[0] in {"'", '"'}
+            ):
+                if raw_source[0] == "'":
+                    return EndpointLiteral(raw_source[1:-1])
+                return self._shell_text_expression(
+                    raw_source[1:-1], scope_id, before
+                )
+            if re.fullmatch(r"[A-Za-z_]\w*", raw_source):
+                return EndpointLiteral(raw_source)
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end:
+            return EndpointUnknown("empty")
+        # `new URL(...)` is routinely stringified before use - `u.toString()`,
+        # `u.href`, `String(u)`. Those wrappers are not part of the endpoint, so
+        # peel them before resolving or the binding reads as an unknown
+        # expression and the send disappears.
+        # A TERNARY selecting the endpoint - `flag ? POOL_URL : OTHER` - was not
+        # modelled at all, so the whole expression read as unknown and the send
+        # vanished: not counted, so the fail-safe could not fire either. The
+        # byte-equivalent if/else form was caught. Resolve BOTH arms and treat a
+        # required endpoint in EITHER as required, which is the safe direction:
+        # the send may take that branch at runtime.
+        ternary = _top_level_ternary(self.lexed.code, start, end)
+        if ternary is not None:
+            for arm_start, arm_end in ternary:
+                arm = self._parse_expression(arm_start, arm_end, scope_id, before)
+                if isinstance(arm, EndpointLiteral) and required_endpoint(arm.value):
+                    return arm
+
+        text_for_peel = self.lexed.code[start:end]
+        # SUFFIX forms: u.toString() / u.href / u.toJSON()
+        stringified = re.match(
+            r"^\s*(.+?)\s*(?:\.\s*(?:toString\s*\(\s*\)|href|toJSON\s*\(\s*\)))\s*$",
+            text_for_peel, re.S,
+        )
+        if stringified is not None and stringified.start(1) != stringified.end(1):
+            inner_end = start + stringified.end(1)
+            if inner_end > start and (start, inner_end) != (start, end):
+                return self._parse_expression(start, inner_end, scope_id, before)
+        # PREFIX and TEMPLATE forms: String(u) and `${u}`. An earlier comment
+        # claimed String(u) was covered while the pattern only matched suffix
+        # member access, so `fetch(String(u), ...)` resolved to UNKNOWN - and
+        # because an unknown endpoint is not counted as a send at all, the
+        # fail-safe could not fire either and the linter reported CLEAN.
+        prefix_peel = re.match(
+            r"^\s*(?:String|globalThis\s*\.\s*String)\s*\(\s*(.+?)\s*\)\s*$",
+            text_for_peel, re.S,
+        ) or re.match(r"^\s*`\s*\$\{\s*(.+?)\s*\}\s*`\s*$", text_for_peel, re.S)
+        if prefix_peel is not None:
+            inner_start = start + prefix_peel.start(1)
+            inner_end = start + prefix_peel.end(1)
+            if inner_end > inner_start and (inner_start, inner_end) != (start, end):
+                return self._parse_expression(inner_start, inner_end, scope_id, before)
+
+        # A BOUND two-argument `new URL(path, base)` must be combined here, the
+        # same way the inline spelling is combined at the call site. Leaving it
+        # unresolved was deliberate, but the consequence was a SILENT PASS, not
+        # a caveat: neither `number_pool` nor the base is a required endpoint on
+        # its own, so the fail-safe backstop never fires either and
+        # `const u = new URL('number_pool', BASE); fetch(u, ...)` certified
+        # clean while the byte-identical inline form was correctly flagged.
+        constructor_base = url_constructor_base(self.lexed, (start, end), self.suffix)
+        if constructor_base is not None:
+            constructed = unwrap_url_constructor(self.lexed, (start, end))
+            if constructed != (start, end):
+                inner = self._parse_expression(
+                    constructed[0], constructed[1], scope_id, before
+                )
+                if isinstance(inner, EndpointLiteral):
+                    return EndpointLiteral(urljoin(constructor_base, inner.value))
+
+        constructed = unwrap_bound_url_constructor(self.lexed, (start, end))
+        if constructed != (start, end):
+            return self._parse_expression(
+                constructed[0], constructed[1], scope_id, before
+            )
+        assertion = self._typescript_assertion_start(start, end)
+        if assertion is not None:
+            return self._parse_expression(start, assertion, scope_id, before)
+        plus_spans = self._top_level_plus_spans(start, end)
+        if plus_spans:
+            return EndpointConcat(
+                tuple(
+                    self._parse_expression(
+                        part_start, part_end, scope_id, before
+                    )
+                    for part_start, part_end in plus_spans
+                )
+            )
+
+        # Common URL/string builders. Restrict literal-suffix rescue to these
+        # named producers; applying it to every unsupported expression makes
+        # an unrelated object member or callback URL displace the real request
+        # URL and creates false positives.
+        builder_source = self.lexed.original[start:end]
+        python_percent_format = (
+            self.suffix == ".py"
+            and re.search(r"%(?:\s*\([^)]*\))?[#0 +\-]?[0-9.*]*[a-zA-Z]", builder_source)
+            is not None
+            and re.search(r"%", self.lexed.code[start:end]) is not None
+        )
+        local_builder = re.match(
+            r"\s*([A-Za-z_$]\w*)\s*\(", self.lexed.code[start:end]
+        )
+        node_join_alias = (
+            self.suffix in JS_TS_SUFFIXES
+            and local_builder is not None
+            and self._is_node_path_join_alias(
+                local_builder.group(1), scope_id, start
+            )
+        )
+        if python_percent_format or node_join_alias or re.search(
+            r"(?:\bfmt\s*\.\s*Sprintf\s*\(|\.\s*format\s*\("
+            r"|\burljoin\s*\(|\bencodeURI(?:Component)?\s*\("
+            r"|\.\s*(?:concat|join)\s*\()",
+            builder_source,
+        ):
+            builder_tokens = [
+                token.contents
+                for token in self.lexed.strings
+                if start <= token.start and token.end <= end
+            ]
+            builder_candidates = builder_tokens + [
+                "".join(builder_tokens),
+                "/".join(builder_tokens),
+            ]
+            # A FORMAT builder substitutes later arguments INTO the first
+            # token, so concatenating tokens in source order yields garbage
+            # ("%snumber_pool" + base). Substitute instead, which is what the
+            # runtime does: "%snumber_pool" % base -> ".../messages/number_pool".
+            if len(builder_tokens) >= 2:
+                remaining = list(builder_tokens[1:])
+                substituted = re.sub(
+                    r"%(?:\([^)]*\))?[#0 +\-]?[0-9.*]*[a-zA-Z]|\{\d*\}",
+                    lambda _match: remaining.pop(0) if remaining else "",
+                    builder_tokens[0],
+                )
+                builder_candidates.append(substituted)
+            required = next(
+                (
+                    candidate
+                    for candidate in builder_candidates
+                    if required_endpoint(candidate)
+                    or required_endpoint_literal_signal(candidate)
+                ),
+                None,
+            )
+            if required is not None:
+                suffix_match = re.search(
+                    r"/messages/(?:number_pool|alphanumeric_sender_id)/?$",
+                    required.split("?", 1)[0].split("#", 1)[0],
+                )
+                return EndpointLiteral(
+                    suffix_match.group(0) if suffix_match else required
+                )
+
+        if self.suffix == ".py":
+            python_tokens = [
+                token
+                for token in self.lexed.strings
+                if start <= token.start and token.end <= end
+            ]
+            if len(python_tokens) == 1:
+                token = python_tokens[0]
+                prefix = self.lexed.original[start:token.start].strip().lower()
+                suffix_text = self.lexed.original[token.end:end].strip()
+                if "f" in prefix and not suffix_text and "{" in token.contents:
+                    return self._parse_template(token, scope_id, before)
+
+        container = root_literal_container(
+            self.lexed, start, end, self.suffix
+        )
+        if container is not None:
+            kind, opening, closing = container
+            selected = selected_members_after_container(
+                self.lexed, closing, end
+            )
+            trailing = self.lexed.code[closing + 1:end].strip(" )\t\r\n")
+            if trailing:
+                if selected is None or not selected:
+                    return EndpointUnknown("dynamic container selector")
+                value_span = literal_value_span(
+                    self.lexed, start, end, selected, self.suffix
+                )
+                return (
+                    self._parse_expression(
+                        value_span[0], value_span[1], scope_id, before
+                    )
+                    if value_span is not None
+                    else EndpointUnknown("missing container member")
+                )
+            return self._parse_container(
+                kind, opening, closing, scope_id, before
+            )
+
+        access = self._parse_access_expression(
+            start, end, scope_id, before
+        )
+        if access is not None:
+            return access
+
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is not None:
+            name = reference[0].lstrip("$")
+            binding_id = self.graph.visible_binding(
+                name, scope_id, before
+            )
+            return (
+                EndpointRef(binding_id, reference[1:])
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{name}")
+            )
+
+        if self.suffix == ".rb":
+            symbol = re.fullmatch(
+                r"\s*:\s*([A-Za-z_]\w*)\s*",
+                self.lexed.original[start:end],
+            )
+            if symbol is not None:
+                return EndpointLiteral(symbol.group(1))
+
+        tokens = [
+            token
+            for token in self.lexed.strings
+            if start <= token.start and token.end <= end
+        ]
+        if len(tokens) == 1:
+            token = tokens[0]
+            residual = (
+                self.lexed.code[start:token.start]
+                + self.lexed.code[token.end:end]
+            ).strip()
+            if self.suffix == ".py":
+                format_match = re.fullmatch(
+                    r"\s*\.\s*format\s*\((.*)\)\s*",
+                    self.lexed.original[token.end:end],
+                    re.S,
+                )
+                if format_match is not None:
+                    opening = self.lexed.code.find("(", token.end, end)
+                    closing = matching_delimiter(
+                        self.lexed.code, opening, "(", ")"
+                    )
+                    arguments = (
+                        split_arguments(
+                            self.lexed.code, opening + 1, closing
+                        )
+                        if closing is not None
+                        else []
+                    )
+                    pieces = token.contents.split("{}")
+                    if len(pieces) == len(arguments) + 1:
+                        parts: list[EndpointExpression] = []
+                        for index, piece in enumerate(pieces):
+                            if piece:
+                                parts.append(EndpointLiteral(piece))
+                            if index < len(arguments):
+                                parts.append(
+                                    self._parse_expression(
+                                        arguments[index][0],
+                                        arguments[index][1],
+                                        scope_id,
+                                        before,
+                                    )
+                                )
+                        return EndpointConcat(tuple(parts))
+            is_template = (
+                self.lexed.original[token.start] == "`"
+                or (self.suffix == ".rb" and "#{" in token.contents)
+                or (self.suffix == ".php" and "{$" in token.contents)
+                or (
+                    self.suffix == ".cs"
+                    and "$" in residual
+                    and "{" in token.contents
+                )
+                or (
+                    self.suffix == ".py"
+                    and "f" in residual.lower()
+                    and "{" in token.contents
+                )
+            )
+            if is_template:
+                return self._parse_template(token, scope_id, before)
+            if (
+                self.suffix == ".sh"
+                and self.lexed.original[token.start] == '"'
+                and "$" in token.contents
+            ):
+                return self._shell_text_expression(
+                    token.contents, scope_id, before
+                )
+            if residual.lower() in {"", "f", "r", "u", "b", "fr", "rf"}:
+                return EndpointLiteral(token.contents)
+        return EndpointUnknown("unsupported expression")
+
+    def _guard_scope(self, scope_id: int) -> int | None:
+        for candidate in self.graph.ancestors(scope_id):
+            if self.graph.scopes[candidate].kind == "conditional":
+                return candidate
+            if self.graph.scopes[candidate].kind in {"function", "module"}:
+                break
+        return None
+
+    def _definition_scope(self, scope_id: int) -> tuple[int, bool]:
+        guard = self._guard_scope(scope_id)
+        return (guard, True) if guard is not None else (scope_id, False)
+
+    def _container_origin_binding(
+        self, binding_id: int, before: int
+    ) -> int:
+        seen: set[int] = set()
+        current = binding_id
+        cutoff = before
+        while current not in seen:
+            seen.add(current)
+            definitions = [
+                definition
+                for definition in self.graph.definitions.get(current, ())
+                if definition.start < cutoff and not definition.member_path
+            ]
+            if not definitions:
+                return current
+            latest = definitions[-1]
+            if not (
+                isinstance(latest.expression, EndpointRef)
+                and not latest.expression.members
+            ):
+                return current
+            current = latest.expression.binding_id
+            cutoff = latest.start
+        return binding_id
+
+    def _add_member_definition(
+        self,
+        binding_id: int,
+        path: EndpointReference,
+        expression: EndpointExpression,
+        offset: int,
+        scope_id: int,
+        guarded: bool,
+    ) -> None:
+        targets = {binding_id, self._container_origin_binding(binding_id, offset)}
+        for target in targets:
+            self.graph.add_definition(
+                target,
+                path,
+                expression,
+                offset,
+                scope_id,
+                "mutation",
+                guarded,
+            )
+
+    def _build_definitions(self) -> None:
+        for assignment in self.root_assignments:
+            binding_id = self.assignment_bindings[assignment.start()]
+            scope_id = self.scope_at(assignment.start())
+            rhs_end = assignment_end(
+                self.lexed, assignment.end(), self.suffix
+            )
+            expression = self._parse_expression(
+                assignment.end(), rhs_end, scope_id, assignment.start()
+            )
+            binding = self.graph.bindings[binding_id]
+            kind = (
+                "declaration"
+                if binding.declaration_start == assignment.start()
+                else "mutation"
+            )
+            definition_scope, guarded = self._definition_scope(scope_id)
+            self.graph.add_definition(
+                binding_id,
+                (),
+                expression,
+                assignment.start(),
+                definition_scope,
+                kind,
+                guarded,
+            )
+
+        for reference, start, rhs_start, rhs_end in direct_member_assignments(
+            self.lexed, len(self.lexed.code), self.suffix
+        ):
+            root = reference[0].lstrip("$")
+            scope_id = self.scope_at(start)
+            binding_id = self.graph.visible_binding(root, scope_id, start)
+            if binding_id is None:
+                continue
+            definition_scope, guarded = self._definition_scope(scope_id)
+            self._add_member_definition(
+                binding_id,
+                reference[1:],
+                self._parse_expression(
+                    rhs_start, rhs_end, scope_id, start
+                ),
+                start,
+                definition_scope,
+                guarded,
+            )
+
+        if self.suffix == ".java":
+            put_pattern = re.compile(
+                r"(?<![\w$.])([A-Za-z_]\w*)\s*\.\s*put\s*\("
+            )
+            for put in put_pattern.finditer(self.lexed.code):
+                opening = self.lexed.code.rfind(
+                    "(", put.start(), put.end()
+                )
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                if closing is None:
+                    continue
+                arguments = split_arguments(
+                    self.lexed.code, opening + 1, closing
+                )
+                if len(arguments) != 2:
+                    continue
+                key = static_lookup_key(self.lexed, *arguments[0])
+                scope_id = self.scope_at(put.start())
+                binding_id = self.graph.visible_binding(
+                    put.group(1), scope_id, put.start()
+                )
+                if key is None or binding_id is None:
+                    continue
+                definition_scope, guarded = self._definition_scope(scope_id)
+                self._add_member_definition(
+                    binding_id,
+                    (key,),
+                    self._parse_expression(
+                        arguments[1][0], arguments[1][1], scope_id, put.start()
+                    ),
+                    put.start(),
+                    definition_scope,
+                    guarded,
+                )
+
+        if self.suffix == ".sh":
+            for reference, start, rhs_start, rhs_end in shell_member_assignments(
+                self.lexed, len(self.lexed.code), self.suffix
+            ):
+                scope_id = self.scope_at(start)
+                binding_id = self.graph.visible_binding(
+                    reference[0], scope_id, start
+                )
+                if binding_id is None:
+                    continue
+                self._add_member_definition(
+                    binding_id,
+                    reference[1:],
+                    self._parse_expression(
+                        rhs_start, rhs_end, scope_id, start
+                    ),
+                    start,
+                    scope_id,
+                    False,
+                )
+
+        for opening, _, rhs_start, rhs_end, leaves in self.destructuring:
+            scope_id = self.scope_at(opening)
+            mutation = opening in self.destructure_mutations
+            definition_scope, guarded = (
+                self._definition_scope(scope_id)
+                if mutation
+                else (scope_id, False)
+            )
+            source = self._parse_expression(
+                rhs_start, rhs_end, scope_id, opening
+            )
+            for name, projection, fallback in leaves:
+                binding_id = self.destructure_bindings.get((opening, name))
+                if binding_id is None:
+                    continue
+                expression: EndpointExpression = EndpointProjected(
+                    source, projection
+                )
+                if fallback is not None:
+                    expression = EndpointDefault(
+                        expression,
+                        self._parse_expression(
+                            fallback[0], fallback[1], scope_id, opening
+                        ),
+                    )
+                self.graph.add_definition(
+                    binding_id,
+                    (),
+                    expression,
+                    opening,
+                    definition_scope,
+                    "mutation" if mutation else "declaration",
+                    guarded,
+                )
+
+        delete_pattern = re.compile(r"\bdelete\s+([^;\n]+)")
+        for deletion in delete_pattern.finditer(self.lexed.code):
+            reference = static_reference_expression(
+                self.lexed, deletion.start(1), deletion.end(1)
+            )
+            if reference is None or len(reference) < 2:
+                continue
+            scope_id = self.scope_at(deletion.start())
+            binding_id = self.graph.visible_binding(
+                reference[0].lstrip("$"), scope_id, deletion.start()
+            )
+            if binding_id is not None:
+                definition_scope, guarded = self._definition_scope(scope_id)
+                self._add_member_definition(
+                    binding_id,
+                    reference[1:],
+                    EndpointUnknown("delete"),
+                    deletion.start(),
+                    definition_scope,
+                    guarded,
+                )
+
+    def resolve_expression(
+        self,
+        start: int,
+        end: int,
+        before: int,
+        projection: EndpointReference = (),
+    ) -> EndpointValue:
+        scope_id = self.scope_at(before)
+        expression = self._parse_expression(
+            start, end, scope_id, before
+        )
+        return self.graph.evaluate(
+            EndpointExpressionState(
+                expression, projection, before, scope_id
+            )
+        )
+
+    def config_method_may_mutate(
+        self, span: tuple[int, int], before: int
+    ) -> bool:
+        """Return whether a request config can use POST, PUT, or PATCH.
+
+        A proven config without a method defaults to GET. Static methods use
+        the shared mutating-method contract, while unresolved dynamic configs
+        remain in scope so analysis fails safely.
+        """
+
+        value = self.resolve_expression(
+            span[0], span[1], before, ("method",)
+        )
+        if value.exact is not None:
+            return value.exact.upper() in MUTATING_HTTP_METHODS
+        method_spans = config_object_member_spans(
+            self.lexed, span, before, self.suffix, ("method",)
+        )
+        if method_spans:
+            method_source = self.lexed.code[slice(*method_spans[-1])].strip()
+            if method_source in {"null", "undefined"}:
+                return False
+            method = static_method_value(
+                self.lexed,
+                method_spans[-1],
+                before,
+                self.suffix,
+            )
+            return method is None or method in MUTATING_HTTP_METHODS
+        if resolved_config_object_span(
+            self.lexed, span, before, self.suffix
+        ) is not None:
+            return False
+        return self.lexed.code[slice(*span)].strip() not in {
+            "null", "undefined"
+        }
+
+    def request_is_required(self, call: Call) -> bool:
+        args = split_arguments(
+            self.lexed.code, call.open_paren + 1, call.end - 1
+        )
+        callee = re.sub(
+            r"\s+", "", self.lexed.code[call.start:call.open_paren]
+        ).lower()
+        if callee == "fetch":
+            # Fetch defaults to GET.  Only known mutating methods, or an
+            # unresolved dynamic method that may be mutating, are sends.
+            if len(args) < 2:
+                return False
+            if not self.config_method_may_mutate(args[1], call.start):
+                return False
+        receiver = call_receiver(self.lexed, call)
+        config_span: tuple[int, int] | None = None
+        if callee in {"axios", "axios.request"} or (
+            callee == "request" and receiver == "axios"
+        ):
+            config_span = args[0] if args else None
+        elif callee == "request" and args:
+            if resolved_config_object_span(
+                self.lexed, args[0], call.start, self.suffix
+            ) is not None:
+                config_span = args[0]
+            elif len(args) > 1 and resolved_config_object_span(
+                self.lexed, args[1], call.start, self.suffix
+            ) is not None:
+                config_span = args[1]
+        if config_span is not None and not self.config_method_may_mutate(
+            config_span, call.start
+        ):
+            return False
+        if callee == "curl_setopt" and len(args) >= 3:
+            option = self.lexed.code[slice(*args[1])].strip()
+            if option == "CURLOPT_URL":
+                handle = self.lexed.code[slice(*args[0])].strip()
+                method = php_curl_handle_method(
+                    self.lexed, handle, call.start, self.suffix
+                )
+                if method is not None and method not in MUTATING_HTTP_METHODS:
+                    return False
+        original_spans = _request_url_spans(self.lexed, call, self.suffix)
+        resolved = []
+        for span in original_spans:
+            unwrapped = unwrap_url_constructor(self.lexed, span)
+            value = self.resolve_expression(
+                unwrapped[0], unwrapped[1], call.start
+            )
+            resolved.append(value)
+            # new URL(path, base) resolves the path relative to the base per
+            # RFC 3986 — a base without a trailing slash drops its last
+            # segment — so use urljoin rather than naive concatenation.
+            constructor_base = url_constructor_base(self.lexed, span, self.suffix)
+            if (
+                constructor_base is not None
+                and value.exact is not None
+                and required_endpoint(urljoin(constructor_base, value.exact))
+            ):
+                return True
+        if any(value.kind == REQUIRED for value in resolved):
+            return True
+        # A client base URL makes the request path relative, so combine the
+        # base with the resolved path before classifying:
+        # axios.create({baseURL: '.../messages'}).post('/number_pool').
+        base = client_base_url(self.lexed, call, self.suffix)
+        if base is not None and any(
+            value.exact is not None
+            and required_endpoint(join_base_and_path(base, value.exact))
+            for value in resolved
+        ):
+            return True
+        # Guzzle, Faraday, and HttpClient also allow the base to be declared
+        # in a nearby client configuration form that is not a root assignment
+        # the binding index can recover. Keep this fallback narrow: only the
+        # three base-client languages, only a relative required suffix, and
+        # only a prior static URL whose path is the messages collection.
+        if self.suffix in {".php", ".rb", ".cs"} and any(
+            value.exact is not None
+            and re.search(r"(?:^|/)(?:number_pool|alphanumeric_sender_id)/?$", value.exact)
+            for value in resolved
+        ):
+            prior_bases = [
+                token.contents
+                for token in self.lexed.strings
+                if token.end <= call.start
+                and re.search(r"/messages/?$", urlsplit(token.contents).path)
+            ]
+            if prior_bases and any(
+                value.exact is not None
+                and required_endpoint(join_base_and_path(prior_bases[-1], value.exact))
+                for value in resolved
+            ):
+                return True
+        if not args:
+            return False
+        return bool(
+            config_span is not None
+            and self.resolve_expression(
+                config_span[0], config_span[1], call.start, ("url",)
+            ).kind
+            == REQUIRED
+        )
+
+    def shell_curl_is_required(self, call: Call) -> bool:
+        method = shell_curl_http_method(self.lexed, call)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return False
+        scope_id = self.scope_at(call.start)
+        allowed_references = shell_curl_url_references(self.lexed, call)
+        for argument in shell_curl_url_arguments(self.lexed, call):
+            if required_endpoint(argument.strip("'\"")):
+                return True
+            references = shell_static_references(argument)
+            if references and any(
+                reference not in allowed_references
+                for reference in references
+            ):
+                continue
+            expression = self._shell_text_expression(
+                argument, scope_id, call.start
+            )
+            if self.graph.evaluate(
+                EndpointExpressionState(
+                    expression, (), call.start, scope_id
+                )
+            ).kind == REQUIRED:
+                return True
+        return False
+
+
+ABSENT, MAYBE, PRESENT = "absent", "maybe", "present"
+NO_WRITE, WRITE_ABSENT, WRITE_MAYBE, WRITE_PRESENT = range(4)
+
+
+@dataclass(frozen=True)
+class Presence:
+    state: str
+    evidence: bool = False
+
+
+ABSENT_VALUE = Presence(ABSENT)
+MAYBE_VALUE = Presence(MAYBE)
+PRESENT_VALUE = Presence(PRESENT, True)
+
+
+def join_presence(values: Iterable[Presence]) -> Presence:
+    values = tuple(values)
+    states = {value.state for value in values}
+    return Presence(
+        next(iter(states)) if len(states) == 1 else MAYBE,
+        any(value.evidence for value in values),
+    ) if values else MAYBE_VALUE
+
+
+def apply_field_effect(value: Presence, effect: int) -> Presence:
+    if effect == NO_WRITE:
+        return value
+    if effect == WRITE_PRESENT:
+        return PRESENT_VALUE
+    if effect == WRITE_ABSENT:
+        return Presence(ABSENT, True)
+    return Presence(MAYBE, True)
+
+
+def overlay_effect(value: Presence) -> int:
+    if value.state == PRESENT:
+        return WRITE_PRESENT
+    if value.state == MAYBE:
+        return WRITE_MAYBE
+    return WRITE_ABSENT if value.evidence else NO_WRITE
+
+
+@dataclass(frozen=True)
+class ObjectTargets:
+    must: frozenset[tuple[int, int]] = frozenset()
+    may: frozenset[tuple[int, int]] = frozenset()
+    unknown: bool = False
+
+    @property
+    def all(self) -> frozenset[tuple[int, int]]:
+        return self.must | self.may
+
+
+def join_targets(values: Iterable[ObjectTargets]) -> ObjectTargets:
+    values = tuple(values)
+    if not values:
+        return ObjectTargets(unknown=True)
+    possible = frozenset().union(*(value.all for value in values))
+    must = set(values[0].must)
+    for value in values[1:]:
+        must.intersection_update(value.must)
+    if any(value.unknown for value in values):
+        must.clear()
+    required = frozenset(must)
+    return ObjectTargets(required, possible - required, any(v.unknown for v in values))
+
+
+@dataclass(frozen=True)
+class ControlArm:
+    group: int
+    branch: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class RootFieldEvent:
+    binding: int
+    start: int
+    rhs: tuple[int, int]
+    scope: int
+    execution: int
+    kind: str
+    path: tuple[tuple[int, int], ...]
+    aliases: tuple[int, ...] | None
+    alias_unknown: bool = False
+
+    @property
+    def object_id(self) -> tuple[int, int]:
+        return self.binding, self.start
+
+
+@dataclass(frozen=True)
+class FieldEvent:
+    binding: int
+    start: int
+    scope: int
+    execution: int
+    path: tuple[tuple[int, int], ...]
+    effect: int
+    overlay: tuple[int, int] | None = None
+
+
+class ControlIndex:
+    """Finite branch index; callable boundaries remain in the binding graph."""
+
+    C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
+
+    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+        self.lexed, self.suffix = lexed, suffix
+        self.arms: list[ControlArm] = []
+        self.exhaustive: set[int] = set()
+        if suffix in self.C_SUFFIXES:
+            self._curly()
+            # Expression-level guards are not a JavaScript peculiarity: PHP,
+            # Ruby and Python all write `cond && payload[...] = x`, `cond and
+            # payload.update(...)` and the ternary forms, and a field written
+            # that way is CONDITIONAL. Indexing them only for JS/TS meant the
+            # same guarded write read as unconditional in every other language -
+            # a silent pass on a profile that may never be set.
+            if suffix in JS_TS_SUFFIXES or suffix == ".php":
+                self._expression_guards()
+        elif suffix in {".py", ".rb", ".sh"}:
+            self._lines()
+            if suffix in {".py", ".rb"}:
+                self._expression_guards()
+
+    def _unbraced_body_end(self, start: int) -> int | None:
+        """End of a single-statement `if (cond) stmt;` body after the ')'.
+
+        The lexer masks string interiors, so scanning the masked code for a
+        top-level ';' or line break is safe. Returns None if no statement
+        follows (e.g. a stray brace).
+        """
+        code = self.lexed.code
+        index = start
+        while index < len(code) and code[index].isspace():
+            index += 1
+        if index >= len(code) or code[index] in "{};":
+            return None
+        depth = 0
+        while index < len(code):
+            character = code[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif depth == 0 and character == ";":
+                return index + 1
+            elif depth == 0 and character == "\n":
+                return index
+            index += 1
+        return None
+
+    def _expression_guards(self) -> None:
+        """Index short-circuit and ternary expression arms in JS/TS.
+
+        A field write after `&&`/`||`, in either side of `?:`, or through a
+        logical assignment (`&&=`/`||=`) is conditional even though no block
+        exists. Scope only the containing statement so adjacent unconditional
+        writes retain an empty control path.
+        """
+        code = self.lexed.code
+        # A WRAPPED guard is still one statement. Breaking on every raw newline
+        # put `usePool &&` and `(payload.messaging_profile_id = p)` into
+        # different segments, so neither held both the operator and the write
+        # and the conditional write read as unconditional. Only a newline that
+        # neither follows nor precedes a logical/ternary operator ends a
+        # statement; nothing else is joined, so unrelated lines cannot merge
+        # into a spurious arm.
+        # Ruby, PHP and Python spell the same operators as WORDS as well.
+        word_ops = self.suffix in {".php", ".rb", ".py"}
+        logical_re = (
+            r"&&=?|\|\|=?|(?<![\w])(?:and|or)(?![\w])" if word_ops
+            else r"&&=?|\|\|=?"
+        )
+        dangling = re.compile(
+            r"(?:&&|\|\||\?|(?<![\w])(?:and|or))\s*$" if word_ops
+            else r"(?:&&|\|\||\?)\s*$"
+        )
+        continuing = re.compile(
+            r"[ \t]*(?:&&|\|\||\?|:|(?<![\w])(?:and|or)(?![\w]))" if word_ops
+            else r"[ \t]*(?:&&|\|\||\?|:)"
+        )
+        statement_start = 0
+        for match in re.finditer(r"[;\n]|$", code):
+            statement_end = match.start()
+            segment = code[statement_start:statement_end]
+            if match.group(0) == "\n" and (
+                dangling.search(segment)
+                or continuing.match(code, match.end())
+            ):
+                continue
+            # Search the ORIGINAL text, not the masked code: a Python/PHP/Ruby
+            # payload spells the key as a STRING ("messaging_profile_id"), and
+            # string interiors are blanked in lexed.code - so the guard was only
+            # ever found in JS, where object keys are usually bare identifiers.
+            # Offsets are preserved by the lexer, so the spans stay valid.
+            profile = PROFILE_IDENTIFIER_RE.search(
+                self.lexed.original[statement_start:statement_end]
+            )
+            if profile is not None:
+                absolute_profile = statement_start + profile.start()
+                logical = list(re.finditer(logical_re, segment))
+                for operator in logical:
+                    operator_end = statement_start + operator.end()
+                    if operator_end <= absolute_profile:
+                        self.arms.append(
+                            ControlArm(statement_start, 0, operator_end, statement_end)
+                        )
+                question = segment.find("?")
+                colon = segment.find(":", question + 1) if question >= 0 else -1
+                if question >= 0 and colon >= 0 and absolute_profile > statement_start + question:
+                    self.arms.append(
+                        ControlArm(
+                            statement_start,
+                            0 if absolute_profile < statement_start + colon else 1,
+                            statement_start + question + 1,
+                            statement_end,
+                        )
+                    )
+            statement_start = match.end()
+
+    def _body_arm(self, group: int, branch: int, after: int) -> int | None:
+        """Index one control body — a braced block OR an unbraced single
+        statement — starting at/after `after`. Appends a ControlArm and
+        returns the position after the body, or None if there is no body.
+
+        Every C-family control construct routes through here so that braced
+        and unbraced bodies are treated identically: a field write inside any
+        of them is conditional. Handling only braced bodies let unbraced if /
+        else / for / while writes look unconditional and pass a send that can
+        run without the profile.
+        """
+        code = self.lexed.code
+        cursor = after
+        while cursor < len(code) and code[cursor].isspace():
+            cursor += 1
+        if self.suffix == ".php" and cursor < len(code) and code[cursor] == ":":
+            # PHP alternative syntax (`if (…): … endif;`). The body runs to its
+            # end-keyword, not to the first ';', so _php_alt spans it. Treating
+            # the ':' as a one-statement body would guard only the first
+            # statement and leave a later profile write looking unconditional.
+            return None
+        if cursor < len(code) and code[cursor] == "{":
+            closing = matching_delimiter(code, cursor, "{", "}")
+            if closing is None:
+                return None
+            self.arms.append(ControlArm(group, branch, cursor, closing + 1))
+            return closing + 1
+        body_end = self._unbraced_body_end(after)
+        if body_end is None:
+            return None
+        self.arms.append(ControlArm(group, branch, after, body_end))
+        return body_end
+
+    def _curly(self) -> None:
+        code = self.lexed.code
+        # PHP spells a chained branch as one word, `elseif`, so `\bif` never
+        # matches inside it: neither the elseif body nor the `else` that closes
+        # the chain was indexed and a profile written there looked
+        # unconditional. Treat it exactly like the C-family `else if` - its own
+        # group, closed by its own `else`.
+        opener = r"\b(?:else)?if\s*\(" if self.suffix == ".php" else r"\bif\s*\("
+        # An `else if` used to open a group of its own, which was then marked
+        # exhaustive by its trailing `else` INDEPENDENTLY of the outer `if` -
+        # so `if (a) {} else if (b) {mp} else {mp}` looked like it always set
+        # the profile even though the `a` path sets nothing. The whole
+        # if/else-if/else chain is one group with one branch per arm, and only
+        # a final bare `else` makes it exhaustive (as Ruby/shell/PHP-alt
+        # chains already do).
+        chained = (
+            r"\s*(?:else\s*if|elseif|else)\b"
+            if self.suffix == ".php"
+            else r"\s*(?:else\s*if|else)\b"
+        )
+        handled: set[int] = set()
+        for match in re.finditer(opener, code):
+            if match.start() in handled:
+                continue
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            if close is None:
+                continue
+            group = match.start()
+            branch = 0
+            after = self._body_arm(group, branch, close + 1)
+            if after is None:
+                continue
+            while True:
+                tail = re.match(chained, code[after:])
+                if tail is None:
+                    break
+                head = after + tail.end()
+                if tail.group(0).strip() == "else":
+                    branch += 1
+                    if self._body_arm(group, branch, head) is not None:
+                        self.exhaustive.add(group)
+                    break
+                token = re.search(r"(?:\belseif|\bif)\s*$", code[after:head])
+                paren = head
+                while paren < len(code) and code[paren].isspace():
+                    paren += 1
+                if token is None or paren >= len(code) or code[paren] != "(":
+                    break
+                closing = matching_delimiter(code, paren, "(", ")")
+                if closing is None:
+                    break
+                handled.add(after + token.start())
+                branch += 1
+                nxt = self._body_arm(group, branch, closing + 1)
+                if nxt is None:
+                    break
+                after = nxt
+        if self.suffix == ".go":
+            # Go conditions and range clauses conventionally omit the
+            # parentheses required by the C-family forms above.
+            for match in re.finditer(r"\bif\b(?!\s*\()[^{}\n]*\{", code):
+                opening = code.rfind("{", match.start(), match.end())
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is None:
+                    continue
+                group = match.start()
+                self.arms.append(ControlArm(group, 0, opening, closing + 1))
+                tail = re.match(r"\s*else\s*", code[closing + 1:])
+                if tail is None:
+                    continue
+                cursor = closing + 1 + tail.end()
+                else_open = code.find("{", cursor)
+                if else_open >= 0 and not code[cursor:else_open].strip():
+                    else_close = matching_delimiter(code, else_open, "{", "}")
+                    if else_close is not None:
+                        self.arms.append(
+                            ControlArm(group, 1, else_open, else_close + 1)
+                        )
+                        self.exhaustive.add(group)
+            for match in re.finditer(r"\bfor\b(?!\s*\()[^{}\n]*\{", code):
+                opening = code.rfind("{", match.start(), match.end())
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is not None:
+                    self.arms.append(
+                        ControlArm(match.start(), 0, opening, closing + 1)
+                    )
+        # for / while / foreach / catch bodies, braced or unbraced. A loop may
+        # execute zero times, so a profile write in its body is conditional —
+        # `while (cond) payload.messaging_profile_id = p; send()` can send
+        # without the profile. A do-while `} while (cond);` has no following
+        # body (the next token is `;`), so _body_arm yields nothing for it,
+        # which is correct: a do body always runs at least once.
+        for match in re.finditer(r"\b(?:for|foreach|while|catch)\s*\(", code):
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            if close is None:
+                continue
+            self._body_arm(match.start(), 0, close + 1)
+        # `try { … }` takes no condition, so the parenthesised sweep above (which
+        # already covers `catch (…)`) never saw it. A try body is NOT
+        # unconditional: when a sibling catch swallows the error, execution
+        # continues past the statement with the write skipped. Treated as an arm,
+        # a send INSIDE the body shares it and stays unguarded, while a send
+        # after the statement is correctly guarded. Same rule as Python's `try`.
+        for match in re.finditer(r"\btry\s*\{", code):
+            opening = code.find("{", match.start())
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is None:
+                continue
+            # ONLY a try whose handler SWALLOWS is a guard. `try { } finally { }`
+            # with no handler propagates, and so does `catch (e) { throw e; }`:
+            # a later send is never reached and the write is not conditional
+            # relative to it - treating either as an arm reported compliant
+            # code as missing the profile.
+            if not self._swallowing_catch(closing + 1):
+                continue
+            self.arms.append(
+                ControlArm(match.start(), 0, opening, closing + 1)
+            )
+        # Go writes `switch mode {`, `switch x := f(); x {` and the bare
+        # `switch {` with NO parentheses, so the paren-anchored scan below never
+        # saw them: every case arm read as unconditional code, and a profile
+        # set in a single arm certified the whole send. Indexed here with the
+        # same per-arm modelling, so an exhaustive switch (one with `default:`)
+        # still counts as covering every path.
+        if self.suffix == ".go":
+            # The body brace is found by a BALANCED SCAN, not a lookahead. Two
+            # successive lookahead patterns were tried and both failed, because
+            # a Go switch header is not lexically simple: it may contain
+            # parentheses (`switch v := i.(type) {`), a semicolon and an init
+            # statement (`switch x := f(); x {`), a newline when it wraps, and
+            # a COMPOSITE LITERAL whose own brace (`switch cfg{A: 1}.mode {`)
+            # is not the body. Each failure indexed no arms at all, so a profile
+            # set in one arm read as unconditional - a silent pass every time.
+            # Scanning for the first brace that opens a BLOCK handles all four
+            # without another round of pattern guessing.
+            for match in re.finditer(r"(?<![\w.])switch(?![\w])", code):
+                opening = _go_block_brace(code, match.end())
+                if opening < 0:
+                    continue
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is None:
+                    continue
+                split = self._switch_arms(opening, closing)
+                if split is None:
+                    self.arms.append(
+                        ControlArm(match.start(), 0, opening, closing + 1)
+                    )
+                    continue
+                spans, has_default = split
+                for branch, (arm_start, arm_end) in enumerate(spans):
+                    self.arms.append(
+                        ControlArm(match.start(), branch, arm_start, arm_end)
+                    )
+                if has_default:
+                    self.exhaustive.add(match.start())
+
+        # switch bodies are always braced.
+        for match in re.finditer(r"\bswitch\s*\(", code):
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            opening = code.find("{", close + 1) if close is not None else -1
+            if opening < 0 or code[close + 1:opening].strip():
+                continue
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is None:
+                continue
+            # One arm for the whole body could never be exhaustive, so a switch
+            # in which EVERY arm (including `default:`) sets the profile was
+            # still reported as missing it. Index one arm per case label and
+            # mark the group exhaustive when a `default:` covers the rest.
+            split = self._switch_arms(opening, closing)
+            if split is None:
+                self.arms.append(ControlArm(match.start(), 0, opening, closing + 1))
+                continue
+            spans, has_default = split
+            for branch, (arm_start, arm_end) in enumerate(spans):
+                self.arms.append(
+                    ControlArm(match.start(), branch, arm_start, arm_end)
+                )
+            if has_default:
+                self.exhaustive.add(match.start())
+        if self.suffix == ".php":
+            self._php_alt()
+
+    def _swallowing_catch(self, cursor: int) -> bool:
+        """True when a `catch` clause at `cursor` can SWALLOW the error.
+
+        Only a swallowing handler makes the try body conditional. A handler
+        that re-raises (`catch (e) { log(e); throw e; }` — the standard
+        log-and-rethrow idiom) never lets execution continue past the
+        statement, so a write in the try body is unconditional relative to a
+        later send. Every handler must re-raise for the body to lose its arm;
+        a handler we cannot parse counts as swallowing, which keeps the
+        cautious FLAG.
+        """
+        code = self.lexed.code
+        while True:
+            head = re.match(r"\s*catch\b", code[cursor:cursor + 40])
+            if head is None:
+                return False
+            index = cursor + head.end()
+            while index < len(code) and code[index].isspace():
+                index += 1
+            if index < len(code) and code[index] == "(":
+                shut = matching_delimiter(code, index, "(", ")")
+                if shut is None:
+                    return True
+                index = shut + 1
+                while index < len(code) and code[index].isspace():
+                    index += 1
+            if index >= len(code) or code[index] != "{":
+                return True
+            shut = matching_delimiter(code, index, "{", "}")
+            if shut is None:
+                return True
+            if not self._braced_tail_throws(code[index + 1:shut]):
+                return True
+            cursor = shut + 1
+
+    @staticmethod
+    def _braced_tail_throws(body: str) -> bool:
+        """True when the LAST statement of a braced handler body re-raises.
+
+        Deliberately conservative: only a trailing top-level `throw` counts, so
+        a nested or conditional `if (fatal) { throw e; }` still reads as
+        swallowing and the body keeps its arm.
+        """
+        text = body.rstrip().rstrip(";").rstrip()
+        depth = 0
+        start = 0
+        for index in range(len(text) - 1, -1, -1):
+            character = text[index]
+            if character in ")]}":
+                depth += 1
+            elif character in "([{":
+                depth -= 1
+                if depth < 0:
+                    start = index + 1
+                    break
+            elif depth == 0 and character == ";":
+                start = index + 1
+                break
+        return re.match(r"\s*(?:throw|rethrow)\b", text[start:]) is not None
+
+    @staticmethod
+    def _label_colon(text: str, start: int) -> int | None:
+        """Offset of the ':' ending a `case …:` label, or None.
+
+        Skips bracketed spans, the `::` scope operator (`Status::SENT`) and the
+        ':' of a ternary so a computed case expression still finds its label.
+        """
+        depth = 0
+        pending = 0
+        index = start
+        while index < len(text):
+            character = text[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+            elif character in ";\n" and depth == 0 and pending == 0:
+                return None
+            elif depth == 0 and character == "?":
+                pending += 1
+            elif depth == 0 and character == ":":
+                if text[index + 1:index + 2] == ":":
+                    index += 2
+                    continue
+                if pending:
+                    pending -= 1
+                else:
+                    return index
+            index += 1
+        return None
+
+    def _switch_arms(
+        self, opening: int, closing: int
+    ) -> tuple[list[tuple[int, int]], bool] | None:
+        """Per-case arm spans for a switch body, plus whether it has a default.
+
+        Returns None when the shape cannot be modelled safely - no labels, an
+        unparsable label, or an IMPLICIT FALL-THROUGH (a non-empty case body
+        with no break/return before the next label). In those cases the caller
+        keeps the single whole-body arm, which over-guards rather than
+        under-guards. Consecutive labels with nothing between them share one
+        arm, which is exactly how `case 'a': case 'b': …` behaves.
+        """
+        code = self.lexed.code
+        body = code[opening + 1:closing]
+        depths: list[int] = []
+        depth = 0
+        for character in body:
+            depths.append(depth)
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+        labels: list[tuple[int, int, bool]] = []
+        for match in re.finditer(r"\b(case|default)\b", body):
+            if depths[match.start()] != 0:
+                continue
+            if match.group(1) == "default":
+                tail = re.match(r"\s*:", body[match.end():])
+                if tail is None:
+                    continue
+                colon = match.end() + tail.end() - 1
+            else:
+                found = self._label_colon(body, match.end())
+                if found is None:
+                    return None
+                colon = found
+            labels.append(
+                (
+                    opening + 1 + match.start(),
+                    opening + 2 + colon,
+                    match.group(1) == "default",
+                )
+            )
+        if not labels:
+            return None
+        terminator = re.compile(r"\b(?:break|return|continue|throw|goto|exit|die)\b")
+        spans: list[tuple[int, int]] = []
+        arm_start: int | None = None
+        for position, (label_start, body_start, _) in enumerate(labels):
+            if arm_start is None:
+                arm_start = label_start
+            body_end = (
+                labels[position + 1][0]
+                if position + 1 < len(labels)
+                else closing
+            )
+            segment = code[body_start:body_end]
+            if not segment.strip():
+                # Consecutive labels share one arm (`case 'a': case 'b': …`) in
+                # the C family, where an empty body falls through. Go does NOT
+                # fall through, so an empty `case "a":` is a real arm that runs
+                # and sets nothing - merging it into the following `default:`
+                # let that default certify a path which writes no profile.
+                if self.suffix == ".go":
+                    spans.append((arm_start, body_end))
+                    arm_start = None
+                continue
+            # Go breaks IMPLICITLY - falling through needs an explicit
+            # `fallthrough` keyword - so a Go arm without `break` is the normal
+            # case, not an unmodellable fall-through. Requiring a terminator
+            # there made every Go switch fall back to one whole-body arm, so an
+            # exhaustive switch whose every arm (including `default:`) sets the
+            # profile was still reported as missing it.
+            if self.suffix == ".go":
+                if re.search(r"\bfallthrough\b", segment):
+                    return None
+            elif position + 1 < len(labels) and terminator.search(segment) is None:
+                return None
+            spans.append((arm_start, body_end))
+            arm_start = None
+        if arm_start is not None:
+            spans.append((arm_start, closing))
+        return spans, any(is_default for _, _, is_default in labels)
+
+    def _php_alt(self) -> None:
+        """Index PHP alternative-syntax bodies (`if (…): … endif;`).
+
+        The colon-delimited forms have no braces, so _body_arm cannot span
+        them; without this a profile write between the ':' and the closing
+        `endif` / `else` / `elseif` looks unconditional. A stack pairs each
+        opener with its terminator so the if/elseif/else chain shares one group
+        (a trailing `else` marks it exhaustive) and the loop/switch forms get a
+        single conditional arm.
+        """
+        code = self.lexed.code
+        openers = {"if", "elseif", "else", "for", "foreach", "while", "switch"}
+        terminators = {
+            "endif": "if",
+            "endforeach": "foreach",
+            "endfor": "for",
+            "endwhile": "while",
+            "endswitch": "switch",
+        }
+        token = re.compile(
+            r"\b(if|elseif|else|for|foreach|while|switch)\b"
+            r"|\b(endif|endforeach|endfor|endwhile|endswitch)\b"
+        )
+        stack: list[list[int | str]] = []
+        for match in token.finditer(code):
+            keyword = match.group(1)
+            if keyword is not None:
+                if keyword == "else":
+                    head_end = match.end()
+                else:
+                    paren = match.end()
+                    while paren < len(code) and code[paren].isspace():
+                        paren += 1
+                    if paren >= len(code) or code[paren] != "(":
+                        continue
+                    close = matching_delimiter(code, paren, "(", ")")
+                    if close is None:
+                        continue
+                    head_end = close + 1
+                probe = head_end
+                while probe < len(code) and code[probe].isspace():
+                    probe += 1
+                if probe >= len(code) or code[probe] != ":":
+                    # Brace syntax or a non-alternative use — leave it to the
+                    # C-family handler.
+                    continue
+                body_start = probe + 1
+                if keyword in {"elseif", "else"}:
+                    if not stack or stack[-1][0] != "if":
+                        continue
+                    entry = stack[-1]
+                    self.arms.append(
+                        ControlArm(entry[1], entry[2], entry[3], match.start())
+                    )
+                    entry[2] += 1
+                    entry[3] = body_start
+                    if keyword == "else":
+                        self.exhaustive.add(entry[1])
+                elif keyword in openers:
+                    kind = "if" if keyword == "if" else keyword
+                    stack.append([kind, match.start(), 0, body_start])
+            else:
+                want = terminators[match.group(2)]
+                if stack and stack[-1][0] == want:
+                    entry = stack.pop()
+                    self.arms.append(
+                        ControlArm(entry[1], entry[2], entry[3], match.start())
+                    )
+
+    def _py_header_colon(self, start: int, end: int) -> int | None:
+        """Offset of the ':' that ends a Python compound-statement header.
+
+        Scans the masked line (strings/comments already blanked) for the first
+        top-level ':' — skipping brackets (slices, dicts, call args) and the
+        walrus ':=' — so a compact `if cond: stmt` header is found even when its
+        condition contains colons.
+        """
+        code = self.lexed.code
+        depth = 0
+        index = start
+        while index < end:
+            character = code[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+            elif character == ":" and depth == 0:
+                if index + 1 < len(code) and code[index + 1] == "=":
+                    index += 2
+                    continue
+                return index
+            index += 1
+        return None
+
+    def _py_logical_row(
+        self, lines: list[tuple[int, int, int, str]], index: int
+    ) -> int:
+        """Index of the last physical row of the logical line starting at `index`.
+
+        A compound header may WRAP: `if (use_pool\n        and enabled):` keeps
+        its ':' on a continuation row, so scanning only the first physical line
+        found no colon at all and the guard was never indexed - a profile
+        written in its body read as unconditional.
+        """
+        code = self.lexed.code
+        depth = 0
+        row = index
+        while True:
+            for position in range(lines[row][0], lines[row][1]):
+                character = code[position]
+                if character in "([{":
+                    depth += 1
+                elif character in ")]}":
+                    depth -= 1
+            if depth <= 0 or row + 1 >= len(lines):
+                return row
+            row += 1
+
+    def _swallowing_except(
+        self, lines: list[tuple[int, int, int, str]], index: int, indent: int
+    ) -> bool:
+        """True when an `except` handler of the `try` at `index` can SWALLOW.
+
+        Python mirror of `_swallowing_catch`: a handler whose last statement is
+        `raise` propagates, so execution never continues past the statement
+        with the write skipped. Every handler must re-raise for the try body to
+        lose its arm; anything unparseable counts as swallowing.
+        """
+        row = index + 1
+        while row < len(lines):
+            _, _, row_indent, text = lines[row]
+            if not text or row_indent > indent:
+                row += 1
+                continue
+            if row_indent < indent:
+                return False
+            if re.match(r"(?:else|finally)\b", text):
+                row += 1
+                continue
+            if re.match(r"except\b", text) is None:
+                return False
+            if not self._py_handler_reraises(lines, row, indent):
+                return True
+            row += 1
+        return False
+
+    def _py_handler_reraises(
+        self, lines: list[tuple[int, int, int, str]], row: int, indent: int
+    ) -> bool:
+        """True when the `except` handler at `row` ends in a bare-level `raise`.
+
+        Deliberately conservative: a `raise` nested deeper than the handler's
+        own body indent is conditional, so it reads as swallowing and the try
+        body keeps its arm.
+        """
+        code = self.lexed.code
+        last = self._py_logical_row(lines, row)
+        header_end = lines[last][1]
+        colon = self._py_header_colon(lines[row][0], header_end)
+        if colon is None:
+            return False
+        inline = code[colon + 1:header_end]
+        if inline.strip():
+            return self._tail_statement_raises(inline)
+        body = []
+        for entry in lines[last + 1:]:
+            if not entry[3]:
+                continue
+            if entry[2] <= indent:
+                break
+            body.append(entry)
+        if not body or body[-1][2] != body[0][2]:
+            return False
+        return self._tail_statement_raises(body[-1][3])
+
+    @staticmethod
+    def _tail_statement_raises(text: str) -> bool:
+        """True when the last `;`-separated statement of `text` is a `raise`."""
+        statements = [part for part in text.split(";") if part.strip()]
+        return bool(statements) and re.match(r"\s*raise\b", statements[-1]) is not None
+
+    def _python(self, lines: list[tuple[int, int, int, str]]) -> None:
+        """Index Python control arms, block and compact one-line forms alike.
+
+        A guard writes a profile only on some path — an `if`/`elif`/`else`
+        branch, a loop body that may not run, an `except` handler, or one
+        `case` arm — whether the body sits on its own indented lines or inline
+        after the header colon (`if cond: payload[...] = p`, or a `;`-separated
+        suite). Block `if`/`else` chains and `match`/`case` groups are tracked
+        so a fully-covering `else` / wildcard `case _` stays exhaustive and a
+        genuinely unconditional write is never guarded.
+        """
+        code = self.lexed.code
+        # A `try` body is NOT unconditional: when a sibling handler swallows the
+        # error, execution continues past the statement with the write skipped.
+        # It is an arm like any other — a send INSIDE the same body shares the
+        # arm and stays unguarded, while a send after the statement is guarded.
+        conditional = {"if", "elif", "else", "for", "while", "except", "case", "try"}
+        if_pending: dict[int, int] = {}
+        case_pending: dict[int, int] = {}
+        for index, (start, line_end, indent, text) in enumerate(lines):
+            header = re.match(
+                r"(if|elif|else|for|while|try|except|finally|with|match|case)\b",
+                text,
+            )
+            if header is None:
+                continue
+            word = header.group(1)
+            if word == "match":
+                # `match` only dispatches; its `case` arms carry the guard.
+                # Start a fresh case chain for any deeper indent.
+                for level in [key for key in case_pending if key > indent]:
+                    del case_pending[level]
+                continue
+            if word not in conditional:
+                # with / finally bodies always execute — not guards.
+                continue
+            if word == "try":
+                # ONLY a try whose handler SWALLOWS is a guard. `try: / finally:`
+                # with no handler propagates, and so does an `except:` whose
+                # body ends in `raise`: a later send is never reached and the
+                # write is not conditional relative to it - treating either as
+                # an arm reported compliant code as missing the profile.
+                if not self._swallowing_except(lines, index, indent):
+                    continue
+            last = self._py_logical_row(lines, index)
+            header_end = lines[last][1]
+            colon = self._py_header_colon(start, header_end)
+            if colon is None:
+                continue
+            if code[colon + 1:header_end].strip():
+                end = header_end  # compact inline body — guard only this line
+            else:
+                end = next(
+                    (row[0] for row in lines[last + 1:] if row[3] and row[2] <= indent),
+                    len(code),
+                )
+            orphan = False
+            if word in {"elif", "else"}:
+                orphan = indent not in if_pending
+                group = if_pending.get(indent, start)
+                if_pending[indent] = group
+            elif word == "case":
+                group = case_pending.get(indent, start)
+                case_pending[indent] = group
+            else:
+                group = start
+                if word in {"if", "for", "while"}:
+                    if_pending[indent] = group
+            self.arms.append(
+                ControlArm(
+                    group,
+                    sum(arm.group == group for arm in self.arms),
+                    start,
+                    end,
+                )
+            )
+            if word == "else" and not orphan:
+                # An `else` with NO recorded opener at this indent is not the
+                # tail of an if/for/while chain - it is `try/except/else`, whose
+                # body runs only when no exception was raised. Marking it
+                # exhaustive made a one-branch group that is always taken, so a
+                # profile written there read as unconditional.
+                self.exhaustive.add(group)
+            elif word == "case":
+                pattern = code[start + indent + len(word):colon].strip()
+                if re.fullmatch(r"_|[a-z]\w*", pattern):
+                    self.exhaustive.add(group)
+
+    def _lines(self) -> None:
+        lines: list[tuple[int, int, int, str]] = []
+        cursor = 0
+        for line in self.lexed.code.splitlines(keepends=True):
+            stripped = line.lstrip(" \t")
+            lines.append((cursor, cursor + len(line), len(line) - len(stripped), stripped.strip()))
+            cursor += len(line)
+        if self.suffix == ".py":
+            self._python(lines)
+            return
+        stack: list[tuple[str, int, int, int]] = []
+        for start, end, indent, text in lines:
+            if self.suffix == ".rb":
+                if re.match(r"(?:if|unless|case|for|while|until|begin)\b", text) or re.match(
+                    r".+\.(?:each|each_pair|each_with_index|times|map|select)\b.*\bdo(?:\s*\|[^|]*\|)?\s*$",
+                    text,
+                ):
+                    stack.append(("end", start, start, 0))
+                elif re.match(r"(?:elsif|when|rescue)\b", text) and stack:
+                    # A MIDDLE branch closes the previous one and opens the
+                    # next, but does NOT make the group exhaustive - only a
+                    # final `else` does. Without this, an `elsif`/`when` body
+                    # folded into branch 0 and a profile written only there
+                    # read as unconditional.
+                    token, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, start))
+                    stack.append((token, group, start, branch + 1))
+                elif text == "else" and stack:
+                    token, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, start))
+                    self.exhaustive.add(group)
+                    stack.append((token, group, start, branch + 1))
+                elif re.match(r"end\b", text) and stack:
+                    _, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, end))
+                elif re.search(
+                    r"\S\s+\b(?:if|unless|while|until)\b\s+\S", text
+                ) and not re.search(r"\b(?:then|do)\b\s*(?:\|[^|]*\|)?\s*$", text):
+                    # Trailing modifier: `stmt if cond` / `stmt unless cond`
+                    # runs the statement only conditionally. It is not a block
+                    # opener (those start with the keyword) so it has no `end`.
+                    self.arms.append(ControlArm(start, 0, start, end))
+            else:
+                one_line_if = re.match(r"if\b.*;\s*then\b.*\bfi\b", text)
+                if one_line_if:
+                    # Self-contained `if …; then …; fi` — the body is guarded
+                    # but there is no separate `fi` line to close it.
+                    self.arms.append(ControlArm(start, 0, start, end))
+                else:
+                    opener = re.match(r"(if|for|while|until|case)\b", text)
+                    if opener:
+                        close = "fi" if opener.group(1) == "if" else "esac" if opener.group(1) == "case" else "done"
+                        stack.append((close, start, start, 0))
+                    elif (
+                        re.match(r"elif\b", text)
+                        and stack
+                        and stack[-1][0] == "fi"
+                    ):
+                        # Same as Ruby's elsif: closes the previous branch,
+                        # opens the next, does not make the group exhaustive.
+                        token, group, branch_start, branch = stack.pop()
+                        self.arms.append(
+                            ControlArm(group, branch, branch_start, start)
+                        )
+                        stack.append((token, group, start, branch + 1))
+                    elif text == "else" and stack and stack[-1][0] == "fi":
+                        token, group, branch_start, branch = stack.pop()
+                        self.arms.append(ControlArm(group, branch, branch_start, start))
+                        self.exhaustive.add(group)
+                        stack.append((token, group, start, branch + 1))
+                    elif stack and re.match(rf"{stack[-1][0]}\b", text):
+                        _, group, branch_start, branch = stack.pop()
+                        self.arms.append(ControlArm(group, branch, branch_start, end))
+                guard = re.search(r"&&|\|\|", text)
+                if guard is not None and not re.match(
+                    r"(?:if|elif|else|fi|for|while|until|case|esac|done|then|do)\b",
+                    text,
+                ):
+                    # `cond && assign` / `cond || assign` runs the right side
+                    # only conditionally; guard from the operator onward so a
+                    # left-hand assignment that always runs stays unguarded.
+                    self.arms.append(
+                        ControlArm(start, 0, start + indent + guard.end(), end)
+                    )
+
+    def path(self, offset: int) -> tuple[tuple[int, int], ...]:
+        arms = [arm for arm in self.arms if arm.start <= offset < arm.end]
+        arms.sort(key=lambda arm: (-(arm.end - arm.start), arm.start))
+        return tuple((arm.group, arm.branch) for arm in arms)
+
+    def environments(self, paths: Iterable[tuple[tuple[int, int], ...]], call_path: tuple[tuple[int, int], ...]) -> list[dict[int, int | None]]:
+        fixed = dict(call_path)
+        groups: dict[int, set[int]] = {}
+        for path in paths:
+            for group, branch in path:
+                if group not in fixed:
+                    groups.setdefault(group, set()).add(branch)
+        environments: list[dict[int, int | None]] = [fixed]
+        for group, branches in groups.items():
+            if group in self.exhaustive:
+                # An exhaustive if/else covers all paths, but a branch that
+                # writes nothing never appears in the write paths above. Pull
+                # in every branch of the group so the path through a
+                # profile-less branch is considered — otherwise
+                # `if (skip) {...} else payload.messaging_profile_id = p;` was
+                # read as always setting the profile.
+                branches = branches | {
+                    arm.branch for arm in self.arms if arm.group == group
+                }
+            choices: list[int | None] = sorted(branches)
+            if group not in self.exhaustive:
+                choices.append(None)
+            expanded: list[dict[int, int | None]] = []
+            for environment in environments:
+                for choice in choices:
+                    candidate = dict(environment)
+                    candidate[group] = choice
+                    expanded.append(candidate)
+            environments = expanded
+            if len(environments) > 64:
+                return []
+        return environments
+
+    @staticmethod
+    def active(path: tuple[tuple[int, int], ...], environment: dict[int, int | None]) -> bool:
+        return all(environment.get(group) == branch for group, branch in path)
+
+
+class PayloadStateResolver:
+    """Indexed abstract interpreter for payload field/object state."""
+
+    JS_SUFFIXES = JS_TS_SUFFIXES
+
+    def __init__(
+        self,
+        lexed: LexedSource,
+        suffix: str,
+        fields: Iterable[str],
+        *,
+        require_value: bool,
+        source: SourceEndpointResolver | None = None,
+    ) -> None:
+        self.lexed, self.suffix = lexed, suffix
+        self.fields, self.require_value = frozenset(fields), require_value
+        self.source = source or SourceEndpointResolver(lexed, suffix)
+        self.control = ControlIndex(lexed, suffix)
+        self.roots: dict[int, list[RootFieldEvent]] = {}
+        self.root_offsets: dict[int, list[int]] = {}
+        self.objects: dict[tuple[int, int], RootFieldEvent] = {}
+        self.events: list[FieldEvent] = []
+        self.event_offsets: list[int] = []
+        self._targets_memo: dict[tuple[int, int, int], ObjectTargets] = {}
+        self._presence_memo: dict[tuple[tuple[int, int], int, int], Presence] = {}
+        self._index_roots()
+        self._index_field_events()
+
+    def _binding(self, start: int, end: int, scope: int, before: int) -> int | None:
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is not None and len(reference) == 1:
+            name = reference[0].lstrip("$")
+        else:
+            text = re.sub(r"^(?:\.\.\.|\*\*|[&*])\s*", "", self.lexed.code[start:end].strip())
+            match = re.fullmatch(r"\$?([A-Za-z_]\w*)", text)
+            if match is None:
+                return None
+            name = match.group(1)
+        return self.source.graph.visible_binding(name, scope, before)
+
+    def _index_roots(self) -> None:
+        for assignment in self.source.root_assignments:
+            binding = self.source.assignment_bindings[assignment.start()]
+            scope = self.source.scope_at(assignment.start())
+            end = assignment_end(self.lexed, assignment.end(), self.suffix)
+            owner = self.source.graph.bindings[binding]
+            direct_alias = self._binding(
+                assignment.end(), end, scope, assignment.start()
+            )
+            conditional = self._conditional(assignment.end(), end)
+            aliases: tuple[int, ...] | None = (
+                (direct_alias,) if direct_alias is not None else None
+            )
+            alias_unknown = False
+            if conditional is not None:
+                choices = tuple(
+                    self._binding(*span, scope, assignment.start())
+                    for span in conditional
+                )
+                aliases = tuple(
+                    dict.fromkeys(choice for choice in choices if choice is not None)
+                )
+                alias_unknown = any(choice is None for choice in choices)
+            event = RootFieldEvent(
+                binding,
+                assignment.start(),
+                (assignment.end(), end),
+                scope,
+                self.source.graph.execution_scope(scope),
+                "declaration" if owner.declaration_start == assignment.start() else "mutation",
+                self.control.path(assignment.start()),
+                aliases,
+                alias_unknown,
+            )
+            self.roots.setdefault(binding, []).append(event)
+            self.root_offsets.setdefault(binding, []).append(event.start)
+            if event.aliases is None:
+                self.objects[event.object_id] = event
+
+    def _add_event(self, binding: int, start: int, effect: int, overlay: tuple[int, int] | None = None) -> None:
+        scope = self.source.scope_at(start)
+        self.events.append(FieldEvent(
+            binding,
+            start,
+            scope,
+            self.source.graph.execution_scope(scope),
+            self.control.path(start),
+            effect,
+            overlay,
+        ))
+
+    def _value_effect(
+        self, start: int, end: int, seen: frozenset[int] = frozenset()
+    ) -> int:
+        if not self.require_value:
+            return WRITE_PRESENT
+        conditional = self._conditional(start, end)
+        if conditional is not None:
+            effects = {
+                self._value_effect(span[0], span[1], seen) for span in conditional
+            }
+            return effects.pop() if len(effects) == 1 else WRITE_MAYBE
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        code = self.lexed.code[start:end].strip()
+        if re.fullmatch(r"(?:null|nil|none|undefined|Optional\s*\.\s*empty\s*\(\s*\))", code, re.I):
+            return WRITE_ABSENT
+        # A messaging_profile_id must be a non-empty identifier. A statically
+        # falsy or empty literal — false/true, 0, [], {}, and empty collection
+        # constructors — is present in shape but unusable, so the Messages API
+        # receives an invalid profile. Treat those as absent (shape vs value).
+        if re.fullmatch(
+            r"(?:false|true"
+            r"|[+-]?0(?:\.0+)?"
+            r"|\[\s*\]|\{\s*\}|\(\s*\)"
+            r"|(?:dict|list|tuple|set|array|Array|Map|Set|Object|String)\s*\(\s*\)"
+            r"|new\s+(?:Array|Map|Set|Object)\s*\(\s*\))",
+            code,
+            re.I,
+        ):
+            return WRITE_ABSENT
+        tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
+        if len(tokens) == 1:
+            residual = (self.lexed.code[start:tokens[0].start] + self.lexed.code[tokens[0].end:end]).strip().lower()
+            if residual in {"", "f", "r", "u", "b", "fr", "rf"}:
+                return (
+                    WRITE_PRESENT
+                    if tokens[0].contents.strip()
+                    else WRITE_ABSENT
+                )
+        # A value with an empty fallback is not guaranteed usable. Treat both
+        # nullish and logical-OR fallbacks consistently; a concrete non-empty
+        # fallback is handled by the conditional resolver above.
+        if re.search(r"(?:\?\?|\|\||\boptional\b|\bmaybe\b)", code, re.I):
+            return WRITE_MAYBE
+        if self.suffix == ".py":
+            env_getter = re.search(
+                r"(?:os\.environ\.get|os\.getenv)\s*\(",
+                self.lexed.code[start:end],
+            )
+            if env_getter is not None:
+                opening = start + env_getter.end() - 1
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                arguments = (
+                    split_arguments(self.lexed.code, opening + 1, closing)
+                    if closing is not None and closing <= end
+                    else []
+                )
+                if len(arguments) < 2:
+                    return WRITE_MAYBE
+        if tokens and all(not token.contents.strip() for token in tokens):
+            # Empty literal concatenations/coercions (`'' + ''`,
+            # `String('   ')`, `.concat('')`, `.join('')`) are statically
+            # unusable even though their source text is non-empty.
+            residual = self.lexed.code[start:end]
+            if not re.search(r"[A-Za-z_$]\w*(?!\s*\()", residual):
+                return WRITE_ABSENT
+        alias = self._alias_absence(start, code, seen)
+        if alias is not None:
+            return alias
+        return WRITE_PRESENT if code else WRITE_ABSENT
+
+    def _assignment_entries(self) -> list[tuple[str, int, int, int]]:
+        cached = getattr(self, "_assignment_entries_cache", None)
+        if cached is None:
+            cached = assignment_index(self.lexed, self.suffix)
+            self._assignment_entries_cache = cached
+        return cached
+
+    def _alias_absence(
+        self, start: int, code: str, seen: frozenset[int]
+    ) -> int | None:
+        """Resolve a bare-identifier value to its nearest static literal.
+
+        A direct empty/falsy literal is already treated as absent above, but a
+        value assigned through a local constant — ``const mp = ''; {..: mp}`` —
+        would otherwise pass as present because the identifier text is non-empty.
+        Resolve the nearest binding-matched assignment and recurse, so every
+        empty/falsy form and any alias chain is caught. This ONLY returns a
+        proven absence: a present/maybe value keeps the existing behaviour, so
+        the resolution can flag more, never fewer (no new false positives on a
+        genuinely populated alias).
+        """
+        match = re.fullmatch(r"\$?([A-Za-z_]\w*)", code)
+        if match is None:
+            return None
+        name = match.group(1)
+        # DECLARED but never assigned - `let mp;` / `var mp;`. Such a name has
+        # no assignment entry at all, so it also has no binding, and the lookup
+        # below returns None before any absence can be proven. The serialized
+        # payload is byte-identical to the explicitly-empty `let mp = ""` case
+        # that IS flagged, so treat a bare declaration as proven absence.
+        # Checked BEFORE the binding lookup for exactly that reason.
+        if not any(
+            entry_name.lstrip("$") == name
+            for entry_name, _, _, _ in self._assignment_entries()
+        ) and re.search(
+            rf"(?:^|[;{{}}\n])[ \t]*(?:let|var|my|our)[ \t]+\$?{re.escape(name)}[ \t]*(?=[;\n])",
+            self.lexed.code[:start],
+        ):
+            return WRITE_ABSENT
+        binding = self.source.graph.visible_binding(
+            name, self.source.scope_at(start), start
+        )
+        if binding is None or binding in seen:
+            return None
+        assignments: list[tuple[int, int, int]] = []
+        for entry_name, entry_start, rhs_start, rhs_end in self._assignment_entries():
+            if entry_name.lstrip("$") != name:
+                continue
+            entry_binding = self.source.graph.visible_binding(
+                name, self.source.scope_at(entry_start), entry_start
+            )
+            if entry_binding == binding:
+                assignments.append((entry_start, rhs_start, rhs_end))
+        # Only a SINGLE static assignment is a constant alias. A reassigned or
+        # conditionally-assigned binding may hold a different value at the use
+        # site, so leave it to the existing present/maybe handling — stay
+        # conservative and never manufacture a false absence.
+        if len(assignments) != 1:
+            return None
+        entry_start, rhs_start, rhs_end = assignments[0]
+        if entry_start >= start:
+            return None
+        resolved = self._value_effect(rhs_start, rhs_end, seen | {binding})
+        return WRITE_ABSENT if resolved == WRITE_ABSENT else None
+
+    def _index_field_events(self) -> None:
+        seen: set[tuple[int, int, int, tuple[int, int] | None]] = set()
+
+        def add(binding: int | None, start: int, effect: int, overlay: tuple[int, int] | None = None) -> None:
+            if binding is None or (binding, start, effect, overlay) in seen:
+                return
+            seen.add((binding, start, effect, overlay))
+            self._add_event(binding, start, effect, overlay)
+
+        for reference, start, rhs_start, rhs_end in direct_member_assignments(self.lexed, len(self.lexed.code), self.suffix):
+            if len(reference) != 2 or reference[1] not in self.fields:
+                continue
+            scope = self.source.scope_at(start)
+            add(self.source.graph.visible_binding(reference[0].lstrip("$"), scope, start), start, self._value_effect(rhs_start, rhs_end))
+        if self.suffix == ".sh":
+            for reference, start, rhs_start, rhs_end in shell_member_assignments(self.lexed, len(self.lexed.code), self.suffix):
+                if len(reference) == 2 and reference[1] in self.fields:
+                    scope = self.source.scope_at(start)
+                    add(self.source.graph.visible_binding(reference[0], scope, start), start, self._value_effect(rhs_start, rhs_end))
+
+        names = "|".join(map(re.escape, sorted(self.fields)))
+        root_spans = [event.rhs for events in self.roots.values() for event in events]
+        setter = re.compile(rf"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:set)?(?:{names})\s*\(")
+        for match in setter.finditer(self.lexed.code):
+            if any(start <= match.start() < end for start, end in root_spans):
+                continue
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            scope = self.source.scope_at(match.start())
+            if closing is not None:
+                add(self.source.graph.visible_binding(match.group(1), scope, match.start()), match.start(), self._value_effect(opening + 1, closing))
+
+        # `.Add(key, value)` (C# Dictionary), `.TryAdd(...)`, `.set(...)` (JS
+        # Map) and `.putIfAbsent(...)` are the same two-argument key/value write
+        # as Java's `.put(...)`. Modelling only `put` meant a C# payload built
+        # with Dictionary.Add was seen as never receiving the profile, so a
+        # COMPLIANT send was reported as missing it.
+        put = re.compile(
+            r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*"
+            r"(?:put|putIfAbsent|Add|TryAdd|set)\s*\("
+        )
+        for match in put.finditer(self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if len(arguments) == 2 and static_lookup_key(self.lexed, *arguments[0]) in self.fields:
+                scope = self.source.scope_at(match.start())
+                add(self.source.graph.visible_binding(match.group(1), scope, match.start()), match.start(), self._value_effect(*arguments[1]))
+
+        # Snapshot overlays and in-place merge/update adapters.
+        merge = re.compile(r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:update|merge!|putAll)\s*\(")
+        for match in merge.finditer(self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            if closing is not None:
+                scope = self.source.scope_at(match.start())
+                binding = self.source.graph.visible_binding(match.group(1), scope, match.start())
+                for span in split_arguments(self.lexed.code, opening + 1, closing):
+                    add(binding, match.start() + span[0] - opening, NO_WRITE, span)
+        for match in re.finditer(r"\bObject\s*\.\s*assign\s*\(", self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if len(arguments) < 2:
+                continue
+            scope = self.source.scope_at(match.start())
+            binding = self._binding(*arguments[0], scope, match.start())
+            for span in arguments[1:]:
+                add(binding, span[0], NO_WRITE, span)
+
+        deletion_patterns = (
+            re.compile(r"\b(?:delete|del)\s+([^;\n]+)"),
+            re.compile(r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:delete|remove|Remove)\s*\(([^)]*)\)"),
+            re.compile(r"\bdelete\s*\(\s*([A-Za-z_]\w*)\s*,([^)]*)\)"),
+            re.compile(r"\bunset\s*\(\s*([^)]*)\)"),
+        )
+        for index, pattern in enumerate(deletion_patterns):
+            for match in pattern.finditer(self.lexed.code):
+                reference = static_reference_expression(self.lexed, match.start(1), match.end(1)) if index in {0, 3} else None
+                if index in {1, 2} and static_lookup_key(self.lexed, *match.span(2)) in self.fields:
+                    reference = (match.group(1), next(iter(self.fields)))
+                if reference is None or len(reference) != 2 or reference[1] not in self.fields:
+                    continue
+                scope = self.source.scope_at(match.start())
+                add(self.source.graph.visible_binding(reference[0].lstrip("$"), scope, match.start()), match.start(), WRITE_ABSENT)
+        self.events.sort(key=lambda event: event.start)
+        self.event_offsets = [event.start for event in self.events]
+
+    def _conditional(self, start: int, end: int) -> tuple[tuple[int, int], tuple[int, int]] | None:
+        round_depth = square_depth = curly_depth = nested = 0
+        question: int | None = None
+        for index in range(start, end):
+            character = self.lexed.code[index]
+            if character == "(": round_depth += 1
+            elif character == ")" and round_depth: round_depth -= 1
+            elif character == "[": square_depth += 1
+            elif character == "]" and square_depth: square_depth -= 1
+            elif character == "{": curly_depth += 1
+            elif character == "}" and curly_depth: curly_depth -= 1
+            elif not (round_depth or square_depth or curly_depth):
+                if character == "?" and not self.lexed.code.startswith(("?.", "??"), index):
+                    if question is None: question = index
+                    else: nested += 1
+                elif character == ":" and question is not None:
+                    if nested: nested -= 1
+                    else: return (question + 1, index), (index + 1, end)
+        # Python's `a if cond else b`. The `if`/`else` must be at the TOP LEVEL
+        # of the span: a plain `build(a if flag else b)` was split by a naive
+        # fullmatch into the bogus alias branches "build(a" and "b)", and the
+        # payload it really assigns became unresolvable - compliant code was
+        # reported as missing the profile.
+        depth = 0
+        word_if: int | None = None
+        for token in re.finditer(
+            r"[()\[\]{}]|\bif\b|\belse\b", self.lexed.code[start:end]
+        ):
+            text = token.group(0)
+            if text in "([{":
+                depth += 1
+            elif text in ")]}":
+                depth -= 1
+            elif depth:
+                continue
+            elif text == "if":
+                if word_if is None and token.start() > 0:
+                    word_if = token.start()
+            elif word_if is not None:
+                return (
+                    (start, start + word_if),
+                    (start + token.end(), end),
+                )
+        return None
+
+    def _root_reaches(self, event: RootFieldEvent, use_scope: int) -> bool:
+        if event.kind == "declaration":
+            return self.source.graph.bindings[event.binding].scope_id in self.source.graph.ancestors(use_scope)
+        return event.execution == self.source.graph.execution_scope(use_scope)
+
+    def targets(self, binding: int, before: int, use_scope: int, visiting: frozenset[tuple[int, int, int]] = frozenset()) -> ObjectTargets:
+        key = (binding, before, use_scope)
+        if key in self._targets_memo:
+            return self._targets_memo[key]
+        if key in visiting:
+            return ObjectTargets(unknown=True)
+        stop = bisect.bisect_left(self.root_offsets.get(binding, ()), before)
+        events = [event for event in self.roots.get(binding, ())[:stop] if self._root_reaches(event, use_scope)]
+        call_path = self.control.path(before)
+        environments = self.control.environments((event.path for event in events), call_path)
+        if not environments:
+            return ObjectTargets(unknown=True)
+        results: list[ObjectTargets] = []
+        for environment in environments:
+            current = ObjectTargets(unknown=True)
+            for event in events:
+                if not self.control.active(event.path, environment):
+                    continue
+                current = (
+                    ObjectTargets(frozenset((event.object_id,)))
+                    if event.aliases is None
+                    else join_targets(
+                        [
+                            self.targets(
+                                alias,
+                                event.start,
+                                event.scope,
+                                visiting | {key},
+                            )
+                            for alias in event.aliases
+                        ]
+                        + (
+                            [ObjectTargets(unknown=True)]
+                            if event.alias_unknown
+                            else []
+                        )
+                    )
+                )
+            results.append(current)
+        value = join_targets(results)
+        self._targets_memo[key] = value
+        return value
+
+    def _effect_from_presence(self, value: Presence) -> int:
+        return overlay_effect(value)
+
+    def _object_presence(self, object_id: tuple[int, int], before: int, use_scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]] = frozenset()) -> Presence:
+        key = (object_id, before, use_scope)
+        if key in self._presence_memo:
+            return self._presence_memo[key]
+        if key in visiting or object_id not in self.objects:
+            return MAYBE_VALUE
+        root = self.objects[object_id]
+        initial = self._span_presence(*root.rhs, root.start, root.scope, visiting | {key})
+        stop = bisect.bisect_left(self.event_offsets, before)
+        # A field write in an ENCLOSING function reaches a send written inside
+        # a callback: the object is captured by the closure and the write has
+        # already run at the point the send is written. Requiring an exact
+        # execution-scope match dropped every such write, so
+        # `payload.messaging_profile_id = mp; items.forEach(i => fetch(...))`
+        # was reported as missing the profile it plainly sets. The reverse
+        # direction stays blocked - a write INSIDE a callback still cannot
+        # prove anything about a send outside it, because the callback may
+        # never run.
+        enclosing = self.source.graph.ancestors(use_scope)
+        events = [event for event in self.events[:stop] if event.execution in enclosing]
+        environments = self.control.environments((event.path for event in events), self.control.path(before))
+        if not environments:
+            return Presence(MAYBE, initial.evidence or bool(events))
+        outcomes: list[Presence] = []
+        for environment in environments:
+            value = initial
+            for event in events:
+                if not self.control.active(event.path, environment):
+                    continue
+                targets = self.targets(event.binding, event.start, event.scope)
+                definite = object_id in targets.must
+                possible = definite or object_id in targets.may or targets.unknown
+                if not possible:
+                    continue
+                effect = event.effect
+                if event.overlay is not None:
+                    effect = self._effect_from_presence(self._span_presence(*event.overlay, event.start, event.scope, visiting | {key}))
+                changed = apply_field_effect(value, effect)
+                value = changed if definite else join_presence((value, changed))
+            outcomes.append(value)
+        result = join_presence(outcomes)
+        self._presence_memo[key] = result
+        return result
+
+    def presence_for_binding(self, binding: int, before: int, use_scope: int) -> Presence:
+        targets = self.targets(binding, before, use_scope)
+        values = [self._object_presence(object_id, before, use_scope) for object_id in targets.all]
+        if targets.unknown:
+            values.append(MAYBE_VALUE)
+        return join_presence(values)
+
+    def presence_for_name(self, name: str, before: int) -> Presence:
+        scope = self.source.scope_at(before)
+        binding = self.source.graph.visible_binding(name.lstrip("$"), scope, before)
+        return self.presence_for_binding(binding, before, scope) if binding is not None else MAYBE_VALUE
+
+    def _serialized(self, value: str) -> Presence | None:
+        candidates = [value]
+        try:
+            decoded = json.loads(f'"{value}"')
+            if decoded != value: candidates.append(decoded)
+        except (TypeError, ValueError):
+            pass
+        for candidate in candidates:
+            try: payload = json.loads(candidate)
+            except (TypeError, ValueError): continue
+            if not isinstance(payload, dict):
+                return ABSENT_VALUE
+            selected = next((payload[name] for name in reversed(tuple(payload)) if name in self.fields), ...)
+            if selected is ...:
+                return ABSENT_VALUE
+            if not self.require_value:
+                return PRESENT_VALUE
+            return Presence(
+                PRESENT
+                if selected not in (None, "", [], {}, False)
+                else ABSENT,
+                True,
+            )
+        return None
+
+    def text_presence(self, value: str) -> Presence:
+        return self._serialized(value) or MAYBE_VALUE
+
+    def _members(self, kind: str, opening: int, closing: int, before: int, scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]]) -> Presence:
+        members = split_arguments(self.lexed.code, opening + 1, closing)
+        value = ABSENT_VALUE
+        if kind == "pairs":
+            for key_span, value_span in zip(members[::2], members[1::2]):
+                key = static_object_key(self.lexed, *key_span)
+                if key in self.fields: value = apply_field_effect(value, self._value_effect(*value_span))
+                elif key is None: value = join_presence((value, MAYBE_VALUE))
+            return value
+        for member_start, member_end in members:
+            text = self.lexed.code[member_start:member_end].strip()
+            if not text: continue
+            # Match on raw source offsets: `text` is stripped, so any offset
+            # derived from it is short by the member's leading whitespace and
+            # `{ a, ...base }` resolved to `.base` instead of `base`.
+            spread = SPREAD_MEMBER_RE.match(self.lexed.code, member_start, member_end)
+            if spread:
+                value = apply_field_effect(value, overlay_effect(self._span_presence(spread.end(), member_end, before, scope, visiting)))
+                continue
+            colon = top_level_colon(self.lexed.code, member_start, member_end)
+            separator = (colon, colon + 1) if colon is not None else top_level_assignment_separator(self.lexed.code, member_start, member_end)
+            if separator is None:
+                key = static_object_key(self.lexed, member_start, member_end)
+                # A separator-less member is either a string key or a JS/TS
+                # shorthand. Shorthand means the VARIABLE's value, so the value
+                # still has to be analysed - hard-coding WRITE_PRESENT
+                # certified `const messaging_profile_id = ''; {..., messaging_profile_id}`.
+                # For a string-literal key the span is its own non-empty
+                # literal, so _value_effect keeps the previous verdict.
+                if key in self.fields: value = apply_field_effect(value, self._value_effect(member_start, member_end))
+                elif key is None and text.startswith("["): value = join_presence((value, MAYBE_VALUE))
+                continue
+            separator_start, value_start = separator
+            key = static_object_key(self.lexed, member_start, separator_start)
+            if key in self.fields: value = apply_field_effect(value, self._value_effect(value_start, member_end))
+            elif key is None: value = join_presence((value, MAYBE_VALUE))
+        return value
+
+    def _builder(self, start: int, end: int) -> Presence | None:
+        names = "|".join(map(re.escape, sorted(self.fields)))
+        matches = list(
+            re.compile(
+                rf"(?:\.|->)\s*(?:set)?(?:{names})\s*\("
+            ).finditer(self.lexed.code, start, end)
+        )
+        matches = [
+            match
+            for match in matches
+            if structural_depth(self.lexed.code, start, match.start())
+            == (0, 0, 0)
+        ]
+        if not matches: return None
+        opening = self.lexed.code.rfind("(", matches[-1].start(), matches[-1].end())
+        closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+        return Presence(MAYBE, True) if closing is None or closing > end else apply_field_effect(ABSENT_VALUE, self._value_effect(opening + 1, closing))
+
+    def _arguments(self, start: int, end: int) -> Presence | None:
+        value, found = ABSENT_VALUE, False
+        for member_start, member_end in split_arguments(self.lexed.code, start, end):
+            colon = top_level_colon(self.lexed.code, member_start, member_end)
+            separator = (colon, colon + 1) if colon is not None else top_level_assignment_separator(self.lexed.code, member_start, member_end)
+            if separator is None: continue
+            key = static_object_key(self.lexed, member_start, separator[0])
+            if key in self.fields:
+                value, found = apply_field_effect(value, self._value_effect(separator[1], member_end)), True
+        return value if found else None
+
+    def _span_presence(self, start: int, end: int, before: int, scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]] = frozenset()) -> Presence:
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end: return ABSENT_VALUE
+        conditional = self._conditional(start, end)
+        if conditional is not None:
+            return join_presence(self._span_presence(*span, before, scope, visiting) for span in conditional)
+        wrapper = re.match(r"\s*(?:JSON\s*\.\s*stringify|json\s*\.\s*dumps)\s*\(", self.lexed.code[start:end])
+        if wrapper:
+            opening = self.lexed.code.find("(", start, start + wrapper.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if arguments: return self._span_presence(*arguments[0], before, scope, visiting)
+        # Ruby's serializer is a suffix, not a call wrapper: `payload.to_json`
+        # is the idiomatic Net::HTTP/Faraday body. Only the inline-literal form
+        # `{..}.to_json` resolved, so a compliant send through a variable was
+        # reported as missing the profile.
+        to_json = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*to_json\s*(?:\(\s*\))?\s*",
+            self.lexed.code[start:end],
+        )
+        if to_json is not None:
+            return self._span_presence(
+                start + to_json.start(1), start + to_json.end(1), before, scope, visiting
+            )
+        assign = re.match(r"\s*Object\s*\.\s*assign\s*\(", self.lexed.code[start:end])
+        if assign:
+            opening = self.lexed.code.find("(", start, start + assign.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            value = ABSENT_VALUE
+            for span in split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []:
+                value = apply_field_effect(value, overlay_effect(self._span_presence(*span, before, scope, visiting)))
+            return value
+        copy_call = re.fullmatch(
+            r"\s*(?:new\s+)?(?:dict|HashMap|Dictionary)"
+            r"(?:\s*<[^>]*>)?\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if copy_call is not None:
+            copy_start = start + copy_call.start(1)
+            return self._span_presence(
+                copy_start,
+                start + copy_call.end(1),
+                before,
+                scope,
+                visiting,
+            )
+        copy_method = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*"
+            r"(?:copy|dup|clone)\s*(?:\(\s*\))?\s*",
+            self.lexed.code[start:end],
+        )
+        if copy_method is not None:
+            name_start = start + copy_method.start(1)
+            binding = self._binding(
+                name_start, start + copy_method.end(1), scope, before
+            )
+            if binding is not None:
+                return self.presence_for_binding(binding, before, scope)
+        clone_call = re.fullmatch(
+            r"\s*maps\s*\.\s*Clone\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if clone_call is not None:
+            clone_start = start + clone_call.start(1)
+            return self._span_presence(
+                clone_start,
+                start + clone_call.end(1),
+                before,
+                scope,
+                visiting,
+            )
+        merge_copy = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*merge\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if merge_copy is not None:
+            receiver_start = start + merge_copy.start(1)
+            value = self._span_presence(
+                receiver_start,
+                start + merge_copy.end(1),
+                before,
+                scope,
+                visiting,
+            )
+            argument_start = start + merge_copy.start(2)
+            for span in split_arguments(
+                self.lexed.code,
+                argument_start,
+                start + merge_copy.end(2),
+            ):
+                value = apply_field_effect(
+                    value,
+                    overlay_effect(
+                        self._span_presence(*span, before, scope, visiting)
+                    ),
+                )
+            return value
+        container = root_literal_container(self.lexed, start, end, self.suffix)
+        if container is not None: return self._members(*container, before, scope, visiting)
+        builder = self._builder(start, end)
+        if builder is not None: return builder
+        arguments = self._arguments(start, end)
+        if arguments is not None: return arguments
+        binding = self._binding(start, end, scope, before)
+        if binding is not None: return self.presence_for_binding(binding, before, scope)
+        tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
+        if len(tokens) == 1:
+            serialized = self._serialized(tokens[0].contents)
+            if serialized is not None: return serialized
+        if (
+            self.require_value
+            and self.suffix == ".sh"
+            and shell_jq_assignment_has_profile(self.lexed, start, end)
+        ):
+            return PRESENT_VALUE
+        old = region_has_profile(self.lexed, start, end, serialized_assignment=True, allow_js_shorthand=self.suffix in self.JS_SUFFIXES) if self.require_value else region_has_message_body(self.lexed, start, end, self.suffix)
+        return PRESENT_VALUE if old else MAYBE_VALUE
+
+    def span_presence(self, start: int, end: int, before: int) -> Presence:
+        return self._span_presence(start, end, before, self.source.scope_at(before))
+
+
+def shell_static_key(source: str) -> str | None:
+    key = source.strip()
+    if len(key) >= 2 and key[0] == key[-1] and key[0] in {"'", '"'}:
+        key = key[1:-1]
+    return key if re.fullmatch(r"(?:[A-Za-z_]\w*|\d+)", key) else None
+
+
+def shell_static_references(
+    source: str,
+) -> list[EndpointReference]:
+    references: list[EndpointReference] = []
+    for match in SHELL_STATIC_REFERENCE_RE.finditer(source):
+        root = match.group(1) or match.group(3)
+        key = shell_static_key(match.group(2)) if match.group(2) else None
+        if match.group(2) and key is None:
+            continue
+        references.append((root, key) if key is not None else (root,))
+    return references
+
+
+def shell_member_assignments(
+    lexed: LexedSource, before: int, suffix: str
+) -> list[tuple[EndpointReference, int, int, int]]:
+    pattern = re.compile(
+        r"(?<![\w$])([A-Za-z_]\w*)\[\s*([^\]]+)\s*\]\s*=(?!=)"
+    )
+    assignments: list[tuple[EndpointReference, int, int, int]] = []
+    for match in pattern.finditer(lexed.without_comments, 0, before):
+        key = shell_static_key(match.group(2))
+        if key is None:
+            continue
+        assignments.append(
+            (
+                (match.group(1), key),
+                match.start(),
+                match.end(),
+                assignment_end(lexed, match.end(), suffix),
+            )
+        )
+    return assignments
+
+
+def shell_separator(lexed: LexedSource, offset: int) -> bool:
+    character = lexed.code[offset]
+    if character not in {"\n", ";", "&", "|"}:
+        return False
+    backslashes = 0
+    cursor = offset - 1
+    while cursor >= 0 and lexed.original[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 0
+
+
+def shell_command_span(lexed: LexedSource, offset: int) -> tuple[int, int]:
+    """Bound one shell command without merging adjacent curl payloads."""
+
+    start = 0
+    for index in range(offset - 1, -1, -1):
+        if shell_separator(lexed, index):
+            start = index + 1
+            break
+    end = len(lexed.original)
+    for index in range(offset, len(lexed.code)):
+        if shell_separator(lexed, index):
+            end = index
+            break
+    return start, end
+
+
+def shell_curl_is_command(
+    lexed: LexedSource, command_start: int, curl_start: int
+) -> bool:
+    """Exclude prose/arguments containing the word curl without executing it."""
+
+    prefix = lexed.original[command_start:curl_start].strip()
+    if not prefix or prefix.endswith("$("):
+        return True
+    try:
+        tokens = shlex.split(prefix, comments=True, posix=True)
+    except ValueError:
+        return False
+    allowed = {
+        "!", "command", "do", "elif", "env", "if", "then", "until", "while"
+    }
+    return all(
+        token in allowed or SHELL_ASSIGNMENT_TOKEN_RE.fullmatch(token)
+        for token in tokens
+    )
+
+
+def shell_curl_calls(lexed: LexedSource) -> list[Call]:
+    calls: list[Call] = []
+    seen: set[tuple[int, int]] = set()
+    for match in SHELL_CURL_RE.finditer(lexed.code):
+        start, end = shell_command_span(lexed, match.start(1))
+        if not shell_curl_is_command(lexed, start, match.start(1)):
+            continue
+        if (start, end) not in seen:
+            seen.add((start, end))
+            calls.append(Call(start, start, end, parenthesized=False))
+    return calls
+
+
+def shell_curl_url_arguments(lexed: LexedSource, call: Call) -> list[str]:
+    """Return curl URL arguments while excluding option values and payloads."""
+
+    source = lexed.original[call.start:call.end]
+    try:
+        tokens = shlex.split(source, comments=True, posix=True)
+    except ValueError:
+        return []
+    curl_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if re.search(r"(?:^|[/$(])curl$", token)
+        ),
+        None,
+    )
+    if curl_index is None:
+        return []
+
+    candidates: list[str] = []
+    index = curl_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        option, separator, attached = token.partition("=")
+        if separator and option in SHELL_CURL_VALUE_OPTIONS:
+            if option in SHELL_CURL_URL_OPTIONS:
+                candidates.append(attached)
+            index += 1
+            continue
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            if index + 1 < len(tokens) and token in SHELL_CURL_URL_OPTIONS:
+                candidates.append(tokens[index + 1])
+            index += 2
+            continue
+        if any(
+            token.startswith(short) and len(token) > len(short)
+            for short in ("-A", "-d", "-H", "-o", "-u", "-w", "-X")
+        ):
+            index += 1
+            continue
+        if not token.startswith("-"):
+            candidates.append(token)
+        index += 1
+    return candidates
+
+
+def shell_curl_url_references(
+    lexed: LexedSource, call: Call
+) -> set[EndpointReference]:
+    expanded: set[EndpointReference] = set()
+    for match in SHELL_STATIC_REFERENCE_RE.finditer(
+        lexed.original, call.start, call.end
+    ):
+        token = next(
+            (
+                candidate
+                for candidate in lexed.strings
+                if candidate.start <= match.start() < candidate.end
+            ),
+            None,
+        )
+        if token is not None and lexed.original[token.start] == "'":
+            continue
+        root = match.group(1) or match.group(3)
+        key = shell_static_key(match.group(2)) if match.group(2) else None
+        expanded.add((root, key) if key is not None else (root,))
+    return {
+        reference
+        for candidate in shell_curl_url_arguments(lexed, call)
+        for reference in shell_static_references(candidate)
+        if reference in expanded
+    }
+
+
+def iter_source_files(project_root: Path):
+    for directory, child_dirs, filenames in os.walk(project_root):
+        child_dirs[:] = sorted(name for name in child_dirs if name not in EXCLUDED_DIRS)
+        for filename in sorted(filenames):
+            # Generated bundles are build OUTPUT, not source. The scanner and
+            # both shell validators already exclude *.bundle.js / *.chunk.js /
+            # *.min.css alongside *.min.js; skipping only *.min.js here meant a
+            # stale webpack bundle carrying an old number-pool POST kept failing
+            # `lint-telnyx-correctness.sh --product messaging` long after the
+            # source was fixed, with no file the user could correct.
+            if filename in EXCLUDED_FILES or filename.endswith(
+                (".min.js", ".min.css", ".bundle.js", ".chunk.js")
+            ):
+                continue
+            path = Path(directory, filename)
+            suffix = path.suffix.lower()
+            if suffix in INCLUDED_SUFFIXES:
+                yield path
+            elif not suffix and shebang_suffix(path) is not None:
+                yield path
+
+
+
+
+# --- member-clearance net (proof-based; see member_net_contexts) ---
+
+ASSIGNMENT_TARGET_RE = re.compile(
+    r"(?<![\w$.>])(\$?[A-Za-z_]\w*)(?!\w)(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+)
+
+
+MEMBER_ACCESS_AFTER_RE = re.compile(r"\s*(?:\?\.|\.)\s*([A-Za-z_]\w*)")
+
+
+SUBSCRIPT_AFTER_RE = re.compile(r"\s*\[([^\[\]\n]*)\]")
+
+
+CALL_AFTER_RE = re.compile(r"\s*\(")
+
+
+IDENTIFIER_TOKEN_RE = re.compile(r"\$?[A-Za-z_]\w*")
+
+
+RESERVED_TARGETS = frozenset(
+    {"export", "default", "module", "exports", "return", "yield", "await",
+     "typeof", "delete", "void", "new", "in", "of", "import", "case"}
+)
+
+
+def quoted_key_before(lexed: LexedSource, position: int) -> str | None:
+    """Read back a masked quoted key ending immediately before `position`."""
+
+    for token in reversed(lexed.strings):
+        if token.end > position:
+            continue
+        if lexed.code[token.end : position].strip():
+            return None
+        key = token.contents
+        return key if re.fullmatch(r"[A-Za-z_]\w*", key) else None
+    return None
+
+
+def literal_subscript_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    """Key of `obj[...]` when the subscript is a literal; None when dynamic."""
+
+    region = lexed.code[start:end]
+    numeric = re.fullmatch(r"\s*(\d+)\s*", region)
+    if numeric is not None:
+        # Normalize so sloppy-mode `[01]` compares equal to position 1.
+        return str(int(numeric.group(1)))
+    symbol = re.fullmatch(r"\s*:\s*([A-Za-z_]\w*)\s*", region)
+    if symbol is not None:
+        return symbol.group(1)
+    if region.strip():
+        return None
+    tokens = [t for t in lexed.strings if start <= t.start and t.end <= end]
+    if len(tokens) != 1:
+        return None
+    key = tokens[0].contents
+    return key if re.fullmatch(r"[A-Za-z_]\w*", key) else None
+
+
+def stored_member_key(lexed: LexedSource, token_start: int) -> str | None:
+    """Mapping key a literal is stored under: `pool:`, `'pool':`, `=>` forms."""
+
+    code = lexed.code
+    end = token_start
+    while end > 0 and code[end - 1].isspace():
+        end -= 1
+    # End-anchored searches only need a small window, not the whole prefix.
+    window_start = max(0, end - 160)
+    window = code[window_start:end]
+    if window.endswith("=>"):
+        symbol = re.search(r":([A-Za-z_]\w*)\s*$", window[:-2])
+        if symbol is not None:
+            return symbol.group(1)
+        return quoted_key_before(lexed, end - 2)
+    if window.endswith(":"):
+        # Not a key when the colon belongs to a ternary (`cond ? x : "..."`).
+        if re.search(r"\?[^:{,\n]*:$", window):
+            return None
+        identifier = re.search(r"(?<![\w$]):?([A-Za-z_]\w*)\s*:$", window)
+        if identifier is not None:
+            return identifier.group(1)
+        return quoted_key_before(lexed, end - 1)
+    return None
+
+
+def container_is_file_private(
+    lexed: LexedSource, assign_start: int, name: str, suffix: str, operator: str
+) -> bool:
+    """Whether the container provably cannot be referenced from another file.
+
+    Clearing is only sound when every use is visible to this analysis, and
+    this analysis reads one file. JS/TS module locals qualify unless exported.
+    Go's `:=` declares a function local; anything else is package-visible
+    across files. Python, Ruby and PHP top-level names are importable or
+    global, so only indented (function-scoped) definitions qualify; Ruby
+    constants (uppercase) never do.
+    """
+
+    line_start, _ = line_bounds(lexed.original, assign_start)
+    line_prefix = lexed.code[line_start:assign_start]
+    if suffix in JS_TS_SUFFIXES:
+        return re.search(r"\bexport\b", line_prefix) is None
+    if suffix == ".go":
+        return operator == ":="
+    if suffix in {".py", ".rb", ".php"}:
+        if suffix == ".rb" and name[:1].isupper():
+            return False
+        # Indented (whitespace-only prefix) AND enclosed by a `def`, not a
+        # `class` body — class attributes are reachable from other files.
+        if line_prefix == "" or line_prefix.strip() != "":
+            return False
+        indent = len(line_prefix)
+        position = line_bounds(lexed.original, assign_start)[0]
+        while position > 0:
+            position = lexed.original.rfind("\n", 0, position - 1) + 1
+            line_end = lexed.original.find("\n", position)
+            line = lexed.original[position : line_end if line_end >= 0 else None]
+            stripped = line.strip()
+            if not stripped or len(line) - len(line.lstrip()) >= indent:
+                if position == 0:
+                    break
+                continue
+            if suffix == ".php":
+                return "function" in stripped
+            return bool(re.match(r"(?:async\s+)?def\s", stripped))
+        return False
+    if suffix in {".cs", ".java"}:
+        return (
+            re.search(r"\b(?:public|protected|internal)\b", line_prefix)
+            is None
+        )
+    return False
+
+
+def assignment_index(
+    lexed: LexedSource, suffix: str
+) -> list[tuple[str, int, int, int]]:
+    """Every assignment as (name, start, rhs_start, rhs_end), computed once.
+
+    Per-token rescans of the file are what made an earlier attempt at this
+    analysis quadratic; everything below reads this index instead.
+    """
+
+    entries = []
+    for assignment in ASSIGNMENT_TARGET_RE.finditer(lexed.code):
+        rhs_start = assignment.end()
+        entries.append(
+            (
+                assignment.group(1),
+                assignment.start(),
+                rhs_start,
+                assignment_end(lexed, rhs_start, suffix),
+            )
+        )
+    return entries
+
+
+def container_for_token(
+    lexed: LexedSource,
+    token: StringToken,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    walkers: dict[int, list],
+) -> tuple[str, list[str], tuple[int, int], str] | None:
+    """(name, required key chain, definition span, operator) for `token`."""
+
+    for name, start, rhs_start, rhs_end in reversed(assignments):
+        if start >= token.start:
+            continue
+        if not (rhs_start <= token.start < rhs_end):
+            continue
+        # Incremental stack walker per RHS: path tokens arrive in ascending
+        # order, so each RHS is walked once in total, not once per token —
+        # a per-token walk made large single-container literals quadratic.
+        walker = walkers.get(rhs_start)
+        if walker is None:
+            walker = [rhs_start, []]
+            walkers[rhs_start] = walker
+        position, stack = walker
+        while position < token.start:
+            character = lexed.code[position]
+            if character in "([{":
+                stack.append([character, position, 0])
+            elif character in ")]}" and stack:
+                stack.pop()
+            elif character == "," and stack:
+                stack[-1][2] += 1
+            position += 1
+        walker[0] = position
+        if not stack:
+            return None
+        # Resolve the FULL key chain, outermost to innermost. Comparing only
+        # the innermost key let a reference to an ancestor member count as
+        # proof while handing out the object that contains the required path.
+        chain: list[str] = []
+        for level, (opener, opener_at, commas) in enumerate(stack):
+            boundary = (
+                stack[level + 1][1]
+                if level + 1 < len(stack)
+                else token.start
+            )
+            if opener == "{":
+                key = stored_member_key(lexed, boundary)
+            elif opener == "[":
+                # PHP spells associative arrays with `[` — a `=>` key wins
+                # over position.
+                key = stored_member_key(lexed, boundary)
+                if key is None:
+                    key = str(commas)
+            else:
+                # A call such as Map.of(...) — not a literal this rule models.
+                return None
+            if key is None:
+                return None
+            chain.append(key)
+        operator = lexed.code[max(0, rhs_start - 2) : rhs_start].strip()
+        return name, chain, (start, rhs_end), operator
+    return None
+
+
+def access_chain_after(
+    lexed: LexedSource, position: int
+) -> tuple[list[str], bool, bool]:
+    """Static keys accessed after an occurrence: (keys, resolvable, is_call)."""
+
+    keys: list[str] = []
+    code = lexed.code
+    while True:
+        member = MEMBER_ACCESS_AFTER_RE.match(code, position)
+        if member is not None:
+            keys.append(member.group(1))
+            position = member.end()
+            continue
+        subscript = SUBSCRIPT_AFTER_RE.match(code, position)
+        if subscript is not None:
+            key = literal_subscript_key(
+                lexed, subscript.start(1), subscript.end(1)
+            )
+            if key is None:
+                return keys, False, False
+            keys.append(key)
+            position = subscript.end()
+            continue
+        break
+    return keys, True, CALL_AFTER_RE.match(code, position) is not None
+
+
+def identifier_occurrences(lexed: LexedSource) -> dict[str, list[int]]:
+    """Map identifier -> end offsets of its standalone occurrences in code.
+
+    One pass per file; per-token lookups replace whole-file rescans (the
+    quadratic trap an earlier attempt fell into).
+    """
+
+    positions: dict[str, list[int]] = {}
+    dotted: dict[str, list[int]] = {}
+    for match in IDENTIFIER_TOKEN_RE.finditer(lexed.code):
+        before = lexed.code[match.start() - 1] if match.start() else " "
+        if before == ".":
+            # Reached through a property path (`globalThis.x`, `Config.x`,
+            # `...x` spread) — a use this rule cannot align, NOT an ignorable
+            # one. Skipping these silently is how a container escaped once.
+            dotted.setdefault(match.group(0), []).append(match.start())
+            continue
+        if before == "$" or before.isalnum() or before == "_":
+            continue
+        positions.setdefault(match.group(0), []).append(match.start())
+    return positions, dotted
+
+
+def masked_identifier_names(lexed: LexedSource) -> dict[str, list[int]]:
+    """Identifiers inside strings or comments (unreadable uses), by position."""
+
+    names: dict[str, list[int]] = {}
+    for match in IDENTIFIER_TOKEN_RE.finditer(lexed.original):
+        if lexed.code[match.start()] != lexed.original[match.start()]:
+            names.setdefault(match.group(0), []).append(match.start())
+    return names
+
+
+def member_accesses_prove_unused(
+    lexed: LexedSource,
+    offset: int,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    occurrences: dict[str, list[int]],
+    masked_names: set[str],
+    dotted_names: set[str],
+    walkers: dict[int, list],
+    reference_cache: dict[str, tuple[bool, bool, list[list[str]]]],
+) -> bool:
+    token = next(
+        (t for t in lexed.strings if t.start <= offset < t.end), None
+    )
+    if token is None:
+        return False
+    resolved = container_for_token(lexed, token, suffix, assignments, walkers)
+    if resolved is None:
+        return False
+    name, required_chain, definition, operator = resolved
+    if not container_is_file_private(
+        lexed, definition[0], name, suffix, operator
+    ):
+        return False
+
+    summary = reference_cache.get(name)
+    if summary is None:
+        names = {name}
+        skip_spans = [definition]
+        for alias, start, rhs_start, rhs_end in assignments:
+            alias_of = lexed.code[rhs_start:rhs_end].strip()
+            if (
+                alias_of == name
+                and alias != name
+                and alias.lstrip("$") not in RESERVED_TARGETS
+            ):
+                names.add(alias)
+                skip_spans.append((start, rhs_end))
+        # Unreadable uses — via a property path, or mentioned inside a string
+        # or comment (template literals, exports lists) — forbid proof.
+        readable = not any(
+            n in dotted_names or n in masked_names for n in names
+        )
+        chains: list[list[str]] = []
+        proved = False
+        if readable:
+            for n in sorted(names):
+                for start in occurrences.get(n, ()):
+                    if any(s <= start < e for s, e in skip_spans):
+                        continue
+                    keys, resolvable, is_call = access_chain_after(
+                        lexed, start + len(n)
+                    )
+                    if not resolvable or not keys or is_call:
+                        readable = False
+                        break
+                    chains.append(keys)
+                    proved = True
+                if not readable:
+                    break
+        summary = (readable, proved, chains)
+        reference_cache[name] = summary
+
+    readable, proved, chains = summary
+    if not readable or not proved:
+        return False
+    for chain in chains:
+        # A reference conflicts when it agrees with the required chain for
+        # its whole shared prefix: it reaches the required member or an
+        # ancestor holding it. Only a divergent chain is proof of non-use.
+        shared = min(len(chain), len(required_chain))
+        if chain[:shared] == required_chain[:shared]:
+            return False
+    return True
+
+
+
+DESTRUCTURE_LHS_RE = re.compile(r"[}\]]\s*$")
+
+
+
+def safe_literal_span(
+    lexed: LexedSource,
+    rhs_from: int,
+    rhs_to: int,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+) -> bool:
+    """Whether an assignment RHS is provably free of required paths.
+
+    Accepts a single string literal, or a bare variable whose own latest
+    assignment is such a literal (one indirection, no recursion)."""
+
+    tokens = [
+        t for t in lexed.strings
+        if rhs_from <= t.start and t.end <= rhs_to
+    ]
+    remainder = lexed.code[rhs_from:rhs_to].strip()
+    if len(tokens) == 1 and not remainder:
+        return not MEMBER_NET_PATH_RE.search(tokens[0].contents)
+    if tokens:
+        return False
+    variable = re.fullmatch(r"\$?[A-Za-z_]\w*", remainder.rstrip(";").strip())
+    if variable is None:
+        return False
+    latest = None
+    for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+        if a_name == variable.group(0) and a_rhs_start < rhs_from:
+            latest = (a_rhs_start, a_rhs_end)
+    if latest is None:
+        return False
+    inner = [
+        t for t in lexed.strings
+        if latest[0] <= t.start and t.end <= latest[1]
+    ]
+    if len(inner) != 1 or lexed.code[latest[0]:latest[1]].strip():
+        return False
+    return not MEMBER_NET_PATH_RE.search(inner[0].contents)
+
+
+def build_binding_index(
+    lexed: LexedSource,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+) -> dict:
+    """Once-per-file maps the per-container summary builder reads: binding
+    positions per name (pattern keys excluded) and bare-name RHS aliases."""
+
+    own: dict[str, list[int]] = {}
+    bare_rhs: dict[str, list[tuple[str, int, int]]] = {}
+    for alias, start, rhs_start, rhs_end in assignments:
+        before = start
+        while before > 0 and lexed.code[before - 1] in " \t":
+            before -= 1
+        if (
+            before > 0
+            and lexed.code[before - 1] in "{,("
+            and ":" in lexed.code[start:rhs_start]
+        ):
+            continue
+        own.setdefault(alias, []).append(start)
+        alias_of = lexed.code[rhs_start:rhs_end].strip()
+        if re.fullmatch(r"\$?[A-Za-z_]\w*;?", alias_of):
+            bare_rhs.setdefault(alias_of.rstrip(";"), []).append(
+                (alias, start, rhs_end)
+            )
+    return {"own": own, "bare_rhs": bare_rhs}
+
+def build_container_summary(
+    lexed: LexedSource,
+    name: str,
+    definition: tuple[int, int],
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    binding_index: dict,
+    occurrences: dict[str, list[int]],
+    masked_names: set[str],
+    dotted_names: set[str],
+    evaluated_spans: list[tuple[int, int]],
+    flagged_spans: list[tuple[int, int]],
+) -> dict:
+    """Chain-independent reference summary for one container, built once.
+
+    Per-token work then reduces to prefix checks against an index keyed by
+    each reference chain's first element — the per-token full rescans of an
+    earlier version were quadratic on large containers."""
+
+    names = {name}
+    skip_spans = [definition]
+    own_assignments = binding_index["own"]
+    for alias, start, rhs_end in binding_index["bare_rhs"].get(name, ()):
+        if alias != name and alias.lstrip("$") not in RESERVED_TARGETS:
+            names.add(alias)
+            skip_spans.append((start, rhs_end))
+
+    summary = {
+        "ok": True,
+        "had_skipped": False,
+        "proved_any": False,
+        "by_first": {},
+        "destructured": [],
+        "kills": [],
+    }
+
+    def flagged_has(word: str) -> bool:
+        ref = re.compile(rf"(?<![\w$.]){re.escape(word)}(?!\w)")
+        return any(ref.search(lexed.code, fs, fe) for fs, fe in flagged_spans)
+
+    def evaluated_has(word: str) -> bool:
+        ref = re.compile(rf"(?<![\w$.]){re.escape(word)}(?!\w)")
+        return any(
+            ref.search(lexed.code, es, ee) for es, ee in evaluated_spans
+        )
+
+    unreadable = [n for n in names if n in dotted_names or n in masked_names]
+    for n in unreadable:
+        spots = list(masked_names.get(n, ())) + list(dotted_names.get(n, ()))
+        for spot in spots:
+            if any(ds <= spot < de for ds, de in skip_spans):
+                continue
+            covering = None
+            for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+                if a_rhs_start <= spot < a_rhs_end:
+                    covering = a_name
+                    break
+            if covering is None or not flagged_has(covering):
+                summary["ok"] = False
+                return summary
+        summary["had_skipped"] = True
+
+    for n in sorted(names):
+        for start in occurrences.get(n, ()):
+            if any(ds <= start < de for ds, de in skip_spans):
+                continue
+            nearest = None
+            for a_start in own_assignments.get(n, ()):
+                if a_start <= start:
+                    nearest = a_start if nearest is None else max(
+                        nearest, a_start
+                    )
+            if nearest is not None and all(
+                nearest != ds for ds, _de in skip_spans
+            ):
+                summary["had_skipped"] = True
+                continue
+            end = start + len(n)
+            keys, resolvable, is_call = access_chain_after(lexed, end)
+            in_evaluated = any(
+                es <= start < ee for es, ee in evaluated_spans
+            )
+            if not resolvable:
+                if in_evaluated:
+                    # Dynamic keys inside evaluated calls are the resolver's
+                    # corpus-pinned domain.
+                    summary["had_skipped"] = True
+                    continue
+                # A dynamic key handed to code the resolver never judged can
+                # reach the required member — no proof.
+                summary["ok"] = False
+                return summary
+            if not keys:
+                prefix_end = start
+                while prefix_end > 0 and lexed.code[prefix_end - 1] in " \t":
+                    prefix_end -= 1
+                if lexed.code[max(0, prefix_end - 1):prefix_end] == "=":
+                    lhs_close = prefix_end - 1
+                    while lhs_close > 0 and lexed.code[lhs_close - 1] in " \t":
+                        lhs_close -= 1
+                    if lexed.code[lhs_close - 1:lhs_close] in "}]":
+                        opener = {"}": "{", "]": "["}[
+                            lexed.code[lhs_close - 1]
+                        ]
+                        depth = 0
+                        lhs_open = -1
+                        for pos in range(lhs_close - 1, -1, -1):
+                            ch = lexed.code[pos]
+                            if ch in ")]}":
+                                depth += 1
+                            elif ch in "([{":
+                                depth -= 1
+                                if depth == 0 and ch == opener:
+                                    lhs_open = pos
+                                    break
+                        if lhs_open >= 0:
+                            pattern = lexed.code[lhs_open:lhs_close]
+                            source_pattern = lexed.original[
+                                lhs_open:lhs_close
+                            ]
+                            if "..." in pattern or "**" in pattern:
+                                # Rest elements can bind the required
+                                # member invisibly.
+                                summary["ok"] = False
+                                return summary
+                            if opener == "[":
+                                # Array patterns bind by position — the
+                                # resolver's corpus tracks them end to end.
+                                summary["had_skipped"] = True
+                                continue
+                            if "[" in pattern[1:]:
+                                # Computed property names in an object
+                                # pattern can bind the required member
+                                # invisibly.
+                                summary["ok"] = False
+                                return summary
+                            words = set(
+                                re.findall(
+                                    r"[A-Za-z_]\w*", source_pattern
+                                )
+                            )
+                            covered = any(
+                                flagged_has(w) for w in words
+                            )
+                            summary["destructured"].append(
+                                (frozenset(words), covered)
+                            )
+                            summary["proved_any"] = True
+                            continue
+                depth = 0
+                callee = None
+                for pos in range(start - 1, -1, -1):
+                    ch = lexed.code[pos]
+                    if ch in ")]}":
+                        depth += 1
+                    elif ch in "([{":
+                        if depth == 0:
+                            if ch == "(":
+                                callee = re.search(
+                                    r"([A-Za-z_$][\w$]*)\s*$",
+                                    lexed.code[max(0, pos - 60):pos],
+                                )
+                            break
+                        depth -= 1
+                if callee is not None and callee.group(1) in {
+                    "axios", "fetch", "request", "post",
+                }:
+                    summary["had_skipped"] = True
+                    continue
+                summary["ok"] = False
+                return summary
+            if is_call:
+                summary["ok"] = False
+                return summary
+            entry = {
+                "start": start,
+                "keys": keys,
+                "in_evaluated": in_evaluated,
+                "flag_covered": any(
+                    fs <= start < fe for fs, fe in flagged_spans
+                ),
+                "alias_covered": False,
+                "alias_evaluated": False,
+                "kill": None,
+            }
+            enclosing_alias = None
+            for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+                if a_rhs_start <= start < a_rhs_end:
+                    enclosing_alias = a_name
+                    break
+            if enclosing_alias is not None:
+                entry["alias_covered"] = flagged_has(enclosing_alias)
+                entry["alias_evaluated"] = evaluated_has(enclosing_alias)
+            m = re.match(
+                r"(?:\s*(?:\?\.|\.)\s*[A-Za-z_]\w*|"
+                r"\s*\[[^\[\]\n]*\])*",
+                lexed.code[end:],
+            )
+            chain_end = end + (m.end() if m else 0)
+            write = re.match(r"\s*=(?!=)", lexed.code[chain_end:])
+            if write is not None:
+                rhs_from = chain_end + write.end()
+                rhs_to = assignment_end(lexed, rhs_from, suffix)
+                open_braces: list[int] = []
+                for position in range(definition[1], start):
+                    character = lexed.code[position]
+                    if character in "([{":
+                        open_braces.append(position)
+                    elif character in ")]}" and open_braces:
+                        open_braces.pop()
+                # A bare statement block always executes, so a kill inside it
+                # dominates; a block belonging to if/else/loop/switch/catch is
+                # conditional and proves nothing about the send's path.
+                conditional = False
+                for brace_at in open_braces:
+                    if lexed.code[brace_at] != "{":
+                        conditional = True
+                        break
+                    before = brace_at
+                    while before > 0 and lexed.code[before - 1].isspace():
+                        before -= 1
+                    if lexed.code[before - 1 : before] == ")":
+                        conditional = True
+                        break
+                    word = re.search(
+                        r"([A-Za-z_]\w*)\s*$", lexed.code[:before]
+                    )
+                    if word is not None and word.group(1) in {
+                        "else", "do", "case", "default", "finally",
+                    }:
+                        conditional = True
+                        break
+                if not conditional and safe_literal_span(
+                    lexed, rhs_from, rhs_to, suffix, assignments
+                ):
+                    entry["kill"] = chain_end
+            summary["by_first"].setdefault(keys[0], []).append(entry)
+    return summary
+
+
+def member_net_proves_unused(
+    lexed: LexedSource,
+    resolved: tuple,
+    suffix: str,
+    summary: dict,
+) -> bool:
+    name, required_chain, definition, operator = resolved
+    if not summary["ok"]:
+        return False
+    private = container_is_file_private(
+        lexed, definition[0], name, suffix, operator
+    )
+    required_key = required_chain[-1] if required_chain else None
+    for words, covered in summary["destructured"]:
+        if required_key in words and not covered:
+            return False
+    had_skipped = summary["had_skipped"] or bool(summary["destructured"])
+    proved = summary["proved_any"]
+    kill_at = None
+    conflicts = []
+    for entry in summary["by_first"].get(required_chain[0], []):
+        keys = entry["keys"]
+        shared = min(len(keys), len(required_chain))
+        if keys[:shared] != required_chain[:shared]:
+            proved = True
+            continue
+        if entry["in_evaluated"] and entry["start"] >= definition[1]:
+            had_skipped = True
+            continue
+        if (
+            entry["kill"] is not None
+            and len(keys) == len(required_chain)
+        ):
+            kill_at = entry["kill"]
+            proved = True
+            continue
+        if entry["flag_covered"] or entry["alias_covered"]:
+            had_skipped = True
+            continue
+        conflicts.append(entry["start"])
+    for first, entries in summary["by_first"].items():
+        if first == required_chain[0]:
+            continue
+        for entry in entries:
+            if entry["in_evaluated"] and entry["start"] >= definition[1]:
+                had_skipped = True
+            elif entry["alias_evaluated"]:
+                had_skipped = True
+            else:
+                proved = True
+    if conflicts:
+        if kill_at is None:
+            return False
+        if any(c < kill_at for c in conflicts):
+            return False
+    if proved:
+        return private
+    return True if had_skipped else private
+
+MEMBER_NET_PATH_RE = re.compile(
+    # A leading slash, or a relative path at the very start of a string
+    # literal (base-URL clients pass "messages/number_pool").
+    r"(?:/|(?<=['\"`]))(?:v2/)?messages/"
+    r"(?:number_pool|alphanumeric_sender_id)\b"
+)
+
+
+def member_net_contexts(
+    lexed: LexedSource,
+    suffix: str,
+    evaluated_spans: list[tuple[int, int]],
+    flagged_spans: list[tuple[int, int]],
+) -> list[Call]:
+    """Literal-driven safety net over the call-centric analysis.
+
+    The resolver only judges recognized calls, so a required path that never
+    flows into one (helper parameters, exports, spreads, dynamic keys,
+    cross-file definitions) would otherwise vanish. Every required-path
+    literal held in a CONTAINER MEMBER outside the evaluated call spans is
+    flagged at its definition unless member-access analysis PROVES the member
+    is unused in this file, or the resolver already flagged a call that
+    references the container (reporting the definition too would be noise).
+    """
+
+    contexts: list[Call] = []
+    assignments = None
+    occurrences: dict[str, list[int]] = {}
+    dotted: set[str] = set()
+    masked: set[str] = set()
+    walkers: dict[int, list] = {}
+    cache: dict[str, tuple[bool, bool, list[list[str]]]] = {}
+    for match in MEMBER_NET_PATH_RE.finditer(lexed.without_comments):
+        if any(s <= match.start() < e for s, e in evaluated_spans):
+            continue
+        if assignments is None:
+            assignments = assignment_index(lexed, suffix)
+            binding_index = build_binding_index(lexed, suffix, assignments)
+            occurrences, dotted = identifier_occurrences(lexed)
+            masked = masked_identifier_names(lexed)
+        token = next(
+            (t for t in lexed.strings if t.start <= match.start() < t.end),
+            None,
+        )
+        if token is None:
+            continue
+        tail = token.contents.rstrip("/")
+        if not (
+            required_endpoint(token.contents)
+            or tail.endswith("messages/number_pool")
+            or tail.endswith("messages/alphanumeric_sender_id")
+            # A URL builder splits the path, so the literal may be only a
+            # fragment ("%snumber_pool"). Accept the distinctive segment, but
+            # ONLY for a URL-shaped token - prose that merely mentions the path
+            # contains whitespace and must not be treated as an endpoint.
+            or (
+                not re.search(r"\s", tail)
+                and re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
+            )
+        ):
+            # The literal merely MENTIONS a required path (prose, docs);
+            # it is not itself an endpoint value.
+            continue
+        resolved = container_for_token(
+            lexed, token, suffix, assignments, walkers
+        )
+        if resolved is None:
+            # Plain variables and direct arguments are the resolver's tested
+            # domain; the net only covers container members, which the
+            # call-centric analysis never evaluates.
+            continue
+        name = resolved[0]
+        summary = cache.get(name)
+        if summary is None:
+            summary = build_container_summary(
+                lexed, name, resolved[2], suffix, assignments,
+                binding_index, occurrences, masked, dotted,
+                evaluated_spans, flagged_spans,
+            )
+            cache[name] = summary
+        if member_net_proves_unused(lexed, resolved, suffix, summary):
+            continue
+        if suffix == ".sh":
+            start, end = shell_command_span(lexed, match.start())
+        else:
+            start, end = resolved[2]
+        contexts.append(Call(start, start, end, parenthesized=False))
+    return contexts
+
+
+# A send is only exempt from the profile requirement when it is provably NOT a
+# mutating request. These are the spellings that prove it.
+def required_path_tokens(lexed: LexedSource) -> list[StringToken]:
+    """Return every string literal that IS a required endpoint value.
+
+    Prose that merely mentions the path is excluded: an endpoint literal has no
+    whitespace and either resolves as a required endpoint or ends with the
+    required path segment.
+    """
+    found: list[StringToken] = []
+    for match in MEMBER_NET_PATH_RE.finditer(lexed.without_comments):
+        token = next(
+            (t for t in lexed.strings if t.start <= match.start() < t.end), None
+        )
+        if token is None or any(t.start == token.start for t in found):
+            continue
+        tail = token.contents.rstrip("/")
+        if re.search(r"\s", tail):
+            continue
+        if (
+            required_endpoint(token.contents)
+            or tail.endswith("messages/number_pool")
+            or tail.endswith("messages/alphanumeric_sender_id")
+            or re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
+        ):
+            found.append(token)
+    return found
+
+
+def _tokens_in_span(
+    lexed: LexedSource, span: tuple[int, int]
+) -> set[tuple[int, int]]:
+    return {
+        (t.start, t.end)
+        for t in lexed.strings
+        if span[0] <= t.start and t.end <= span[1]
+    }
+
+
+def consumed_endpoint_tokens(
+    lexed: LexedSource, call: Call, suffix: str
+) -> set[tuple[int, int]]:
+    """Return the endpoint literals this call's URL resolution actually USED.
+
+    PROVENANCE, not proximity. A literal counts as accounted-for only when the
+    analyzer consumed it while resolving THIS call's endpoint - directly as the
+    URL expression, or indirectly through the binding the URL expression names.
+    Two sends in one file therefore consume their own literals independently,
+    and a recognised send can never account for a different, unrecognised one.
+    """
+    consumed: set[tuple[int, int]] = set()
+    if suffix == ".sh":
+        # Shell curl resolves URLs from word-split tokens rather than spans, so
+        # the call's own text plus any variable it dereferences is the region.
+        consumed |= _tokens_in_span(lexed, (call.start, call.end))
+        for name in set(re.findall(r"\$\{?([A-Za-z_]\w*)", lexed.original[call.start:call.end])):
+            for form in (f"${name}", name):
+                for match in assignment_matches(lexed.code, form, call.end):
+                    rhs = match.end()
+                    consumed |= _tokens_in_span(
+                        lexed, (rhs, assignment_end(lexed, rhs, suffix))
+                    )
+        return consumed
+
+    # An ANALYSED call consumes the endpoint literals of its own statement even
+    # when it is ultimately dismissed (a GET, or a request object that is never
+    # executed). The analyzer examined those literals and reached a verdict, so
+    # they are accounted for - "analysed and rejected" is not "never analysed",
+    # and only the latter is unresolved.
+    # Consumption is therefore per ENCLOSING STATEMENT, not per call span: a
+    # builder chain puts the URL literal outside the span of the call that was
+    # analysed (HttpRequest.newBuilder().uri(URI.create(URL)).POST(...)), so a
+    # span-only check re-reported a send the analyser had already resolved.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        chain_newline_boundary(lexed.code, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    ) + 1
+    statement_end = call.end
+    for terminator in (";", "\n"):
+        found = lexed.code.find(terminator, call.end)
+        if found > 0:
+            # Forward mirror of `chain_newline_boundary`: a wrapped chain's
+            # remaining links belong to the same statement, so a newline the
+            # chain continues across is not the end of it.
+            while (
+                terminator == "\n"
+                and found > 0
+                and newline_continues_chain(lexed.code, found)
+            ):
+                nxt = lexed.code.find("\n", found + 1)
+                if nxt < 0:
+                    found = len(lexed.code)
+                    break
+                found = nxt
+            statement_end = max(statement_end, found)
+            break
+    consumed |= _tokens_in_span(lexed, (statement_start, statement_end))
+
+    for span in request_url_spans(lexed, call, suffix):
+        consumed |= _tokens_in_span(lexed, span)
+        # Follow the alias chain the resolver itself walked. The endpoint is
+        # often held one or more hops away - `url = routes.get("pool")` where
+        # `routes` is a Map.of/dict/array literal - so stopping at the first hop
+        # left the real literal looking unconsumed and reported it as
+        # unresolved. Bounded to keep this linear and cycle-free.
+        pending = [lexed.code[span[0]:span[1]].strip()]
+        seen: set[str] = set()
+        for _ in range(4):
+            names: list[str] = []
+            for text in pending:
+                for name in re.findall(r"\$?[A-Za-z_]\w*", text):
+                    if name not in seen:
+                        seen.add(name)
+                        names.append(name)
+            if not names:
+                break
+            pending = []
+            for name in names:
+                for form in {name, name.lstrip("$")}:
+                    for match in assignment_matches(lexed.code, form, call.end):
+                        rhs = match.end()
+                        end = assignment_end(lexed, rhs, suffix)
+                        consumed |= _tokens_in_span(lexed, (rhs, end))
+                        pending.append(lexed.code[rhs:end])
+    return consumed
+
+
+def unresolved_endpoint_tokens(
+    lexed: LexedSource,
+    suffix: str,
+    analysed_calls: list[Call],
+) -> list[StringToken]:
+    """Return required endpoints that NO analysed send accounted for.
+
+    These are reported as "could not verify" - a distinct outcome from "missing
+    profile". The analyzer recognised a required endpoint in the source but was
+    unable to attribute it to a send it understands, so it must not certify the
+    file either way.
+    """
+    consumed: set[tuple[int, int]] = set()
+    unexplained_calls = 0
+    for call in analysed_calls:
+        tokens = consumed_endpoint_tokens(lexed, call, suffix)
+        if tokens:
+            consumed |= tokens
+        else:
+            # The analyzer resolved this call's endpoint through a path this
+            # consumption model does not mirror - a destructuring default, an
+            # interprocedural alias, a computed member. It still ACCOUNTED for
+            # one endpoint, so it explains one otherwise-unconsumed literal.
+            # Budgeting them this way keeps two independent sends independent:
+            # a file with two endpoint literals and one resolved call still
+            # reports the second.
+            unexplained_calls += 1
+    candidates = [
+        token
+        for token in required_path_tokens(lexed)
+        if (token.start, token.end) not in consumed
+        and _looks_like_a_send_target(lexed, token, suffix)
+    ]
+    return candidates[unexplained_calls:] if unexplained_calls else candidates
+
+
+# A required path can appear WITHOUT being a request target: as a curl -d body,
+# in a header value, or in prose (`echo curl "$url"`). Those are not sends and
+# reporting them blocks valid code, so an unconsumed literal is only actionable
+# when it is used somewhere that looks like a request.
+_SEND_SITE_RE = re.compile(
+    # NOT preceded by a word character - the same guard the read-verb regex
+    # below already carries. Without it `isOpen ` matches the `open`
+    # alternative and `recall ` matches `call `, so an ordinary declaration
+    # looks like a send. `do` is restricted to `do(` (Go's `client.Do(req)`)
+    # because bare `do ` matches the English word in a trailing comment.
+    r"(?<![A-Za-z0-9_])"
+    r"(?:(?:post|put|patch|send|transmit|request|fetch|execute|dispatch|submit"
+    r"|invoke|call|open|urlopen|curl)\s*(?:\(|\s)"
+    r"|do\s*\()",
+    re.I,
+)
+_ENDPOINT_KEY_RE = re.compile(
+    r"(?:url|uri|endpoint|href|target|address)\s*[:=]\s*$", re.I
+)
+
+
+# A literal sitting under a NON-URL key is payload, headers or metadata - not an
+# endpoint - even when the enclosing line is a real send to a DIFFERENT endpoint.
+_NON_URL_KEY_RE = re.compile(
+    r"(?:data|body|json|header|headers|metadata|meta|audit|params|query|form"
+    r"|note|comment|description|payload|options|context|extra|tags)"
+    r"\s*[:=]\s*$",
+    re.I,
+)
+
+
+_ANY_KEY_RE = re.compile(
+    r"""(?:['"`]?)(\w+)(?:['"`]?)\s*(?::|=>)\s*$"""
+)
+
+
+def _under_non_url_key(prefix: str) -> bool:
+    """Return whether the literal sits under a key that is not an endpoint.
+
+    Inverted deliberately: if the literal has ANY immediately-preceding object
+    key, that key must be URL-like. A decoy under `audit:`, a route table under
+    `pool:`, or a payload under `data:` are all non-endpoints, and enumerating
+    only the bad names would leave every unlisted key looking like a send.
+    A POSITIONAL literal (no key) keeps its normal treatment.
+    """
+    stripped = prefix.rstrip()[-80:]
+    if _ENDPOINT_KEY_RE.search(stripped):
+        return False
+    return _ANY_KEY_RE.search(stripped) is not None
+
+
+# The verb of the call that ENCLOSES the literal, split off its receiver. The
+# line-anchored `echo|printf|print|console.log` test only sees a display command
+# that starts the line, so `console.error(...)`, `logger.info(...)`,
+# `fmt.Printf(...)`, `var_dump(...)` and a mid-line `echo` all read as sends.
+_DISPLAY_VERB_RE = re.compile(
+    r"^(?:echo|puts|write_?line|[sf]?print(?:f|ln|_r)?|printStackTrace"
+    r"|var_dump|var_export|dump|inspect"
+    r"|log|logf|logln|debug|info|warn|warnf|warning|error|errorf|fatal|fatalf"
+    r"|trace|critical|exception)$",
+    re.I,
+)
+# A string INSPECTION is not a transport. `url.endswith(URL)` reaches the
+# fluent-client catch-all otherwise, because the literal is an argument of a
+# call like any other.
+_INSPECTION_VERB_RE = re.compile(
+    r"^(?:ends?_?with|starts?_?with|includes|contains|str_?contains"
+    r"|index_?of|last_?index_?of|strpos|strcmp"
+    r"|match|matches|search|test|replace|replace_?all|split"
+    r"|equals|equals_?ignore_?case|compare|compare_?to"
+    r"|substr|substring|slice|trim)$",
+    re.I,
+)
+# `if (url === URL)` is a comparison, not a call - but the catch-all only asks
+# whether a `(` precedes the literal and a `,` or `)` follows it.
+_NOT_A_CALL_VERB_RE = re.compile(
+    r"^(?:if|elif|elsif|while|switch|for|foreach|when|unless|until|case"
+    r"|catch|except|with|return|and|or|not|in|is)$",
+    re.I,
+)
+# A display STATEMENT has no parentheses to enclose the literal: `<?php echo
+# "$url"`, `then echo "$url"`.
+_DISPLAY_STATEMENT_RE = re.compile(
+    # The tail must not cross a call or a command separator: `echo start; curl
+    # -X POST "$URL"` is a SEND, and letting `echo` reach across the `;` would
+    # excuse it.
+    r"(?:^|[;&|`>{}\s])(?:echo|print|print_r|var_dump|var_export|puts|printf)"
+    r"\s+[^()\n;&|]*$",
+    re.I,
+)
+
+_CALLEE_SPLIT_RE = re.compile(r"\s*(?:->|::|\?\.|\.)\s*")
+_CALLEE_TAIL_RE = re.compile(
+    r"[A-Za-z_$][\w$]*(?:\s*(?:->|::|\?\.|\.)\s*[A-Za-z_$][\w$]*)*$"
+)
+
+
+def _enclosing_call_verb(lexed: LexedSource, position: int) -> str:
+    """Return the verb of the innermost unclosed CALL enclosing `position`.
+
+    Scans the blanked source backwards so brackets inside strings and comments
+    cannot unbalance the walk. Returns "" when the innermost enclosure is an
+    object/array literal rather than a call, or when there is no enclosure.
+    """
+    window_start = max(0, position - 600)
+    prefix = lexed.code[window_start:position]
+    depth = 0
+    for index in range(len(prefix) - 1, -1, -1):
+        char = prefix[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth:
+                depth -= 1
+                continue
+            if char != "(":
+                return ""
+            head = lexed.original[window_start:window_start + index].rstrip()
+            match = _CALLEE_TAIL_RE.search(head)
+            if match is None:
+                return ""
+            return _CALLEE_SPLIT_RE.split(match.group(0))[-1]
+    return ""
+
+
+def _is_display_or_inspection(lexed: LexedSource, position: int, prefix: str) -> bool:
+    """Return whether the literal is shown, compared or inspected, not sent."""
+    verb = _enclosing_call_verb(lexed, position)
+    if verb and (
+        _DISPLAY_VERB_RE.match(verb)
+        or _INSPECTION_VERB_RE.match(verb)
+        or _NOT_A_CALL_VERB_RE.match(verb)
+    ):
+        return True
+    return _DISPLAY_STATEMENT_RE.search(prefix) is not None
+
+
+def _is_standalone_binding(lexed: LexedSource, token: StringToken) -> bool:
+    """Return whether the literal is a statement-level `NAME = "..."` binding.
+
+    A binding stands alone when nothing on its line opens a call, an object or
+    an array around it - `export const POOL_URL = "..."`, `POOL_URL="..."`,
+    `const NumberPoolURL = "..."`. A MEMBER (`{endpoint: "..."}`, `url="..."`
+    inside a call) always sits within an opener, on its line or an earlier one,
+    and a member separator is `:`/`=>`, never a bare `=`.
+    """
+    line_start = lexed.code.rfind("\n", 0, token.start) + 1
+    declaration = lexed.code[line_start:token.start]
+    if any(bracket in declaration for bracket in "([{,"):
+        return False
+    return re.search(r"(?<![=!<>])=\s*$", declaration) is not None
+
+
+def _looks_like_a_send_target(
+    lexed: LexedSource, token: StringToken, suffix: str
+) -> bool:
+    """Return whether an unconsumed endpoint literal is plausibly a request."""
+    # A ROUTE TABLE is data, not a send. `Map.of("pool", URL)`, `{pool: URL}`,
+    # `["...URL"]` assigned to a name are declarations; the send happens where
+    # the table is READ, and that site is judged on its own. Reporting the
+    # declaration duplicates the real send and contradicts the documented scope
+    # boundary for computed/interprocedural lookups.
+    line_start_decl = lexed.code.rfind("\n", 0, token.start) + 1
+    declaration = lexed.original[line_start_decl:token.start]
+    if re.search(
+        r"(?:=|:=)\s*(?:new\s+\w+[^=]*)?(?:Map\s*\.\s*of|List\s*\.\s*of"
+        r"|Arrays\s*\.\s*asList|array|dict|\{|\[|\()",
+        declaration,
+    ) and not _SEND_SITE_RE.search(declaration):
+        return False
+
+    prefix = lexed.original[max(0, token.start - 120):token.start]
+    if _under_non_url_key(prefix):
+        return False
+    key = _ENDPOINT_KEY_RE.search(prefix.rstrip()[-60:])
+    if key is not None:
+        name = re.search(r"([A-Za-z_]\w*)\s*[:=]\s*$", prefix.rstrip())
+        if name is None:
+            return True
+        # An endpoint-named MEMBER (`endpoint: "..."`) sits inside the call that
+        # would send it. An endpoint-named VARIABLE does not - it must still be
+        # used somewhere that looks like a request, or it is just a constant
+        # that happens to be printed or documented.
+        references = [
+            match
+            for match in re.finditer(
+                rf"(?<![\w$])\$?\{{?{re.escape(name.group(1))}(?![\w])",
+                lexed.original,
+            )
+            if match.start() > token.end
+        ]
+        if not references:
+            # NO use of the binding in this file. A MEMBER is still a send: the
+            # call that would send it is the one it sits inside. A standalone
+            # BINDING is not - an endpoint constants module exports the URL and
+            # the request lives in another file, where it is judged on its own.
+            # Reporting the declaration instead blocks the most common correct
+            # layout in a migrated project.
+            return not _is_standalone_binding(lexed, token)
+        for match in references:
+            start = lexed.original.rfind("\n", 0, match.start()) + 1
+            stop = lexed.original.find("\n", match.end())
+            line = lexed.original[start:stop if stop > 0 else len(lexed.original)]
+            if re.match(
+                r"\s*(?:echo|printf|print|console\s*\.\s*log|#|//)\b", line
+            ) or _is_display_or_inspection(
+                lexed, match.start(), lexed.original[start:match.start()]
+            ):
+                continue
+            if _under_non_url_key(lexed.original[:match.start()]):
+                # `fetch(other, {metadata: endpoint})` - the variable reaches a
+                # send, but not as its URL.
+                continue
+            if _SEND_SITE_RE.search(line):
+                return True
+        return False
+    # Otherwise require a request-like call on the same logical line, and NOT a
+    # display command, which is how prose mentions reach the source.
+    line_start = lexed.code.rfind("\n", 0, token.start) + 1
+    line_end = lexed.code.find("\n", token.end)
+    line = lexed.original[line_start:line_end if line_end > 0 else len(lexed.original)]
+    if re.match(r"\s*(?:echo|printf|print|console\s*\.\s*log|#|//)\b", line):
+        return False
+    # The line-anchored test above only catches a display command that STARTS
+    # the line. `console.error(..., URL)`, `logger.info(..., URL)`,
+    # `fmt.Printf(..., URL)`, `var_dump(URL)`, a mid-line `echo`, a string
+    # inspection (`url.endsWith(URL)`) and a comparison (`if (url === URL)`)
+    # all reach the fluent-client catch-all below otherwise.
+    if _is_display_or_inspection(
+        lexed, token.start, lexed.original[line_start:token.start]
+    ):
+        return False
+    # A TEST ASSERTION is not a send. `expect(x).toBe(URL)`, `assertEqual(...)`,
+    # `x.should.equal(URL)` all mention the endpoint to compare against it.
+    if re.search(
+        r"(?<![\w])(?:expect|assert\w*|should|toBe|toEqual|toHaveBeenCalledWith"
+        r"|assertEqual|assertIn|is_expected)\s*[.(]",
+        line,
+        re.I,
+    ):
+        return False
+    # A READ verb is not a send. Without this, `requests.get(url)` - which the
+    # analyzer deliberately does not treat as a required send - was reported as
+    # unverifiable purely because no send consumed its endpoint.
+    if re.search(
+        # NOT preceded by a word character - otherwise the `get` inside
+        # `target(` matches and a fluent send is silently excused. `.get(` is
+        # fine because `.` is not a word character. Async suffixes included for
+        # C# (`GetAsync(`).
+        r"(?<![A-Za-z0-9_])"
+        r"(?:get|head|options|read|download|list|find|query)(?:Async)?\s*\(",
+        line,
+        re.I,
+    ) and not _SEND_SITE_RE.search(line):
+        return False
+    if _SEND_SITE_RE.search(line) is not None:
+        return True
+    # A fluent client can spell its verbs anything (`zoom.target(url).fire()`),
+    # so relying on a known-verb list makes the gate brittle in the dangerous
+    # direction. Any CALL that takes the endpoint as an argument counts, with
+    # display/logging commands excluded above.
+    tail = lexed.original[token.end:token.end + 4]
+    return bool(re.match(r"\s*[,)]", tail)) and "(" in line[: line.find(
+        token.contents[:20]
+    ) if token.contents[:20] in line else len(line)]
+
+
+
+def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
+    source = path.read_text(encoding="utf-8", errors="replace")
+    suffix = canonical_suffix(path)
+    lexed = lex_source(source, suffix)
+    sdk_calls = calls_matching(lexed, SDK_CALL_RE)
+    fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
+    shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
+    required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
+    source_resolver = SourceEndpointResolver(lexed, suffix)
+    profile_resolver = PayloadStateResolver(
+        lexed,
+        suffix,
+        PROFILE_NAMES,
+        require_value=True,
+        source=source_resolver,
+    )
+
+    seen_rest_contexts: set[tuple[int, int]] = set()
+    endpoint_calls = shell_curls if suffix == ".sh" else fetch_calls
+    if endpoint_calls:
+        for context in endpoint_calls:
+            is_required = (
+                source_resolver.shell_curl_is_required(context)
+                if suffix == ".sh"
+                else source_resolver.request_is_required(context)
+            )
+            if is_required:
+                seen_rest_contexts.add((context.start, context.end))
+                required_calls.append((context, False))
+
+    # Literal-driven safety net: required container-member paths the
+    # call-centric resolver never evaluated stay reported unless provably
+    # unused (see member_net_contexts). A miss is worse than an extra report.
+    evaluated_spans = [(c.start, c.end) for c in endpoint_calls]
+    flagged_spans = [
+        (c.start, c.end) for c, sdk in required_calls if not sdk
+    ]
+    for context in member_net_contexts(
+        lexed, suffix, evaluated_spans, flagged_spans
+    ):
+        key = (context.start, context.end)
+        if key not in seen_rest_contexts:
+            seen_rest_contexts.add(key)
+            required_calls.append((context, False))
+
+    required_calls.sort(key=lambda item: (item[0].start, item[0].end))
+    missing = [
+        call_detail(path, lexed, call)
+        for call, sdk_call in required_calls
+        if not call_has_profile(
+            lexed,
+            call,
+            suffix,
+            path,
+            project_root,
+            sdk_call=sdk_call,
+            resolver=profile_resolver,
+        )
+    ]
+
+    # Fail-safe backstop: a required endpoint the analysis never accounted for
+    # is reported for manual verification rather than passed silently.
+    # BLOCKING, provenance-based. A required endpoint that NO analysed send
+    # consumed is reported as "could not verify" - a distinct outcome from
+    # "missing profile". Attribution is by CONSUMPTION, so each send accounts
+    # only for the literals it actually resolved: multiple sends in one file are
+    # independent, and a recognised send never suppresses an unrecognised one.
+    analysed = list(endpoint_calls) + [call for call, _ in required_calls]
+    unresolved = unresolved_endpoint_tokens(lexed, suffix, analysed)
+    for token in unresolved:
+        bounds = line_bounds(source, token.start)
+        missing.append(
+            finding_row(
+                path,
+                line_number(source, token.start),
+                f"{source[bounds[0]:bounds[1]].strip()}"
+                "  [could not verify this send - the endpoint was found but no "
+                "recognized request consumed it; verify messaging_profile_id manually]",
+            )
+        )
+    # An unresolved endpoint is a CANDIDATE send, so it counts toward the total.
+    # Reporting it while excluding it from the count produced total=0 with
+    # missing=1, breaking the missing <= total contract every caller assumes.
+    return len(required_calls) + len(unresolved), missing
+
+
+def at_object_member_start(
+    code: str, start: int, end: int, offset: int
+) -> bool:
+    """Return true when offset starts a direct object-literal member."""
+
+    root_depth = payload_root_depth(code, start, end)
+    if root_depth[2] == 0 or structural_depth(code, start, offset) != root_depth:
+        return False
+    cursor = offset - 1
+    while cursor >= start and code[cursor].isspace():
+        cursor -= 1
+    return cursor >= start and code[cursor] in {"{", ","}
+
+
+def region_has_message_body(
+    lexed: LexedSource, start: int, end: int, suffix: str
+) -> bool:
+    """Recognize a real top-level message body field in one payload region."""
+
+    body_identifier = re.compile(r"(?<![\w$])body(?!\w)")
+    for match in body_identifier.finditer(lexed.code, start, end):
+        if not at_payload_root(lexed.code, start, end, match.start()):
+            continue
+        after = lexed.code[match.end() : end]
+        if re.match(r"\s*(?::|=(?!=))", after):
+            return True
+        if (
+            suffix in JS_TS_SUFFIXES
+            and at_object_member_start(
+                lexed.code, start, end, match.start()
+            )
+            and re.match(r"\s*(?=[,}])", after)
+        ):
+            return True
+
+    for token in lexed.strings:
+        if token.contents != "body" or token.start < start or token.end > end:
+            continue
+        after = lexed.without_comments[token.end : end]
+        if (
+            at_payload_root(lexed.code, start, end, token.start)
+            and re.match(r"\s*(?::|=>|=(?!=))", after)
+        ):
+            return True
+        if suffix not in JS_TS_SUFFIXES:
+            continue
+        prefix = lexed.code[start : token.start]
+        computed = re.search(r"\[\s*$", prefix)
+        if computed is None or not re.match(r"\s*\]\s*:", after):
+            continue
+        opening = start + computed.start()
+        if at_object_member_start(lexed.code, start, end, opening):
+            return True
+    return False
+
+
+def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
+    """Return real top-level body fields from selected messaging calls."""
+
+    source = path.read_text(encoding="utf-8", errors="replace")
+    suffix = canonical_suffix(path)
+    lexed = lex_source(source, suffix)
+    source_resolver = SourceEndpointResolver(lexed, suffix)
+    resolver = PayloadStateResolver(
+        lexed,
+        suffix,
+        ("body", "Body"),
+        require_value=False,
+        source=source_resolver,
+    )
+    matches: list[str] = []
+    for call in calls_matching(lexed, pattern):
+        states = [
+            resolver.span_presence(start, end, call.start)
+            for start, end in payload_spans(
+                lexed, call, suffix, "body"
+            )
+        ]
+        if any(
+            state.state == PRESENT
+            or (state.state == MAYBE and state.evidence)
+            for state in states
+        ):
+            matches.append(call_detail(path, lexed, call))
+    return matches
+
+
+def main(argv: list[str]) -> int:
+    source_modes = {
+        "--twilio-body-fields": TWILIO_MESSAGE_CREATE_RE,
+        "--message-body-fields": MESSAGE_BODY_CALL_RE,
+    }
+    if len(argv) == 3 and argv[1] in source_modes:
+        project_root = Path(argv[2]).resolve()
+        if not project_root.is_dir():
+            print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
+            return 2
+        findings = [
+            finding
+            for path in iter_source_files(project_root)
+            for finding in message_body_fields(path, source_modes[argv[1]])
+        ]
+        print("\n".join(findings))
+        return 0
+    if len(argv) != 2:
+        print(
+            f"Usage: {Path(argv[0]).name} "
+            "[--twilio-body-fields|--message-body-fields] <project-root>",
+            file=sys.stderr,
+        )
+        return 2
+    project_root = Path(argv[1]).resolve()
+    if not project_root.is_dir():
+        print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
+        return 2
+
+    total = 0
+    missing: list[str] = []
+    for path in iter_source_files(project_root):
+        try:
+            file_total, file_missing = analyze_file(path, project_root)
+        except Exception as error:  # noqa: BLE001 - one file must not abort the scan
+            # A pathological file previously took the WHOLE run down, so every
+            # other file went unanalysed and the project was reported clean.
+            # Fail safe instead: keep scanning and surface the file for manual
+            # review rather than silently dropping it.
+            total += 1
+            missing.append(
+                finding_row(
+                    path,
+                    1,
+                    f"  [could not analyze this file "
+                    f"({type(error).__name__}) - verify messaging_profile_id manually]",
+                )
+            )
+            continue
+        total += file_total
+        missing.extend(file_missing)
+
+    print(total)
+    print("\n".join(missing))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -682,8 +682,27 @@ SDK_CALL_RE = re.compile(
     rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
     r"\s*(?:\?\.)?\s*\("
 )
+CSHARP_HTTP_CONTENT_METHODS = ("PostAsync", "PutAsync", "PatchAsync")
+CSHARP_JSON_MUTATING_METHOD_NAMES = (
+    "PostAsJsonAsync",
+    "PutAsJsonAsync",
+    "PatchAsJsonAsync",
+)
+CSHARP_HTTP_CONTENT_METHOD_PATTERN = "|".join(CSHARP_HTTP_CONTENT_METHODS)
+CSHARP_JSON_MUTATING_METHOD_PATTERN = "|".join(
+    CSHARP_JSON_MUTATING_METHOD_NAMES
+)
+CSHARP_JSON_MUTATING_METHODS = frozenset(
+    name.lower() for name in CSHARP_JSON_MUTATING_METHOD_NAMES
+)
+CSHARP_ONLY_FETCH_METHODS = frozenset(
+    {"PutAsync", "PatchAsync", *CSHARP_JSON_MUTATING_METHOD_NAMES}
+)
 FETCH_CALL_RE = re.compile(
-    r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
+    rf"(?<![\w$])(?:fetch|request|post_form|postAsync|"
+    rf"(?:{CSHARP_HTTP_CONTENT_METHOD_PATTERN})|"
+    rf"(?:{CSHARP_JSON_MUTATING_METHOD_PATTERN})(?:\s*<[^()]{{0,512}}>)?|"
+    r"post|Post|POST|"
     # curl_init($url) is the documented one-liner that sets CURLOPT_URL
     # directly. Listing only the setopt spellings made that whole shape
     # invisible: no endpoint resolved, so the send was never counted and the
@@ -1922,7 +1941,14 @@ def rest_payload_spans(
             if projected is not None:
                 return [projected]
 
-    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    callee = normalized_call_callee(lexed, call)
+    callee_lower = callee.lower()
+    if suffix == ".cs" and callee_lower in CSHARP_JSON_MUTATING_METHODS:
+        named_value = named_argument_spans(lexed, arguments, "value")
+        if named_value:
+            return named_value[-1:]
+        offset = csharp_json_extension_argument_offset(lexed, call)
+        return arguments[offset + 1 : offset + 2]
     if suffix == ".php" and callee == "file_get_contents":
         region = php_stream_context_region(lexed, call, suffix)
         if region is None:
@@ -3045,6 +3071,44 @@ def call_receiver(lexed: LexedSource, call: Call) -> str | None:
     return match.group(1).lstrip("$") if match is not None else None
 
 
+def normalized_call_callee(lexed: LexedSource, call: Call) -> str:
+    """Return a call name without whitespace or C# generic type arguments."""
+
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    return re.sub(r"<[^()]{0,512}>$", "", callee)
+
+
+def csharp_json_extension_argument_offset(
+    lexed: LexedSource, call: Call
+) -> int:
+    """Return the URL offset for instance versus static extension calls.
+
+    ``client.PostAsJsonAsync(url, value)`` starts at URL argument zero, while
+    ``HttpClientJsonExtensions.PostAsJsonAsync(client, url, value)`` and a
+    ``using static`` call start at argument one.  A type alias for the official
+    extension class is the same static form.  Expression receivers such as
+    ``GetClient().PostAsJsonAsync(...)`` remain instance calls even though they
+    do not have a simple identifier receiver.
+    """
+
+    receiver = call_receiver(lexed, call)
+    explicit_receiver = bool(
+        re.search(r"(?:\?|!)?\s*\.\s*$", lexed.code[:call.start])
+    )
+    if receiver is None:
+        return 0 if explicit_receiver else 1
+    if receiver == "HttpClientJsonExtensions":
+        return 1
+    if re.search(
+        rf"(?m)^\s*(?:global\s+)?using\s+{re.escape(receiver)}\s*=\s*"
+        r"(?:global\s*::\s*)?System\s*\.\s*Net\s*\.\s*Http\s*\.\s*Json"
+        r"\s*\.\s*HttpClientJsonExtensions\s*;",
+        lexed.original,
+    ):
+        return 1
+    return 0
+
+
 # Factory methods that build an HTTP client which then sends. A `.post()` on
 # such a factory (requests.Session().post, httpx.Client().post,
 # axios.create(...).post) is a real send; a `.post()` on a mock/assertion
@@ -4114,7 +4178,10 @@ def request_write_payload_spans(
 
 
 URL_CONSTRUCTOR_RE = re.compile(
-    r"^\s*(?:new\s+)?(?:URI|URL)(?:\s*\.\s*(?:create|parse|join))?\s*\("
+    # Java/Ruby use URI/URL; .NET's official overload uses System.Uri.  The
+    # case-sensitive type spelling matters because strings are already masked
+    # and this runs on arbitrary expressions, not on a C# AST.
+    r"^\s*(?:new\s+)?(?:URI|URL|Uri)(?:\s*\.\s*(?:create|parse|join))?\s*\("
 )
 
 
@@ -4424,9 +4491,7 @@ def _request_url_spans(
     args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
     if not args:
         return []
-    callee = re.sub(
-        r"\s+", "", lexed.code[call.start:call.open_paren]
-    )
+    callee = normalized_call_callee(lexed, call)
     callee_lower = callee.lower()
     receiver = call_receiver(lexed, call)
     explicit_receiver = bool(
@@ -4484,6 +4549,11 @@ def _request_url_spans(
         for name in URL_MEMBER_NAMES
         for span in named_argument_spans(lexed, args, name)
     ]
+    if suffix == ".cs" and callee_lower in CSHARP_JSON_MUTATING_METHODS:
+        if named_url:
+            return named_url[-1:]
+        offset = csharp_json_extension_argument_offset(lexed, call)
+        return args[offset : offset + 1]
     if callee_lower in {"post", "postasync"} and named_url:
         return named_url[-1:]
     if suffix == ".php" and callee == "file_get_contents" and args:
@@ -11413,6 +11483,16 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     lexed = lex_source(source, suffix)
     sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
+    if suffix != ".cs":
+        # These PascalCase names are official .NET HttpClient methods. Keeping
+        # their discovery C#-only avoids turning an unrelated Java/JavaScript
+        # method with the same name into a recognised transport call.
+        fetch_calls = [
+            call
+            for call in fetch_calls
+            if normalized_call_callee(lexed, call)
+            not in CSHARP_ONLY_FETCH_METHODS
+        ]
     shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
     required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
     source_resolver = SourceEndpointResolver(

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -56,6 +56,7 @@ SUFFIX_LANGUAGE_ALIASES = {
     ".pyw": ".py",
     ".rake": ".rb",
     ".cshtml": ".cs",
+    ".razor": ".cs",
     ".scala": ".java",
     # Kotlin shares Java's grammar for everything this linter models - the
     # OkHttp/java.net.http builder chains, the braced control-flow arms, the
@@ -224,6 +225,200 @@ def _balanced_parenthesis_ranges(
     return ranges
 
 
+def _balanced_delimiter_end(source: str, opening: int) -> int | None:
+    """Return the index after a quote-aware (), [], or {} expression."""
+
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    opening_character = source[opening] if opening < len(source) else ""
+    if opening_character not in pairs:
+        return None
+    stack = [pairs[opening_character]]
+    quote = ""
+    escaped = False
+    for index in range(opening + 1, len(source)):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif character in pairs:
+            stack.append(pairs[character])
+        elif character == stack[-1]:
+            stack.pop()
+            if not stack:
+                return index + 1
+    return None
+
+
+def _razor_implicit_expression_ranges(source: str) -> list[tuple[int, int]]:
+    """Return executable C# spans introduced by Razor's implicit ``@`` form.
+
+    Razor permits member, invocation, indexer, null-conditional, and ``await``
+    expressions without the explicit ``@(...)`` wrapper.  Parse those access
+    chains instead of preserving a handful of examples; markup and email-like
+    text remain excluded by requiring a non-word boundary before ``@``.
+    """
+
+    ranges: list[tuple[int, int]] = []
+    start_pattern = re.compile(
+        r"(?<![\w@])@(?!@)(?P<expression>await\s+|[A-Za-z_][\w]*)",
+        re.IGNORECASE,
+    )
+    for match in start_pattern.finditer(source):
+        start = match.start("expression")
+        cursor = match.end("expression")
+        if source[start:cursor].lower().startswith("await"):
+            identifier = re.match(r"[A-Za-z_][\w]*", source[cursor:])
+            if not identifier:
+                continue
+            cursor += identifier.end()
+
+        # Directives and control blocks are handled by the dedicated ranges
+        # below.  Treating their keyword as an expression adds no coverage and
+        # can retain adjacent markup as though it were C#.
+        first_identifier = re.match(r"[A-Za-z_][\w]*", source[start:])
+        if first_identifier and first_identifier.group(0).lower() in {
+            "addtaghelper", "attribute", "case", "catch", "class", "code",
+            "default", "do", "else", "finally", "for", "foreach", "functions",
+            "helper", "if", "implements", "inherits", "inject", "lock", "model",
+            "namespace", "page", "removetaghelper", "section", "switch",
+            "taghelperprefix", "try", "using", "while",
+        }:
+            continue
+
+        while cursor < len(source):
+            chain = re.match(r"(?:\?\.|\.)[A-Za-z_][\w]*", source[cursor:])
+            if chain:
+                cursor += chain.end()
+                continue
+            if source[cursor] in "([{":
+                end = _balanced_delimiter_end(source, cursor)
+                if end is None:
+                    break
+                cursor = end
+                continue
+            if source[cursor] in "!?":
+                cursor += 1
+                continue
+            break
+        ranges.append((start, cursor))
+    return ranges
+
+
+def _razor_continuation_block_ranges(
+    source: str, initial_ranges: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Return ``else``/``catch``/``finally`` blocks chained to Razor C#."""
+
+    continuations: list[tuple[int, int]] = []
+    pending = list(initial_ranges)
+    while pending:
+        _, closing = pending.pop()
+        tail = source[closing + 1 :]
+        match = re.match(
+            r"\s*@?(?:else(?:\s+if\b[^{}]*)?|catch\b[^{}]*|finally\b)\s*\{",
+            tail,
+            flags=re.IGNORECASE,
+        )
+        if not match:
+            continue
+        opening = closing + 1 + match.end() - 1
+        balanced = _balanced_brace_ranges(source, [opening])
+        if balanced:
+            continuations.extend(balanced)
+            pending.extend(balanced)
+    return continuations
+
+
+def _vue_directive_expression_ranges(source: str) -> list[tuple[int, int]]:
+    """Return value and dynamic-argument expressions for every Vue directive."""
+
+    directive = (
+        r"(?<!\S)(?:v-[\w-]+(?::(?:[\w:-]+|\[[^\]\r\n]+\]))?"
+        r"|[@:#.](?:[\w:-]+|\[[^\]\r\n]+\]))"
+        r"(?:\.[\w-]+)*"
+    )
+    ranges: list[tuple[int, int]] = []
+
+    # Restrict directive discovery to opening tags.  A documentation snippet
+    # rendered as text (``<pre>v-if="..."</pre>``) is not executable Vue and
+    # must not become a false positive merely because it resembles an
+    # attribute.  Scan tag endings quote-aware so ``>`` inside an expression
+    # does not truncate the attribute list.
+    tag_ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        if opening + 1 >= len(source) or not re.match(
+            r"[A-Za-z]", source[opening + 1]
+        ):
+            cursor = opening + 1
+            continue
+        quote = ""
+        for index in range(opening + 1, len(source)):
+            character = source[index]
+            if quote:
+                if character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+            elif character == ">":
+                tag_ranges.append((opening, index + 1))
+                cursor = index + 1
+                break
+        else:
+            break
+
+    for tag_start, tag_end in tag_ranges:
+        tag = source[tag_start:tag_end]
+        outside_attribute_value: list[bool] = []
+        quote = ""
+        for character in tag:
+            outside_attribute_value.append(not quote)
+            if quote:
+                if character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+
+        value_pattern = re.compile(
+            directive
+            + r"\s*=\s*(?:(?P<quote>['\"])(?P<quoted>.*?)(?P=quote)"
+            + r"|(?P<unquoted>[^\s>]+))",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        for candidate in re.finditer(directive, tag, flags=re.IGNORECASE):
+            if not outside_attribute_value[candidate.start()]:
+                continue
+            match = value_pattern.match(tag, candidate.start())
+            if not match:
+                continue
+            group = "quoted" if match.group("quoted") is not None else "unquoted"
+            start, end = match.span(group)
+            ranges.append((tag_start + start, tag_start + end))
+
+        # A dynamic directive argument is JavaScript independently of its
+        # value: ``:[selectEndpoint()]="payload"`` executes both expressions.
+        for match in re.finditer(
+            r"(?<!\S)(?:v-[\w-]+:|[@:#])\[(?P<argument>[^\]\r\n]+)\]",
+            tag,
+            flags=re.IGNORECASE,
+        ):
+            if not outside_attribute_value[match.start()]:
+                continue
+            start, end = match.span("argument")
+            ranges.append((tag_start + start, tag_start + end))
+    return ranges
+
+
 def _javascript_template_expression_ranges(
     source: str, start: int, end: int
 ) -> list[tuple[int, int]]:
@@ -283,15 +478,7 @@ def executable_source(path: Path, source: str) -> str:
             if frontmatter:
                 ranges.append(frontmatter.span(1))
         if suffix == ".vue":
-            ranges.extend(
-                match.span("expression")
-                for match in re.finditer(
-                    r"(?:v-on:[\w:-]+|@[\w:-]+)(?:\.[\w-]+)*\s*=\s*"
-                    r"(?P<quote>['\"])(?P<expression>.*?)(?P=quote)",
-                    template_source,
-                    re.DOTALL,
-                )
-            )
+            ranges.extend(_vue_directive_expression_ranges(template_source))
             # Vue interpolations may contain nested object literals. A
             # non-greedy regex leaves such calls unterminated; balance the
             # entire double-brace region and retain its inner expression.
@@ -320,37 +507,66 @@ def executable_source(path: Path, source: str) -> str:
                 for match in re.finditer(r"\{", expression_source)
             ]
             ranges.extend(_balanced_brace_ranges(expression_source, openings))
-    elif suffix == ".cshtml":
+    elif suffix in {".cshtml", ".razor"}:
         # Razor is a mixed HTML/C# template. Retain explicit expressions,
         # statement/code blocks, and single-line directives while blanking page
         # markup so text such as `<p>VoiceResponse()</p>` is not treated as C#.
+        razor_source = re.sub(
+            r"@\*.*?\*@",
+            lambda match: "".join(
+                char if char in "\r\n" else " " for char in match.group(0)
+            ),
+            source,
+            flags=re.DOTALL,
+        )
         brace_openings = [
             match.end() - 1
             for match in re.finditer(
                 r"(?<!@)@(?:\s*|(?:code|functions)\s*)\{",
-                source,
+                razor_source,
                 flags=re.IGNORECASE,
             )
         ]
-        brace_openings.extend(
+        control_openings = [
             match.end() - 1
             for match in re.finditer(
-                r"(?<!@)@(?:if|for|foreach|while|switch|try|catch|finally|using|lock)\b[^{}]*\{",
-                source,
+                r"(?<!@)@(?:if|for|foreach|while|do|switch|try|catch|finally|using|lock)\b[^{}]*\{",
+                razor_source,
                 flags=re.IGNORECASE,
             )
+        ]
+        ordinary_brace_ranges = _balanced_brace_ranges(
+            razor_source, brace_openings
         )
-        ranges.extend(_balanced_brace_ranges(source, brace_openings))
+        control_ranges = _balanced_brace_ranges(razor_source, control_openings)
+        ranges.extend(ordinary_brace_ranges)
+        ranges.extend(control_ranges)
+        ranges.extend(_razor_continuation_block_ranges(razor_source, control_ranges))
+
+        # The condition after a Razor do/while body is executable C# too.
+        for opening in control_openings:
+            prefix = razor_source[max(0, opening - 16) : opening]
+            if not re.search(r"@do\s*$", prefix, re.IGNORECASE):
+                continue
+            body = _balanced_brace_ranges(razor_source, [opening])
+            if not body:
+                continue
+            tail = razor_source[body[0][1] + 1 :]
+            while_match = re.match(r"\s*while\s*\(", tail, re.IGNORECASE)
+            if while_match:
+                paren = body[0][1] + 1 + while_match.end() - 1
+                ranges.extend(_balanced_parenthesis_ranges(razor_source, [paren]))
         paren_openings = [
             match.end() - 1
-            for match in re.finditer(r"(?<!@)@\s*\(", source)
+            for match in re.finditer(r"(?<!@)@\s*\(", razor_source)
         ]
-        ranges.extend(_balanced_parenthesis_ranges(source, paren_openings))
+        ranges.extend(_balanced_parenthesis_ranges(razor_source, paren_openings))
+        ranges.extend(_razor_implicit_expression_ranges(razor_source))
         ranges.extend(
             match.span()
             for match in re.finditer(
                 r"(?m)^\s*@(?:using|inject|model|inherits|implements|namespace|addTagHelper|removeTagHelper|tagHelperPrefix)\b[^\r\n]*",
-                source,
+                razor_source,
             )
         )
     elif suffix == ".phtml":
@@ -358,9 +574,13 @@ def executable_source(path: Path, source: str) -> str:
         # Feeding its markup to the PHP lexer lets an apostrophe in page text
         # open a string that masks a later request inside <?php ... ?>.
         ranges.extend(
-            match.span(1)
+            match.span("code")
             for match in re.finditer(
-                r"<\?(?:php\b|=)(.*?)(?:\?>|\Z)",
+                # Plain ``<?`` is executable when short_open_tag is enabled.
+                # Keep XML declarations out: with short tags disabled they are
+                # markup, and with short tags enabled they make the PHP file
+                # invalid rather than forming a customer request.
+                r"<\?(?:php\b|=|(?!(?:xml)\b))(?P<code>.*?)(?:\?>|\Z)",
                 source,
                 flags=re.IGNORECASE | re.DOTALL,
             )

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -11,6 +11,7 @@ their nearest real assignment in the same file.
 from __future__ import annotations
 
 import bisect
+import html
 import json
 import os
 import posixpath
@@ -150,7 +151,7 @@ def canonical_suffix(path: Path) -> str:
         if re.search(
             r"<script\b[^>]*\blang\s*=\s*(?:(['\"])(?:ts|typescript)\1|(?:ts|typescript)(?=\s|>))",
             source,
-            re.I,
+            re.I | re.ASCII,
         ):
             return ".ts"
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
@@ -1268,6 +1269,298 @@ def _mask_jsx_markup(source: str, suffix: str) -> str:
     return "".join(output)
 
 
+_JAVASCRIPT_MIME_ESSENCES = {
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "text/ecmascript",
+    "text/javascript",
+    "text/javascript1.0",
+    "text/javascript1.1",
+    "text/javascript1.2",
+    "text/javascript1.3",
+    "text/javascript1.4",
+    "text/javascript1.5",
+    "text/jscript",
+    "text/livescript",
+    "text/x-ecmascript",
+    "text/x-javascript",
+}
+
+
+def _html_attributes(attributes: str) -> list[tuple[str, str]]:
+    """Parse static HTML attributes without matching inside quoted values."""
+
+    parsed: list[tuple[str, str]] = []
+    index = 0
+    while index < len(attributes):
+        while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+            index += 1
+        if index >= len(attributes) or attributes[index] in {">", "/"}:
+            break
+        name_start = index
+        while (
+            index < len(attributes)
+            and attributes[index] not in "\t\n\f\r "
+            and attributes[index] not in {'=', '>', '/'}
+        ):
+            index += 1
+        name = attributes[name_start:index].lower()
+        if not name:
+            index += 1
+            continue
+        while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+            index += 1
+        value = ""
+        if index < len(attributes) and attributes[index] == "=":
+            index += 1
+            while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+                index += 1
+            if index < len(attributes) and attributes[index] in {'"', "'"}:
+                quote = attributes[index]
+                index += 1
+                value_start = index
+                closing = attributes.find(quote, index)
+                if closing < 0:
+                    value = attributes[value_start:]
+                    index = len(attributes)
+                else:
+                    value = attributes[value_start:closing]
+                    index = closing + 1
+            else:
+                value_start = index
+                while (
+                    index < len(attributes)
+                    and attributes[index] not in "\t\n\f\r "
+                    and attributes[index] != ">"
+                ):
+                    index += 1
+                value = attributes[value_start:index]
+        parsed.append((name, html.unescape(value)))
+    return parsed
+
+
+def _script_attributes_execute_javascript(attributes: str) -> bool:
+    """Return whether a browser treats a static script tag as JavaScript."""
+
+    attribute_values: dict[str, str] = {}
+    for name, value in _html_attributes(attributes):
+        # HTML keeps the first duplicate attribute and ignores later ones.
+        attribute_values.setdefault(name, value)
+
+    if "type" in attribute_values:
+        value = attribute_values["type"].strip("\t\n\f\r ")
+        # A server-generated type cannot be classified statically. Retaining
+        # its body prevents a dynamic JavaScript block from silently escaping.
+        if "<%" in value:
+            return True
+        if not value:
+            return True
+        lowered = value.lower()
+        if lowered == "module":
+            return True
+        # HTML's JavaScript MIME *essence match* is an exact comparison against
+        # these legacy strings, not MIME parsing.  In particular the standard
+        # says `text/javascript; charset=utf-8` is a data block and is not run.
+        return lowered in _JAVASCRIPT_MIME_ESSENCES
+
+    language = attribute_values.get("language", "").strip("\t\n\f\r ")
+    if not language or "<%" in language:
+        return True
+    essence = language.lower()
+    if "/" not in essence:
+        essence = f"text/{essence}"
+    return essence in _JAVASCRIPT_MIME_ESSENCES
+
+
+_HTML_TAG_RE = re.compile(r"<(?P<closing>/)?(?P<name>[^\t\n\f\r />]+)")
+_HTML_INERT_RAW_TEXT_ELEMENTS = {
+    "iframe",
+    "noembed",
+    "noframes",
+    "noscript",
+    "plaintext",
+    "style",
+    "template",
+    "textarea",
+    "title",
+    "xmp",
+}
+
+
+def _html_tag_end(source: str, start: int) -> int | None:
+    """Return the first tag-closing angle bracket outside quoted attributes."""
+
+    quote = ""
+    index = start
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if character == quote:
+                quote = ""
+        elif character in {'"', "'"}:
+            quote = character
+        elif character == ">":
+            return index
+        index += 1
+    return None
+
+
+def _html_raw_text_end(
+    source: str, start: int, name: str
+) -> tuple[int, int] | None:
+    """Return the start/end of a raw-text element's next matching end tag."""
+
+    closer = re.compile(
+        rf"</{re.escape(name)}(?=[\t\n\f\r />])", re.I | re.ASCII
+    ).search(source, start)
+    if closer is None:
+        return None
+    end = _html_tag_end(source, closer.end())
+    return closer.start(), len(source) if end is None else end + 1
+
+
+def _html_template_end(source: str, start: int) -> int | None:
+    """Return the end of a template element, including nested templates."""
+
+    depth = 1
+    cursor = start
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            return None
+        tag = _HTML_TAG_RE.match(source, opening)
+        if tag is None:
+            cursor = opening + 1
+            continue
+        tag_end = _html_tag_end(source, tag.end())
+        if tag_end is None:
+            return None
+        name = tag.group("name").lower()
+        if tag.group("closing"):
+            if name == "template":
+                depth -= 1
+                if depth == 0:
+                    return tag_end + 1
+            cursor = tag_end + 1
+            continue
+        if name == "plaintext":
+            cursor = len(source)
+            continue
+        if name == "template":
+            depth += 1
+            cursor = tag_end + 1
+            continue
+        if name == "script" or name in (_HTML_INERT_RAW_TEXT_ELEMENTS - {"template"}):
+            closer = _html_raw_text_end(source, tag_end + 1, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return None
+
+
+def _script_element_body_ranges(source: str) -> list[tuple[int, int]]:
+    """Return executable JavaScript bodies from quote-aware HTML script tags."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        opener = _HTML_TAG_RE.match(source, opening)
+        if opener is None:
+            cursor = opening + 1
+            continue
+        boundary = opener.end()
+        tag_end = _html_tag_end(source, boundary)
+        if tag_end is None:
+            break
+        name = opener.group("name").lower()
+        if opener.group("closing"):
+            cursor = tag_end + 1
+            continue
+
+        body_start = tag_end + 1
+        if name == "script":
+            closer = _html_raw_text_end(source, body_start, name)
+            body_end = len(source) if closer is None else closer[0]
+            if _script_attributes_execute_javascript(source[boundary:tag_end]):
+                ranges.append((body_start, body_end))
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        if name == "template":
+            closing_end = _html_template_end(source, body_start)
+            cursor = len(source) if closing_end is None else closing_end
+            continue
+        if name in _HTML_INERT_RAW_TEXT_ELEMENTS:
+            closer = _html_raw_text_end(source, body_start, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return ranges
+
+
+def _html_comment_end(source: str, opening: int) -> int:
+    """Return the offset after an HTML comment, or EOF when unterminated."""
+
+    content_start = opening + 4
+    abrupt = (
+        content_start + 1
+        if source.startswith(">", content_start)
+        else content_start + 2
+        if source.startswith("->", content_start)
+        else -1
+    )
+    normal = source.find("-->", content_start)
+    bang = source.find("--!>", content_start)
+    closers = [position for position in (abrupt, normal, bang) if position >= 0]
+    closing = min(closers) if closers else -1
+    if closing < 0:
+        return len(source)
+    if closing == abrupt:
+        return abrupt
+    if closing == bang:
+        return bang + 4
+    return normal + 3
+
+
+def _without_html_comments(source: str) -> str:
+    """Blank HTML comments in markup state while preserving source offsets."""
+
+    output = list(source)
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        if source.startswith("<!--", opening):
+            end = _html_comment_end(source, opening)
+            _blank(output, opening, end)
+            cursor = end
+            continue
+        tag = _HTML_TAG_RE.match(source, opening)
+        if tag is None:
+            cursor = opening + 1
+            continue
+        tag_end = _html_tag_end(source, tag.end())
+        if tag_end is None:
+            break
+        name = tag.group("name").lower()
+        if tag.group("closing"):
+            cursor = tag_end + 1
+            continue
+        if name == "plaintext":
+            break
+        if name == "script" or name in (_HTML_INERT_RAW_TEXT_ELEMENTS - {"template"}):
+            closer = _html_raw_text_end(source, tag_end + 1, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return "".join(output)
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
@@ -1275,32 +1568,28 @@ def executable_source(path: Path, source: str) -> str:
     if suffix in JSX_CAPABLE_SUFFIXES:
         return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
-        # Comments may contain complete, syntactically valid examples. Preserve
-        # their offsets/newlines but remove their contents before discovering
-        # script blocks, handlers, interpolations, or balanced expressions.
-        template_source = re.sub(
-            r"<!--.*?-->",
-            lambda match: "".join(
-                char if char in "\r\n" else " " for char in match.group(0)
-            ),
-            source,
-            flags=re.DOTALL,
-        )
-        ranges.extend(
-            match.span(1)
-            for match in re.finditer(
-                r"<script\b[^>]*>(.*?)</script\b[^>]*>", template_source,
-                flags=re.IGNORECASE | re.DOTALL,
-            )
-        )
+        frontmatter = None
+        markup_source = source
         if suffix == ".astro":
+            # Astro frontmatter is JavaScript/TypeScript, not HTML markup. A
+            # string such as `"<!--"` must therefore not open an HTML comment
+            # that erases the remaining executable frontmatter.
             frontmatter = re.match(
                 r"\A\s*---\s*\r?\n(.*?)\r?\n---(?:\s*\r?\n|\Z)",
-                template_source,
+                source,
                 re.DOTALL,
             )
             if frontmatter:
-                ranges.append(frontmatter.span(1))
+                markup = list(source)
+                _blank(markup, *frontmatter.span(1))
+                markup_source = "".join(markup)
+        # Comments may contain complete, syntactically valid examples. Preserve
+        # their offsets/newlines but remove their contents before discovering
+        # script blocks, handlers, interpolations, or balanced expressions.
+        template_source = _without_html_comments(markup_source)
+        ranges.extend(_script_element_body_ranges(template_source))
+        if frontmatter:
+            ranges.append(frontmatter.span(1))
         if suffix == ".vue":
             ranges.extend(_vue_directive_expression_ranges(template_source))
             # Vue interpolations may contain nested object literals. A
@@ -1418,11 +1707,7 @@ def executable_source(path: Path, source: str) -> str:
             # blocks execute in the generated browser page. Both can contain
             # migration-sensitive JavaScript and must remain visible.
             ranges.extend(
-                match.span(1)
-                for match in re.finditer(
-                    r"<script\b[^>]*>(.*?)</script\b[^>]*>", source,
-                    flags=re.IGNORECASE | re.DOTALL,
-                )
+                _script_element_body_ranges(_without_html_comments(source))
             )
         for match in re.finditer(
             r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL
@@ -1539,8 +1824,11 @@ FETCH_CALL_RE = re.compile(
     r"axios\s*\.\s*post|axios)\s*\("
 )
 TWILIO_MESSAGE_CREATE_RE = re.compile(
+    r"(?:"
     r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
     r"create\s*(?:\?\.)?\s*\("
+    r"|(?<![\w$])MessageResource\s*\.\s*Create\s*\("
+    r")"
 )
 MESSAGE_BODY_CALL_RE = re.compile(
     r"(?:"
@@ -1550,6 +1838,7 @@ MESSAGE_BODY_CALL_RE = re.compile(
     r"Send\s*\("
     r"|(?:\?\.|\.|->)\s*messages\s*\(\s*\)\s*"
     r"(?:\?\.|\.|->)\s*send\s*\("
+    r"|(?<![\w$])MessageResource\s*\.\s*Create\s*\("
     r")"
 )
 SIMPLE_VARIABLE_RE = re.compile(r"(?:\.\.\.|\*\*|[&*])?\s*(\$?[A-Za-z_]\w*)\s*$")
@@ -1815,13 +2104,89 @@ def _line_comment_end(source: str, start: int, suffix: str) -> int:
 _HEREDOC_OPENER_RE = re.compile(
     r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)(?!\w)"
 )
+_RUBY_HEREDOC_OPENER_RE = re.compile(
+    r"<<(?P<indent>[-~]?)(?:"
+    r"'(?P<single>[^'\r\n]*)'|"
+    r'"(?P<double>[^"\r\n]*)"|'
+    r"`(?P<command>[^`\r\n]*)`|"
+    r"(?P<tag>(?!\d)\w+)"
+    r")"
+)
 # Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
 # singleton-class syntax `class <<self` also puts a bare word straight after
 # `<<` at end of line, so it parsed as a heredoc opening a body that never
 # closed - blanking the rest of the file and silently passing every send below
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
-_NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+def _ruby_heredoc_tag(match: "re.Match[str]") -> str:
+    """Return the delimiter spelling from a Ruby heredoc opener match."""
+
+    for name in ("single", "double", "command", "tag"):
+        value = match.group(name)
+        if value is not None:
+            return value
+    return ""
+
+
+def _ruby_heredoc_quote(match: "re.Match[str]") -> str:
+    """Return the quote mode used by one Ruby heredoc opener."""
+
+    if match.group("single") is not None:
+        return "'"
+    if match.group("double") is not None:
+        return '"'
+    if match.group("command") is not None:
+        return "`"
+    return ""
+
+
+def _ruby_heredoc_has_shift_left_context(source: str, index: int) -> bool:
+    """Return whether Ruby lexes this compact ``<<TAG`` as left shift."""
+
+    cursor = index - 1
+    adjacent = cursor >= 0 and source[cursor] not in " \t\r\n"
+    while cursor >= 0 and source[cursor] in " \t":
+        cursor -= 1
+    if cursor < 0 or source[cursor] in "\r\n":
+        return False
+    # Ruby's lexical ambiguity treats command/local/constant receivers followed
+    # by whitespace and <<TAG as heredocs, but literals, completed expressions,
+    # and instance/global variables remain shift operands.  These are the
+    # contexts Ripper emits as on_op rather than on_heredoc_beg.
+    if source[cursor].isdigit() or source[cursor] in "'\"`)]}/":
+        return True
+    if not (source[cursor].isalnum() or source[cursor] == "_"):
+        return False
+    end = cursor + 1
+    while cursor >= 0 and (source[cursor].isalnum() or source[cursor] == "_"):
+        cursor -= 1
+    word = source[cursor + 1:end]
+    return (
+        adjacent
+        or word
+        in {
+            "nil",
+            "true",
+            "false",
+            "self",
+            "__FILE__",
+            "__LINE__",
+            "__ENCODING__",
+        }
+        or (cursor >= 0 and source[cursor] in {"@", "$", ":"})
+    )
+
+
+def _ruby_heredoc_has_class_left_context(source: str, index: int) -> bool:
+    """Return whether the token before ``<<`` is Ruby's ``class`` keyword."""
+
+    cursor = index - 1
+    while cursor >= 0 and source[cursor] in " \t":
+        cursor -= 1
+    end = cursor + 1
+    while cursor >= 0 and (source[cursor].isalnum() or source[cursor] == "_"):
+        cursor -= 1
+    return source[cursor + 1:end] == "class"
 
 
 def _heredoc_opener_at(
@@ -1833,7 +2198,18 @@ def _heredoc_opener_at(
     applying the rejection there would disable heredoc masking on any opener
     line that merely ENDS with the word `class` (`echo class <<EOT`).
     """
-    match = _HEREDOC_OPENER_RE.match(source, index)
+    opener_pattern = _HEREDOC_OPENER_RE
+    if suffix == ".rb":
+        match = _RUBY_HEREDOC_OPENER_RE.match(source, index)
+        if match is None:
+            return None
+        if (
+            _ruby_heredoc_has_class_left_context(source, index)
+            or _ruby_heredoc_has_shift_left_context(source, index)
+        ):
+            return None
+        return match
+    match = opener_pattern.match(source, index)
     if match is None:
         return None
     # In shell, three opening angle brackets introduce an inline here-string,
@@ -1850,10 +2226,68 @@ def _heredoc_opener_at(
         line_end = len(source)
     if suffix != ".sh" and source[match.end():line_end].strip():
         return None
-    if suffix == ".rb":
-        if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
-            return None
     return match
+
+
+def _ruby_heredoc_openers_at(
+    source: str, index: int
+) -> list["re.Match[str]"]:
+    """Return ordered Ruby heredoc openers declared by one expression.
+
+    Ruby consumes multiple heredoc bodies after the declaration line, in the
+    same order as their openers. The ordinary single-opener validator requires
+    an opener to end its line, so this also accepts comma-separated openers on
+    the declaration line without lending one opener's mode to another body.
+    """
+
+    first = _heredoc_opener_at(source, index, ".rb")
+    if first is None:
+        return []
+    line_end = source.find("\n", first.end())
+    if line_end < 0:
+        line_end = len(source)
+
+    openers = [first]
+    cursor = first.end()
+    quote = ""
+    escaped = False
+    while cursor < line_end:
+        character = source[cursor]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            cursor += 1
+            continue
+        if character == "#":
+            break
+        if character in {"'", '"', "`"}:
+            quote = character
+            cursor += 1
+            continue
+        if character == "/":
+            regexp = _ruby_slash_regex(source, cursor, allow_newlines=False)
+            if regexp is not None and regexp[0] <= line_end:
+                cursor = regexp[0]
+                continue
+        if character == "%":
+            percent = _ruby_percent_literal(source, cursor)
+            if percent is not None and percent[0] <= line_end:
+                cursor = percent[0]
+                continue
+        if source.startswith("<<", cursor):
+            candidate = _heredoc_opener_at(source, cursor, ".rb")
+            if candidate is not None:
+                openers.append(candidate)
+                cursor = candidate.end()
+                continue
+            cursor += 2
+            continue
+        cursor += 1
+    return openers
 
 
 def _heredoc_langs(suffix: str) -> bool:
@@ -2283,7 +2717,244 @@ def _ruby_command_regex_has_valid_tail(source: str, regexp_end: int) -> bool:
     return re.match(r"(?:[+-]\s*)?(?:[$@A-Za-z_\d]|[('\"\[{])", tail) is None
 
 
-def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
+def _ruby_bound_shift_offsets(source: str, code: str) -> frozenset[int]:
+    """Return ambiguous ``<<TAG`` offsets whose receiver is a local binding.
+
+    Ruby lexes ``puts <<DOC`` as a heredoc, but lexes ``value <<BITS`` as an
+    operator once ``value`` has been introduced as a local in the same lexical
+    method/top-level scope.  A first masking pass gives us comment/string-safe
+    code and method boundaries; this binding pass then prevents the second pass
+    from swallowing the rest of the file as a nonexistent heredoc body.
+    """
+
+    spans = sorted(_ruby_function_spans(code))
+    span_starts = [start for start, _ in spans]
+    parents: list[int] = []
+    stack: list[int] = []
+    for span_index, (start, end) in enumerate(spans):
+        while stack and spans[stack[-1]][1] <= start:
+            stack.pop()
+        parents.append(stack[-1] if stack else -1)
+        stack.append(span_index)
+
+    def owner(offset: int) -> tuple[int, int] | None:
+        # Intervals are nested or disjoint. Start with the latest possible
+        # owner and follow its precomputed parent chain instead of scanning all
+        # method spans for every binding/candidate (quadratic on large files).
+        span_index = bisect.bisect_right(span_starts, offset) - 1
+        while span_index >= 0:
+            start, end = spans[span_index]
+            if start <= offset < end:
+                return start, end
+            span_index = parents[span_index]
+        return None
+
+    def parameter_names(parameters: str) -> set[str]:
+        """Return declaration names, excluding identifiers in defaults."""
+
+        names: set[str] = set()
+        start = 0
+        depth = 0
+        for index, character in enumerate(parameters + ","):
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth = max(0, depth - 1)
+            elif character in {",", ";"} and depth == 0:
+                piece = parameters[start:index].strip()
+                start = index + 1
+                while (
+                    len(piece) >= 2
+                    and piece[0] == "("
+                    and matching_delimiter(piece, 0, "(", ")")
+                    == len(piece) - 1
+                ):
+                    piece = piece[1:-1].strip()
+                if "," in piece:
+                    names.update(parameter_names(piece))
+                    continue
+                declared = re.match(
+                    r"(?:\*\*?|&)?\s*(?P<name>[a-z_]\w*)\b", piece
+                )
+                if declared is not None:
+                    names.add(declared.group("name"))
+        return names
+
+    def do_block_end(opening_end: int) -> int:
+        """Match a Ruby ``do`` with its structurally corresponding ``end``."""
+
+        depth = 1
+        boundaries = list(re.finditer(r"[;\r\n]", code[opening_end:]))
+        start = opening_end
+        pieces: list[tuple[int, int]] = []
+        for boundary in boundaries:
+            end = opening_end + boundary.start()
+            pieces.append((start, end))
+            start = opening_end + boundary.end()
+        pieces.append((start, len(code)))
+        for statement_start, statement_end in pieces:
+            stripped = code[statement_start:statement_end].strip()
+            if not stripped:
+                continue
+            if re.match(r"end\b", stripped):
+                depth -= 1
+                if depth == 0:
+                    return statement_end
+                continue
+            if (
+                re.match(
+                    r"(?:def|class|module|if|unless|case|begin|for|while|until)\b",
+                    stripped,
+                )
+                or re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped)
+            ):
+                depth += 1
+        return len(code)
+
+    # Identify block parameter lists before ordinary assignments: a default
+    # such as `|item = fallback|` binds only `item` inside the block and must
+    # not invent either name as an outer local.
+    pipe_spans = [
+        (match.start(), match.end(), parameter_names(match.group("params")))
+        for match in re.finditer(r"\|(?P<params>[^|\r\n]*)\|", code)
+    ]
+    block_bindings: list[tuple[int, int, set[str], tuple[int, int] | None]] = []
+    for pipe_start, pipe_end, names in pipe_spans:
+        if not names:
+            continue
+        prefix_start = max(0, pipe_start - 120)
+        prefix = code[prefix_start:pipe_start]
+        brace = prefix.rfind("{")
+        if brace >= 0:
+            opening = prefix_start + brace
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is not None:
+                block_bindings.append((pipe_end, closing, names, owner(pipe_start)))
+                continue
+        do_match = re.search(r"\bdo\s*$", prefix)
+        if do_match is not None:
+            opening_end = prefix_start + do_match.end()
+            closing = do_block_end(opening_end)
+            block_bindings.append((pipe_end, closing, names, owner(pipe_start)))
+
+    bindings: dict[tuple[tuple[int, int] | None, str], list[int]] = {}
+
+    def bind(name: str, offset: int) -> None:
+        if not re.fullmatch(r"[a-z_]\w*", name):
+            return
+        bindings.setdefault((owner(offset), name), []).append(offset)
+
+    # Simple and compound assignments establish a Ruby local from that point
+    # onward.  Strings/comments/heredoc bodies are blank in ``code``, so text
+    # that merely resembles an assignment cannot leak a binding into code.
+    assignment = re.compile(
+        r"(?<![\w@$.])([a-z_]\w*)\s*"
+        r"(?:\|\|=|&&=|<<=|>>=|\*\*=|[+\-*/%&|^]=|=(?!=|>))"
+    )
+    for match in assignment.finditer(code):
+        if any(start <= match.start() < end for start, end, _ in pipe_spans):
+            continue
+        if any(
+            start <= match.start() < end and match.group(1) in names
+            for start, end, names, _ in block_bindings
+        ):
+            continue
+        bind(match.group(1), match.start(1))
+
+    # Multiple assignment binds every bare local on its left side, not just
+    # the identifier adjacent to ``=``.
+    for match in re.finditer(
+        r"(?:^|[;\r\n])\s*"
+        r"(?P<lhs>[a-z_]\w*(?:\s*,\s*[a-z_]\w*)+)\s*=(?!=|>)",
+        code,
+        re.M,
+    ):
+        for name in re.findall(r"[a-z_]\w*", match.group("lhs")):
+            if any(
+                start <= match.start("lhs") < end
+                for start, end, _ in pipe_spans
+            ):
+                continue
+            if any(
+                start <= match.start("lhs") < end and name in names
+                for start, end, names, _ in block_bindings
+            ):
+                continue
+            bind(name, match.start("lhs"))
+
+    # Method parameters are local for the whole method body.  Their binding
+    # position is the method opener so a shift in an endless method expression
+    # is covered too.
+    for start, end in spans:
+        method = re.match(
+            r"\s*(?:(?:private|protected|public)\s+)?def\s+"
+            r"(?:self\s*\.\s*)?(?:\[\]=?|[A-Za-z_]\w*[!?=]?)",
+            code[start:end],
+        )
+        if method is None:
+            continue
+        params_start = start + method.end()
+        while params_start < end and code[params_start] in " \t":
+            params_start += 1
+        if params_start < end and code[params_start] == "(":
+            params_end = matching_delimiter(code, params_start, "(", ")")
+            if params_end is None:
+                continue
+            parameters = code[params_start + 1:params_end]
+        else:
+            ends = [
+                position
+                for position in (
+                    code.find("\n", params_start, end),
+                    code.find(";", params_start, end),
+                )
+                if position >= 0
+            ]
+            params_end = min(ends) if ends else end
+            parameters = code[params_start:params_end]
+        for name in parameter_names(parameters):
+            bind(name, start)
+
+    for positions in bindings.values():
+        positions.sort()
+
+    shifts: set[int] = set()
+    for candidate in re.finditer(r"<<", code):
+        index = candidate.start()
+        opener = _RUBY_HEREDOC_OPENER_RE.match(source, index)
+        if opener is None:
+            continue
+        cursor = index - 1
+        if cursor < 0 or code[cursor] not in " \t":
+            continue
+        while cursor >= 0 and code[cursor] in " \t":
+            cursor -= 1
+        word_end = cursor + 1
+        while cursor >= 0 and (code[cursor].isalnum() or code[cursor] == "_"):
+            cursor -= 1
+        name = code[cursor + 1:word_end]
+        if re.fullmatch(r"[a-z_]\w*", name) is None:
+            continue
+        scope = owner(index)
+        positions = bindings.get((scope, name), [])
+        insertion = bisect.bisect_left(positions, index)
+        if insertion and positions[insertion - 1] < index:
+            shifts.add(index)
+            continue
+        if any(
+            start <= index < end and block_owner == scope and name in names
+            for start, end, names, block_owner in block_bindings
+        ):
+            shifts.add(index)
+    return frozenset(shifts)
+
+
+def _lex_source_once(
+    source: str,
+    suffix: str,
+    dialect: str = "",
+    ruby_shift_offsets: frozenset[int] = frozenset(),
+) -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
     code = list(source)
@@ -2472,17 +3143,31 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         # Heredoc bodies are DATA, not code. They were lexed as code, so an
         # apostrophe inside one ("Don't edit by hand") paired with a later quote
         # and masked the send that followed.
-        heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
-        if heredoc is not None:
-            body_start = source.find("\n", heredoc.end())
+        openers: list["re.Match[str]"] = []
+        if suffix == ".rb":
+            if index not in ruby_shift_offsets:
+                openers = _ruby_heredoc_openers_at(source, index)
+        elif _heredoc_langs(suffix):
+            heredoc = _heredoc_opener_at(source, index, suffix)
+            if heredoc is not None:
+                openers = [heredoc]
+        if openers:
+            body_start = source.find("\n", openers[0].end())
             if body_start < 0:
-                index = heredoc.end()
+                index = openers[-1].end()
                 continue
             body_start += 1
-            openers = [heredoc]
             for opener in openers:
-                tag = opener.group("tag")
-                terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
+                if suffix == ".rb":
+                    tag = _ruby_heredoc_tag(opener)
+                    indentation = opener.group("indent")
+                    line_prefix = r"^[ \t]*" if indentation in {"-", "~"} else "^"
+                    terminator_pattern = (
+                        rf"{line_prefix}{re.escape(tag)}(?=\r?$)"
+                    )
+                else:
+                    tag = opener.group("tag")
+                    terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
                 terminator = re.compile(terminator_pattern, re.M).search(
                     source, body_start
                 )
@@ -2491,7 +3176,7 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 )
                 _blank(code, body_start, body_end)
                 _blank(without_comments, body_start, body_end)
-                if suffix == ".rb" and opener.group("q") != "'":
+                if suffix == ".rb" and _ruby_heredoc_quote(opener) != "'":
                     for expression_start, expression_end in _ruby_interpolation_ranges(
                         source, body_start, body_end
                     ):
@@ -2775,6 +3460,24 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
             last_js_opaque_end = index
 
     return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
+
+
+def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
+    """Mask comments/strings, resolving Ruby's binding-sensitive ``<<``."""
+
+    if suffix != ".rb":
+        return _lex_source_once(source, suffix, dialect)
+
+    ruby_shift_offsets: frozenset[int] = frozenset()
+    while True:
+        lexed = _lex_source_once(
+            source, suffix, dialect, ruby_shift_offsets
+        )
+        discovered = _ruby_bound_shift_offsets(source, lexed.code)
+        combined = ruby_shift_offsets | discovered
+        if combined == ruby_shift_offsets:
+            return lexed
+        ruby_shift_offsets = combined
 
 
 def matching_delimiter(code: str, opening: int, left: str, right: str) -> int | None:
@@ -4089,6 +4792,10 @@ def payload_spans(
             # the argument list this region covers.
             spans.append(arguments[-1])
         return spans
+    if suffix == ".cs" and mode == "body":
+        # Twilio's MessageResource.Create uses independent named arguments;
+        # `body:` is commonly the third argument, not an object in argument 0.
+        return [(start, end)]
     return arguments[:1]
 
 
@@ -4876,6 +5583,13 @@ def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
                 r"(?:if|unless|case|begin|for|while|until)\b", stripped
             ):
                 stack.append(("control", None))
+    # A provisional heredoc pass can mask the `end` belonging to a method whose
+    # body contains a binding-sensitive shift. Retain such open named scopes to
+    # EOF so the repair pass can still associate parameters and assignments
+    # with the correct method rather than dropping the scope entirely.
+    for kind, opener_start in stack:
+        if kind in {"def", "class", "module"} and opener_start is not None:
+            spans.append((opener_start, len(code)))
     return spans
 
 
@@ -13827,6 +14541,92 @@ def call_belongs_to_kept_product(
     )
 
 
+def csharp_twilio_message_calls(
+    lexed: LexedSource, source: SourceEndpointResolver | None = None
+) -> list[Call]:
+    return csharp_twilio_resource_calls(
+        lexed, "Twilio.Rest.Api.V2010.Account.MessageResource", ("Create",), source
+    )
+
+
+def csharp_twilio_resource_calls(
+    lexed: LexedSource, target: str, methods: tuple[str, ...],
+    source: SourceEndpointResolver | None = None,
+) -> list[Call]:
+    """Resolve the SDK resource's C# using/alias forms before checking its body.
+
+    Generic class names are not sufficient ownership evidence. Keep imports
+    scoped to their namespace and let local types shadow namespace imports.
+    """
+    code = lexed.code
+    namespaces = _csharp_namespace_spans(code)
+    types = _csharp_type_spans(code)
+    source = source or SourceEndpointResolver(lexed, ".cs")
+
+    def namespace_at(offset: int) -> tuple[int, int, str] | None:
+        return max((span for span in namespaces if span[0] < offset < span[1]),
+                   key=lambda span: span[0], default=None)
+
+    imports = []
+    for match in re.finditer(
+        r"\b(?:global\s+)?using\s+(?:(?P<static>static)\s+)?"
+        r"(?:(?P<alias>\w+)\s*=\s*)?(?:global\s*::\s*)?"
+        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;", code
+    ):
+        imports.append((match, re.sub(r"\s+", "", match.group("target")),
+                        namespace_at(match.start())))
+    candidates = calls_matching(lexed, re.compile(
+        r"(?<![\w$.])(?:global\s*::\s*)?(?:\w+\s*\.\s*)*(?:"
+        + "|".join(re.escape(method) for method in methods) + r")\s*\("
+    ))
+    result = []
+    for call in candidates:
+        head = re.sub(r"\s+", "", code[call.start:call.open_paren])
+        receiver = head.rsplit(".", 1)[0] if "." in head else ""
+        if receiver.startswith("global::"):
+            if receiver.removeprefix("global::") == target:
+                result.append(call)
+            continue
+        visible = [(match, name) for match, name, scope in imports
+                   if scope is None or scope[0] < call.start < scope[1]]
+        aliases = {match.group("alias"): name for match, name in visible
+                   if match.group("alias")}
+        first, dot, rest = receiver.partition(".")
+        binding_id = source.graph.visible_binding(
+            first, source.scope_at(call.start), call.start
+        ) if first else None
+        if binding_id is not None:
+            declaration = source.graph.bindings[binding_id].declaration_start
+            if (scope_contains(code, declaration, call.start)
+                    and not any(match.start() <= declaration < match.end()
+                                for match, _, _ in imports)):
+                # Local variables, parameters and fields beat a using alias.
+                # Reuse the normal scope index so an unrelated method/block
+                # cannot hide the SDK receiver here.
+                continue
+        expanded = aliases.get(first, first) + (dot + rest if dot else "")
+        if expanded == target:
+            result.append(call)
+            continue
+        # A same-namespace or enclosing type declaration takes precedence over
+        # imported namespace members, even when declared after the use.
+        local = any(name == first and (
+            opening < call.start < closing
+            or namespace_at(opening) == namespace_at(call.start)
+        ) for opening, closing, name in types)
+        if local or first in aliases:
+            continue
+        if receiver == target.rsplit(".", 1)[-1] and any(
+            not match.group("alias") and not match.group("static")
+            and name == target.rsplit(".", 1)[0] for match, name in visible
+        ):
+            result.append(call)
+        elif not receiver and any(match.group("static") and name == target
+                                  for match, name in visible):
+            result.append(call)
+    return result
+
+
 def message_body_fields(
     path: Path, pattern: re.Pattern[str], kept_products: set[str] | None = None
 ) -> list[str]:
@@ -13845,7 +14645,15 @@ def message_body_fields(
         source=source_resolver,
     )
     matches: list[str] = []
-    for call in calls_matching(lexed, pattern):
+    # Ownership applies only to the ambiguous C# resource class, not to the
+    # existing generic Messages.Send / messages.create body-check families.
+    calls = [call for call in calls_matching(lexed, pattern)
+             if not re.search(r"\bMessageResource\s*\.\s*Create\s*$",
+                              lexed.code[call.start:call.open_paren])]
+    if suffix == ".cs":
+        calls.extend(csharp_twilio_message_calls(lexed, source_resolver))
+    calls = list({call.open_paren: call for call in calls}.values())
+    for call in calls:
         if call_belongs_to_kept_product(
             lexed, call, kept_products or set(), pattern
         ):

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -6473,6 +6473,12 @@ class SourceEndpointResolver:
         self.suffix = suffix
         self.external_values = external_values or {}
         self.external_names = external_names or set()
+        self.csharp_namespace_spans = (
+            _csharp_namespace_spans(lexed.original) if suffix == ".cs" else []
+        )
+        self.csharp_type_spans = (
+            _csharp_type_spans(lexed.original) if suffix == ".cs" else []
+        )
         self.unverified_external_calls: set[int] = set()
         self.graph = EndpointGraph(len(lexed.code))
         self.c_headers = c_function_headers(lexed, suffix)
@@ -8107,7 +8113,14 @@ class SourceEndpointResolver:
         if access is not None:
             return access
 
-        reference = static_reference_expression(self.lexed, start, end)
+        reference_start = start
+        if self.suffix == ".cs":
+            global_prefix = re.match(
+                r"\s*global\s*::\s*", self.lexed.original[start:end]
+            )
+            if global_prefix is not None:
+                reference_start += global_prefix.end()
+        reference = static_reference_expression(self.lexed, reference_start, end)
         if reference is not None:
             name = reference[0].lstrip("$")
             binding_id = self.graph.visible_binding(
@@ -8432,11 +8445,45 @@ class SourceEndpointResolver:
         # per-file binding graph. Keeping module provenance explicit avoids
         # conflating same-named locals and makes the cross-file boundary the
         # only special case; all endpoint classification remains shared.
-        expression_text = self.lexed.code[start:end].strip()
-        if not projection and re.fullmatch(r"[A-Za-z_$]\w*", expression_text):
-            external = self.external_values.get(expression_text.lstrip("$"))
-            if external is not None:
-                return endpoint_literal_value(external)
+        reference_start = start
+        if self.suffix == ".cs":
+            global_prefix = re.match(
+                r"\s*global\s*::\s*", self.lexed.original[start:end]
+            )
+            if global_prefix is not None:
+                reference_start += global_prefix.end()
+        reference = static_reference_expression(self.lexed, reference_start, end)
+        if not projection and reference is not None:
+            reference_key = ".".join(
+                part.lstrip("$") for part in reference
+            )
+            scope_id = self.scope_at(before)
+            if self.suffix == ".cs" and self.graph.visible_binding(
+                reference[0].lstrip("$"), scope_id, before
+            ) is not None:
+                expression = self._parse_expression(
+                    start, end, scope_id, before
+                )
+                return self.graph.evaluate(
+                    EndpointExpressionState(
+                        expression, projection, before, scope_id
+                    )
+                )
+            candidates = (
+                _csharp_reference_candidates(
+                    before,
+                    reference_key,
+                    self.csharp_namespace_spans,
+                    self.csharp_type_spans,
+                    global_only=global_prefix is not None,
+                )
+                if self.suffix == ".cs"
+                else (reference_key,)
+            )
+            for candidate in candidates:
+                external = self.external_values.get(candidate)
+                if external is not None:
+                    return endpoint_literal_value(external)
         scope_id = self.scope_at(before)
         expression = self._parse_expression(
             start, end, scope_id, before
@@ -11804,7 +11851,9 @@ def _looks_like_a_send_target(
         r"|\b(?:public|private|protected|internal)[ \t]+const"
         r"|\b(?:public|private|protected|internal)?[ \t]*static[ \t]+readonly)"
         r"[ \t]+[A-Za-z_$][\w$<>,.?\[\]]*[ \t]+"
-        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*$",
+        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*"
+        r"(?:new[ \t]*(?:(?:System[ \t]*\.[ \t]*)?Uri[ \t]*)?"
+        r"\([ \t]*)?@?[ \t]*$",
         declaration,
         re.I,
     ) and _SEND_SITE_RE.search(declaration) is None:
@@ -12072,8 +12121,233 @@ def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
     return assignment.group("value") if assignment is not None else None
 
 
+def _python_from_imports(visible: str) -> list[tuple[str, str, str]]:
+    """Return ``(module, exported, local)`` for logical Python imports.
+
+    Python permits a parenthesized member list to span physical lines, and a
+    backslash can continue the unparenthesized form. Parse the bounded logical
+    statement once and share it between exact local-module resolution and the
+    fail-closed external-provenance index so those two contracts cannot drift.
+    """
+
+    imports: list[tuple[str, str, str]] = []
+    header = re.compile(
+        r"(?m)(?:^|;)[ \t]*from[ \t]+"
+        r"(?P<module>\.*(?:[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)?)"
+        r"[ \t]+import[ \t]*"
+    )
+    for match in header.finditer(visible):
+        module = match.group("module")
+        if not module:
+            continue
+        start = match.end()
+        while start < len(visible) and visible[start] in " \t":
+            start += 1
+        if start < len(visible) and visible[start] == "(":
+            closing = matching_delimiter(visible, start, "(", ")")
+            if closing is None:
+                continue
+            members = visible[start + 1 : closing]
+        else:
+            end = start
+            while end < len(visible):
+                line_break = re.search(r"\r\n|\r|\n", visible[end:])
+                if line_break is None:
+                    end = len(visible)
+                    break
+                line_end = end + line_break.start()
+                semicolon = visible.find(";", end, line_end)
+                if semicolon >= 0:
+                    end = semicolon
+                    break
+                if visible[start:line_end].rstrip().endswith("\\"):
+                    end += line_break.end()
+                    continue
+                end = line_end
+                break
+            members = re.sub(r"\\(?:\r\n|\r|\n)", " ", visible[start:end])
+        for member in members.split(","):
+            parsed = re.fullmatch(
+                r"\s*(?P<export>[A-Za-z_]\w*)"
+                r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
+                member,
+            )
+            if parsed is not None:
+                imports.append(
+                    (
+                        module,
+                        parsed.group("export"),
+                        parsed.group("local") or parsed.group("export"),
+                    )
+                )
+    return imports
+
+
+def _csharp_namespace_spans(source: str) -> list[tuple[int, int, str]]:
+    """Return namespace scopes with their fully qualified names."""
+
+    code = lex_source(source, ".cs").code
+    raw: list[tuple[int, int, str]] = []
+    for match in re.finditer(
+        r"\bnamespace\s+(?P<name>[A-Za-z_]\w*"
+        r"(?:\s*\.\s*[A-Za-z_]\w*)*)\s*(?P<kind>;|\{)",
+        code,
+    ):
+        name = re.sub(r"\s+", "", match.group("name"))
+        if match.group("kind") == ";":
+            raw.append((match.end(), len(code), name))
+            continue
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is not None:
+            raw.append((opening, closing, name))
+
+    qualified: list[tuple[int, int, str]] = []
+    for start, end, name in sorted(raw, key=lambda item: (item[0], -item[1])):
+        parents = [
+            span for span in qualified if span[0] < start and end < span[1]
+        ]
+        parent = max(parents, key=lambda span: span[0], default=None)
+        full_name = f"{parent[2]}.{name}" if parent is not None else name
+        qualified.append((start, end, full_name))
+    return qualified
+
+
+def _csharp_static_scalars(source: str) -> dict[str, str]:
+    """Return fully qualified, statically addressable C# scalar members."""
+
+    lexed = lex_source(source, ".cs")
+    code = lexed.code
+    type_spans = _csharp_type_spans(source)
+
+    values: dict[str, str] = {}
+    namespace_spans = _csharp_namespace_spans(source)
+    for token in lexed.strings:
+        enclosing = sorted(
+            (span for span in type_spans if span[0] < token.start < span[1]),
+            key=lambda span: span[0],
+        )
+        if not enclosing:
+            continue
+        innermost = enclosing[-1]
+        # Type fields are at curly depth zero. A static readonly Uri keeps the
+        # string inside its constructor parentheses, so round depth is allowed.
+        if structural_depth(code, innermost[0] + 1, token.start)[2] != 0:
+            continue
+        declaration_start = max(
+            code.rfind(";", innermost[0] + 1, token.start),
+            code.rfind("{", innermost[0] + 1, token.start),
+            code.rfind("}", innermost[0] + 1, token.start),
+        ) + 1
+        prefix = code[declaration_start:token.start]
+        field = re.search(
+            r"(?P<head>.*?)\b(?P<name>[A-Za-z_]\w*)\s*=\s*"
+            r"(?:new\s*(?:(?:System\s*\.\s*)?Uri\s*)?\(\s*)?@?$",
+            prefix,
+            re.DOTALL,
+        )
+        if field is None:
+            continue
+        modifiers = field.group("head")
+        if not (
+            re.search(r"\bconst\b", modifiers)
+            or (
+                re.search(r"\bstatic\b", modifiers)
+                and re.search(r"\breadonly\b", modifiers)
+            )
+        ):
+            continue
+        type_path = ".".join(span[2] for span in enclosing)
+        namespaces = [
+            span for span in namespace_spans if span[0] < token.start < span[1]
+        ]
+        namespace = max(namespaces, key=lambda span: span[0], default=None)
+        prefix = f"{namespace[2]}." if namespace is not None else ""
+        values[f"{prefix}{type_path}.{field.group('name')}"] = token.contents
+    return values
+
+
+def _csharp_type_spans(source: str) -> list[tuple[int, int, str]]:
+    """Return nested C# type scopes as ``(open, close, local_name)``."""
+
+    code = lex_source(source, ".cs").code
+    type_spans: list[tuple[int, int, str]] = []
+    for match in re.finditer(
+        r"\b(?:class|struct|record(?:\s+class|\s+struct)?)\s+"
+        r"(?P<name>[A-Za-z_]\w*)[^;{}]*\{",
+        code,
+    ):
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is not None:
+            type_spans.append((opening, closing, match.group("name")))
+    return type_spans
+
+
+def _csharp_project_static_index(project_root: Path) -> dict[str, str]:
+    """Build one exact C# static-member index for an analyzer invocation."""
+
+    resolved: dict[str, str] = {}
+    for candidate in project_root.rglob("*.cs"):
+        try:
+            relative = candidate.relative_to(project_root)
+        except ValueError:
+            continue
+        if any(part in EXCLUDED_DIRS for part in relative.parts[:-1]):
+            continue
+        candidate_source = _read_source_text(candidate)
+        resolved.update(_csharp_static_scalars(candidate_source))
+    return resolved
+
+
+def _csharp_reference_candidates(
+    position: int,
+    reference: str,
+    namespace_spans: list[tuple[int, int, str]],
+    type_spans: list[tuple[int, int, str]],
+    *,
+    global_only: bool = False,
+) -> tuple[str, ...]:
+    """Return C# member spellings from nearest lexical scope to global."""
+
+    if global_only:
+        return (reference,)
+    candidates: list[str] = []
+    namespaces = [
+        span
+        for span in namespace_spans
+        if span[0] < position < span[1]
+    ]
+    namespace = max(namespaces, key=lambda span: span[0], default=None)
+    namespace_name = namespace[2] if namespace is not None else ""
+    enclosing_types = sorted(
+        (
+            span
+            for span in type_spans
+            if span[0] < position < span[1]
+        ),
+        key=lambda span: span[0],
+    )
+    for count in range(len(enclosing_types), 0, -1):
+        prefix = ".".join(span[2] for span in enclosing_types[:count])
+        candidates.append(
+            ".".join(part for part in (namespace_name, prefix, reference) if part)
+        )
+    namespace_parts = namespace_name.split(".") if namespace_name else []
+    for count in range(len(namespace_parts), 0, -1):
+        candidates.append(
+            f"{'.'.join(namespace_parts[:count])}.{reference}"
+        )
+    candidates.append(reference)
+    return tuple(dict.fromkeys(candidates))
+
+
 def external_static_values(
-    path: Path, project_root: Path, source: str, suffix: str
+    path: Path,
+    project_root: Path,
+    source: str,
+    suffix: str,
+    csharp_project_values: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Resolve relative named imports to statically exported scalar strings.
 
@@ -12147,28 +12421,26 @@ def external_static_values(
                         )
                     )
     elif suffix == ".py":
-        for match in re.finditer(
-            r"(?m)^\s*from\s+(?P<module>\.*[A-Za-z_][\w.]*)\s+import\s+"
-            r"(?P<members>[^\r\n]+)",
-            visible,
+        for module, exported, local in _python_from_imports(
+            lex_source(source, ".py").code
         ):
-            for member in match.group("members").split(","):
-                parsed = re.fullmatch(
-                    r"\s*(?P<export>[A-Za-z_]\w*)"
-                    r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
-                    member,
+            dots = len(module) - len(module.lstrip("."))
+            module_tail = module[dots:].replace(".", "/")
+            relative = "../" * max(0, dots - 1) + module_tail
+            imports.append(
+                (
+                    "./" + relative if dots else module,
+                    exported,
+                    local,
                 )
-                if parsed is not None:
-                    dots = len(match.group("module")) - len(match.group("module").lstrip("."))
-                    module_tail = match.group("module")[dots:].replace(".", "/")
-                    relative = "../" * max(0, dots - 1) + module_tail
-                    imports.append(
-                        (
-                            "./" + relative if dots else match.group("module"),
-                            parsed.group("export"),
-                            parsed.group("local") or parsed.group("export"),
-                        )
-                    )
+            )
+    elif suffix == ".cs":
+        project_values = (
+            csharp_project_values
+            if csharp_project_values is not None
+            else _csharp_project_static_index(project_root)
+        )
+        return project_values
 
     resolved: dict[str, str] = {}
     for module, exported, local in imports:
@@ -12310,14 +12582,12 @@ def external_reference_names(
                 if parsed is not None:
                     names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
     elif suffix == ".py":
-        for match in re.finditer(r"(?m)^\s*from\s+[\w.]+\s+import\s+([^\r\n]+)", visible):
-            for member in match.group(1).split(","):
-                parsed = re.fullmatch(
-                    r"\s*([A-Za-z_]\w*)(?:\s+as\s+([A-Za-z_]\w*))?\s*",
-                    member,
-                )
-                if parsed is not None:
-                    names.add(parsed.group(2) or parsed.group(1))
+        names.update(
+            local
+            for _, _, local in _python_from_imports(
+                lex_source(source, ".py").code
+            )
+        )
         for match in re.finditer(
             r"(?m)^\s*import\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)"
             r"(?:\s+as\s+([A-Za-z_]\w*))?",
@@ -12353,7 +12623,11 @@ def external_reference_names(
     return names
 
 
-def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
+def analyze_file(
+    path: Path,
+    project_root: Path,
+    csharp_project_values: dict[str, str] | None = None,
+) -> tuple[int, list[str]]:
     # newline="" is required: Path.read_text() performs universal-newline
     # translation, destroying bare-CR and CRLF source boundaries before the
     # lexer and grep-line protocol can agree on them.
@@ -12382,7 +12656,13 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source_resolver = SourceEndpointResolver(
         lexed,
         suffix,
-        external_static_values(path, project_root, source, suffix),
+        external_static_values(
+            path,
+            project_root,
+            source,
+            suffix,
+            csharp_project_values,
+        ),
         external_reference_names(source, suffix, project_root),
     )
     profile_resolver = PayloadStateResolver(
@@ -12651,9 +12931,12 @@ def main(argv: list[str]) -> int:
 
     total = 0
     missing: list[str] = []
+    csharp_project_values = _csharp_project_static_index(project_root)
     for path in iter_source_files(project_root):
         try:
-            file_total, file_missing = analyze_file(path, project_root)
+            file_total, file_missing = analyze_file(
+                path, project_root, csharp_project_values
+            )
         except Exception as error:  # noqa: BLE001 - one file must not abort the scan
             # A pathological file previously took the WHOLE run down, so every
             # other file went unanalysed and the project was reported clean.

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1007,6 +1007,162 @@ def _heredoc_langs(suffix: str) -> bool:
     return suffix in {".sh", ".php", ".rb"}
 
 
+_JS_REGEX_PREFIX_WORDS = {
+    "await",
+    "break",
+    "case",
+    "continue",
+    "debugger",
+    "delete",
+    "do",
+    "else",
+    "in",
+    "instanceof",
+    "new",
+    "of",
+    "return",
+    "throw",
+    "typeof",
+    "void",
+    "yield",
+}
+_JS_CONTROL_PAREN_WORDS = {"catch", "for", "if", "switch", "while", "with"}
+
+
+def _previous_code_index(code: list[str], before: int) -> int | None:
+    for index in range(before - 1, -1, -1):
+        if not code[index].isspace():
+            return index
+    return None
+
+
+def _word_before(code: list[str], before: int) -> str:
+    end = before
+    start = end
+    while start > 0 and (code[start - 1].isalnum() or code[start - 1] in "_$"):
+        start -= 1
+    return "".join(code[start:end])
+
+
+def _javascript_control_paren(code: list[str], closing: int) -> bool:
+    """Whether `closing` ends a control header after which a statement starts."""
+
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == ")":
+            depth += 1
+        elif code[index] == "(":
+            depth -= 1
+            if depth == 0:
+                previous = _previous_code_index(code, index)
+                return (
+                    previous is not None
+                    and _word_before(code, previous + 1).lower()
+                    in _JS_CONTROL_PAREN_WORDS
+                )
+    return False
+
+
+def _javascript_block_brace(code: list[str], closing: int) -> bool:
+    """Conservatively identify a closing statement/class/function block."""
+
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == "}":
+            depth += 1
+        elif code[index] == "{":
+            depth -= 1
+            if depth != 0:
+                continue
+            previous = _previous_code_index(code, index)
+            if previous is None:
+                return True
+            if code[previous] == ")":
+                return True
+            if code[previous] == ">" and previous > 0 and code[previous - 1] == "=":
+                return True
+            return _word_before(code, previous + 1).lower() in {
+                "class",
+                "do",
+                "else",
+                "finally",
+                "function",
+                "try",
+            }
+    return False
+
+
+def _javascript_regex_can_start(
+    source: str, code: list[str], index: int, last_opaque_end: int
+) -> bool:
+    """Approximate ECMAScript's regexp lexical goal from the preceding token.
+
+    JavaScript uses the same slash for division and regexp literals. The
+    distinction is grammatical: a regexp can begin where an expression is
+    expected, but not after an operand. `code` already has earlier comments and
+    literals blanked, while `last_opaque_end` prevents a preceding string,
+    template, or regexp operand from disappearing from that decision.
+    """
+
+    previous = _previous_code_index(code, index)
+    if last_opaque_end and (previous is None or previous < last_opaque_end):
+        if all(character.isspace() for character in code[last_opaque_end:index]):
+            return False
+    if previous is None:
+        return True
+
+    character = code[previous]
+    if (
+        character == "<"
+        and previous == index - 1
+        and index + 1 < len(source)
+        and (source[index + 1].isalpha() or source[index + 1] in "_$>")
+    ):
+        # JSX closing tags (`</Panel>` and `</>`) are markup delimiters, not a
+        # regexp in the expression position that `<` would otherwise permit.
+        return False
+    if character in "([,;:=!?&|^~<>*%":
+        return True
+    if character in "+-":
+        return previous == 0 or code[previous - 1] != character
+    if character == ")":
+        return _javascript_control_paren(code, previous)
+    if character == "}":
+        return _javascript_block_brace(code, previous)
+    if character.isalnum() or character in "_$":
+        return _word_before(code, previous + 1).lower() in _JS_REGEX_PREFIX_WORDS
+    return False
+
+
+def _javascript_regex_end(source: str, start: int) -> int | None:
+    """Return the end of a valid-looking JS regexp literal, including flags."""
+
+    if source.startswith(("//", "/*"), start):
+        return None
+    index = start + 1
+    in_class = False
+    while index < len(source):
+        character = source[index]
+        if character in {"\r", "\n", "\u2028", "\u2029"}:
+            return None
+        if character == "\\":
+            index += 2
+            continue
+        if character == "[":
+            in_class = True
+        elif character == "]" and in_class:
+            in_class = False
+        elif character == "/" and not in_class:
+            index += 1
+            while index < len(source) and (
+                source[index].isalpha() or source[index] in "_$"
+            ):
+                index += 1
+            return index
+        index += 1
+    return None
+
+
 def lex_source(source: str, suffix: str) -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
@@ -1017,8 +1173,24 @@ def lex_source(source: str, suffix: str) -> LexedSource:
     c_block_comments = c_line_comments
     hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
     index = 0
+    last_js_opaque_end = 0
 
     while index < len(source):
+        if (
+            suffix in JS_TS_SUFFIXES
+            and source[index] == "/"
+            and _javascript_regex_can_start(
+                source, code, index, last_js_opaque_end
+            )
+        ):
+            regex_end = _javascript_regex_end(source, index)
+            if regex_end is not None:
+                _blank(code, index, regex_end)
+                _blank(without_comments, index, regex_end)
+                last_js_opaque_end = regex_end
+                index = regex_end
+                continue
+
         if c_block_comments and source.startswith("/*", index):
             end = source.find("*/", index + 2)
             end = len(source) if end < 0 else end + 2
@@ -1170,6 +1342,8 @@ def lex_source(source: str, suffix: str) -> LexedSource:
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
+        if suffix in JS_TS_SUFFIXES:
+            last_js_opaque_end = index
 
     return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -74,6 +74,8 @@ SUFFIX_LANGUAGE_ALIASES = {
     ".svelte": ".js",
     ".astro": ".js",
     ".erb": ".rb",
+    ".ejs": ".js",
+    ".jsp": ".java",
 }
 INCLUDED_SUFFIXES = {
     ".cs",
@@ -120,8 +122,281 @@ def canonical_suffix(path: Path) -> str:
     """Return the language suffix a file should be analysed as."""
     suffix = path.suffix.lower()
     if not suffix:
+        if path.name.lower() == "rakefile":
+            return ".rb"
         return shebang_suffix(path) or ""
+    # Component files can opt into TypeScript inside their script block. Keep
+    # that grammar mode: treating `as const` as JavaScript can make endpoint
+    # resolution fail while provenance still consumes the literal, silently
+    # certifying a required-profile send.
+    # Astro frontmatter is TypeScript-capable by default; JavaScript remains a
+    # valid subset, so using the TS grammar avoids consuming an endpoint literal
+    # while failing to resolve a legal `as const` alias.
+    if suffix == ".astro":
+        return ".ts"
+    if suffix in {".vue", ".svelte"}:
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            source = ""
+        if re.search(
+            r"<script\b[^>]*\blang\s*=\s*(?:(['\"])(?:ts|typescript)\1|(?:ts|typescript)(?=\s|>))",
+            source,
+            re.I,
+        ):
+            return ".ts"
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
+
+
+def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
+    """Preserve offsets/newlines while retaining only executable ranges."""
+    keep = bytearray(len(source))
+    for start, end in ranges:
+        keep[start:end] = b"\x01" * (end - start)
+    return "".join(
+        char if char in "\r\n" or keep[index] else " "
+        for index, char in enumerate(source)
+    )
+
+
+def _balanced_brace_ranges(source: str, openings: list[int]) -> list[tuple[int, int]]:
+    """Return quote-aware inner spans for balanced template expressions."""
+
+    ranges: list[tuple[int, int]] = []
+    for opening in openings:
+        depth = 0
+        quote = ""
+        escaped = False
+        for index in range(opening, len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+                continue
+            if character in {"'", '"', "`"}:
+                quote = character
+            elif character == "{":
+                depth += 1
+            elif character == "}":
+                depth -= 1
+                if depth == 0:
+                    ranges.append((opening + 1, index))
+                    break
+    return ranges
+
+
+def _balanced_parenthesis_ranges(
+    source: str, openings: list[int]
+) -> list[tuple[int, int]]:
+    """Return quote-aware inner spans for balanced parenthesized expressions."""
+
+    ranges: list[tuple[int, int]] = []
+    for opening in openings:
+        depth = 0
+        quote = ""
+        escaped = False
+        for index in range(opening, len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+                continue
+            if character in {"'", '"', "`"}:
+                quote = character
+            elif character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+                if depth == 0:
+                    ranges.append((opening + 1, index))
+                    break
+    return ranges
+
+
+def _javascript_template_expression_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable `${...}` spans inside one JavaScript template literal."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("${", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        probe = marker - 1
+        while probe >= start and source[probe] == "\\":
+            backslashes += 1
+            probe -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        balanced = _balanced_brace_ranges(source, [marker + 1])
+        if not balanced or balanced[0][1] > end:
+            break
+        ranges.append(balanced[0])
+        cursor = balanced[0][1] + 1
+    return ranges
+
+
+def executable_source(path: Path, source: str) -> str:
+    """Extract executable host-language regions from mixed template files."""
+    suffix = path.suffix.lower()
+    ranges: list[tuple[int, int]] = []
+    if suffix in {".vue", ".svelte", ".astro"}:
+        # Comments may contain complete, syntactically valid examples. Preserve
+        # their offsets/newlines but remove their contents before discovering
+        # script blocks, handlers, interpolations, or balanced expressions.
+        template_source = re.sub(
+            r"<!--.*?-->",
+            lambda match: "".join(
+                char if char in "\r\n" else " " for char in match.group(0)
+            ),
+            source,
+            flags=re.DOTALL,
+        )
+        ranges.extend(
+            match.span(1)
+            for match in re.finditer(
+                r"<script\b[^>]*>(.*?)</script\s*>", template_source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+        )
+        if suffix == ".astro":
+            frontmatter = re.match(
+                r"\A\s*---\s*\r?\n(.*?)\r?\n---(?:\s*\r?\n|\Z)",
+                template_source,
+                re.DOTALL,
+            )
+            if frontmatter:
+                ranges.append(frontmatter.span(1))
+        if suffix == ".vue":
+            ranges.extend(
+                match.span("expression")
+                for match in re.finditer(
+                    r"(?:v-on:[\w:-]+|@[\w:-]+)(?:\.[\w-]+)*\s*=\s*"
+                    r"(?P<quote>['\"])(?P<expression>.*?)(?P=quote)",
+                    template_source,
+                    re.DOTALL,
+                )
+            )
+            # Vue interpolations may contain nested object literals. A
+            # non-greedy regex leaves such calls unterminated; balance the
+            # entire double-brace region and retain its inner expression.
+            for opening in (
+                match.start() for match in re.finditer(r"\{\{", template_source)
+            ):
+                balanced = _balanced_brace_ranges(template_source, [opening])
+                if balanced:
+                    _, closing = balanced[0]
+                    ranges.append((opening + 2, closing - 1))
+        else:
+            # Svelte event handlers / expressions and Astro template
+            # expressions are executable JavaScript outside <script> too.
+            # Preserve their complete balanced spans, including nested payload
+            # objects, rather than stopping at the first closing brace.
+            expression_source = re.sub(
+                r"<style\b[^>]*>.*?</style\s*>",
+                lambda match: "".join(
+                    char if char in "\r\n" else " " for char in match.group(0)
+                ),
+                template_source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            openings = [
+                match.start()
+                for match in re.finditer(r"\{", expression_source)
+            ]
+            ranges.extend(_balanced_brace_ranges(expression_source, openings))
+    elif suffix == ".cshtml":
+        # Razor is a mixed HTML/C# template. Retain explicit expressions,
+        # statement/code blocks, and single-line directives while blanking page
+        # markup so text such as `<p>VoiceResponse()</p>` is not treated as C#.
+        brace_openings = [
+            match.end() - 1
+            for match in re.finditer(
+                r"(?<!@)@(?:\s*|(?:code|functions)\s*)\{",
+                source,
+                flags=re.IGNORECASE,
+            )
+        ]
+        brace_openings.extend(
+            match.end() - 1
+            for match in re.finditer(
+                r"(?<!@)@(?:if|for|foreach|while|switch|try|catch|finally|using|lock)\b[^{}]*\{",
+                source,
+                flags=re.IGNORECASE,
+            )
+        )
+        ranges.extend(_balanced_brace_ranges(source, brace_openings))
+        paren_openings = [
+            match.end() - 1
+            for match in re.finditer(r"(?<!@)@\s*\(", source)
+        ]
+        ranges.extend(_balanced_parenthesis_ranges(source, paren_openings))
+        ranges.extend(
+            match.span()
+            for match in re.finditer(
+                r"(?m)^\s*@(?:using|inject|model|inherits|implements|namespace|addTagHelper|removeTagHelper|tagHelperPrefix)\b[^\r\n]*",
+                source,
+            )
+        )
+    elif suffix == ".phtml":
+        # PHTML is a mixed HTML/PHP template, not a plain PHP source file.
+        # Feeding its markup to the PHP lexer lets an apostrophe in page text
+        # open a string that masks a later request inside <?php ... ?>.
+        ranges.extend(
+            match.span(1)
+            for match in re.finditer(
+                r"<\?(?:php\b|=)(.*?)(?:\?>|\Z)",
+                source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+        )
+    elif suffix in {".ejs", ".erb", ".jsp"}:
+        if suffix == ".ejs":
+            # EJS scriptlets execute on the server, while ordinary <script>
+            # blocks execute in the generated browser page. Both can contain
+            # migration-sensitive JavaScript and must remain visible.
+            ranges.extend(
+                match.span(1)
+                for match in re.finditer(
+                    r"<script\b[^>]*>(.*?)</script\s*>", source,
+                    flags=re.IGNORECASE | re.DOTALL,
+                )
+            )
+        for match in re.finditer(
+            r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL
+        ):
+            # ERB/EJS <%# ... %> and JSP <%-- ... --%> are template
+            # comments, not executable scriptlets.
+            if source.startswith(("<%#", "<%--"), match.start()):
+                continue
+            ranges.append(match.span(1))
+    else:
+        return source
+    return _blank_outside_ranges(source, ranges)
+
+
+def backend_executable_source(path: Path, source: str) -> str:
+    """Return executable regions that can declare server-side handlers."""
+    if path.suffix.lower() != ".ejs":
+        return executable_source(path, source)
+    ranges: list[tuple[int, int]] = []
+    for match in re.finditer(r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL):
+        if source.startswith("<%#", match.start()):
+            continue
+        ranges.append(match.span(1))
+    return _blank_outside_ranges(source, ranges)
 # Kept in step with the EXCLUDE_DIRS list in scan-twilio-usage.sh. Generated
 # output belongs here as much as node_modules: a stale compiled bundle under
 # .next carrying a pre-fix number-pool send would fail Phase 4 after the
@@ -612,6 +887,30 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         _blank(code, string_start, index)
+        if delimiter == "`" and suffix in JS_TS_SUFFIXES:
+            # JavaScript template literal text is inert, but every `${...}`
+            # interpolation is executable JavaScript. Recursively lex those
+            # spans and restore their code/comments at the original offsets.
+            # Nested string tokens are recorded before the enclosing template
+            # token so lookups inside an interpolation select the narrow token.
+            for expression_start, expression_end in _javascript_template_expression_ranges(
+                source, contents_start, contents_end
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
@@ -3517,13 +3816,20 @@ def client_base_url(lexed: LexedSource, call: Call, suffix: str) -> str | None:
             return base
 
     if receiver is None:
-        region = _paren_group_span_before_accessor(lexed, call)
-        return _base_url_in_region(lexed, region) if region is not None else None
+        # `axios.post(...)` has no client instance receiver. Use the dotted
+        # callee prefix so `axios.defaults.baseURL = ...` participates in the
+        # same member-assignment resolution as an axios instance.
+        prefix = re.split(r"->|::|\.", callee)[0] if "." in callee else ""
+        if prefix and re.fullmatch(r"[a-z_]\w*", prefix):
+            receiver = prefix
+        else:
+            region = _paren_group_span_before_accessor(lexed, call)
+            return _base_url_in_region(lexed, region) if region is not None else None
 
-    # C# commonly configures HttpClient in a separate member assignment:
-    # `client.BaseAddress = new Uri("..."); client.PostAsync(path, ...)`.
+    # C# and Axios both support assigning a base URL after construction.
     member_base_pattern = re.compile(
-        rf"\b{re.escape(receiver)}\s*\.\s*BaseAddress\s*="
+        rf"\b{re.escape(receiver)}\s*\.\s*"
+        rf"(?:BaseAddress|(?:defaults\s*\.\s*)?base[Uu][Rr][LlIi]?)\s*="
     )
     member_base = list(
         member_base_pattern.finditer(lexed.code, 0, call.start)
@@ -8787,7 +9093,7 @@ def iter_source_files(project_root: Path):
                 continue
             path = Path(directory, filename)
             suffix = path.suffix.lower()
-            if suffix in INCLUDED_SUFFIXES:
+            if suffix in INCLUDED_SUFFIXES or filename.lower() == "rakefile":
                 yield path
             elif not suffix and shebang_suffix(path) is not None:
                 yield path
@@ -9630,12 +9936,13 @@ def required_path_tokens(lexed: LexedSource) -> list[StringToken]:
         tail = token.contents.rstrip("/")
         if re.search(r"\s", tail):
             continue
-        if (
-            required_endpoint(token.contents)
-            or tail.endswith("messages/number_pool")
-            or tail.endswith("messages/alphanumeric_sender_id")
-            or re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
-        ):
+        template_endpoint = re.fullmatch(
+            r"(?:\$\{[^{}\s]+\}|#\{[^{}\s]+\}|\{[^{}\s]+\})"
+            r"(?:/v2)?/messages/(?:number_pool|alphanumeric_sender_id)/?"
+            r"(?:[?#][^\s]*)?",
+            tail,
+        )
+        if required_endpoint(token.contents) or template_endpoint:
             found.append(token)
     return found
 
@@ -9752,27 +10059,19 @@ def unresolved_endpoint_tokens(
     file either way.
     """
     consumed: set[tuple[int, int]] = set()
-    unexplained_calls = 0
     for call in analysed_calls:
         tokens = consumed_endpoint_tokens(lexed, call, suffix)
         if tokens:
             consumed |= tokens
-        else:
-            # The analyzer resolved this call's endpoint through a path this
-            # consumption model does not mirror - a destructuring default, an
-            # interprocedural alias, a computed member. It still ACCOUNTED for
-            # one endpoint, so it explains one otherwise-unconsumed literal.
-            # Budgeting them this way keeps two independent sends independent:
-            # a file with two endpoint literals and one resolved call still
-            # reports the second.
-            unexplained_calls += 1
     candidates = [
         token
         for token in required_path_tokens(lexed)
         if (token.start, token.end) not in consumed
         and _looks_like_a_send_target(lexed, token, suffix)
     ]
-    return candidates[unexplained_calls:] if unexplained_calls else candidates
+    # Never use one call as a positional "budget" for an unrelated literal.
+    # Only provenance from that exact call may consume a candidate endpoint.
+    return candidates
 
 
 # A required path can appear WITHOUT being a request target: as a curl -d body,
@@ -9855,6 +10154,14 @@ _NOT_A_CALL_VERB_RE = re.compile(
     r"|catch|except|with|return|and|or|not|in|is)$",
     re.I,
 )
+_READ_VERB_RE = re.compile(
+    r"^(?:get|head|options|read|download|list|find|query)(?:Async)?$", re.I
+)
+_ASSERTION_VERB_RE = re.compile(
+    r"^(?:expect|assert\w*|should|toBe|toEqual|toHaveBeenCalledWith"
+    r"|assertEqual|assertIn|is_expected)$",
+    re.I,
+)
 # A display STATEMENT has no parentheses to enclose the literal: `<?php echo
 # "$url"`, `then echo "$url"`.
 _DISPLAY_STATEMENT_RE = re.compile(
@@ -9870,6 +10177,30 @@ _CALLEE_SPLIT_RE = re.compile(r"\s*(?:->|::|\?\.|\.)\s*")
 _CALLEE_TAIL_RE = re.compile(
     r"[A-Za-z_$][\w$]*(?:\s*(?:->|::|\?\.|\.)\s*[A-Za-z_$][\w$]*)*$"
 )
+
+
+def _enclosing_call_verbs(lexed: LexedSource, position: int) -> list[str]:
+    """Return innermost-to-outermost unclosed call verbs at `position`."""
+
+    window_start = max(0, position - 600)
+    prefix = lexed.code[window_start:position]
+    depth = 0
+    verbs: list[str] = []
+    for index in range(len(prefix) - 1, -1, -1):
+        char = prefix[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth:
+                depth -= 1
+                continue
+            if char != "(":
+                continue
+            head = lexed.original[window_start:window_start + index].rstrip()
+            match = _CALLEE_TAIL_RE.search(head)
+            if match is not None:
+                verbs.append(_CALLEE_SPLIT_RE.split(match.group(0))[-1])
+    return verbs
 
 
 def _enclosing_call_verb(lexed: LexedSource, position: int) -> str:
@@ -9991,6 +10322,28 @@ def _looks_like_a_send_target(
             if _SEND_SITE_RE.search(line):
                 return True
         return False
+    # Use the lexical call enclosure before falling back to a physical line.
+    # A custom request call commonly wraps its URL onto the next line; limiting
+    # this check to the URL's line silently certified such unknown clients.
+    # The nearest call can be a helper nested inside an OUTER assertion, e.g.
+    # `assertTrue(required_endpoint(URL))`. Consider every enclosing call before
+    # treating the innermost unknown helper as a send.
+    if any(
+        _ASSERTION_VERB_RE.match(verb)
+        for verb in _enclosing_call_verbs(lexed, token.start)
+    ):
+        return False
+    enclosing_verb = _enclosing_call_verb(lexed, token.start)
+    if enclosing_verb:
+        if (
+            _DISPLAY_VERB_RE.match(enclosing_verb)
+            or _INSPECTION_VERB_RE.match(enclosing_verb)
+            or _NOT_A_CALL_VERB_RE.match(enclosing_verb)
+            or _READ_VERB_RE.match(enclosing_verb)
+            or _ASSERTION_VERB_RE.match(enclosing_verb)
+        ):
+            return False
+        return True
     # Otherwise require a request-like call on the same logical line, and NOT a
     # display command, which is how prose mentions reach the source.
     line_start = lexed.code.rfind("\n", 0, token.start) + 1
@@ -10045,6 +10398,7 @@ def _looks_like_a_send_target(
 
 def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = path.read_text(encoding="utf-8", errors="replace")
+    source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
     sdk_calls = calls_matching(lexed, SDK_CALL_RE)
@@ -10185,10 +10539,50 @@ def region_has_message_body(
     return False
 
 
-def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
+def call_belongs_to_kept_product(
+    lexed: LexedSource,
+    call: Call,
+    kept_products: set[str],
+    pattern: re.Pattern[str],
+) -> bool:
+    """Recognize product-qualified calls that intentionally remain on Twilio."""
+
+    call_head = lexed.code[call.start:call.open_paren]
+    # A retained Twilio Messaging client uses messages.create({body: ...}).
+    # Do not waive Telnyx-only messages.send({body: ...}) calls in the same
+    # hybrid file.
+    if pattern is MESSAGE_BODY_CALL_RE and "messaging" in kept_products and re.search(
+        r"\bcreate\s*$", call_head, re.IGNORECASE
+    ):
+        return True
+
+    if "conversations" not in kept_products and "conversation" not in kept_products:
+        return False
+
+    # Bind the waiver to the immediate receiver of `.messages`, not to any
+    # conversation-looking identifier earlier on the line. Preserve newlines
+    # inside a fluent `client.conversations(id)\n  .messages.create(...)` chain.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        lexed.code.rfind("{", 0, call.start),
+        lexed.code.rfind("}", 0, call.start),
+    ) + 1
+    receiver = lexed.code[statement_start:call.start].strip()
+    return bool(
+        re.search(r"(?:^|[^\w$])(?:conversation|channel)\s*$", receiver, re.I)
+        or re.search(
+            r"\.\s*conversations?\s*\([^;{}]*\)\s*$", receiver, re.I
+        )
+    )
+
+
+def message_body_fields(
+    path: Path, pattern: re.Pattern[str], kept_products: set[str] | None = None
+) -> list[str]:
     """Return real top-level body fields from selected messaging calls."""
 
     source = path.read_text(encoding="utf-8", errors="replace")
+    source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
     source_resolver = SourceEndpointResolver(lexed, suffix)
@@ -10201,6 +10595,10 @@ def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
     )
     matches: list[str] = []
     for call in calls_matching(lexed, pattern):
+        if call_belongs_to_kept_product(
+            lexed, call, kept_products or set(), pattern
+        ):
+            continue
         states = [
             resolver.span_presence(start, end, call.start)
             for start, end in payload_spans(
@@ -10221,22 +10619,43 @@ def main(argv: list[str]) -> int:
         "--twilio-body-fields": TWILIO_MESSAGE_CREATE_RE,
         "--message-body-fields": MESSAGE_BODY_CALL_RE,
     }
-    if len(argv) == 3 and argv[1] in source_modes:
-        project_root = Path(argv[2]).resolve()
+    if len(argv) in {3, 5} and argv[1] in source_modes:
+        kept_products: set[str] = set()
+        if len(argv) == 5:
+            if argv[2] != "--kept-products":
+                print("Error: expected --kept-products", file=sys.stderr)
+                return 2
+            kept_products = {
+                product.strip().lower()
+                for product in argv[3].split(",")
+                if product.strip()
+            }
+        project_root = Path(argv[-1]).resolve()
         if not project_root.is_dir():
             print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
             return 2
-        findings = [
-            finding
-            for path in iter_source_files(project_root)
-            for finding in message_body_fields(path, source_modes[argv[1]])
-        ]
+        findings: list[str] = []
+        for path in iter_source_files(project_root):
+            try:
+                findings.extend(
+                    message_body_fields(path, source_modes[argv[1]], kept_products)
+                )
+            except Exception as error:  # noqa: BLE001 - fail safe per file
+                findings.append(
+                    finding_row(
+                        path,
+                        1,
+                        f"  [could not analyze this file "
+                        f"({type(error).__name__}) - verify body fields manually]",
+                    )
+                )
         print("\n".join(findings))
         return 0
     if len(argv) != 2:
         print(
             f"Usage: {Path(argv[0]).name} "
-            "[--twilio-body-fields|--message-body-fields] <project-root>",
+            "[--twilio-body-fields|--message-body-fields] "
+            "[--kept-products <csv>] <project-root>",
             file=sys.stderr,
         )
         return 2

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -10898,16 +10898,95 @@ def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
 
     lexed = lex_source(source, suffix)
     visible = lexed.without_comments
-    escaped = re.escape(name)
     if suffix in JS_TS_SUFFIXES:
-        assignment = re.search(
+        def literal(
+            pattern: str, separator: str = r"\s*=\s*"
+        ) -> str | None:
+            match = re.search(
+                pattern
+                + separator
+                + r"(?P<quote>['\"`])(?P<value>.*?)(?P=quote)",
+                visible,
+                re.S,
+            )
+            if match is None:
+                return None
+            value = match.group("value")
+            if match.group("quote") == "`" and "${" in value:
+                return None
+            return value
+
+        def local_literal(local: str) -> str | None:
+            escaped_local = re.escape(local)
+            return literal(
+                rf"\b(?:const|let|var)\s+{escaped_local}"
+            )
+
+        if name == "default":
+            direct = literal(r"\bexport\s+default", r"\s+")
+            if direct is None:
+                direct = literal(
+                    r"(?:\b(?:module\s*\.\s*)?exports\s*\.\s*default|"
+                    r"\bmodule\s*\.\s*exports)"
+                )
+            if direct is not None:
+                return direct
+            alias = re.search(
+                r"(?:\bexport\s+default\s+"
+                r"|\bmodule\s*\.\s*exports\s*=\s*"
+                r"|\b(?:module\s*\.\s*)?exports\s*\.\s*default\s*=\s*)"
+                r"(?P<local>[A-Za-z_$]\w*)\b"
+                r"|\bexport\s*\{\s*(?P<braced>[A-Za-z_$]\w*)"
+                r"\s+as\s+default\s*\}",
+                visible,
+            )
+            if alias is not None:
+                return local_literal(alias.group("local") or alias.group("braced"))
+            for export_list in re.finditer(
+                r"\bexport\s*\{(?P<members>[^{}]*)\}", visible
+            ):
+                for member in export_list.group("members").split(","):
+                    parsed = re.fullmatch(
+                        r"\s*(?P<local>[A-Za-z_$]\w*)\s+as\s+default\s*",
+                        member,
+                    )
+                    if parsed is not None:
+                        return local_literal(parsed.group("local"))
+            return None
+        if name == "<module>":
+            direct = literal(r"\bmodule\s*\.\s*exports")
+            if direct is not None:
+                return direct
+            alias = re.search(
+                r"\bmodule\s*\.\s*exports\s*=\s*"
+                r"(?P<local>[A-Za-z_$]\w*)\b",
+                visible,
+            )
+            return local_literal(alias.group("local")) if alias is not None else None
+
+        escaped = re.escape(name)
+        direct = literal(
             rf"(?:\bexport\s+(?:const|let|var)\s+{escaped}"
             rf"|\b(?:module\s*\.\s*)?exports\s*\.\s*{escaped})"
-            r"\s*=\s*(['\"])(?P<value>.*?)\1",
-            visible,
-            re.S,
         )
+        if direct is not None:
+            return direct
+        for export_list in re.finditer(
+            r"\bexport\s*\{(?P<members>[^{}]*)\}", visible
+        ):
+            for member in export_list.group("members").split(","):
+                parsed = re.fullmatch(
+                    rf"\s*(?P<local>[A-Za-z_$]\w*)"
+                    rf"(?:\s+as\s+{escaped})?\s*",
+                    member,
+                )
+                if parsed is not None and (
+                    " as " in member or parsed.group("local") == name
+                ):
+                    return local_literal(parsed.group("local"))
+        return None
     elif suffix == ".py":
+        escaped = re.escape(name)
         assignment = re.search(
             rf"(?m)^[ \t]*{escaped}\s*=\s*(['\"])(?P<value>.*?)\1",
             visible,
@@ -10931,7 +11010,17 @@ def external_static_values(
     imports: list[tuple[str, str, str]] = []
     if suffix in JS_TS_SUFFIXES:
         for match in re.finditer(
-            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
+            r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
+            r"from\s*(['\"])(?P<module>\.[^'\"]*)\2",
+            visible,
+        ):
+            imports.append(
+                (match.group("module"), "default", match.group("local"))
+            )
+        for match in re.finditer(
+            r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+            r"\{(?P<members>[^{}]*)\}\s*from\s*"
             r"(['\"])(?P<module>\.[^'\"]*)\2",
             visible,
         ):
@@ -10949,6 +11038,19 @@ def external_static_values(
                             parsed.group("local") or parsed.group("export"),
                         )
                     )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+(?P<local>[A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)"
+            r"(?P<default>\s*\.\s*default)?",
+            visible,
+        ):
+            imports.append(
+                (
+                    match.group("module"),
+                    "default" if match.group("default") else "<module>",
+                    match.group("local"),
+                )
+            )
         for match in re.finditer(
             r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
             r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)",
@@ -11022,8 +11124,18 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
     visible = lex_source(source, suffix).without_comments
     names: set[str] = set()
     if suffix in JS_TS_SUFFIXES:
+        names.update(
+            match.group("local")
+            for match in re.finditer(
+                r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
+                r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
+                r"from\s*(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
         for match in re.finditer(
-            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+            r"\{(?P<members>[^{}]*)\}\s*from\s*"
             r"(['\"])\.[^'\"]*\2",
             visible,
         ):
@@ -11037,7 +11149,8 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
         names.update(
             match.group(1)
             for match in re.finditer(
-                r"\bimport\s+\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
+                r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+                r"\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
                 r"(['\"])\.[^'\"]*\2",
                 visible,
             )

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -2872,21 +2872,59 @@ def ruby_request_body_spans(
     arrives in a later statement as `req.body = ...`, so the constructor's own
     arguments never reveal it.
     """
-    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    # Ruby permits several statements on one line.  Starting at the physical
+    # line boundary makes `uri = ...; req = Post.new(uri)` bind the request to
+    # `uri`, and reading the body through the next newline absorbs every later
+    # compact statement.  Use logical statement boundaries in both directions.
+    line_start = max(
+        lexed.code.rfind("\n", 0, call.start),
+        lexed.code.rfind(";", 0, call.start),
+    ) + 1
     binding = re.search(
-        r"([A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+        r"(?<![\w@$.])((?:@@|@|\$)?[A-Za-z_]\w*)\s*=",
+        lexed.code[line_start:call.start],
     )
     if binding is None:
         return []
     name = re.escape(binding.group(1))
-    match = re.search(
-        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*", lexed.code[call.end:]
+    local_binding = not binding.group(1).startswith(("@", "$"))
+    ruby_spans = _ruby_function_spans(lexed.code)
+
+    # A later body assignment is relevant only if it reaches the execution of
+    # THIS request in the SAME Ruby method.  Without both bounds, a helper's
+    # body assignment could satisfy a top-level send, or an assignment after
+    # `http.request(req)` could retroactively make the already-issued request
+    # look compliant.
+    execution_pattern = re.compile(
+        rf"\.\s*request\s*(?:\(\s*{name}\b|[ \t]+{name}\b)"
     )
-    if match is None:
+    execution_offset = None
+    for execution in execution_pattern.finditer(lexed.code, call.end):
+        if not local_binding or _same_ruby_function_scope(
+            lexed.code, call.start, execution.start(), ruby_spans
+        ):
+            execution_offset = execution.start()
+            break
+    if execution_offset is None:
         return []
-    start = call.end + match.end()
-    end = lexed.code.find("\n", start)
-    span = (start, end if end > 0 else len(lexed.code))
+
+    body_pattern = re.compile(
+        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*"
+    )
+    assignments = [
+        match
+        for match in body_pattern.finditer(
+            lexed.code, call.end, execution_offset
+        )
+        if not local_binding
+        or _same_ruby_function_scope(
+            lexed.code, call.start, match.start(), ruby_spans
+        )
+    ]
+    if not assignments:
+        return []
+    start = assignments[-1].end()
+    span = (start, assignment_end(lexed, start, suffix))
     return [resolve_wrapped_payload(lexed, span, span[0], suffix)]
 
 
@@ -4270,35 +4308,166 @@ _EXECUTION_LINK_RE = {
 _INLINE_EXECUTION_RE = re.compile(
     # The constructor may be namespaced inside the execution call, as in
     # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
-    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
+    r"(?:urlopen|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
     r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
 )
 
 
 def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
-    """Return conservative Ruby `def ... end` spans from masked source."""
+    """Return Ruby local-scope spans for methods, classes, and modules."""
 
     stack: list[tuple[str, int | None]] = []
     spans: list[tuple[int, int]] = []
-    cursor = 0
-    for line in code.splitlines(keepends=True):
-        stripped = line.strip()
+    # Newlines and semicolons are equivalent Ruby statement separators.  The
+    # old line-only stack leaked executions from `def f; ...; end` into top
+    # level and ignored endless methods (`def f = expr`) altogether.
+    boundaries = list(re.finditer(r"[;\r\n]", code))
+    pieces: list[tuple[int, int, int]] = []
+    start = 0
+    for boundary in boundaries:
+        pieces.append((start, boundary.start(), boundary.end()))
+        start = boundary.end()
+    pieces.append((start, len(code), len(code)))
+
+    for statement_start, statement_end, terminated_end in pieces:
+        statement = code[statement_start:statement_end]
+        stripped = statement.strip()
+        if not stripped:
+            continue
+        content_start = statement_start + len(statement) - len(statement.lstrip())
         if re.match(r"end\b", stripped) and stack:
-            kind, start = stack.pop()
-            if kind == "def" and start is not None:
-                spans.append((start, cursor + len(line)))
+            kind, opener_start = stack.pop()
+            if kind in {"def", "class", "module"} and opener_start is not None:
+                spans.append((opener_start, terminated_end))
         else:
-            opener = re.match(r"(def|class|module)\b", stripped)
+            opener = re.match(
+                r"(?:(?:private|protected|public)\s+)?(?P<def>def)\b"
+                r"|(?P<container>class|module)\b",
+                stripped,
+            )
             if opener is not None:
-                stack.append((opener.group(1), cursor))
+                kind = "def" if opener.group("def") else opener.group("container")
+                if kind == "def":
+                    separator = top_level_assignment_separator(
+                        stripped, opener.end(), len(stripped)
+                    )
+                    # A setter's name owns its adjacent `=` (`writer=`, `[]=`).
+                    # It is an ordinary `def ... end` unless a SECOND top-level
+                    # `=` follows its parameter list, as in an endless setter.
+                    setter = False
+                    if separator is not None:
+                        left, right = separator
+                        setter = left > 0 and not stripped[left - 1].isspace()
+                        if setter:
+                            later = top_level_assignment_separator(
+                                stripped, right, len(stripped)
+                            )
+                            if later is not None:
+                                separator = later
+                                setter = False
+                    if separator is not None and not setter:
+                        spans.append((content_start, statement_end))
+                        continue
+                stack.append((kind, content_start))
             elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
                 stack.append(("block", None))
             elif re.match(
                 r"(?:if|unless|case|begin|for|while|until)\b", stripped
             ):
                 stack.append(("control", None))
-        cursor += len(line)
     return spans
+
+
+def _enclosing_named_call(
+    code: str, position: int, name: str
+) -> tuple[int, int] | None:
+    """Return `(open, close)` for the innermost named call around position."""
+
+    candidate: tuple[int, int] | None = None
+    pattern = re.compile(rf"\b{re.escape(name)}\s*\(")
+    for match in pattern.finditer(code, 0, position):
+        opening = code.rfind("(", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "(", ")")
+        if closing is not None and opening < position < closing:
+            candidate = (opening, closing)
+    return candidate
+
+
+def _inline_okhttp_is_executed(lexed: LexedSource, call: Call) -> bool:
+    """An inline OkHttp request is live only after execute()/enqueue()."""
+
+    enclosing = _enclosing_named_call(lexed.code, call.start, "newCall")
+    if enclosing is None:
+        return False
+    tail = lexed.code[enclosing[1] + 1 : enclosing[1] + 80]
+    if re.match(
+        r"\s*(?:\?|!!)?\s*\.\s*(?:execute|enqueue)\s*\(", tail
+    ) is not None:
+        return True
+
+    # The Call itself may be stored before execution:
+    #   Call pending = client.newCall(new Request.Builder()...build());
+    #   pending.execute();
+    statement_start = max(
+        lexed.code.rfind(";", 0, enclosing[0]),
+        lexed.code.rfind("\n", 0, enclosing[0]),
+        lexed.code.rfind("{", 0, enclosing[0]),
+    ) + 1
+    prefix = lexed.code[statement_start:enclosing[0]]
+    assignment = re.search(
+        r"(?:(?:final|public|private|protected|static)\s+)*"
+        r"(?:[\w.<>,?\[\]]+\s+)?(?P<alias>[A-Za-z_]\w*)\s*=\s*"
+        r"[^;\n]*\bnewCall\s*$",
+        prefix,
+    )
+    if assignment is None:
+        return False
+    alias = assignment.group("alias")
+    after = enclosing[1] + 1
+    execution = re.search(
+        rf"(?<![\w$]){re.escape(alias)}\s*(?:\?|!!)?\s*\.\s*"
+        rf"(?:execute|enqueue)\s*\(",
+        lexed.code[after:],
+    )
+    if execution is None:
+        return False
+    execution_offset = after + execution.start()
+    return re.search(
+        rf"(?<![\w$]){re.escape(alias)}\s*=(?!=)",
+        lexed.code[after:execution_offset],
+    ) is None
+
+
+def _stored_okhttp_execution_offsets(
+    tail: str, request_name: str
+) -> list[tuple[int, int]]:
+    """`(execution, capture)` offsets for stored OkHttp Call aliases."""
+
+    offsets: list[tuple[int, int]] = []
+    assignment_re = re.compile(
+        rf"(?:^|[;\n{{}}])\s*(?:(?:final|public|private|protected|static)\s+)*"
+        rf"(?:[\w.<>,?\[\]]+\s+)?"
+        rf"(?P<alias>[A-Za-z_]\w*)\s*=\s*[^;\n]*?"
+        rf"\bnewCall\s*\(\s*{re.escape(request_name)}\s*\)"
+    )
+    for assignment in assignment_re.finditer(tail):
+        alias = assignment.group("alias")
+        after = assignment.end()
+        execution = re.search(
+            rf"(?<![\w$]){re.escape(alias)}\s*(?:\?|!!)?\s*\.\s*"
+            rf"(?:execute|enqueue)\s*\(",
+            tail[after:],
+        )
+        if execution is None:
+            continue
+        execution_offset = after + execution.start()
+        rebound = re.search(
+            rf"(?<![\w$]){re.escape(alias)}\s*=(?!=)",
+            tail[after:execution_offset],
+        )
+        if rebound is None:
+            offsets.append((execution_offset, assignment.start()))
+    return offsets
 
 
 def _same_ruby_function_scope(
@@ -4328,7 +4497,13 @@ def request_object_is_executed(
     if pattern is None:
         return True
 
-    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)).
+    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)). OkHttp's
+    # newCall(...) only creates a Call; network I/O begins at execute/enqueue.
+    if canonical == ".java" and _BUILDER_LINK_KIND.get(
+        (id(lexed), call.start)
+    ) == "url":
+        if _inline_okhttp_is_executed(lexed, call):
+            return True
     prefix = lexed.code[max(0, call.start - 160):call.start]
     if _INLINE_EXECUTION_RE.search(prefix):
         return True
@@ -4347,7 +4522,7 @@ def request_object_is_executed(
         # An UNBOUND chain can still be executed inline:
         #   client.send(HttpRequest.newBuilder()...build(), handler)
         return re.search(
-            r"(?:send|sendAsync|newCall|execute|enqueue|urlopen|Do)\s*\(", head
+            r"(?:send|sendAsync|execute|enqueue|urlopen|Do)\s*\(", head
         ) is not None
     # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
     # never the one executed, so every candidate must be tried.
@@ -4372,8 +4547,18 @@ def request_object_is_executed(
         rebound_pattern = re.compile(
             rf"{binding_boundary}{re.escape(name)}\s*=(?!=)"
         )
-        for execution in re.finditer(execution_pattern, tail):
-            execution_offset = call.end + execution.start()
+        execution_events = [
+            (execution.start(), execution.start())
+            for execution in re.finditer(execution_pattern, tail)
+        ]
+        if canonical == ".java":
+            execution_events.extend(
+                _stored_okhttp_execution_offsets(tail, name)
+            )
+        for relative_execution_offset, capture_offset in sorted(
+            set(execution_events)
+        ):
+            execution_offset = call.end + relative_execution_offset
             # Ruby locals belong to one method/top-level scope. Instance,
             # class and global variables retain their identity across methods.
             local_ruby_binding = suffix == ".rb" and not name.startswith(
@@ -4387,7 +4572,9 @@ def request_object_is_executed(
             # every exact-binding assignment before THIS execution; for Ruby
             # locals, assignments in unrelated methods do not rebind it.
             rebound = False
-            for candidate in rebound_pattern.finditer(tail, 0, execution.start()):
+            for candidate in rebound_pattern.finditer(
+                tail, 0, capture_offset
+            ):
                 candidate_offset = call.end + candidate.start()
                 if local_ruby_binding and not _same_ruby_function_scope(
                     lexed.code, call.start, candidate_offset, ruby_spans

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -906,6 +906,68 @@ def _shell_command_substitution_ranges(
     return ranges
 
 
+def _php_closing_tag(source: str, start: int) -> int | None:
+    """Return the next PHP closing tag outside strings/comments/heredocs."""
+
+    index = start
+    quote = ""
+    escaped = False
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if source.startswith("/*", index):
+            closing = source.find("*/", index + 2)
+            index = len(source) if closing < 0 else closing + 2
+            continue
+        heredoc = _heredoc_opener_at(source, index, ".php")
+        if heredoc is not None and source.startswith("<<<", index):
+            body_start = source.find("\n", heredoc.end())
+            if body_start < 0:
+                return None
+            terminator = re.compile(
+                rf"^[ \t]*{re.escape(heredoc.group('tag'))}\b[^\r\n]*",
+                re.MULTILINE,
+            ).search(source, body_start + 1)
+            index = len(source) if terminator is None else terminator.end()
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if source.startswith("?>", index):
+            return index
+        index += 1
+    return None
+
+
+def _php_executable_ranges(source: str) -> list[tuple[int, int]]:
+    """Return PHP code regions with lexical, rather than textual, closers."""
+
+    opener = re.compile(
+        r"<\?(?:php\b|=|(?!(?:xml)\b))",
+        re.IGNORECASE,
+    )
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while match := opener.search(source, cursor):
+        start = match.end()
+        closing = _php_closing_tag(source, start)
+        end = len(source) if closing is None else closing
+        ranges.append((start, end))
+        if closing is None:
+            break
+        cursor = closing + 2
+    return ranges
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
@@ -1037,18 +1099,10 @@ def executable_source(path: Path, source: str) -> str:
         # regions whenever tags are present. Tagless `.php` remains supported
         # because many analyzer fixtures and generated snippets contain raw PHP
         # statements without an opening tag; tagless `.phtml` remains markup.
-        php_ranges = [
-            match.span("code")
-            for match in re.finditer(
-                # Plain ``<?`` is executable when short_open_tag is enabled.
-                # Keep XML declarations out: with short tags disabled they are
-                # markup, and with short tags enabled they make the PHP file
-                # invalid rather than forming a customer request.
-                r"<\?(?:php\b|=|(?!(?:xml)\b))(?P<code>.*?)(?:\?>|\Z)",
-                source,
-                flags=re.IGNORECASE | re.DOTALL,
-            )
-        ]
+        # Plain ``<?`` is executable when short_open_tag is enabled. Keep XML
+        # declarations out, and find closing tags lexically: a textual `?>`
+        # inside a PHP string, block comment, heredoc, or nowdoc is data.
+        php_ranges = _php_executable_ranges(source)
         if (
             suffix == ".php"
             and not php_ranges
@@ -1134,11 +1188,15 @@ PROFILE_IDENTIFIER_RE = re.compile(
     rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
 )
 PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
-SDK_METHOD_PATTERN = (
-    r"sendNumberPool|send_number_pool|SendNumberPool|"
-    r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
-    r"SendWithAlphanumericSender"
+SDK_METHOD_NAMES = (
+    "sendNumberPool",
+    "send_number_pool",
+    "SendNumberPool",
+    "sendWithAlphanumericSender",
+    "send_with_alphanumeric_sender",
+    "SendWithAlphanumericSender",
 )
+SDK_METHOD_PATTERN = "|".join(map(re.escape, SDK_METHOD_NAMES))
 SDK_CALL_RE = re.compile(
     rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
     r"\s*(?:\?\.)?\s*\("
@@ -1601,7 +1659,7 @@ def _javascript_regex_can_start(
         # JSX closing tags (`</Panel>` and `</>`) are markup delimiters, not a
         # regexp in the expression position that `<` would otherwise permit.
         return False
-    if character in "([,;:=!?&|^~<>*%":
+    if character in "([{,;:=!?&|^~<>*%":
         return True
     if character in "+-":
         return previous == 0 or code[previous - 1] != character
@@ -2158,6 +2216,70 @@ def sdk_alias_calls(lexed: LexedSource) -> list[Call]:
             if callable_arg == alias and key not in seen:
                 seen.add(key)
                 calls.append(call)
+    return calls
+
+
+def sdk_computed_calls(lexed: LexedSource, suffix: str) -> list[Call]:
+    """Find JS/TS SDK calls with a statically named bracket member.
+
+    The lexer deliberately blanks string literals, so the direct SDK regex
+    cannot see ``messages['sendNumberPool'](...)``. Recover only exact static
+    method-name tokens that are bracket members on a real receiver. Dynamic
+    lookups and object/array literals remain unresolved rather than being
+    misclassified as SDK sends.
+    """
+
+    if suffix not in JS_TS_SUFFIXES:
+        return []
+
+    code = lexed.code
+    calls: list[Call] = []
+    for token in lexed.strings:
+        if token.contents not in SDK_METHOD_NAMES:
+            continue
+
+        opening_bracket = token.start - 1
+        while opening_bracket >= 0 and code[opening_bracket].isspace():
+            opening_bracket -= 1
+        if opening_bracket < 0 or code[opening_bracket] != "[":
+            continue
+
+        receiver_end = opening_bracket - 1
+        while receiver_end >= 0 and code[receiver_end].isspace():
+            receiver_end -= 1
+        if (
+            receiver_end >= 1
+            and code[receiver_end] == "."
+            and code[receiver_end - 1] == "?"
+        ):
+            receiver_end -= 2
+            while receiver_end >= 0 and code[receiver_end].isspace():
+                receiver_end -= 1
+        if receiver_end < 0 or not (
+            code[receiver_end].isalnum()
+            or code[receiver_end] in {"_", "$", "]", ")"}
+        ):
+            continue
+
+        closing_bracket = token.end
+        while closing_bracket < len(code) and code[closing_bracket].isspace():
+            closing_bracket += 1
+        if closing_bracket >= len(code) or code[closing_bracket] != "]":
+            continue
+
+        opening = closing_bracket + 1
+        while opening < len(code) and code[opening].isspace():
+            opening += 1
+        if code.startswith("?.", opening):
+            opening += 2
+            while opening < len(code) and code[opening].isspace():
+                opening += 1
+        if opening >= len(code) or code[opening] != "(":
+            continue
+
+        closing = matching_delimiter(code, opening, "(", ")")
+        if closing is not None:
+            calls.append(Call(opening_bracket, opening, closing + 1))
     return calls
 
 
@@ -12239,7 +12361,11 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix, source_dialect(path))
-    sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
+    sdk_calls = (
+        calls_matching(lexed, SDK_CALL_RE)
+        + sdk_alias_calls(lexed)
+        + sdk_computed_calls(lexed, suffix)
+    )
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     if suffix != ".cs":
         # These PascalCase names are official .NET HttpClient methods. Keeping

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -136,7 +136,10 @@ def canonical_suffix(path: Path) -> str:
         return ".ts"
     if suffix in {".vue", ".svelte"}:
         try:
-            source = path.read_text(encoding="utf-8", errors="replace")
+            with path.open(
+                "r", encoding="utf-8", errors="replace", newline=""
+            ) as source_file:
+                source = source_file.read()
         except OSError:
             source = ""
         if re.search(
@@ -154,7 +157,7 @@ def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
     for start, end in ranges:
         keep[start:end] = b"\x01" * (end - start)
     return "".join(
-        char if char in "\r\n" or keep[index] else " "
+        char if char in "\r\n\u2028\u2029" or keep[index] else " "
         for index, char in enumerate(source)
     )
 
@@ -440,12 +443,14 @@ PROFILE_IDENTIFIER_RE = re.compile(
     rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
 )
 PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
-SDK_CALL_RE = re.compile(
-    r"(?:\?\.|\.|->)\s*(?:"
+SDK_METHOD_PATTERN = (
     r"sendNumberPool|send_number_pool|SendNumberPool|"
     r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
     r"SendWithAlphanumericSender"
-    r")\s*(?:\?\.)?\s*\("
+)
+SDK_CALL_RE = re.compile(
+    rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
+    r"\s*(?:\?\.)?\s*\("
 )
 FETCH_CALL_RE = re.compile(
     r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
@@ -710,8 +715,24 @@ class EndpointFrame:
 
 def _blank(buffer: list[str], start: int, end: int) -> None:
     for index in range(start, end):
-        if buffer[index] != "\n":
+        # Preserve every source line terminator. JavaScript recognizes U+2028
+        # and U+2029 in addition to CR/LF, and all C-style languages accept a
+        # bare CR as a physical line boundary. Replacing one with a space can
+        # merge the comment with executable code on the following line.
+        if buffer[index] not in {"\r", "\n", "\u2028", "\u2029"}:
             buffer[index] = " "
+
+
+def _line_comment_end(source: str, start: int, suffix: str) -> int:
+    """Return the first language-valid line terminator after ``start``."""
+
+    terminators = {"\r", "\n"}
+    if suffix in JS_TS_SUFFIXES:
+        terminators.update({"\u2028", "\u2029"})
+    for index in range(start, len(source)):
+        if source[index] in terminators:
+            return index
+    return len(source)
 
 
 # Heredoc openers: shell/ruby `<<TAG`, `<<-TAG`, `<<~TAG`, `<<'TAG'`; PHP
@@ -777,8 +798,7 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         if c_line_comments and source.startswith("//", index):
-            end = source.find("\n", index + 2)
-            end = len(source) if end < 0 else end
+            end = _line_comment_end(source, index + 2, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)
             index = end
@@ -786,11 +806,10 @@ def lex_source(source: str, suffix: str) -> LexedSource:
 
         if hash_comments and source[index] == "#":
             if suffix == ".sh" and index == 0 and source.startswith("#!", index):
-                end = source.find("\n", index + 2)
-                index = len(source) if end < 0 else end
+                end = _line_comment_end(source, index + 2, suffix)
+                index = end
                 continue
-            end = source.find("\n", index + 1)
-            end = len(source) if end < 0 else end
+            end = _line_comment_end(source, index + 1, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)
             index = end
@@ -866,7 +885,14 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             if honours_escapes and source[index] == "\\":
                 index = min(len(source), index + 2)
                 continue
-            if source[index] == "\n" and line_bounded:
+            if (
+                line_bounded
+                and source[index] in {"\r", "\n", "\u2028", "\u2029"}
+                and (
+                    source[index] in {"\r", "\n"}
+                    or suffix in JS_TS_SUFFIXES
+                )
+            ):
                 # A single/double-quoted JS/TS or Python literal cannot contain a
                 # raw newline, so hitting one means the quote never opened a
                 # string at all (an apostrophe in JSX text, prose, or a comment).
@@ -940,6 +966,118 @@ def calls_matching(lexed: LexedSource, pattern: re.Pattern[str]) -> list[Call]:
             closing = lexed.code.find("\n", opening)
             closing = len(lexed.code) - 1 if closing < 0 else closing
         calls.append(Call(match.start(), opening, closing + 1))
+    return calls
+
+
+def sdk_alias_calls(lexed: LexedSource) -> list[Call]:
+    """Find calls through local aliases of required-profile SDK methods.
+
+    Method values/delegates are ordinary customer code in Python, JS/TS, Go,
+    Java/Kotlin and C#. The direct-call regex cannot see them once the member
+    name is assigned. Track both assignment/bind forms and JS destructuring,
+    and require the defining assignment to remain the nearest one before each
+    call so a later reassignment does not create a false SDK finding.
+    """
+
+    code = lexed.code
+    definitions: list[tuple[str, int]] = []
+    member = re.compile(
+        rf"(?:\?\.|\.|->|::)\s*(?:{SDK_METHOD_PATTERN})(?!\w)"
+    )
+    for match in member.finditer(code):
+        # A direct invocation is already covered by SDK_CALL_RE.
+        after = code[match.end():]
+        if re.match(r"\s*(?:\?\.)?\s*\(", after):
+            continue
+        line_start = max(code.rfind("\n", 0, match.start()), code.rfind(";", 0, match.start())) + 1
+        prefix = code[line_start:match.start()]
+        assignment = re.search(
+            r"(?P<alias>\$?[A-Za-z_][A-Za-z0-9_]*)\s*(?:=|:=)\s*.*$",
+            prefix,
+        )
+        if assignment is not None:
+            definitions.append((assignment.group("alias").lstrip("$"), match.end()))
+
+    # JavaScript/TypeScript/CommonJS destructuring aliases.
+    for match in re.finditer(r"\{(?P<members>[^{}]*)\}\s*=", code):
+        for item in split_arguments(code, match.start("members"), match.end("members")):
+            text = code[slice(*item)].strip()
+            parsed = re.fullmatch(
+                rf"(?P<method>{SDK_METHOD_PATTERN})(?:\s*:\s*(?P<alias>[A-Za-z_$]\w*))?",
+                text,
+            )
+            if parsed is not None:
+                definitions.append(
+                    ((parsed.group("alias") or parsed.group("method")).lstrip("$"), match.end())
+                )
+
+    # Ruby's bound Method and PHP callable-array/Closure forms store the SDK
+    # method name as a symbol or string, so it is intentionally absent from the
+    # masked code view used above. without_comments retains those values while
+    # still excluding prose and comments.
+    visible = lexed.without_comments
+    for match in re.finditer(
+        rf"(?m)^\s*(?P<alias>[A-Za-z_]\w*)\s*=\s*[^\r\n;]*"
+        rf"\.\s*method\s*\(\s*:\s*(?:{SDK_METHOD_PATTERN})\s*\)",
+        visible,
+    ):
+        definitions.append((match.group("alias"), match.end()))
+    for match in re.finditer(
+        rf"(?m)^\s*\$(?P<alias>[A-Za-z_]\w*)\s*=\s*"
+        rf"(?:Closure\s*::\s*fromCallable\s*\(\s*)?\["
+        rf"[^\]\r\n]*,\s*['\"](?:{SDK_METHOD_PATTERN})['\"]\s*\]",
+        visible,
+    ):
+        definitions.append((match.group("alias"), match.end()))
+
+    calls: list[Call] = []
+    seen: set[tuple[int, int]] = set()
+    for alias, definition_end in definitions:
+        invocation_patterns = (
+            re.compile(rf"(?<![\w$.>])\$?{re.escape(alias)}\s*\("),
+            re.compile(
+                rf"(?<![\w$])\$?{re.escape(alias)}\s*(?:\.|->)\s*"
+                r"(?:call|apply|accept|invoke|Invoke)\s*\("
+            ),
+        )
+        invocations = sorted(
+            (
+                match
+                for pattern in invocation_patterns
+                for match in pattern.finditer(code, definition_end)
+            ),
+            key=lambda match: match.start(),
+        )
+        for match in invocations:
+            # A later assignment/shadowing invalidates the original method
+            # value. Nearest-definition semantics match the rest of the linter.
+            between = code[definition_end:match.start()]
+            if re.search(
+                rf"(?<![\w$])\$?{re.escape(alias)}\s*(?:=|:=)(?!=)",
+                between,
+            ):
+                continue
+            opening = code.find("(", match.start(), match.end())
+            closing = matching_delimiter(code, opening, "(", ")")
+            if closing is None:
+                continue
+            key = (match.start(), closing + 1)
+            if key not in seen:
+                seen.add(key)
+                calls.append(Call(match.start(), opening, closing + 1))
+
+        # PHP also invokes callable arrays via call_user_func(_array).
+        for call in calls_matching(
+            lexed, re.compile(r"(?<!\w)call_user_func(?:_array)?\s*\(")
+        ):
+            args = split_arguments(code, call.open_paren + 1, call.end - 1)
+            if not args:
+                continue
+            callable_arg = code[slice(*args[0])].strip().lstrip("$")
+            key = (call.start, call.end)
+            if callable_arg == alias and key not in seen:
+                seen.add(key)
+                calls.append(call)
     return calls
 
 
@@ -2073,7 +2211,12 @@ def finding_row(path: Path, line: int, detail: str) -> str:
     in one run leaves a consumer unable to group, dedupe or open by file.
     """
 
-    return f"{path}:{line}:{detail}"
+    # The analyzer-to-shell protocol is LF-delimited. POSIX permits CR and LF
+    # in filenames, so emitting a raw path can turn one finding into several
+    # records and inflate both counts and details.files. Escape only the record
+    # delimiters; keep the rest of the path byte-for-byte displayable.
+    display_path = str(path).replace("\r", "\\r").replace("\n", "\\n")
+    return f"{display_path}:{line}:{detail}"
 
 
 def call_detail(path: Path, lexed: LexedSource, call: Call) -> str:
@@ -5060,9 +5203,18 @@ class SourceEndpointResolver:
     JAVASCRIPT_SUFFIXES = JS_TS_SUFFIXES
     C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
 
-    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+    def __init__(
+        self,
+        lexed: LexedSource,
+        suffix: str,
+        external_values: dict[str, str] | None = None,
+        external_names: set[str] | None = None,
+    ) -> None:
         self.lexed = lexed
         self.suffix = suffix
+        self.external_values = external_values or {}
+        self.external_names = external_names or set()
+        self.unverified_external_calls: set[int] = set()
         self.graph = EndpointGraph(len(lexed.code))
         self.c_headers = c_function_headers(lexed, suffix)
         self.class_fields = class_field_regions(lexed, suffix)
@@ -7017,6 +7169,15 @@ class SourceEndpointResolver:
         before: int,
         projection: EndpointReference = (),
     ) -> EndpointValue:
+        # Resolve statically imported scalar endpoints before entering the
+        # per-file binding graph. Keeping module provenance explicit avoids
+        # conflating same-named locals and makes the cross-file boundary the
+        # only special case; all endpoint classification remains shared.
+        expression_text = self.lexed.code[start:end].strip()
+        if not projection and re.fullmatch(r"[A-Za-z_$]\w*", expression_text):
+            external = self.external_values.get(expression_text.lstrip("$"))
+            if external is not None:
+                return endpoint_literal_value(external)
         scope_id = self.scope_at(before)
         expression = self._parse_expression(
             start, end, scope_id, before
@@ -7026,6 +7187,33 @@ class SourceEndpointResolver:
                 expression, projection, before, scope_id
             )
         )
+
+    def _is_external_expression(self, start: int, end: int) -> bool:
+        """Return whether an unresolved URL expression crosses a module boundary."""
+
+        # Shell references commonly live inside double-quoted URL arguments,
+        # which the code view masks as string data. This check is already
+        # bounded to the selected URL/call span, so the original view is the
+        # correct place to recover the imported reference spelling.
+        text = self.lexed.original[start:end].strip()
+        references = re.findall(r"\$?[A-Za-z_][A-Za-z0-9_$]*", text)
+        normalized = [reference.lstrip("$") for reference in references]
+        if any(reference in self.external_names for reference in normalized):
+            return True
+        if "<uppercase>" in self.external_names and any(
+            re.fullmatch(r"[A-Z][A-Z0-9_]*", reference)
+            for reference in normalized
+        ):
+            return True
+        if "<qualified>" in self.external_names and re.search(
+            r"(?:\.|::|->)\s*[A-Za-z_]", text
+        ):
+            return True
+        if "<shell>" in self.external_names and re.search(
+            r"\$(?:\{)?[A-Za-z_]", text
+        ):
+            return True
+        return False
 
     def config_method_may_mutate(
         self, span: tuple[int, int], before: int
@@ -7158,6 +7346,19 @@ class SourceEndpointResolver:
                 for value in resolved
             ):
                 return True
+        # A mutating request whose URL crosses a module boundary must not be
+        # certified merely because this file has no literal. Resolve exact
+        # local exports where possible; otherwise fail closed only for a URL
+        # expression proven to originate from an import/require/source form.
+        # The caller emits a distinct manual-verification finding, rather than
+        # pretending the unknown endpoint is definitely a number-pool route.
+        if any(
+            value.kind in {UNKNOWN, MISSING}
+            and self._is_external_expression(*span)
+            for span, value in zip(original_spans, resolved)
+        ):
+            self.unverified_external_calls.add(call.start)
+            return True
         if not args:
             return False
         return bool(
@@ -7191,6 +7392,20 @@ class SourceEndpointResolver:
                     expression, (), call.start, scope_id
                 )
             ).kind == REQUIRED:
+                return True
+            if (
+                self.graph.evaluate(
+                    EndpointExpressionState(
+                        expression, (), call.start, scope_id
+                    )
+                ).kind
+                in {UNKNOWN, MISSING}
+                and self._is_external_expression(
+                    call.start,
+                    call.end,
+                )
+            ):
+                self.unverified_external_calls.add(call.start)
                 return True
         return False
 
@@ -8329,6 +8544,19 @@ class PayloadStateResolver:
             r"|new\s+(?:Array|Map|Set|Object)\s*\(\s*\))",
             code,
             re.I,
+        ):
+            return WRITE_ABSENT
+        # The public API contract is a UUID string. Reject every statically
+        # numeric literal (not just zero) across the advertised languages;
+        # dynamic expressions remain MAYBE/PRESENT because their runtime type
+        # cannot be proven here.
+        if re.fullmatch(
+            r"[+-]?(?:(?:0[xX][0-9a-fA-F](?:_?[0-9a-fA-F])*)"
+            r"|(?:0[bB][01](?:_?[01])*)|(?:0[oO][0-7](?:_?[0-7])*)"
+            r"|(?:(?:\d(?:_?\d)*)(?:\.(?:\d(?:_?\d)*)?)?"
+            r"|\.(?:\d(?:_?\d)*))(?:[eE][+-]?\d(?:_?\d)*)?)"
+            r"(?:[nNlLfFdDmM])?",
+            code,
         ):
             return WRITE_ABSENT
         tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
@@ -10270,6 +10498,21 @@ def _looks_like_a_send_target(
     # boundary for computed/interprocedural lookups.
     line_start_decl = lexed.code.rfind("\n", 0, token.start) + 1
     declaration = lexed.original[line_start_decl:token.start]
+    # A class/package constant is a declaration, not a send. Braces from the
+    # surrounding class made _is_standalone_binding reject Java/C# fields, so a
+    # compliant cross-file consumer was still accompanied by an unverifiable
+    # finding on the constant definition itself. The imported use site is now
+    # judged (or failed closed) independently.
+    if re.search(
+        r"(?:\bstatic[ \t]+final"
+        r"|\b(?:public|private|protected|internal)[ \t]+const"
+        r"|\b(?:public|private|protected|internal)?[ \t]*static[ \t]+readonly)"
+        r"[ \t]+[A-Za-z_$][\w$<>,.?\[\]]*[ \t]+"
+        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*$",
+        declaration,
+        re.I,
+    ) and _SEND_SITE_RE.search(declaration) is None:
+        return False
     if re.search(
         r"(?:=|:=)\s*(?:new\s+\w+[^=]*)?(?:Map\s*\.\s*of|List\s*\.\s*of"
         r"|Arrays\s*\.\s*asList|array|dict|\{|\[|\()",
@@ -10396,16 +10639,271 @@ def _looks_like_a_send_target(
 
 
 
+def _read_source_text(path: Path) -> str:
+    """Read source without universal-newline translation."""
+
+    with path.open(
+        "r", encoding="utf-8", errors="replace", newline=""
+    ) as source_file:
+        return source_file.read()
+
+
+def _relative_module_candidates(
+    source_path: Path, module: str, suffix: str, project_root: Path
+) -> list[Path]:
+    """Return bounded local-module candidates for JS/TS and Python imports."""
+
+    if module.startswith("."):
+        base = source_path.parent / module
+    elif suffix == ".py":
+        # Python commonly imports a sibling/top-level project module without a
+        # leading dot. Resolve only beneath the scanned project root; package
+        # dependencies are intentionally outside this static contract.
+        base = project_root / module.replace(".", "/")
+    else:
+        return []
+    candidates = [base]
+    if base.suffix:
+        return candidates
+    if suffix in JS_TS_SUFFIXES:
+        candidates.extend(base.with_suffix(ext) for ext in sorted(JS_TS_SUFFIXES))
+        candidates.extend((base / "index").with_suffix(ext) for ext in sorted(JS_TS_SUFFIXES))
+    elif suffix == ".py":
+        candidates.extend((base.with_suffix(".py"), base / "__init__.py"))
+    return candidates
+
+
+def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
+    """Resolve one exported/top-level name when its value is a string literal."""
+
+    lexed = lex_source(source, suffix)
+    visible = lexed.without_comments
+    escaped = re.escape(name)
+    if suffix in JS_TS_SUFFIXES:
+        assignment = re.search(
+            rf"(?:\bexport\s+(?:const|let|var)\s+{escaped}"
+            rf"|\b(?:module\s*\.\s*)?exports\s*\.\s*{escaped})"
+            r"\s*=\s*(['\"])(?P<value>.*?)\1",
+            visible,
+            re.S,
+        )
+    elif suffix == ".py":
+        assignment = re.search(
+            rf"(?m)^[ \t]*{escaped}\s*=\s*(['\"])(?P<value>.*?)\1",
+            visible,
+        )
+    else:
+        assignment = None
+    return assignment.group("value") if assignment is not None else None
+
+
+def external_static_values(
+    path: Path, project_root: Path, source: str, suffix: str
+) -> dict[str, str]:
+    """Resolve relative named imports to statically exported scalar strings.
+
+    This deliberately follows only explicit relative modules and literal
+    exports. Dynamic/package imports stay unknown instead of being guessed.
+    """
+
+    lexed = lex_source(source, suffix)
+    visible = lexed.without_comments
+    imports: list[tuple[str, str, str]] = []
+    if suffix in JS_TS_SUFFIXES:
+        for match in re.finditer(
+            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"(['\"])(?P<module>\.[^'\"]*)\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_$]\w*)"
+                    r"(?:\s+as\s+(?P<local>[A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    imports.append(
+                        (
+                            match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_$]\w*)"
+                    r"(?:\s*:\s*(?P<local>[A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    imports.append(
+                        (
+                            match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+    elif suffix == ".py":
+        for match in re.finditer(
+            r"(?m)^\s*from\s+(?P<module>\.*[A-Za-z_][\w.]*)\s+import\s+"
+            r"(?P<members>[^\r\n]+)",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_]\w*)"
+                    r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    dots = len(match.group("module")) - len(match.group("module").lstrip("."))
+                    module_tail = match.group("module")[dots:].replace(".", "/")
+                    relative = "../" * max(0, dots - 1) + module_tail
+                    imports.append(
+                        (
+                            "./" + relative if dots else match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+
+    resolved: dict[str, str] = {}
+    for module, exported, local in imports:
+        for candidate in _relative_module_candidates(
+            path, module, suffix, project_root
+        ):
+            if not candidate.is_file():
+                continue
+            target_suffix = canonical_suffix(candidate)
+            value = _exported_scalar(
+                _read_source_text(candidate), target_suffix, exported
+            )
+            if value is not None:
+                resolved[local] = value
+            break
+    return resolved
+
+
+def external_reference_names(source: str, suffix: str) -> set[str]:
+    """Return local names whose values originate outside the current file.
+
+    Exact static exports are resolved separately. This index covers the wider
+    language-level import boundary so an unresolved mutating request fails
+    closed instead of silently passing. Sentinels are intentionally narrow:
+    uppercase constants after require/include, qualified package/class members,
+    and shell variables only when a source command is present.
+    """
+
+    visible = lex_source(source, suffix).without_comments
+    names: set[str] = set()
+    if suffix in JS_TS_SUFFIXES:
+        for match in re.finditer(
+            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"(['\"])\.[^'\"]*\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_$]\w*)(?:\s+as\s+([A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"\bimport\s+\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
+                r"(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+                r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_$]\w*)(?:\s*:\s*([A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
+    elif suffix == ".py":
+        for match in re.finditer(r"(?m)^\s*from\s+[\w.]+\s+import\s+([^\r\n]+)", visible):
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_]\w*)(?:\s+as\s+([A-Za-z_]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add(parsed.group(2) or parsed.group(1))
+        for match in re.finditer(
+            r"(?m)^\s*import\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)"
+            r"(?:\s+as\s+([A-Za-z_]\w*))?",
+            visible,
+        ):
+            names.add(match.group(2) or match.group(1).split(".")[0])
+    elif suffix == ".rb" and re.search(r"(?m)^\s*require(?:_relative)?\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".php" and re.search(r"\b(?:require|require_once|include|include_once)\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".go" and re.search(r"(?m)^\s*import\b", visible):
+        names.add("<qualified>")
+        for match in re.finditer(
+            r"(?m)^\s*(?:import\s+)?(?:(\w+)\s+)?['\"]([^'\"]+)['\"]",
+            visible,
+        ):
+            names.add(match.group(1) or match.group(2).rsplit("/", 1)[-1])
+    elif suffix == ".java" and re.search(r"(?m)^\s*import\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"(?m)^\s*import\s+(?:static\s+)?(?:[\w$]+\.)*([A-Za-z_$]\w*)\s*;",
+                visible,
+            )
+        )
+    elif suffix == ".cs" and re.search(r"(?m)^\s*using\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".sh" and re.search(
+        r"(?m)^\s*(?:source\s+|\.\s+)[^\r\n]+", visible
+    ):
+        names.add("<shell>")
+    return names
+
+
 def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
-    source = path.read_text(encoding="utf-8", errors="replace")
+    # newline="" is required: Path.read_text() performs universal-newline
+    # translation, destroying bare-CR and CRLF source boundaries before the
+    # lexer and grep-line protocol can agree on them.
+    source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
-    sdk_calls = calls_matching(lexed, SDK_CALL_RE)
+    sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
     required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
-    source_resolver = SourceEndpointResolver(lexed, suffix)
+    source_resolver = SourceEndpointResolver(
+        lexed,
+        suffix,
+        external_static_values(path, project_root, source, suffix),
+        external_reference_names(source, suffix),
+    )
     profile_resolver = PayloadStateResolver(
         lexed,
         suffix,
@@ -10443,10 +10941,9 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
             required_calls.append((context, False))
 
     required_calls.sort(key=lambda item: (item[0].start, item[0].end))
-    missing = [
-        call_detail(path, lexed, call)
-        for call, sdk_call in required_calls
-        if not call_has_profile(
+    missing: list[str] = []
+    for call, sdk_call in required_calls:
+        if call_has_profile(
             lexed,
             call,
             suffix,
@@ -10454,8 +10951,15 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
             project_root,
             sdk_call=sdk_call,
             resolver=profile_resolver,
-        )
-    ]
+        ):
+            continue
+        detail = call_detail(path, lexed, call)
+        if call.start in source_resolver.unverified_external_calls:
+            detail += (
+                "  [could not resolve the imported endpoint for this mutating "
+                "request; verify messaging_profile_id manually]"
+            )
+        missing.append(detail)
 
     # Fail-safe backstop: a required endpoint the analysis never accounted for
     # is reported for manual verification rather than passed silently.
@@ -10581,7 +11085,7 @@ def message_body_fields(
 ) -> list[str]:
     """Return real top-level body fields from selected messaging calls."""
 
-    source = path.read_text(encoding="utf-8", errors="replace")
+    source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -38,6 +38,10 @@ JS_TS_SUFFIXES = {
     ".tsx",
 }
 TYPESCRIPT_SUFFIXES = {".ts", ".tsx", ".mts", ".cts"}
+# Babel, SWC, esbuild, and React Native commonly accept JSX in ordinary
+# JavaScript module files. TypeScript reserves JSX for `.tsx`, so applying JSX
+# masking to `.ts`/`.mts`/`.cts` would risk hiding valid type assertions.
+JSX_CAPABLE_SUFFIXES = {".cjs", ".js", ".jsx", ".mjs", ".tsx"}
 # Keys a request-style config object may carry its URL under. Shared so the
 # named-argument path and the config-object path cannot recognise different
 # spellings, which is how `uri` came to work as a named argument but not as
@@ -582,12 +586,98 @@ def _ruby_interpolation_ranges(
         if backslashes % 2:
             cursor = marker + 2
             continue
-        balanced = _balanced_brace_ranges(source, [marker + 1])
-        if not balanced or balanced[0][1] > end:
+        closing = _ruby_interpolation_closing(source, marker + 1, end)
+        if closing is None:
             break
-        ranges.append(balanced[0])
-        cursor = balanced[0][1] + 1
+        ranges.append((marker + 2, closing))
+        cursor = closing + 1
     return ranges
+
+
+def _ruby_interpolation_closing(
+    source: str, opening: int, end: int
+) -> int | None:
+    """Return a Ruby-aware closing brace for one interpolation expression.
+
+    Generic brace matching is insufficient here: Ruby regexp and percent
+    literals may legally contain ``}``, and comments may contain arbitrary
+    braces. Treat those regions as opaque while balancing executable braces so
+    a data character cannot truncate the restored expression.
+    """
+
+    depth = 0
+    index = opening
+    code = list(source)
+    last_opaque_end = 0
+    while index < end:
+        character = source[index]
+        if character == "#":
+            line_end = source.find("\n", index + 1, end)
+            index = end if line_end < 0 else line_end + 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            literal_start = index
+            index += 1
+            while index < end:
+                if source[index] == "\\":
+                    index = min(end, index + 2)
+                    continue
+                if quote in {'"', "`"} and source.startswith("#{", index):
+                    nested_closing = _ruby_interpolation_closing(
+                        source, index + 1, end
+                    )
+                    if nested_closing is None:
+                        return None
+                    index = nested_closing + 1
+                    continue
+                if source[index] == quote:
+                    index += 1
+                    _blank(code, literal_start, index)
+                    last_opaque_end = index
+                    break
+                index += 1
+            else:
+                return None
+            continue
+        if character == "%":
+            percent_literal = _ruby_percent_literal(source, index)
+            if percent_literal is not None and percent_literal[0] <= end:
+                literal_end = percent_literal[0]
+                _blank(code, index, literal_end)
+                last_opaque_end = literal_end
+                index = literal_end
+                continue
+        if character == "/":
+            regexp_context = _ruby_regex_can_start(
+                source, code, index, last_opaque_end
+            )
+            regexp = (
+                _ruby_slash_regex(
+                    source,
+                    index,
+                    allow_newlines=regexp_context == "command",
+                )
+                if regexp_context
+                else None
+            )
+            if regexp is not None and regexp[0] <= end and (
+                regexp_context != "command"
+                or _ruby_command_regex_has_valid_tail(source, regexp[0])
+            ):
+                regexp_end = regexp[0]
+                _blank(code, index, regexp_end)
+                last_opaque_end = regexp_end
+                index = regexp_end
+                continue
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
 
 
 def _ruby_percent_literal(
@@ -1112,50 +1202,69 @@ def _jsx_element(
 def _mask_jsx_markup(source: str, suffix: str) -> str:
     """Blank definite JSX markup/text while retaining expression containers."""
 
-    # Locate roots in lexed code so `<Panel>` inside an ordinary string or
-    # comment cannot cause subsequent JavaScript to be hidden. The JSX parser
-    # itself uses the raw source after a root is established because inert text
-    # may legally contain quote characters that are not JavaScript strings.
-    lexical = lex_source(source, suffix).code
     output = list(source)
-    cursor = 0
-    while cursor < len(source):
-        start = lexical.find("<", cursor)
-        if start < 0:
-            break
-        previous = start - 1
-        while previous >= 0 and lexical[previous].isspace():
-            previous -= 1
-        previous_word = _word_before(list(lexical), previous + 1).lower()
-        expression_context = (
-            previous < 0
-            or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
-            or (
-                lexical[previous] == ")"
-                and _javascript_control_paren(list(lexical), previous)
+    # Process expression containers with an explicit worklist. The former
+    # recursive call overflowed Python's stack on valid deeply nested JSX.
+    # Each queued span is strictly contained by the JSX element that exposed
+    # it, so the traversal always makes progress without a recursion limit.
+    pending = [(0, len(source))]
+    while pending:
+        span_start, span_end = pending.pop()
+        segment = source[span_start:span_end]
+        # Locate roots in lexed code so `<Panel>` inside an ordinary string or
+        # comment cannot hide subsequent JavaScript. The JSX parser itself uses
+        # raw source after a root is established because inert JSX text may
+        # legally contain quote characters that are not JavaScript strings.
+        lexical = lex_source(segment, suffix).code
+        lexical_chars = list(lexical)
+        cursor = 0
+        while cursor < len(segment):
+            start = lexical.find("<", cursor)
+            if start < 0:
+                break
+            previous = start - 1
+            while previous >= 0 and lexical[previous].isspace():
+                previous -= 1
+            previous_word = _word_before(lexical_chars, previous + 1).lower()
+            expression_context = (
+                previous < 0
+                or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
+                or (
+                    lexical[previous] == ")"
+                    and _javascript_control_paren(lexical_chars, previous)
+                )
+                or (
+                    lexical[previous] == "}"
+                    and _javascript_block_brace(lexical_chars, previous)
+                )
+                or previous_word
+                in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
             )
-            or (
-                lexical[previous] == "}"
-                and _javascript_block_brace(list(lexical), previous)
-            )
-            or previous_word
-            in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
-        )
-        if not expression_context:
-            cursor = start + 1
-            continue
-        element = _jsx_element(source, lexical, start, suffix)
-        if element is None:
-            cursor = start + 1
-            continue
-        end, expressions = element
-        _blank(output, start, end)
-        for expression_start, expression_end in expressions:
-            nested = _mask_jsx_markup(
-                source[expression_start:expression_end], suffix
-            )
-            output[expression_start:expression_end] = list(nested)
-        cursor = end
+            if not expression_context:
+                cursor = start + 1
+                continue
+            element = _jsx_element(segment, lexical, start, suffix)
+            if element is None:
+                cursor = start + 1
+                continue
+            element_end, expressions = element
+            absolute_start = span_start + start
+            absolute_end = span_start + element_end
+            _blank(output, absolute_start, absolute_end)
+            for expression_start, expression_end in expressions:
+                absolute_expression_start = span_start + expression_start
+                absolute_expression_end = span_start + expression_end
+                output[
+                    absolute_expression_start:absolute_expression_end
+                ] = list(
+                    source[
+                        absolute_expression_start:absolute_expression_end
+                    ]
+                )
+                pending.append(
+                    (absolute_expression_start, absolute_expression_end)
+                )
+            cursor = element_end
     return "".join(output)
 
 
@@ -1163,7 +1272,7 @@ def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
     ranges: list[tuple[int, int]] = []
-    if suffix in {".jsx", ".tsx"}:
+    if suffix in JSX_CAPABLE_SUFFIXES:
         return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
         # Comments may contain complete, syntactically valid examples. Preserve
@@ -2381,6 +2490,26 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                     len(source) if terminator is None else terminator.start()
                 )
                 _blank(code, body_start, body_end)
+                _blank(without_comments, body_start, body_end)
+                if suffix == ".rb" and opener.group("q") != "'":
+                    for expression_start, expression_end in _ruby_interpolation_ranges(
+                        source, body_start, body_end
+                    ):
+                        nested = lex_source(
+                            source[expression_start:expression_end], suffix, dialect
+                        )
+                        code[expression_start:expression_end] = list(nested.code)
+                        without_comments[expression_start:expression_end] = list(
+                            nested.without_comments
+                        )
+                        strings.extend(
+                            StringToken(
+                                expression_start + token.start,
+                                expression_start + token.end,
+                                token.contents,
+                            )
+                            for token in nested.strings
+                        )
                 strings.append(
                     StringToken(
                         body_start, body_end, source[body_start:body_end]
@@ -2445,6 +2574,18 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         ) and not (csharp_verbatim or jvm_raw)
         terminated = False
         while index < len(source):
+            if (
+                suffix == ".rb"
+                and delimiter in {'"', "`"}
+                and source.startswith("#{", index)
+            ):
+                interpolation_end = _ruby_interpolation_closing(
+                    source, index + 1, len(source)
+                )
+                if interpolation_end is None:
+                    break
+                index = interpolation_end + 1
+                continue
             if python_f_string or csharp_interpolates or jvm_interpolates:
                 brace_count = csharp_brace_count if csharp_interpolates else 1
                 opener = "${" if jvm_interpolates else "{" * brace_count

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -968,10 +968,203 @@ def _php_executable_ranges(source: str) -> list[tuple[int, int]]:
     return ranges
 
 
+def _jsx_tag_end(
+    source: str, lexical: str, start: int, suffix: str
+) -> int | None:
+    """Return the first JSX tag-closing ``>`` outside quotes/expressions."""
+
+    index = start + 1
+    quote = ""
+    escaped = False
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+        elif character in {"'", '"', "`"}:
+            quote = character
+        elif character == "{":
+            expression = _jsx_brace_range(
+                source, lexical, index, suffix
+            )
+            if expression is None:
+                return None
+            index = expression[1] + 1
+            continue
+        elif character == ">":
+            return index + 1
+        index += 1
+    return None
+
+
+def _jsx_brace_range(
+    source: str, lexical: str, opening: int, suffix: str
+) -> tuple[int, int] | None:
+    """Return one JSX expression range after masking JS lexical data."""
+
+    balanced = _balanced_brace_ranges(lexical, [opening])
+    if balanced:
+        return balanced[0]
+    # JSX text may contain quote characters which the host lexer paired across
+    # an expression. Retry only this exceptional span locally; normal files use
+    # the single cached lexical projection above and remain linear.
+    local = lex_source(source[opening:], suffix).code
+    balanced = _balanced_brace_ranges(local, [0])
+    if balanced:
+        start, end = balanced[0]
+        return opening + start, opening + end
+    return None
+
+
+def _jsx_element(
+    source: str,
+    lexical: str,
+    start: int,
+    suffix: str,
+    depth: int = 0,
+) -> tuple[int, list[tuple[int, int]]] | None:
+    """Parse one balanced JSX element and return its executable expressions."""
+
+    if depth > 128:
+        return None
+    fragment = source.startswith("<>", start)
+    identifier_start = r"(?:[^\W\d]|[$_])"
+    name_match = re.match(
+        rf"<({identifier_start}[\w$:.-]*)(?=[\s/>])", source[start:]
+    )
+    if not fragment and name_match is None:
+        return None
+    name = "" if fragment else name_match.group(1)
+    opening_end = _jsx_tag_end(source, lexical, start, suffix)
+    if opening_end is None:
+        return None
+
+    expressions: list[tuple[int, int]] = []
+    opening = source[start:opening_end]
+    # Attribute expressions execute even though tag names and quoted values do
+    # not. Keep only outermost balanced braces found outside quoted values.
+    cursor = start + 1
+    quote = ""
+    escaped = False
+    while cursor < opening_end:
+        character = source[cursor]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            cursor += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            cursor += 1
+            continue
+        if character == "{":
+            balanced = _jsx_brace_range(source, lexical, cursor, suffix)
+            if balanced is None or balanced[1] >= opening_end:
+                return None
+            expressions.append(balanced)
+            cursor = balanced[1] + 1
+            continue
+        cursor += 1
+
+    if opening.rstrip().endswith("/>"):
+        return opening_end, expressions
+
+    cursor = opening_end
+    while cursor < len(source):
+        if source[cursor] == "{":
+            balanced = _jsx_brace_range(source, lexical, cursor, suffix)
+            if balanced is None:
+                return None
+            expressions.append(balanced)
+            cursor = balanced[1] + 1
+            continue
+        if source[cursor] == "<":
+            if fragment and source.startswith("</>", cursor):
+                return cursor + 3, expressions
+            closing = re.match(
+                rf"</\s*({identifier_start}[\w$:.-]*)\s*>",
+                source[cursor:],
+            )
+            if closing and closing.group(1) == name:
+                return cursor + closing.end(), expressions
+            child = _jsx_element(
+                source, lexical, cursor, suffix, depth + 1
+            )
+            if child is not None:
+                child_end, child_expressions = child
+                expressions.extend(child_expressions)
+                cursor = child_end
+                continue
+            if re.match(rf"<{identifier_start}", source[cursor:]):
+                return None
+        cursor += 1
+    return None
+
+
+def _mask_jsx_markup(source: str, suffix: str) -> str:
+    """Blank definite JSX markup/text while retaining expression containers."""
+
+    # Locate roots in lexed code so `<Panel>` inside an ordinary string or
+    # comment cannot cause subsequent JavaScript to be hidden. The JSX parser
+    # itself uses the raw source after a root is established because inert text
+    # may legally contain quote characters that are not JavaScript strings.
+    lexical = lex_source(source, suffix).code
+    output = list(source)
+    cursor = 0
+    while cursor < len(source):
+        start = lexical.find("<", cursor)
+        if start < 0:
+            break
+        previous = start - 1
+        while previous >= 0 and lexical[previous].isspace():
+            previous -= 1
+        previous_word = _word_before(list(lexical), previous + 1).lower()
+        expression_context = (
+            previous < 0
+            or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
+            or (
+                lexical[previous] == ")"
+                and _javascript_control_paren(list(lexical), previous)
+            )
+            or (
+                lexical[previous] == "}"
+                and _javascript_block_brace(list(lexical), previous)
+            )
+            or previous_word
+            in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
+        )
+        if not expression_context:
+            cursor = start + 1
+            continue
+        element = _jsx_element(source, lexical, start, suffix)
+        if element is None:
+            cursor = start + 1
+            continue
+        end, expressions = element
+        _blank(output, start, end)
+        for expression_start, expression_end in expressions:
+            nested = _mask_jsx_markup(
+                source[expression_start:expression_end], suffix
+            )
+            output[expression_start:expression_end] = list(nested)
+        cursor = end
+    return "".join(output)
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
     ranges: list[tuple[int, int]] = []
+    if suffix in {".jsx", ".tsx"}:
+        return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
         # Comments may contain complete, syntactically valid examples. Preserve
         # their offsets/newlines but remove their contents before discovering
@@ -1790,7 +1983,7 @@ def _javascript_regex_can_start(
     previous = _previous_code_index(code, index)
     if last_opaque_end and (previous is None or previous < last_opaque_end):
         if all(character.isspace() for character in code[last_opaque_end:index]):
-            return False
+            return ""
     if previous is None:
         return True
 
@@ -1862,6 +2055,125 @@ def _javascript_regex_end(source: str, start: int) -> int | None:
     return None
 
 
+_RUBY_REGEXP_PREFIX_WORDS = {
+    "and",
+    "begin",
+    "case",
+    "do",
+    "else",
+    "elsif",
+    "if",
+    "in",
+    "not",
+    "or",
+    "rescue",
+    "return",
+    "then",
+    "unless",
+    "until",
+    "when",
+    "while",
+    "yield",
+}
+
+
+def _ruby_regex_can_start(
+    source: str, code: list[str], index: int, last_opaque_end: int
+) -> str:
+    """Distinguish a Ruby regexp opener from division and ``/=``."""
+
+    if index + 1 < len(code) and code[index + 1] == "=":
+        return ""
+    previous = _previous_code_index(code, index)
+    if last_opaque_end and (previous is None or previous < last_opaque_end):
+        if all(character.isspace() for character in code[last_opaque_end:index]):
+            return False
+    if previous is None:
+        return "exact"
+    character = code[previous]
+    if character in "([{,;:=!?&|^~<>*%":
+        return "exact"
+    if character in "+-":
+        return "exact" if previous == 0 or code[previous - 1] != character else ""
+    if character.isalnum() or character in "_$@":
+        word = _word_before(code, previous + 1).lower()
+        if word in _RUBY_REGEXP_PREFIX_WORDS:
+            return "exact"
+        # Ruby permits a regexp as the unparenthesized argument of a command
+        # call (`warn /pattern/`). Mark the command-shaped form separately so
+        # its closing context can still distinguish chained division.
+        word_start = previous + 1 - len(word)
+        line_start = source.rfind("\n", 0, word_start) + 1
+        prefix = source[line_start:word_start].strip()
+        if not prefix or prefix.endswith((".", "&.")):
+            return "command"
+    return ""
+
+
+def _ruby_slash_regex(
+    source: str, start: int, allow_newlines: bool
+) -> tuple[int, int, int] | None:
+    """Return slash-regexp bounds, respecting escapes, classes and holes."""
+
+    index = start + 1
+    in_class = False
+    while index < len(source):
+        character = source[index]
+        if character in {"\r", "\n"} and not allow_newlines:
+            return None
+        if character == "\\":
+            index += 2
+            continue
+        if source.startswith("#{", index):
+            balanced = _balanced_brace_ranges(source, [index + 1])
+            if not balanced:
+                return None
+            index = balanced[0][1] + 1
+            continue
+        if character == "[":
+            in_class = True
+        elif character == "]" and in_class:
+            in_class = False
+        elif character == "/" and not in_class:
+            contents_end = index
+            index += 1
+            while index < len(source) and source[index].isalpha():
+                index += 1
+            return index, start + 1, contents_end
+        index += 1
+    return None
+
+
+def _ruby_command_regex_has_valid_tail(source: str, regexp_end: int) -> bool:
+    """Reject command-regexp guesses that are actually chained division."""
+
+    line_end = source.find("\n", regexp_end)
+    if line_end < 0:
+        line_end = len(source)
+    tail = source[regexp_end:line_end].strip()
+    if not tail or tail.startswith(("#", ",", ")", "]", "}", ";")):
+        return True
+    if tail.startswith("/"):
+        # Most importantly, do not pair a division slash with the first slash
+        # of a later `https://...` literal when command regexes span lines.
+        return False
+    word = re.match(r"([A-Za-z_]\w*)", tail)
+    if word and word.group(1) in {
+        "and",
+        "do",
+        "if",
+        "or",
+        "rescue",
+        "unless",
+        "until",
+        "while",
+    }:
+        return True
+    # An operand immediately following the second slash identifies `a / b / c`,
+    # not `command /regexp/`.
+    return re.match(r"(?:[+-]\s*)?(?:[$@A-Za-z_\d]|[('\"\[{])", tail) is None
+
+
 def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
@@ -1875,6 +2187,7 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     shell_heredoc_index = 0
     index = 0
     last_js_opaque_end = 0
+    last_ruby_opaque_end = 0
 
     while index < len(source):
         while (
@@ -1907,6 +2220,51 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 _blank(without_comments, index, regex_end)
                 last_js_opaque_end = regex_end
                 index = regex_end
+                continue
+
+        ruby_regex_context = (
+            _ruby_regex_can_start(source, code, index, last_ruby_opaque_end)
+            if suffix == ".rb" and source[index] == "/"
+            else ""
+        )
+        if ruby_regex_context:
+            regexp = _ruby_slash_regex(
+                source,
+                index,
+                allow_newlines=True,
+            )
+            if regexp is not None:
+                regexp_end, contents_start, contents_end = regexp
+                if (
+                    ruby_regex_context == "command"
+                    and not _ruby_command_regex_has_valid_tail(
+                        source, regexp_end
+                    )
+                ):
+                    index += 1
+                    continue
+                _blank(code, index, regexp_end)
+                _blank(without_comments, index, regexp_end)
+                for expression_start, expression_end in _ruby_interpolation_ranges(
+                    source, contents_start, contents_end
+                ):
+                    nested = lex_source(
+                        source[expression_start:expression_end], suffix, dialect
+                    )
+                    code[expression_start:expression_end] = list(nested.code)
+                    without_comments[expression_start:expression_end] = list(
+                        nested.without_comments
+                    )
+                    strings.extend(
+                        StringToken(
+                            expression_start + token.start,
+                            expression_start + token.end,
+                            token.contents,
+                        )
+                        for token in nested.strings
+                    )
+                last_ruby_opaque_end = regexp_end
+                index = regexp_end
                 continue
 
         if c_block_comments and source.startswith("/*", index):
@@ -2270,6 +2628,8 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
+        if suffix == ".rb":
+            last_ruby_opaque_end = index
         if suffix in JS_TS_SUFFIXES:
             last_js_opaque_end = index
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -267,7 +267,7 @@ def executable_source(path: Path, source: str) -> str:
         ranges.extend(
             match.span(1)
             for match in re.finditer(
-                r"<script\b[^>]*>(.*?)</script\s*>", template_source,
+                r"<script\b[^>]*>(.*?)</script\b[^>]*>", template_source,
                 flags=re.IGNORECASE | re.DOTALL,
             )
         )
@@ -370,7 +370,7 @@ def executable_source(path: Path, source: str) -> str:
             ranges.extend(
                 match.span(1)
                 for match in re.finditer(
-                    r"<script\b[^>]*>(.*?)</script\s*>", source,
+                    r"<script\b[^>]*>(.*?)</script\b[^>]*>", source,
                     flags=re.IGNORECASE | re.DOTALL,
                 )
             )

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -336,6 +336,112 @@ def _razor_continuation_block_ranges(
     return continuations
 
 
+def _html_element_ranges(source: str) -> list[tuple[int, int]]:
+    """Return quote-aware complete HTML element and standalone-tag spans."""
+
+    tokens: list[tuple[int, int, str, bool, bool]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        match = re.match(r"<\s*(?P<closing>/)?\s*(?P<name>[A-Za-z][\w:.-]*)", source[opening:])
+        if match is None:
+            cursor = opening + 1
+            continue
+        quote = ""
+        escaped = False
+        end = None
+        for index in range(opening + match.end(), len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+            elif character == ">":
+                end = index + 1
+                break
+        if end is None:
+            break
+        tag_text = source[opening:end]
+        tokens.append(
+            (
+                opening,
+                end,
+                match.group("name").lower(),
+                bool(match.group("closing")),
+                bool(re.search(r"/\s*>$", tag_text)),
+            )
+        )
+        cursor = end
+
+    void_elements = {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    }
+    stack: list[tuple[str, int, int]] = []
+    ranges: list[tuple[int, int]] = []
+    for start, end, name, closing, self_closing in tokens:
+        if closing:
+            for stack_index in range(len(stack) - 1, -1, -1):
+                if stack[stack_index][0] != name:
+                    continue
+                _, element_start, _ = stack[stack_index]
+                del stack[stack_index:]
+                ranges.append((element_start, end))
+                break
+        elif self_closing or name in void_elements:
+            ranges.append((start, end))
+        else:
+            stack.append((name, start, end))
+    return ranges
+
+
+def _mask_razor_markup(
+    source: str, executable_ranges: list[tuple[int, int]]
+) -> str:
+    """Mask nested Razor markup with the innermost syntax region winning.
+
+    Razor control bodies mix raw C# with complete HTML elements. A union of
+    executable ranges retains the markup too, so quotes in prose can become
+    fake C# literals and hide a request. HTML and C# transition spans nest;
+    applying larger spans first and smaller spans last preserves the deepest
+    language boundary (markup -> @code -> nested markup -> @expression).
+    """
+
+    rendered = list(source)
+    markup_ranges = _html_element_ranges(source)
+    markup_ranges.extend(
+        match.span()
+        for match in re.finditer(r"<!--.*?-->", source, flags=re.DOTALL)
+    )
+    markup_ranges.extend(
+        match.span("text")
+        for match in re.finditer(
+            r"(?m)(?:^|(?<=[;{}]))[ \t]*@:(?P<text>[^\r\n]*)", source
+        )
+    )
+    operations = [
+        (end - start, 0, start, end) for start, end in markup_ranges
+    ]
+    operations.extend(
+        (end - start, 1, start, end) for start, end in executable_ranges
+    )
+    for _, keep, start, end in sorted(
+        operations, key=lambda item: (-item[0], item[1])
+    ):
+        if keep:
+            rendered[start:end] = source[start:end]
+        else:
+            _blank(rendered, start, end)
+    return "".join(rendered)
+
+
 def _vue_directive_expression_ranges(source: str) -> list[tuple[int, int]]:
     """Return value and dynamic-argument expressions for every Vue directive."""
 
@@ -444,6 +550,90 @@ def _javascript_template_expression_ranges(
         ranges.append(balanced[0])
         cursor = balanced[0][1] + 1
     return ranges
+
+
+def _ruby_interpolation_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable ``#{...}`` spans within an interpolating literal."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("#{", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        probe = marker - 1
+        while probe >= start and source[probe] == "\\":
+            backslashes += 1
+            probe -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        balanced = _balanced_brace_ranges(source, [marker + 1])
+        if not balanced or balanced[0][1] > end:
+            break
+        ranges.append(balanced[0])
+        cursor = balanced[0][1] + 1
+    return ranges
+
+
+def _ruby_percent_literal(
+    source: str, start: int
+) -> tuple[int, int, int, bool] | None:
+    """Return percent-literal bounds and interpolation behavior at ``start``."""
+
+    if start >= len(source) or source[start] != "%":
+        return None
+    cursor = start + 1
+    kind = "Q"
+    if cursor < len(source) and source[cursor] in "qQwWiIxrs":
+        kind = source[cursor]
+        cursor += 1
+    elif cursor >= len(source) or source[cursor] not in "([{<":
+        # Bare `%` is also modulo/assignment syntax. Its untyped literal form
+        # is unambiguous for paired delimiters; typed forms support every Ruby
+        # delimiter below.
+        return None
+    else:
+        previous = start - 1
+        while previous >= 0 and source[previous].isspace():
+            previous -= 1
+        if previous >= 0 and (
+            source[previous].isalnum() or source[previous] in "_$)]}'\""
+        ):
+            return None
+    if cursor >= len(source):
+        return None
+    opening = source[cursor]
+    if opening.isalnum() or opening.isspace():
+        return None
+    closing = {"(": ")", "[": "]", "{": "}", "<": ">"}.get(
+        opening, opening
+    )
+    paired = closing != opening
+    depth = 1
+    contents_start = cursor + 1
+    cursor = contents_start
+    while cursor < len(source):
+        character = source[cursor]
+        if character == "\\":
+            cursor = min(len(source), cursor + 2)
+            continue
+        if paired and character == opening:
+            depth += 1
+        elif character == closing:
+            depth -= 1
+            if depth == 0:
+                return (
+                    cursor + 1,
+                    contents_start,
+                    cursor,
+                    kind in {"Q", "W", "I", "x", "r"},
+                )
+        cursor += 1
+    return None
 
 
 def executable_source(path: Path, source: str) -> str:
@@ -569,6 +759,7 @@ def executable_source(path: Path, source: str) -> str:
                 razor_source,
             )
         )
+        source = _mask_razor_markup(razor_source, ranges)
     elif suffix in {".php", ".phtml"}:
         # Both extensions may be mixed HTML/PHP templates. Feeding surrounding
         # markup to the PHP lexer lets an apostrophe in page text open a string
@@ -1265,6 +1456,44 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             index = end
             continue
 
+        if suffix == ".rb" and source[index] == "%":
+            percent_literal = _ruby_percent_literal(source, index)
+            if percent_literal is not None:
+                literal_end, contents_start, contents_end, interpolates = (
+                    percent_literal
+                )
+                string_start = index
+                _blank(code, string_start, literal_end)
+                _blank(without_comments, string_start, literal_end)
+                if interpolates:
+                    for expression_start, expression_end in _ruby_interpolation_ranges(
+                        source, contents_start, contents_end
+                    ):
+                        nested = lex_source(
+                            source[expression_start:expression_end], suffix
+                        )
+                        code[expression_start:expression_end] = list(nested.code)
+                        without_comments[expression_start:expression_end] = list(
+                            nested.without_comments
+                        )
+                        strings.extend(
+                            StringToken(
+                                expression_start + token.start,
+                                expression_start + token.end,
+                                token.contents,
+                            )
+                            for token in nested.strings
+                        )
+                strings.append(
+                    StringToken(
+                        string_start,
+                        literal_end,
+                        source[contents_start:contents_end],
+                    )
+                )
+                index = literal_end
+                continue
+
         # Heredoc bodies are DATA, not code. They were lexed as code, so an
         # apostrophe inside one ("Don't edit by hand") paired with a later quote
         # and masked the send that followed.
@@ -1350,6 +1579,29 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             # Nested string tokens are recorded before the enclosing template
             # token so lookups inside an interpolation select the narrow token.
             for expression_start, expression_end in _javascript_template_expression_ranges(
+                source, contents_start, contents_end
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif delimiter in {'"', "`"} and suffix == ".rb":
+            # Ruby double-quoted strings and command literals execute
+            # interpolation expressions.
+            # Preserve the code within each `#{...}` while keeping surrounding
+            # string data masked, just as JavaScript template literals do.
+            for expression_start, expression_end in _ruby_interpolation_ranges(
                 source, contents_start, contents_end
             ):
                 nested = lex_source(

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1522,7 +1522,8 @@ _HEREDOC_OPENER_RE = re.compile(
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
 _SHELL_HEREDOC_REDIRECTION_RE = re.compile(
     r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
-    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"])*\"|(?:\\.|[^ \t\r\n;<>&|])+)",
+    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"\\])*\"|"
+    r"(?:\\.|[^\\ \t\r\n;<>&|])+)",
 )
 
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1230,6 +1230,15 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 end = _line_comment_end(source, index + 2, suffix)
                 index = end
                 continue
+            if suffix == ".php" and source.startswith("#[", index):
+                # PHP 8 attributes begin with `#[`. Treating that opener as a
+                # legacy hash comment masks the rest of the physical line,
+                # including a declaration and request that legally follow the
+                # attribute. The attribute body remains ordinary PHP syntax;
+                # the normal string and block-comment branches below still
+                # mask data nested inside it.
+                index += 2
+                continue
             end = _line_comment_end(source, index + 1, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -152,6 +152,17 @@ def canonical_suffix(path: Path) -> str:
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
 
 
+def source_dialect(path: Path) -> str:
+    """Return a dialect that shares a canonical grammar suffix."""
+
+    suffix = path.suffix.lower()
+    if suffix in {".kt", ".kts"}:
+        return "kotlin"
+    if suffix == ".scala":
+        return "scala"
+    return ""
+
+
 def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
     """Preserve offsets/newlines while retaining only executable ranges."""
     keep = bytearray(len(source))
@@ -634,6 +645,253 @@ def _ruby_percent_literal(
                 )
         cursor += 1
     return None
+
+
+def _python_f_string_prefix(source: str, quote_start: int) -> str:
+    """Return a valid Python f-string prefix immediately before a quote."""
+
+    start = quote_start
+    while start > 0 and source[start - 1].isalpha():
+        start -= 1
+    prefix = source[start:quote_start].lower()
+    if prefix not in {"f", "fr", "rf"}:
+        return ""
+    if start > 0 and (source[start - 1].isalnum() or source[start - 1] == "_"):
+        return ""
+    return prefix
+
+
+def _csharp_string_info(
+    source: str, quote_start: int, quote_run: int
+) -> tuple[bool, bool, int]:
+    """Return ``(verbatim_or_raw, interpolates, brace_count)`` for C#."""
+
+    if quote_run >= 3:
+        cursor = quote_start
+        while cursor > 0 and source[cursor - 1] == "$":
+            cursor -= 1
+        dollars = quote_start - cursor
+        return True, dollars > 0, max(1, dollars)
+    prefix_start = max(0, quote_start - 2)
+    prefix = source[prefix_start:quote_start]
+    if prefix in {"$@", "@$"}:
+        return True, True, 1
+    if quote_start > 0 and source[quote_start - 1] == "@":
+        return True, False, 1
+    if quote_start > 0 and source[quote_start - 1] == "$":
+        return False, True, 1
+    return False, False, 1
+
+
+def _scala_interpolated_string_prefix(source: str, quote_start: int) -> str:
+    """Return a Scala interpolator prefix immediately before a quote."""
+
+    start = quote_start
+    while start > 0 and source[start - 1].isalpha():
+        start -= 1
+    prefix = source[start:quote_start]
+    if prefix not in {"s", "f", "raw"}:
+        return ""
+    if start > 0 and (source[start - 1].isalnum() or source[start - 1] == "_"):
+        return ""
+    return prefix
+
+
+def _interpolation_expression_end(
+    source: str, start: int, end: int, language: str
+) -> int:
+    """Trim alignment/conversion/format syntax from an interpolation hole."""
+
+    stack: list[str] = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    quote = ""
+    escaped = False
+    for index in range(start, end):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif character in pairs:
+            stack.append(pairs[character])
+        elif stack and character == stack[-1]:
+            stack.pop()
+        elif not stack and (
+            (language == "python" and character in "!:")
+            or (language == "csharp" and character in ",:")
+        ):
+            return index
+    return end
+
+
+def _interpolation_ranges(
+    source: str,
+    start: int,
+    end: int,
+    *,
+    language: str,
+    brace_count: int = 1,
+    dollar_marker: bool = False,
+) -> list[tuple[int, int]]:
+    """Return executable expression spans within interpolated strings."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    opener = "${" if dollar_marker else "{" * brace_count
+    while cursor < end:
+        marker = source.find(opener, cursor, end)
+        if marker < 0:
+            break
+        if (
+            dollar_marker
+            and language == "scala"
+            and marker > start
+            and source[marker - 1] == "$"
+        ):
+            # Scala's s/f/raw interpolators spell a literal dollar as `$$`.
+            cursor = marker + 2
+            continue
+        if brace_count == 1 and source.startswith("{{", marker):
+            cursor = marker + 2
+            continue
+        expression_start = marker + len(opener)
+        closing = _interpolation_hole_closing(
+            source, expression_start, end, brace_count
+        )
+        if closing is None:
+            break
+        expression_end = _interpolation_expression_end(
+            source, expression_start, closing, language
+        )
+        if expression_start < expression_end:
+            ranges.append((expression_start, expression_end))
+        if language == "python" and expression_end < closing:
+            # Python format specs can themselves contain replacement fields.
+            ranges.extend(
+                _interpolation_ranges(
+                    source,
+                    expression_end + 1,
+                    closing,
+                    language=language,
+                )
+            )
+        cursor = closing + brace_count
+    return ranges
+
+
+def _interpolation_hole_closing(
+    source: str, start: int, end: int, brace_count: int
+) -> int | None:
+    """Return the closing-brace index for one interpolation expression."""
+
+    closer = "}" * brace_count
+    index = start
+    nested_braces = 0
+    quote = ""
+    escaped = False
+    while index < end:
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if character == "{":
+            nested_braces += 1
+            index += 1
+            continue
+        if character == "}":
+            if nested_braces:
+                nested_braces -= 1
+                index += 1
+                continue
+            if source.startswith(closer, index):
+                return index
+        index += 1
+    return None
+
+
+def _shell_command_substitution_end(
+    source: str, start: int, end: int
+) -> int | None:
+    """Return the closing parenthesis for a shell ``$(...)`` expression."""
+
+    depth = 1
+    index = start
+    quote = ""
+    escaped = False
+    while index < end:
+        character = source[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if character == "\\":
+            escaped = True
+            index += 1
+            continue
+        if quote:
+            if character == quote:
+                quote = ""
+            index += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif source.startswith("$(", index):
+            depth += 1
+            index += 1
+        elif character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
+
+
+def _shell_command_substitution_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable command spans inside a shell double-quoted string."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("$(", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        before = marker - 1
+        while before >= start and source[before] == "\\":
+            backslashes += 1
+            before -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        closing = _shell_command_substitution_end(source, marker + 2, end)
+        if closing is None:
+            break
+        ranges.append((marker + 2, closing))
+        ranges.extend(
+            _shell_command_substitution_ranges(source, marker + 2, closing)
+        )
+        cursor = closing + 1
+    return ranges
 
 
 def executable_source(path: Path, source: str) -> str:
@@ -1373,7 +1631,7 @@ def _javascript_regex_end(source: str, start: int) -> int | None:
     return None
 
 
-def lex_source(source: str, suffix: str) -> LexedSource:
+def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
     code = list(source)
@@ -1522,7 +1780,32 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         delimiter = quote
-        if quote in {"'", '"'} and source.startswith(quote * 3, index):
+        quote_run = 1
+        while index + quote_run < len(source) and source[index + quote_run] == quote:
+            quote_run += 1
+        python_f_string = suffix == ".py" and bool(
+            _python_f_string_prefix(source, index)
+        )
+        jvm_interpolates = quote == '"' and (
+            dialect == "kotlin"
+            or (
+                dialect == "scala"
+                and bool(_scala_interpolated_string_prefix(source, index))
+            )
+        )
+        jvm_raw = jvm_interpolates and quote_run >= 3
+        csharp_verbatim = False
+        csharp_interpolates = False
+        csharp_brace_count = 1
+        if suffix == ".cs" and quote == '"':
+            (
+                csharp_verbatim,
+                csharp_interpolates,
+                csharp_brace_count,
+            ) = _csharp_string_info(source, index, quote_run)
+            if quote_run >= 3:
+                delimiter = quote * quote_run
+        elif quote in {"'", '"'} and quote_run >= 3:
             delimiter = quote * 3
         string_start = index
         index += len(delimiter)
@@ -1530,12 +1813,54 @@ def lex_source(source: str, suffix: str) -> LexedSource:
         # A backtick delimits a Go RAW string, which has no escape sequences, so
         # a literal `\` inside one previously consumed the closing backtick and
         # ran the "string" to end of file.
-        honours_escapes = not (suffix == ".go" and delimiter == "`")
-        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
-            JS_TS_SUFFIXES | {".py"}
+        honours_escapes = not (
+            (suffix == ".go" and delimiter == "`")
+            or csharp_verbatim
+            or jvm_raw
         )
+        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
+            JS_TS_SUFFIXES | {".py", ".cs", ".java"}
+        ) and not (csharp_verbatim or jvm_raw)
         terminated = False
         while index < len(source):
+            if python_f_string or csharp_interpolates or jvm_interpolates:
+                brace_count = csharp_brace_count if csharp_interpolates else 1
+                opener = "${" if jvm_interpolates else "{" * brace_count
+                if source.startswith(opener, index):
+                    if (
+                        dialect == "scala"
+                        and jvm_interpolates
+                        and index > contents_start
+                        and source[index - 1] == "$"
+                    ):
+                        index += 2
+                        continue
+                    if brace_count == 1 and source.startswith("{{", index):
+                        index += 2
+                        continue
+                    hole_end = _interpolation_hole_closing(
+                        source,
+                        index + len(opener),
+                        len(source),
+                        brace_count,
+                    )
+                    if hole_end is not None:
+                        index = hole_end + brace_count
+                        continue
+            if suffix == ".sh" and delimiter == '"' and source.startswith("$(", index):
+                hole_end = _shell_command_substitution_end(
+                    source, index + 2, len(source)
+                )
+                if hole_end is not None:
+                    index = hole_end + 1
+                    continue
+            if (
+                csharp_verbatim
+                and len(delimiter) == 1
+                and source.startswith('""', index)
+            ):
+                index += 2
+                continue
             if source.startswith(delimiter, index):
                 contents_end = index
                 index += len(delimiter)
@@ -1582,7 +1907,7 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 source, contents_start, contents_end
             ):
                 nested = lex_source(
-                    source[expression_start:expression_end], suffix
+                    source[expression_start:expression_end], suffix, dialect
                 )
                 code[expression_start:expression_end] = list(nested.code)
                 without_comments[expression_start:expression_end] = list(
@@ -1605,7 +1930,63 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 source, contents_start, contents_end
             ):
                 nested = lex_source(
-                    source[expression_start:expression_end], suffix
+                    source[expression_start:expression_end], suffix, dialect
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif python_f_string or csharp_interpolates or jvm_interpolates:
+            language = (
+                "python"
+                if python_f_string
+                else "csharp"
+                if csharp_interpolates
+                else dialect
+            )
+            brace_count = csharp_brace_count if csharp_interpolates else 1
+            for expression_start, expression_end in _interpolation_ranges(
+                source,
+                contents_start,
+                contents_end,
+                language=language,
+                brace_count=brace_count,
+                dollar_marker=jvm_interpolates,
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix, dialect
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif suffix == ".sh" and delimiter in {'"', "`"}:
+            ranges = (
+                [(contents_start, contents_end)]
+                if delimiter == "`"
+                else _shell_command_substitution_ranges(
+                    source, contents_start, contents_end
+                )
+            )
+            for expression_start, expression_end in ranges:
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix, dialect
                 )
                 code[expression_start:expression_end] = list(nested.code)
                 without_comments[expression_start:expression_end] = list(
@@ -9938,6 +10319,41 @@ def shell_command_span(lexed: LexedSource, offset: int) -> tuple[int, int]:
     return start, end
 
 
+def shell_embedded_command_span(
+    lexed: LexedSource, offset: int
+) -> tuple[int, int] | None:
+    """Bound the narrowest quoted shell command containing ``offset``."""
+
+    candidates: list[tuple[int, int]] = []
+    for token in lexed.strings:
+        if not (token.start < offset < token.end):
+            continue
+        delimiter = lexed.original[token.start]
+        if delimiter == "`":
+            candidates.append((token.start + 1, token.end - 1))
+        elif delimiter == '"':
+            candidates.extend(
+                span
+                for span in _shell_command_substitution_ranges(
+                    lexed.original, token.start + 1, token.end - 1
+                )
+                if span[0] <= offset < span[1]
+            )
+    if not candidates:
+        return None
+    lower, upper = min(candidates, key=lambda span: span[1] - span[0])
+    start, end = lower, upper
+    for index in range(offset - 1, lower - 1, -1):
+        if shell_separator(lexed, index):
+            start = index + 1
+            break
+    for index in range(offset, upper):
+        if shell_separator(lexed, index):
+            end = index
+            break
+    return start, end
+
+
 def shell_curl_is_command(
     lexed: LexedSource, command_start: int, curl_start: int
 ) -> bool:
@@ -9963,7 +10379,9 @@ def shell_curl_calls(lexed: LexedSource) -> list[Call]:
     calls: list[Call] = []
     seen: set[tuple[int, int]] = set()
     for match in SHELL_CURL_RE.finditer(lexed.code):
-        start, end = shell_command_span(lexed, match.start(1))
+        start, end = shell_embedded_command_span(
+            lexed, match.start(1)
+        ) or shell_command_span(lexed, match.start(1))
         if not shell_curl_is_command(lexed, start, match.start(1)):
             continue
         if (start, end) not in seen:
@@ -11526,7 +11944,7 @@ def external_static_values(
     exports. Dynamic/package imports stay unknown instead of being guessed.
     """
 
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     visible = lexed.without_comments
     imports: list[tuple[str, str, str]] = []
     if suffix in JS_TS_SUFFIXES:
@@ -11805,7 +12223,7 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     if suffix != ".cs":
@@ -12010,7 +12428,7 @@ def message_body_fields(
     source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     source_resolver = SourceEndpointResolver(lexed, suffix)
     resolver = PayloadStateResolver(
         lexed,

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1511,7 +1511,7 @@ def _line_comment_end(source: str, start: int, suffix: str) -> int:
 # as heredoc openers, and since no later line matched the pseudo-tag the "body"
 # ran to EOF and blanked every send below it - a silent pass.
 _HEREDOC_OPENER_RE = re.compile(
-    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)[ \t]*(?=\r?\n|$)"
+    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)(?!\w)"
 )
 # Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
 # singleton-class syntax `class <<self` also puts a bare word straight after
@@ -1520,6 +1520,32 @@ _HEREDOC_OPENER_RE = re.compile(
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+_SHELL_HEREDOC_REDIRECTION_RE = re.compile(
+    r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
+    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"])*\"|(?:\\.|[^ \t\r\n;<>&|])+)",
+)
+
+
+def _shell_heredoc_redirection_tail(tail: str) -> bool:
+    """Accept only shell redirections after a heredoc delimiter.
+
+    A delimiter need not end the physical command: `cat <<EOF >out 2>&1` is
+    valid shell.  The lexer must mask that body, while still rejecting an
+    arbitrary expression containing `<< WORD`.  Consuming a sequence of
+    concrete redirections keeps that boundary explicit.
+    """
+
+    position = 0
+    while position < len(tail):
+        if tail[position:].strip() == "":
+            return True
+        if tail[position:].lstrip().startswith("#"):
+            return True
+        match = _SHELL_HEREDOC_REDIRECTION_RE.match(tail, position)
+        if match is None or match.end() == position:
+            return False
+        position = match.end()
+    return True
 
 
 def _heredoc_opener_at(
@@ -1534,8 +1560,17 @@ def _heredoc_opener_at(
     match = _HEREDOC_OPENER_RE.match(source, index)
     if match is None:
         return None
+    line_start = source.rfind("\n", 0, index) + 1
+    line_end = source.find("\n", match.end())
+    if line_end < 0:
+        line_end = len(source)
+    tail = source[match.end():line_end]
+    if suffix == ".sh":
+        if not _shell_heredoc_redirection_tail(tail):
+            return None
+    elif tail.strip():
+        return None
     if suffix == ".rb":
-        line_start = source.rfind("\n", 0, index) + 1
         if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
             return None
     return match
@@ -1668,7 +1703,23 @@ def _javascript_regex_can_start(
     if character == "}":
         return _javascript_block_brace(code, previous)
     if character.isalnum() or character in "_$":
-        return _word_before(code, previous + 1).lower() in _JS_REGEX_PREFIX_WORDS
+        word = _word_before(code, previous + 1).lower()
+        if word == "default":
+            # `export default /pattern/` expects an expression, but treating
+            # every property named `default` as that keyword would mislex
+            # `config.default / divisor` (ordinary division).  Require the
+            # complete contextual keyword pair.
+            word_start = previous + 1 - len(word)
+            before_word = _previous_code_index(code, word_start)
+            if before_word is None:
+                return False
+            export_word = _word_before(code, before_word + 1).lower()
+            export_start = before_word + 1 - len(export_word)
+            before_export = _previous_code_index(code, export_start)
+            return export_word == "export" and (
+                before_export is None or code[before_export] != "."
+            )
+        return word in _JS_REGEX_PREFIX_WORDS
     return False
 
 
@@ -4067,13 +4118,56 @@ _EXECUTION_LINK_RE = {
     ),
     ".py": r"urlopen\s*\(\s*{name}\b",
     ".go": r"\.\s*Do\s*\(\s*{name}\b",
+    # Net::HTTP::{Post,Put,Patch}.new only constructs a request. Ruby sends it
+    # later through Net::HTTP#request, with either parenthesized or command-call
+    # syntax. Requiring that link prevents fixtures/builders from being
+    # reported as live customer sends.
+    ".rb": r"\.\s*request\s*(?:\(\s*{name}\b|[ \t]+{name}\b)",
 }
 _INLINE_EXECUTION_RE = re.compile(
     # The constructor may be namespaced inside the execution call, as in
     # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
-    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do)\s*\(\s*"
+    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
     r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
 )
+
+
+def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
+    """Return conservative Ruby `def ... end` spans from masked source."""
+
+    stack: list[tuple[str, int | None]] = []
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for line in code.splitlines(keepends=True):
+        stripped = line.strip()
+        if re.match(r"end\b", stripped) and stack:
+            kind, start = stack.pop()
+            if kind == "def" and start is not None:
+                spans.append((start, cursor + len(line)))
+        else:
+            opener = re.match(r"(def|class|module)\b", stripped)
+            if opener is not None:
+                stack.append((opener.group(1), cursor))
+            elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
+                stack.append(("block", None))
+            elif re.match(
+                r"(?:if|unless|case|begin|for|while|until)\b", stripped
+            ):
+                stack.append(("control", None))
+        cursor += len(line)
+    return spans
+
+
+def _same_ruby_function_scope(
+    code: str, left: int, right: int, spans: list[tuple[int, int]]
+) -> bool:
+    """Whether two offsets belong to the same Ruby method (or top level)."""
+
+    def owner(offset: int) -> tuple[int, int] | None:
+        containing = [span for span in spans if span[0] <= offset < span[1]]
+        return min(containing, key=lambda span: span[1] - span[0]) if containing else None
+
+    return owner(left) == owner(right)
 
 
 def request_object_is_executed(
@@ -4114,15 +4208,34 @@ def request_object_is_executed(
         ) is not None
     # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
     # never the one executed, so every candidate must be tried.
+    name_pattern = (
+        r"(?:@@|@|\$)?[A-Za-z_]\w*" if suffix == ".rb" else r"[A-Za-z_]\w*"
+    )
     names = [
         name
-        for name in re.findall(r"[A-Za-z_]\w*", assignment.group(1))
+        for name in re.findall(name_pattern, assignment.group(1))
         if name != "_"
     ]
-    return any(
-        re.search(pattern.format(name=re.escape(name)), lexed.code[statement_start:])
-        for name in names
-    )
+    tail = lexed.code[call.end:]
+    ruby_spans = _ruby_function_spans(lexed.code) if suffix == ".rb" else []
+    for name in names:
+        execution = re.search(pattern.format(name=re.escape(name)), tail)
+        if execution is None:
+            continue
+        execution_offset = call.end + execution.start()
+        if suffix == ".rb" and not _same_ruby_function_scope(
+            lexed.code, call.start, execution_offset, ruby_spans
+        ):
+            continue
+        # A new reaching definition supersedes this request object. A later
+        # execution of the same variable must not retroactively execute the
+        # discarded constructor.
+        rebound = re.search(
+            rf"(?<![\w@$]){re.escape(name)}\s*=(?!=)", tail[:execution.start()]
+        )
+        if rebound is None:
+            return True
+    return False
 
 
 def php_stream_context_region(
@@ -5425,7 +5538,7 @@ def _request_url_spans(
         # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
         return args[1:2]
     if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
-        return args[0:1]
+        return args[0:1] if request_object_is_executed(lexed, call, suffix) else []
     if callee == "curl_init" and len(args) >= 1:
         # `curl_init($url)` sets CURLOPT_URL directly - it is the documented
         # one-liner form and is at least as common as the setopt spelling.
@@ -11588,7 +11701,30 @@ def consumed_endpoint_tokens(
             break
     consumed |= _tokens_in_span(lexed, (statement_start, statement_end))
 
-    for span in request_url_spans(lexed, call, suffix):
+    resolved_spans = request_url_spans(lexed, call, suffix)
+    if not resolved_spans:
+        # Recognised request-object constructors can be deliberately rejected
+        # because they are never executed (or use a read-only verb). Their URL
+        # is still accounted for by this analysed call; otherwise an alias such
+        # as `uri = URI(URL); req = Net::HTTP::Post.new(uri)` is re-reported by
+        # the fail-safe as an unknown send. Keep this list to constructors whose
+        # URL position is part of an explicit client signature.
+        args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+        callee = normalized_call_callee(lexed, call)
+        if args and callee.endswith("new") and "Net::HTTP::" in callee:
+            resolved_spans = args[0:1]
+        elif args and suffix == ".py" and callee.split(".")[-1] == "Request":
+            resolved_spans = args[0:1]
+        elif args and callee == "HttpRequestMessage":
+            resolved_spans = args[1:2]
+        elif args and callee == "RestRequest":
+            resolved_spans = args[0:1]
+        elif suffix in {".java", ".kt", ".kts", ".scala"}:
+            builder_span = builder_uri_span(lexed, call)
+            if builder_span is not None:
+                resolved_spans = [builder_span]
+
+    for span in resolved_spans:
         consumed |= _tokens_in_span(lexed, span)
         # Follow the alias chain the resolver itself walked. The endpoint is
         # often held one or more hops away - `url = routes.get("pool")` where

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -738,6 +738,7 @@ def _interpolation_ranges(
     language: str,
     brace_count: int = 1,
     dollar_marker: bool = False,
+    backslash_escapes_marker: bool = False,
 ) -> list[tuple[int, int]]:
     """Return executable expression spans within interpolated strings."""
 
@@ -748,6 +749,17 @@ def _interpolation_ranges(
         marker = source.find(opener, cursor, end)
         if marker < 0:
             break
+        if dollar_marker and backslash_escapes_marker:
+            backslashes = 0
+            before = marker - 1
+            while before >= start and source[before] == "\\":
+                backslashes += 1
+                before -= 1
+            if backslashes % 2:
+                # Kotlin normal strings spell a literal dollar as `\$`.
+                # An even run escapes only itself, leaving `$` executable.
+                cursor = marker + 2
+                continue
         if (
             dollar_marker
             and language == "scala"
@@ -1960,6 +1972,9 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 language=language,
                 brace_count=brace_count,
                 dollar_marker=jvm_interpolates,
+                backslash_escapes_marker=(
+                    dialect == "kotlin" and not jvm_raw
+                ),
             ):
                 nested = lex_source(
                     source[expression_start:expression_end], suffix, dialect

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -569,11 +569,14 @@ def executable_source(path: Path, source: str) -> str:
                 razor_source,
             )
         )
-    elif suffix == ".phtml":
-        # PHTML is a mixed HTML/PHP template, not a plain PHP source file.
-        # Feeding its markup to the PHP lexer lets an apostrophe in page text
-        # open a string that masks a later request inside <?php ... ?>.
-        ranges.extend(
+    elif suffix in {".php", ".phtml"}:
+        # Both extensions may be mixed HTML/PHP templates. Feeding surrounding
+        # markup to the PHP lexer lets an apostrophe in page text open a string
+        # that masks a later request inside <?php ... ?>. Preserve only PHP
+        # regions whenever tags are present. Tagless `.php` remains supported
+        # because many analyzer fixtures and generated snippets contain raw PHP
+        # statements without an opening tag; tagless `.phtml` remains markup.
+        php_ranges = [
             match.span("code")
             for match in re.finditer(
                 # Plain ``<?`` is executable when short_open_tag is enabled.
@@ -584,7 +587,14 @@ def executable_source(path: Path, source: str) -> str:
                 source,
                 flags=re.IGNORECASE | re.DOTALL,
             )
-        )
+        ]
+        if (
+            suffix == ".php"
+            and not php_ranges
+            and re.search(r"</?[A-Za-z!]", source) is None
+        ):
+            return source
+        ranges.extend(php_ranges)
     elif suffix in {".ejs", ".erb", ".jsp"}:
         if suffix == ".ejs":
             # EJS scriptlets execute on the server, while ordinary <script>

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -928,6 +928,24 @@ def _interpolation_hole_closing(
     return None
 
 
+def _shell_comment_start(source: str, index: int, start: int = 0) -> bool:
+    """A shell hash starts a comment only at an unescaped word boundary."""
+    before = index - 1
+    # A continued physical line does not introduce a new shell word.
+    while before > start and source[before - 1:before + 1] == "\\\n":
+        before -= 2
+    if before < start:
+        return True
+    if not (source[before].isspace() or source[before] in ";|&()<>"):
+        return False
+    backslashes = 0
+    cursor = before - 1
+    while cursor >= start and source[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 0
+
+
 def _shell_command_substitution_end(
     source: str, start: int, end: int
 ) -> int | None:
@@ -952,6 +970,12 @@ def _shell_command_substitution_end(
                 quote = ""
             index += 1
             continue
+        if character == "#" and _shell_comment_start(source, index, start):
+            # Parentheses in a shell comment cannot close (or nest) this
+            # substitution. Commands after its newline still execute.
+            newline = source.find("\n", index, end)
+            index = end if newline < 0 else newline + 1
+            continue
         if character in {"'", '"', "`"}:
             quote = character
         elif source.startswith("$(", index):
@@ -970,29 +994,40 @@ def _shell_command_substitution_end(
 def _shell_command_substitution_ranges(
     source: str, start: int, end: int
 ) -> list[tuple[int, int]]:
-    """Return executable command spans inside a shell double-quoted string."""
+    """Return outer substitutions in expanding shell text.
+
+    Each command is lexed in its own shell context by the caller. Descending
+    here would incorrectly execute substitutions inside that command's single
+    quotes or comments. Quotes in the surrounding string/heredoc are data.
+    """
 
     ranges: list[tuple[int, int]] = []
     cursor = start
     while cursor < end:
-        marker = source.find("$(", cursor, end)
-        if marker < 0:
-            break
-        backslashes = 0
-        before = marker - 1
-        while before >= start and source[before] == "\\":
-            backslashes += 1
-            before -= 1
-        if backslashes % 2:
-            cursor = marker + 2
+        if source[cursor] == "\\":
+            cursor += 2
             continue
-        closing = _shell_command_substitution_end(source, marker + 2, end)
+        if source.startswith("$(", cursor):
+            opening = cursor + 2
+            closing = _shell_command_substitution_end(source, opening, end)
+        elif source[cursor] == "`":
+            opening = cursor + 1
+            closing = opening
+            while closing < end:
+                if source[closing] == "\\":
+                    closing += 2
+                elif source[closing] == "`":
+                    break
+                else:
+                    closing += 1
+            if closing >= end:
+                closing = None
+        else:
+            cursor += 1
+            continue
         if closing is None:
             break
-        ranges.append((marker + 2, closing))
-        ranges.extend(
-            _shell_command_substitution_ranges(source, marker + 2, closing)
-        )
+        ranges.append((opening, closing))
         cursor = closing + 1
     return ranges
 
@@ -1804,6 +1839,8 @@ CSHARP_JSON_MUTATING_METHODS = frozenset(
 CSHARP_ONLY_FETCH_METHODS = frozenset(
     {"PutAsync", "PatchAsync", *CSHARP_JSON_MUTATING_METHOD_NAMES}
 )
+# Both net/http constructors share method/URL/body order after optional context.
+GO_REQUEST_METHOD_INDEX = {"NewRequest": 0, "NewRequestWithContext": 1}
 FETCH_CALL_RE = re.compile(
     rf"(?<![\w$])(?:fetch|request|post_form|postAsync|"
     rf"(?:{CSHARP_HTTP_CONTENT_METHOD_PATTERN})|"
@@ -1819,7 +1856,7 @@ FETCH_CALL_RE = re.compile(
     # migrated Ruby uses. Modelling only Net::HTTP.post made the whole shape
     # invisible: zero sends detected, so the fail-safe could not fire either.
     r"Net::HTTP::(?:Post|Put|Patch)\s*\.\s*new|"
-    r"NewRequest|curl_setopt_array|curl_setopt|curl_init|"
+    r"NewRequest(?:WithContext)?|curl_setopt_array|curl_setopt|curl_init|"
     r"HttpRequestMessage|RestRequest|Request|open|file_get_contents|"
     r"axios\s*\.\s*post|axios)\s*\("
 )
@@ -2294,7 +2331,7 @@ def _heredoc_langs(suffix: str) -> bool:
     return suffix in {".php", ".rb"}
 
 
-def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
+def _shell_heredoc_ranges(source: str) -> list[tuple[int, int, bool]]:
     """Return shell heredoc body ranges in one command-aware linear pass.
 
     The scan follows quotes, arithmetic contexts and backslash continuations,
@@ -2304,8 +2341,11 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
     arithmetic shifts and here-strings.
     """
 
-    ranges: list[tuple[int, int]] = []
-    pending: list[tuple[str, bool]] = []
+    ranges: list[tuple[int, int, bool]] = []
+    pending: list[tuple[str, bool, bool]] = []
+    opener_re = re.compile(
+        r'''<<(?P<tabs>-)?[ \t]*(?P<word>(?:\\.|'[^'\n]*'|"[^"\n]*"|[^\s\\'"<>;&|])+)'''
+    )
     quote = ""
     escaped = False
     parenthesis_depth = 0
@@ -2360,9 +2400,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
             quote = character
             index += 1
             continue
-        if character == "#" and (
-            index == command_start or source[index - 1].isspace()
-        ):
+        if character == "#" and _shell_comment_start(source, index, command_start):
             comment_start = index
             newline = source.find("\n", index + 1)
             index = len(source) if newline < 0 else newline
@@ -2370,11 +2408,17 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
         if source.startswith("<<<", index):
             index += 3
             continue
-        opener = _HEREDOC_OPENER_RE.match(source, index)
+        opener = opener_re.match(source, index)
         if opener is not None and (
             index == 0 or source[index - 1] != "<"
         ):
-            pending.append((opener.group("tag"), "<<-" in opener.group(0)))
+            word = opener.group("word")
+            try:
+                tag = shlex.split(word, posix=True)[0]
+            except (ValueError, IndexError):
+                index = opener.end()
+                continue
+            pending.append((tag, bool(opener.group("tabs")), not any(c in word for c in "'\"\\")))
             index = opener.end()
             continue
         if character != "\n":
@@ -2393,7 +2437,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
             continue
 
         body_start = index + 1
-        for tag, strips_tabs in pending:
+        for tag, strips_tabs, expands in pending:
             cursor = body_start
             terminator_start: int | None = None
             terminator_end: int | None = None
@@ -2411,7 +2455,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
                 cursor = line_end + 1
             body_end = len(source) if terminator_start is None else terminator_start
             if body_start < body_end:
-                ranges.append((body_start, body_end))
+                ranges.append((body_start, body_end, expands))
             if terminator_end is None:
                 body_start = len(source)
                 break
@@ -2976,9 +3020,16 @@ def _lex_source_once(
         ):
             shell_heredoc_index += 1
         if shell_heredoc_index < len(shell_heredoc_ranges):
-            body_start, body_end = shell_heredoc_ranges[shell_heredoc_index]
+            body_start, body_end, expands = shell_heredoc_ranges[shell_heredoc_index]
             if body_start <= index < body_end:
                 _blank(code, body_start, body_end)
+                if expands:
+                    for start, end in _shell_command_substitution_ranges(source, body_start, body_end):
+                        nested = lex_source(source[start:end], suffix, dialect)
+                        code[start:end] = list(nested.code)
+                        without_comments[start:end] = list(nested.without_comments)
+                        strings.extend(StringToken(start + token.start, start + token.end, token.contents)
+                                       for token in nested.strings)
                 strings.append(
                     StringToken(
                         body_start, body_end, source[body_start:body_end]
@@ -3062,7 +3113,9 @@ def _lex_source_once(
             index = end
             continue
 
-        if hash_comments and source[index] == "#":
+        if hash_comments and source[index] == "#" and (
+            suffix != ".sh" or _shell_comment_start(source, index)
+        ):
             if suffix == ".sh" and index == 0 and source.startswith("#!", index):
                 end = _line_comment_end(source, index + 2, suffix)
                 index = end
@@ -4251,6 +4304,18 @@ def rest_payload_spans(
         return assigned_named_payload_spans(
             lexed, arguments[0], call.start, suffix
         )
+    if suffix in JS_TS_SUFFIXES and callee == "request":
+        if node_core_request(lexed, call, suffix):
+            return request_write_payload_spans(lexed, call, suffix)
+        # URL/options overloads carry no positional body. In particular the
+        # optional callback must never be inspected as a request payload.
+        config = next((span for span in arguments[:2]
+                       if resolved_config_object_span(lexed, span, call.start, suffix)
+                       is not None), None)
+        if config is not None:
+            configured = named_payload_spans(lexed.code, [config], allow_js_shorthand=True)
+            configured = configured or assigned_named_payload_spans(lexed, config, call.start, suffix)
+            return configured or request_write_payload_spans(lexed, call, suffix)
     named = named_payload_spans(
         lexed.code,
         arguments,
@@ -4263,11 +4328,11 @@ def rest_payload_spans(
         if method is None or method.upper() in MUTATING_HTTP_METHODS:
             return arguments[2:3]
 
-    if callee == "NewRequest" and len(arguments) >= 3:
+    if callee in GO_REQUEST_METHOD_INDEX and len(arguments) >= GO_REQUEST_METHOD_INDEX[callee] + 3:
         # http.NewRequest(method, url, body): the body is the third argument,
         # normally wrapped (bytes.NewBuffer(json.Marshal output)).
         return [
-            resolve_wrapped_payload(lexed, arguments[2], call.start, suffix)
+            resolve_wrapped_payload(lexed, arguments[GO_REQUEST_METHOD_INDEX[callee] + 2], call.start, suffix)
         ]
     if callee.split(".")[-1] == "post_form":
         # Net::HTTP.post_form(uri, k => v, ...): every pair after the URI is
@@ -4832,6 +4897,11 @@ def call_has_profile(
             if resolver.text_presence(value).state == PRESENT:
                 return True
         return False
+    if not sdk_call and suffix in JS_TS_SUFFIXES and normalized_call_callee(lexed, call) == "request":
+        written = request_write_events(lexed, call, suffix)
+        spans = rest_payload_spans(lexed, call, suffix)
+        if node_core_request(lexed, call, suffix) or spans == [event.span for event in written if event.span]:
+            return request_writes_have_profile(lexed, call, suffix, resolver, written)
     return any(
         resolver.span_presence(start, end, call.start).state == PRESENT
         for start, end in payload_spans(
@@ -6020,21 +6090,26 @@ def _top_level_ternary(
         elif char in ")]}":
             depth -= 1
         elif char == "?" and depth == 0:
-            if code[index + 1:index + 2] in (".", "?"):
+            if code[index + 1:index + 2] in (".", "?") or code[index - 1:index] == "?":
                 continue
             question = index
             break
     if question < 0:
         return None
-    depth = 0
+    depth = nested = 0
     for index in range(question + 1, end):
         char = code[index]
         if char in "([{":
             depth += 1
         elif char in ")]}":
             depth -= 1
+        elif char == "?" and depth == 0 and code[index + 1:index + 2] not in (".", "?") and code[index - 1:index] != "?":
+            nested += 1
         elif char == ":" and depth == 0:
-            return (question + 1, index), (index + 1, end)
+            if nested:
+                nested -= 1
+            else:
+                return (question + 1, index), (index + 1, end)
     return None
 
 
@@ -6615,28 +6690,550 @@ ASSIGNED_HANDLE_RE = re.compile(
 )
 
 
-def request_write_payload_spans(
-    lexed: LexedSource, call: Call
-) -> list[tuple[int, int]]:
-    """Return <handle>.write(...) payload spans after a request(...) call."""
+def node_core_request(lexed: LexedSource, call: Call, suffix: str) -> bool:
+    """Resolve core http(s) module ownership without treating library body as core."""
+    source = SourceEndpointResolver(lexed, suffix)
+    receiver = re.search(r"([A-Za-z_$][\w$]*)\s*\.\s*$", lexed.code[:call.start])
+    name = receiver[1] if receiver else "request"
+
+    def owned(name: str, before: int, seen: frozenset[str]) -> bool:
+        if name in seen:
+            return False
+        binding = source.graph.visible_binding(name, source.scope_at(before), before)
+        assignments = [a for a in source.root_assignments if a.start() < before and a[1] == name
+                       and source.graph.visible_binding(name, source.scope_at(a.start()), a.start()) == binding]
+        if assignments:
+            assignment = assignments[-1]
+            end = assignment_end(lexed, assignment.end(), suffix)
+            rhs = lexed.without_comments[assignment.end():end].strip().rstrip(";").strip()
+            if re.fullmatch(r"require\s*\(\s*['\"](?:node:)?https?['\"]\s*\)(?:\s*\.\s*request)?", rhs):
+                return True
+            alias = re.fullmatch(r"([A-Za-z_$][\w$]*)(?:\s*\.\s*request)?", rhs)
+            return bool(alias and owned(alias[1], assignment.start(), seen | {name}))
+        prefix = lexed.without_comments[:before]
+        module = r"['\"](?:node:)?https?['\"]"
+        if receiver:
+            patterns = [r"\bimport\s+(?:\*\s+as\s+)?" + re.escape(name) + r"\s+from\s*" + module]
+        else:
+            patterns = [r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*" + module,
+                        r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*require\s*\(\s*" + module]
+        for pattern in patterns:
+            for origin in re.finditer(pattern, prefix):
+                # Require executable syntax, and the same binding at its origin:
+                # neither import-looking strings nor shadowed parameters own it.
+                if not re.match(r"(?:import|const|let|var)\b", lexed.code[origin.start():]):
+                    continue
+                if not receiver and not any(re.fullmatch(r"request(?:\s*(?:as|:)\s*request)?", member.strip())
+                                            for member in origin["members"].split(",")):
+                    continue
+                if source.graph.visible_binding(name, source.scope_at(origin.start()), origin.end()) == binding:
+                    return True
+        return False
+
+    return owned(name, call.start, frozenset())
+
+
+@dataclass(frozen=True)
+class RequestWriteEvent:
+    offset: int
+    method: str
+    span: tuple[int, int] | None = None
+    binding: int | tuple[int | None, str] | None = None
+    source_binding: int | tuple[int | None, str] | None = None
+
+
+@dataclass(frozen=True)
+class RequestClosure:
+    start: int
+    parameters: tuple[tuple[int, int], ...]
+    body: int
+    end: int
+    arguments: tuple[tuple[int, int], ...] | None
+    invocation_end: int | None
+
+
+def request_closures(resolver: SourceEndpointResolver) -> list[RequestClosure]:
+    """Balanced closure boundaries, including deferred parameter initializers.
+
+    Only direct synchronous invocations are folded. A callback, stored closure,
+    async function or generator does not establish a write before a later end.
+    """
+    cached = getattr(resolver, "_request_closures", None)
+    if cached is not None:
+        return cached
+    code = resolver.lexed.code
+    pairs: dict[int, int] = {}
+    stack: list[int] = []
+    for index, char in enumerate(code):
+        if char in "([{":
+            stack.append(index)
+        elif char in ")]}" and stack:
+            opening = stack.pop()
+            pairs[opening] = index
+            pairs[index] = opening
+    closures = []
+    for token in re.finditer(r"\bfunction\b|=>", code):
+        start = token.start()
+        if token[0] == "function":
+            header = re.match(r"function\s*\*?\s*(?:[A-Za-z_$][\w$]*\s*)?\(", code[start:])
+            if header is None:
+                continue
+            opening = start + header.end() - 1
+            closing = pairs.get(opening)
+            if closing is None:
+                continue
+            body = closing + 1
+        else:
+            closing = token.start() - 1
+            while closing >= 0 and code[closing].isspace():
+                closing -= 1
+            if code[closing:closing + 1] == ")":
+                opening = pairs.get(closing)
+                if opening is None:
+                    continue
+                start = opening
+            else:
+                parameter = re.search(r"[A-Za-z_$][\w$]*$", code[:closing + 1])
+                if parameter is None:
+                    continue
+                start = parameter.start()
+                opening = start - 1
+            body = token.end()
+        parameters = tuple(span for span in split_arguments(code, opening + 1, closing)
+                           if code[slice(*span)].strip())
+        async_prefix = re.search(r"\basync\s*$", code[:start])
+        if async_prefix:
+            start = async_prefix.start()
+        while body < len(code) and code[body].isspace():
+            body += 1
+        if code[body:body + 1] == "{":
+            if body not in pairs:
+                continue
+            end = pairs[body] + 1
+        else:
+            end = body
+            while end < len(code) and code[end] not in ",;\n)]}":
+                end = pairs[end] + 1 if code[end] in "([{" and end in pairs else end + 1
+        wrapped_start, wrapped_end = start, end
+        while True:
+            before = wrapped_start - 1
+            while before >= 0 and code[before].isspace():
+                before -= 1
+            after = wrapped_end
+            while after < len(code) and code[after].isspace():
+                after += 1
+            if before < 0 or code[before] != "(" or pairs.get(before) != after:
+                break
+            # Parentheses owned by an outer call are not grouping parentheses.
+            if re.search(r"[\w$)\]]\s*$", code[:before]):
+                break
+            wrapped_start, wrapped_end = before, after + 1
+        invocation = re.match(r"\s*(?:\.\s*call\s*)?\(", code[wrapped_end:])
+        # A declaration followed by a parenthesized statement is not an IIFE.
+        if (re.match(r"function\s+[A-Za-z_$][\w$]*\s*\(", code[start:])
+                and wrapped_start == start
+                and not re.search(r"[=(:,\[!&|?]\s*$|\breturn\s*$", code[:start])):
+            invocation = None
+        arguments = None
+        invocation_end = None
+        if invocation and not async_prefix and not re.match(r"function\s*\*", code[start:]):
+            argument_open = wrapped_end + invocation.end() - 1
+            argument_end = pairs.get(argument_open)
+            if argument_end is not None:
+                invocation_end = argument_end + 1
+                arguments = tuple(span for span in split_arguments(code, argument_open + 1, argument_end)
+                                  if code[slice(*span)].strip())
+                if "." in invocation[0]:
+                    arguments = arguments[1:]
+        closures.append(RequestClosure(start, parameters, body, end, arguments, invocation_end))
+    resolver._request_closures = closures
+    return closures
+
+
+def request_argument_is_undefined(resolver: SourceEndpointResolver, span: tuple[int, int]) -> bool:
+    """Recognize undefined values without running code or guessing call results."""
+    start, end = span
+    code = resolver.lexed.code
+    while start < end and code[start].isspace():
+        start += 1
+    while end > start and code[end - 1].isspace():
+        end -= 1
+    while code[start:start + 1] == "(" and matching_delimiter(code, start, "(", ")") == end - 1:
+        start, end = start + 1, end - 1
+        while start < end and code[start].isspace():
+            start += 1
+        while end > start and code[end - 1].isspace():
+            end -= 1
+    value = code[start:end]
+    if value == "undefined":
+        return resolver.graph.visible_binding("undefined", resolver.scope_at(start), start) is None
+    # The operand may have effects; event ordering evaluates it before defaults.
+    void = re.match(r"void\b\s*", value)
+    if void:
+        cursor = start + void.end()
+        # A unary void expression is undefined; a binary/conditional
+        # expression containing void need not be. Consume one primary and
+        # balanced postfix operations, not a prefix of an arbitrary expression.
+        primary = re.match(r"[A-Za-z_$][\w$]*|\d+(?:\.\d+)?", code[cursor:end])
+        if primary:
+            cursor += primary.end()
+        elif code[cursor:cursor + 1] != "(":
+            return False
+        while cursor < end:
+            if code[cursor] in "([":
+                closing = matching_delimiter(code, cursor, code[cursor], {"(": ")", "[": "]"}[code[cursor]])
+                if closing is None or closing >= end:
+                    return False
+                cursor = closing + 1
+            elif code[cursor].isspace():
+                cursor += 1
+            elif code[cursor] == ".":
+                member = re.match(r"\.\s*[A-Za-z_$][\w$]*", code[cursor:end])
+                if member is None:
+                    return False
+                cursor += member.end()
+            else:
+                return False
+        return True
+    for closure in request_closures(resolver):
+        if (closure.start < start or code[start:closure.start].strip("( \t\r\n")
+                or closure.invocation_end != end or closure.parameters):
+            continue
+        body = code[closure.body:closure.end]
+        returned = re.fullmatch(r"\{\s*return\s*(undefined|void\s+0)?\s*;?\s*\}", body)
+        if returned:
+            return returned[1] != "undefined" or resolver.graph.visible_binding(
+                "undefined", resolver.scope_at(closure.body), closure.body
+            ) is None
+    return False
+
+
+def request_event_order(resolver: SourceEndpointResolver, offset: int) -> tuple[int, ...]:
+    """Arguments execute before parameters/body, despite their source positions."""
+    key: list[int] = []
+    for closure in sorted(request_closures(resolver), key=lambda item: item.start):
+        if closure.invocation_end is not None and closure.start <= offset < closure.invocation_end:
+            key.extend((closure.start, int(offset < closure.end)))
+    return (*key, offset)
+
+
+def request_argument_has_unknown_call(resolver: SourceEndpointResolver, span: tuple[int, int]) -> bool:
+    """Do not lend ownership across calls whose side effects are unmodelled.
+
+    Direct closures have explicit events. A named no-argument empty function
+    is also harmless, but arbitrary helpers need interprocedural analysis and
+    conservatively invalidate ownership even when void fixes their result.
+    """
+    code = resolver.lexed.code
+    closures = request_closures(resolver)
+    for called in re.finditer(r"(?<![\w$])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)\s*\(", code[slice(*span)]):
+        offset = span[0] + called.start()
+        if called[1] == "void" or any(closure.start <= offset < closure.body for closure in closures):
+            continue
+        candidates = [closure for closure in closures
+                      if not closure.parameters
+                      and re.fullmatch(r"\{\s*\}", code[closure.body:closure.end])
+                      and re.match(rf"function\s+{re.escape(called[1])}\s*\(", code[closure.start:])
+                      and resolver.scope_at(closure.start) in resolver.graph.ancestors(resolver.scope_at(offset))]
+        if len(candidates) != 1 or resolver.graph.visible_binding(
+            called[1], resolver.scope_at(offset), offset
+        ) is not None:
+            return True
+    # Parenthesized callee expressions are not ordinary direct closures.
+    for invoked in re.finditer(r"\)\s*\(", code[slice(*span)]):
+        opening = span[0] + invoked.end() - 1
+        if not any(closure.invocation_end is not None and closure.end <= opening
+                   and re.fullmatch(r"\s*\)*\s*\(", code[closure.end:opening + 1])
+                   for closure in closures):
+            return True
+    return False
+
+
+def request_execution_scope(resolver: SourceEndpointResolver, offset: int) -> int:
+    """Fold invoked closures, but not skipped defaults, into their caller."""
+    closures = request_closures(resolver)
+    containing = [closure for closure in closures if closure.start <= offset < closure.end]
+    for closure in containing:
+        if closure.arguments is None:
+            return -closure.start - 1
+        for index, (start, end) in enumerate(closure.parameters):
+            if not start <= offset < end:
+                continue
+            # Destructuring adds property-level defaults whose execution
+            # depends on the supplied/default object's shape. Do not lend
+            # those effects without resolving that additional condition.
+            if not re.match(r"\s*[A-Za-z_$][\w$]*\s*=", resolver.lexed.code[start:end]):
+                return -closure.start - 1
+            if index < len(closure.arguments):
+                if not request_argument_is_undefined(resolver, closure.arguments[index]):
+                    return -closure.start - 1
+    execution = resolver.graph.execution_scope(resolver.scope_at(offset))
+    while execution:
+        scope = resolver.graph.scopes[execution]
+        if not any(closure.body == scope.start for closure in containing):
+            break
+        execution = resolver.graph.execution_scope(scope.parent or 0)
+    return execution
+
+
+def request_write_events(
+    lexed: LexedSource, call: Call, suffix: str = ".js"
+) -> list[RequestWriteEvent]:
+    """Return write/end bodies belonging to this request handle's lifetime."""
+    chained = re.match(r"\s*\.\s*end\s*\(", lexed.code[call.end:])
+    if chained:
+        opening = call.end + chained.end() - 1
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is not None:
+            args = split_arguments(lexed.code, opening + 1, closing)
+            return [RequestWriteEvent(call.end, "init"),
+                    RequestWriteEvent(call.end, "end", args[0] if args else None)]
     prefix = lexed.code[max(0, call.start - 160):call.start]
-    match = ASSIGNED_HANDLE_RE.search(prefix)
+    match = re.search(
+        r"(?<![\w$.])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)"
+        r"\s*=\s*(?:new\s+)?(?:[A-Za-z_$][\w$]*\s*\.\s*)?$", prefix
+    )
     if match is None:
         return []
-    handle = match.group(1)
+    handle = re.sub(r"\s+", "", match.group(1))
+    resolver = SourceEndpointResolver(lexed, suffix)
+
+    def receiver_binding(receiver: str, offset: int) -> int | tuple[int | None, str] | None:
+        root, separator, members = re.sub(r"\s+", "", receiver).partition(".")
+        # Parameters are in scope during later initializers as well as the body.
+        parameter_owner = [closure for closure in request_closures(resolver)
+                           if closure.start <= offset < closure.body]
+        lookup = max(parameter_owner, key=lambda item: item.start).body if parameter_owner else offset
+        root_binding = resolver.graph.visible_binding(root, resolver.scope_at(lookup), lookup)
+        return ((root_binding, members if root_binding is not None else root + "." + members)
+                if separator else root_binding)
+
+    binding = receiver_binding(handle, call.start)
+    execution = request_execution_scope(resolver, call.start)
+    assignments: list[RequestWriteEvent] = []
+    # Direct invocation binds arguments before entering the closure body.
+    # Parameter bindings remain lexical, so a stored callback or shadowing
+    # parameter cannot acquire ownership from a similarly named request.
+    for closure in request_closures(resolver):
+        if closure.start <= call.end or closure.arguments is None or request_execution_scope(resolver, closure.body) != execution:
+            continue
+        for index, parameter in enumerate(closure.parameters):
+            declared = re.fullmatch(r"\s*([A-Za-z_$][\w$]*)\s*(?:=([\s\S]*))?", lexed.code[slice(*parameter)])
+            if declared is None:
+                continue
+            name = declared[1]
+            argument = closure.arguments[index] if index < len(closure.arguments) else None
+            defaulted = argument is None or request_argument_is_undefined(resolver, argument)
+            value = (declared[2] or "").strip() if defaulted else lexed.code[slice(*argument)].strip()
+            if not re.fullmatch(
+                r"[A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*", value
+            ):
+                continue
+            target = resolver.graph.visible_binding(name, resolver.scope_at(closure.body), closure.body)
+            source = receiver_binding(value, parameter[0] if defaulted else argument[0])
+            # Supplied arguments capture their value before subsequent
+            # arguments can rebind it; defaults run in parameter order later.
+            assigned_at = parameter[1] if defaulted else argument[1]
+            assignments.append(RequestWriteEvent(assigned_at, "assign", binding=target, source_binding=source))
+            if isinstance(binding, tuple):
+                assignments.append(RequestWriteEvent(
+                    assigned_at, "assign", binding=(target, binding[1]),
+                    source_binding=(source, binding[1]) if isinstance(source, int) else None,
+                ))
+    # A broad typed-declaration match can cross an object literal and swallow
+    # a later bare assignment. Recover those lifetime mutations independently
+    # of the endpoint graph's declaration parser.
+    root_assignments = {assignment.start(): assignment for assignment in resolver.root_assignments}
+    parameter_starts = {start + len(lexed.code[start:end]) - len(lexed.code[start:end].lstrip())
+                        for closure in request_closures(resolver) for start, end in closure.parameters}
+    for assignment in re.finditer(r"(?<![\w$.>])([A-Za-z_$][\w$]*)\s*=(?!=|>)", lexed.code):
+        if assignment.start() not in parameter_starts:
+            root_assignments.setdefault(assignment.start(), assignment)
+    for assignment in root_assignments.values():
+        if assignment.start() <= call.end:
+            continue
+        scope = resolver.scope_at(assignment.start())
+        if request_execution_scope(resolver, assignment.start()) != execution:
+            continue
+        assigned_binding = receiver_binding(assignment[1], assignment.start())
+        end = assignment_end(lexed, assignment.end(), suffix)
+        rhs = lexed.code[assignment.end():end].strip().rstrip(";").strip()
+        source_binding = (receiver_binding(rhs, assignment.start())
+                          if re.fullmatch(r"[A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*", rhs) else None)
+        assignments.append(RequestWriteEvent(assignment.start(), "assign",
+                                             binding=assigned_binding, source_binding=source_binding))
+        if isinstance(binding, tuple):
+            # Root aliases carry the owned member at this point in time.
+            # A later root rebind kills only that root's view, not aliases
+            # which still point at the original owner object.
+            assignments.append(RequestWriteEvent(
+                assignment.start(), "assign", binding=(assigned_binding, binding[1]),
+                source_binding=(source_binding, binding[1])
+                if isinstance(source_binding, int) else None,
+            ))
+    if isinstance(binding, tuple):
+        for reference, start, _, _ in direct_member_assignments(lexed, len(lexed.code), suffix):
+            if start <= call.end or request_execution_scope(resolver, start) != execution:
+                continue
+            target = receiver_binding(".".join(reference), start)
+            if isinstance(target, tuple) and (
+                target[1] == binding[1] or binding[1].startswith(target[1] + ".")
+            ):
+                assignments.append(RequestWriteEvent(start, "member_assign", binding=(target[0], binding[1])))
+    # Finite alias closure keeps unrelated assignments/branches out of the
+    # path product. Runtime ownership is still evaluated per environment below.
+    aliases = {binding}
+    for _ in range(len(assignments)):
+        expanded = aliases | {event.binding for event in assignments
+                              if event.source_binding is not None and event.source_binding in aliases}
+        if expanded == aliases:
+            break
+        aliases = expanded
     write_re = re.compile(
-        r"(?<![\w$])" + re.escape(handle) + r"\s*\.\s*write\s*\("
+        r"(?<![\w$.])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)"
+        r"\s*\.\s*(write|end)\s*\("
     )
-    spans: list[tuple[int, int]] = []
+    events = [RequestWriteEvent(call.end, "init", binding=binding)]
+    events.extend(event for event in assignments if event.binding in aliases)
+    for closure in request_closures(resolver):
+        for argument in closure.arguments or ():
+            if (argument[0] > call.end and request_execution_scope(resolver, argument[0]) == execution
+                    and request_argument_is_undefined(resolver, argument)
+                    and request_argument_has_unknown_call(resolver, argument)):
+                events.append(RequestWriteEvent(argument[1], "invalidate"))
+    # Abrupt completion skips the remainder of this closure on its active
+    # branch. Keep return-expression effects before the skip boundary.
+    for abrupt in re.finditer(r"\b(?:return|throw)\b", lexed.code[call.end:]):
+        position = call.end + abrupt.start()
+        if lexed.code[:position].rstrip().endswith("."):
+            continue
+        containing = [closure for closure in request_closures(resolver)
+                      if closure.body <= position < closure.end]
+        if not containing or request_execution_scope(resolver, position) != execution:
+            continue
+        closure = max(containing, key=lambda item: item.start)
+        after = position + len(abrupt[0])
+        while after < closure.end and lexed.code[after] not in ";\n}":
+            if lexed.code[after] in "([{":
+                closing = matching_delimiter(lexed.code, after, lexed.code[after],
+                                             {"(": ")", "[": "]", "{": "}"}[lexed.code[after]])
+                if closing is not None:
+                    after = closing + 1
+                    continue
+            after += 1
+        # Return leaves the closure only after enclosing finally bodies run.
+        # Preserve their writes AND lifetime mutations (e.g. req = other).
+        finalizers: list[tuple[int, int]] = []
+        for attempt in re.finditer(r"\btry\s*\{", lexed.code[closure.body:position]):
+            opening = closure.body + attempt.end() - 1
+            try_end = matching_delimiter(lexed.code, opening, "{", "}")
+            if try_end is None:
+                continue
+            protected = opening < position < try_end
+            tail = try_end + 1
+            catcher = re.match(r"\s*catch\s*(?:\([^()]*\)\s*)?\{", lexed.code[tail:])
+            if catcher:
+                catch_end = matching_delimiter(lexed.code, tail + catcher.end() - 1, "{", "}")
+                if catch_end is None:
+                    continue
+                protected = protected or tail + catcher.end() - 1 < position < catch_end
+                tail = catch_end + 1
+            if not protected:
+                continue
+            finalizer = re.match(r"\s*finally\s*\{", lexed.code[tail:])
+            if finalizer:
+                final_open = tail + finalizer.end() - 1
+                final_end = matching_delimiter(lexed.code, final_open, "{", "}")
+                if final_end is not None:
+                    finalizers.append((final_open, final_end + 1))
+        skip = after
+        for final_start, final_end in sorted(finalizers):
+            events.append(RequestWriteEvent(position, "terminate", (skip, final_start)))
+            skip = final_end
+        events.append(RequestWriteEvent(position, "terminate", (skip, closure.end)))
+        if abrupt[0] == "throw":
+            # Catch dispatch is not modelled as a callable return. It can
+            # change ownership before control resumes; do not certify later
+            # writes through handles whose lifetime crossed that exception.
+            events.append(RequestWriteEvent(position, "throw"))
     for found in write_re.finditer(lexed.code, call.end):
+        if lexed.code[:found.start()].rstrip().endswith("."):
+            continue
+        event_binding = receiver_binding(found[1], found.start())
+        if event_binding not in aliases or (event_binding is None and found[1] != handle):
+            continue
+        if request_execution_scope(resolver, found.start()) != execution:
+            continue
         open_paren = lexed.code.index("(", found.end() - 1)
         closing = matching_delimiter(lexed.code, open_paren, "(", ")")
         if closing is None:
             continue
         arguments = split_arguments(lexed.code, open_paren + 1, closing)
-        if arguments:
-            spans.append(arguments[0])
-    return spans
+        events.append(RequestWriteEvent(found.start(), found[2], arguments[0] if arguments else None,
+                                        binding=event_binding))
+    return sorted(events, key=lambda event: request_event_order(resolver, event.offset))
+
+
+def request_write_payload_spans(lexed: LexedSource, call: Call, suffix: str = ".js") -> list[tuple[int, int]]:
+    return [event.span for event in request_write_events(lexed, call, suffix) if event.span]
+
+
+def request_writes_have_profile(lexed: LexedSource, call: Call, suffix: str,
+                               resolver: PayloadStateResolver,
+                               events: list[RequestWriteEvent]) -> bool:
+    control = resolver.control
+    paths = [control.path(event.offset) for event in events]
+    environments = control.environments(paths, control.path(call.start))
+    # Refine literal conditions within the same branch model. Unknown tests
+    # retain every environment; no conditional write alone certifies a send.
+    literal: dict[int, bool] = {}
+    for path in paths:
+        for group, _ in path:
+            condition = re.match(r"if\s*\(\s*(true|false)\s*\)", lexed.code[group:])
+            if condition:
+                literal[group] = condition[1] == "true"
+    environments = [env for env in environments if all(
+        (env.get(group) == 0) == value for group, value in literal.items())]
+    if not environments:
+        return False
+    for environment in environments:
+        present = False
+        aliases: set[int | tuple[int | None, str] | None] = set()
+        terminated: list[tuple[int, int]] = []
+        for event, path in zip(events, paths):
+            if not control.active(path, environment) or any(
+                start <= event.offset < end for start, end in terminated
+            ):
+                continue
+            if event.method == "terminate":
+                if event.span:
+                    terminated.append(event.span)
+                continue
+            if event.method in {"throw", "invalidate"}:
+                aliases.clear()
+                continue
+            if event.method == "init":
+                aliases.add(event.binding)
+                continue
+            if event.method == "member_assign":
+                if event.binding in aliases:
+                    aliases = {alias for alias in aliases if not isinstance(alias, tuple)}
+                continue
+            if event.method == "assign":
+                if event.source_binding is not None and event.source_binding in aliases:
+                    aliases.add(event.binding)
+                else:
+                    aliases.discard(event.binding)
+                continue
+            if event.binding not in aliases:
+                continue
+            if event.span and resolver.span_presence(*event.span, event.offset).state == PRESENT:
+                present = True
+            if event.method == "end":
+                break
+        if not present:
+            return False
+    return True
 
 
 URL_CONSTRUCTOR_RE = re.compile(
@@ -7087,10 +7684,11 @@ def _request_url_spans(
         # ENDPOINT, unlike net/http.Post(url, contentType, body). Without this
         # the whole send was invisible.
         return args[0:1]
-    if callee == "NewRequest" and len(args) >= 2:
+    if callee in GO_REQUEST_METHOD_INDEX and len(args) >= GO_REQUEST_METHOD_INDEX[callee] + 3:
         # Go net/http: http.NewRequest(method, url, body) + client.Do(req).
         # The idiomatic non-shortcut form; only mutating methods matter here.
-        method = static_method_value(lexed, args[0], call.start, suffix)
+        method_index = GO_REQUEST_METHOD_INDEX[callee]
+        method = static_method_value(lexed, args[method_index], call.start, suffix)
         if method is not None and method not in MUTATING_HTTP_METHODS:
             return []
         # NOTE: http.NewRequest is NOT gated on a client.Do(req) execution link.
@@ -7100,7 +7698,7 @@ def _request_url_spans(
         # behaviour change beyond the scope of this work, so it is left as-is;
         # the execution requirement applies only to the clients newly modelled
         # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
-        return args[1:2]
+        return args[method_index + 1:method_index + 2]
     if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
         return args[0:1] if request_object_is_executed(lexed, call, suffix) else []
     if callee == "curl_init" and len(args) >= 1:
@@ -7525,12 +8123,27 @@ def c_function_headers(
     if suffix not in supported:
         return {}
     headers: dict[int, tuple[int, int]] = {}
+    if suffix in JS_TS_SUFFIXES:
+        # Grouping and default expressions can contain parentheses/braces
+        # before the function body; index its balanced parameter pair directly.
+        for function in re.finditer(r"\bfunction\s*\*?\s*(?:[A-Za-z_$][\w$]*\s*)?\(", lexed.code):
+            params_open = function.end() - 1
+            params_close = matching_delimiter(lexed.code, params_open, "(", ")")
+            if params_close is None:
+                continue
+            body = params_close + 1
+            while body < len(lexed.code) and lexed.code[body].isspace():
+                body += 1
+            if lexed.code[body:body + 1] == "{":
+                headers[body] = (params_open + 1, params_close)
     controls = {
         "catch", "checked", "fixed", "for", "foreach", "if", "lock",
         "switch", "synchronized", "try", "unchecked", "using", "while",
         "with",
     }
     for opening in (index for index, char in enumerate(lexed.code) if char == "{"):
+        if opening in headers:
+            continue
         statement_start = max(
             lexed.code.rfind(";", 0, opening),
             lexed.code.rfind("{", 0, opening),
@@ -7555,7 +8168,7 @@ def c_function_headers(
                 params_open = matching_opening(
                     lexed.code, cursor, "(", ")"
                 )
-                if params_open is not None and params_open >= statement_start:
+                if params_open is not None:
                     headers[opening] = (params_open + 1, cursor)
                 continue
             parameter = re.search(
@@ -10505,6 +11118,7 @@ class ControlIndex:
         self.lexed, self.suffix = lexed, suffix
         self.arms: list[ControlArm] = []
         self.exhaustive: set[int] = set()
+        self.logical_traces: list[list[dict[int, int | None]]] = []
         if suffix in self.C_SUFFIXES:
             self._curly()
             # Expression-level guards are not a JavaScript peculiarity: PHP,
@@ -10549,6 +11163,57 @@ class ControlIndex:
             index += 1
         return None
 
+    def _logical_expression_traces(self, start: int, end: int) -> None:
+        """Keep short-circuit choices correlated by expression evaluation.
+
+        In ``a && b || c``, skipping b forces c to run. Independent optional
+        guards invent a path which skips both. Leaves have unknown truthiness;
+        no API-specific return-value assumptions are needed.
+        """
+        code = self.lexed.code
+        if len(re.findall(r"&&|\|\|", code[start:end])) > 6:
+            return  # Preserve the existing conservative finite-path bound.
+
+        def traces(left: int, right: int) -> list[tuple[bool, dict[int, int | None]]]:
+            while left < right and code[left].isspace():
+                left += 1
+            while right > left and code[right - 1].isspace():
+                right -= 1
+            if left < right and code[left] == "(" and matching_delimiter(code, left, "(", ")") == right - 1:
+                return traces(left + 1, right - 1)
+            operators: list[tuple[int, str]] = []
+            index = left
+            while index < right:
+                if code[index] in "([{":
+                    closing = matching_delimiter(code, index, code[index], {"(": ")", "[": "]", "{": "}"}[code[index]])
+                    if closing is None:
+                        return [(True, {}), (False, {})]
+                    index = closing + 1
+                    continue
+                if code[index:index + 2] in {"&&", "||"} and code[index + 2:index + 3] != "=":
+                    operators.append((index, code[index:index + 2]))
+                    index += 2
+                    continue
+                index += 1
+            if not operators:
+                return [(True, {}), (False, {})]
+            # Lowest precedence, rightmost operator is the expression root.
+            position, operator = next((item for item in reversed(operators) if item[1] == "||"), operators[-1])
+            before, after = traces(left, position), traces(position + 2, right)
+            right_groups = {group for _, path in after for group in path}
+            result = []
+            for value, path in before:
+                evaluate = value if operator == "&&" else not value
+                if evaluate:
+                    result.extend((outcome, path | tail | {position: 0}) for outcome, tail in after)
+                else:
+                    result.append((value, path | dict.fromkeys(right_groups) | {position: None}))
+            return result
+
+        choices = [path for _, path in traces(start, end)]
+        if any(choices):
+            self.logical_traces.append(choices)
+
     def _expression_guards(self) -> None:
         """Index short-circuit and ternary expression arms in JS/TS.
 
@@ -10569,15 +11234,15 @@ class ControlIndex:
         word_ops = self.suffix in {".php", ".rb", ".py"}
         logical_re = (
             r"&&=?|\|\|=?|(?<![\w])(?:and|or)(?![\w])" if word_ops
-            else r"&&=?|\|\|=?"
+            else r"&&=?|\|\|=?|\?\?=?"
         )
         dangling = re.compile(
             r"(?:&&|\|\||\?|(?<![\w])(?:and|or))\s*$" if word_ops
-            else r"(?:&&|\|\||\?)\s*$"
+            else r"(?:&&|\|\||\?\?|\?)\s*$"
         )
         continuing = re.compile(
             r"[ \t]*(?:&&|\|\||\?|:|(?<![\w])(?:and|or)(?![\w]))" if word_ops
-            else r"[ \t]*(?:&&|\|\||\?|:)"
+            else r"[ \t]*(?:&&|\|\||\?\?|\?|:)"
         )
         statement_start = 0
         for match in re.finditer(r"[;\n]|$", code):
@@ -10596,26 +11261,99 @@ class ControlIndex:
             profile = PROFILE_IDENTIFIER_RE.search(
                 self.lexed.original[statement_start:statement_end]
             )
-            if profile is not None:
-                absolute_profile = statement_start + profile.start()
+            if profile is not None or self.suffix in JS_TS_SUFFIXES:
+                absolute_profile = statement_start + profile.start() if profile else statement_end
                 logical = list(re.finditer(logical_re, segment))
                 for operator in logical:
                     operator_end = statement_start + operator.end()
-                    if operator_end <= absolute_profile:
+                    if self.suffix in JS_TS_SUFFIXES or operator_end <= absolute_profile:
+                        guard_end = statement_end
+                        if self.suffix in JS_TS_SUFFIXES and not operator[0].endswith("="):
+                            # A logical RHS may be skipped, but a surrounding
+                            # ternary still chooses an arm after evaluating
+                            # its whole condition: `a ?? b ? yes : no`.
+                            # Logical assignments instead guard the entire
+                            # RHS ternary, due to their lower precedence.
+                            stack: list[int] = []
+                            for index in range(statement_start, operator_end):
+                                if code[index] in "([{":
+                                    stack.append(index)
+                                elif code[index] in ")]}" and stack:
+                                    stack.pop()
+                            expression_start = statement_start
+                            if stack:
+                                opening = stack[-1]
+                                closing = matching_delimiter(code, opening, code[opening], {"(": ")", "[": "]", "{": "}"}[code[opening]])
+                                if closing is not None:
+                                    expression_start, guard_end = opening + 1, closing
+                            outer = _top_level_ternary(code, expression_start, guard_end)
+                            if outer and operator_end < outer[0][0]:
+                                guard_end = outer[0][0] - 1
+                        if self.suffix in JS_TS_SUFFIXES:
+                            # The RHS stops at its own comma/closing delimiter
+                            # or an enclosing ternary's alternate arm. Nested
+                            # expressions keep their internal separators.
+                            depth = ternaries = 0
+                            for index in range(operator_end, guard_end):
+                                char = code[index]
+                                if char in "([{":
+                                    depth += 1
+                                elif char in ")]}":
+                                    if not depth:
+                                        guard_end = index
+                                        break
+                                    depth -= 1
+                                elif not depth:
+                                    if not operator[0].endswith("=") and (
+                                        code[index:index + 2] == "||" or
+                                        code[index:index + 2] == "&&" and operator[0] == "&&"
+                                    ):
+                                        guard_end = index
+                                        break
+                                    if char == "?" and code[index:index + 2] not in {"??", "?."} and code[index - 1] != "?":
+                                        ternaries += 1
+                                    elif char == ":" and ternaries:
+                                        ternaries -= 1
+                                    elif char == "," or char == ":":
+                                        guard_end = index
+                                        break
                         self.arms.append(
-                            ControlArm(statement_start, 0, operator_end, statement_end)
+                            ControlArm(statement_start + operator.start(), 0, operator_end, guard_end)
                         )
-                question = segment.find("?")
-                colon = segment.find(":", question + 1) if question >= 0 else -1
-                if question >= 0 and colon >= 0 and absolute_profile > statement_start + question:
-                    self.arms.append(
-                        ControlArm(
-                            statement_start,
-                            0 if absolute_profile < statement_start + colon else 1,
-                            statement_start + question + 1,
-                            statement_end,
-                        )
-                    )
+                # Visit balanced subexpressions too: a ternary inside `(…)`
+                # or a call argument still guards its mutations. Balanced
+                # extraction avoids mistaking object-key colons for `?:`.
+                pending = [(statement_start, statement_end)]
+                seen: set[tuple[int, int]] = set()
+                while pending:
+                    start, end = pending.pop()
+                    if (start, end) in seen:
+                        continue
+                    seen.add((start, end))
+                    if self.suffix in JS_TS_SUFFIXES:
+                        # Comma has lower precedence than ?:; a following
+                        # expression is outside both conditional arms.
+                        expressions = split_arguments(code, start, end)
+                        if len(expressions) > 1:
+                            pending.extend(expressions)
+                            continue
+                    ternary = _top_level_ternary(code, start, end)
+                    if self.suffix in JS_TS_SUFFIXES and ternary is None:
+                        self._logical_expression_traces(start, end)
+                    if ternary is not None:
+                        group = ternary[0][0] - 1
+                        for branch, (arm_start, arm_end) in enumerate(ternary):
+                            self.arms.append(ControlArm(group, branch, arm_start, arm_end))
+                        self.exhaustive.add(group)
+                        pending.extend(ternary)
+                    stack: list[int] = []
+                    for index in range(start, end):
+                        if code[index] in "([{":
+                            stack.append(index)
+                        elif code[index] in ")]}" and stack:
+                            opening = stack.pop()
+                            if not stack:
+                                pending.append((opening + 1, index))
             statement_start = match.end()
 
     def _body_arm(self, group: int, branch: int, after: int) -> int | None:
@@ -11402,7 +12140,11 @@ class ControlIndex:
             environments = expanded
             if len(environments) > 64:
                 return []
-        return environments
+        return [environment for environment in environments if all(
+            any(all(group not in environment or environment[group] == choice
+                    for group, choice in trace.items()) for trace in traces)
+            for traces in self.logical_traces
+        )]
 
     @staticmethod
     def active(path: tuple[tuple[int, int], ...], environment: dict[int, int | None]) -> bool:
@@ -12186,6 +12928,10 @@ def shell_embedded_command_span(
     """Bound the narrowest quoted shell command containing ``offset``."""
 
     candidates: list[tuple[int, int]] = []
+    for start, end, expands in _shell_heredoc_ranges(lexed.original):
+        if expands and start <= offset < end:
+            candidates.extend(span for span in _shell_command_substitution_ranges(lexed.original, start, end)
+                              if span[0] <= offset < span[1])
     for token in lexed.strings:
         if not (token.start < offset < token.end):
             continue

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -99,6 +99,21 @@ ci_glob() {
   esac
 }
 
+# grep returns 1 when it found no matches and >1 for an operational error.
+# Static-analysis discovery may accept the former, but must never translate
+# the latter into a clean migration result.
+grep_allow_no_match() {
+  local status
+  set +e
+  grep "$@"
+  status=$?
+  set -e
+  if [ "$status" -gt 1 ]; then
+    return "$status"
+  fi
+  return 0
+}
+
 # Extensionless executables with shebangs (package.json "bin" entry points,
 # repo CLIs) are source files no --include glob can ever match; the Phase-1
 # scanner greps without includes and sees them, so skipping them here made
@@ -153,7 +168,7 @@ grep_shebang_files() {
     list=$(shebang_files_for_glob "$glob")
     [ -z "$list" ] && continue
     while IFS= read -r _f; do
-      [ -n "$_f" ] && { grep -nH -E "$pattern" "$_f" 2>/dev/null || true; }
+      [ -n "$_f" ] && grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
     done <<< "$list"
   done
 }
@@ -180,14 +195,6 @@ expand_source_globs() {
   done
 }
 
-# Comment-leading lines are prose, not residual code: '# migrated from
-# twilio' must not fail a completed migration. Live code with a TRAILING
-# comment still matches, since only lines STARTING with a comment marker are
-# stripped.
-strip_comment_lines() {
-  grep -v '^\([^:]*:[0-9]*:\)[[:space:]]*\(#\|//\|/\*\|\*\|--\|%\|<!--\)' || true
-}
-
 # Filter grep hits through the same lexer used by the messaging-profile
 # analyzer.  Line-prefix filters cannot distinguish a trailing dead comment
 # from live code, and syntax checks must not treat a quoted migration note as
@@ -210,6 +217,7 @@ filter_backend_matches() {
   scripts_dir=$(cd "$(dirname "$0")" && pwd)
   python3 -B "$scripts_dir/filter-source-matches.py" \
     --mode comments --region backend --pattern "$pattern" \
+    --exclude-suffix .vue --exclude-suffix .svelte --exclude-suffix .astro \
     --analyzer "$scripts_dir/lint-required-messaging-profile.py"
 }
 
@@ -246,7 +254,7 @@ search_raw_files() {
   done
   # shellcheck disable=SC2086
   set +f
-  grep -rn $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep_allow_no_match -a -rnH --null $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT"
   grep_shebang_files "$pattern" "$@"
 }
 
@@ -357,17 +365,21 @@ hybrid_waiver_applies() {
     [ -n "$MIGRATED_FILES" ] || return 0
     while IFS= read -r match; do
       [ -n "$match" ] || continue
-      path=$(printf '%s\n' "$match" | sed -E 's/:[0-9]+:.*$//')
-      case "$path" in
-        "$PROJECT_ROOT"/*) path=${path#"$PROJECT_ROOT"/} ;;
-        ./*) path=${path#./} ;;
-      esac
       while IFS= read -r migrated_file; do
         [ -n "$migrated_file" ] || continue
+        migrated_path="$PROJECT_ROOT/$migrated_file"
+        # Filtered grep output is `<absolute path>:<line>:<text>`. Do not
+        # recover the path with a colon regex: POSIX paths may themselves
+        # contain `:<digits>:`. Instead compare each complete, known migrated
+        # path and then validate only its numeric locator suffix.
+        remainder=${match#"$migrated_path:"}
+        if [ "$remainder" != "$match" ] && [[ "$remainder" =~ ^[0-9]+: ]]; then
+          return 1
+        fi
         # A directory finding covers every file below it. Do not waive a
         # Twilio-named directory when any explicitly migrated file lives in
         # that directory, even though the grep finding names only the parent.
-        if [ "$migrated_file" = "$path" ] || [[ "$migrated_file" = "$path"/* ]]; then
+        if [ "$migrated_path" = "$match" ] || [[ "$migrated_path" = "$match"/* ]]; then
           return 1
         fi
       done <<<"$MIGRATED_FILES"
@@ -848,19 +860,16 @@ if product_applies "all"; then
   # cross-file heuristic after applying the normal executable-source filter.
   webhook_pattern="(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)"
   webhook_handlers=$(search_raw_files "$webhook_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-    | filter_backend_matches "$webhook_pattern" \
-    | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+    | filter_backend_matches "$webhook_pattern")
   webhook_count=$(count_matches "$webhook_handlers")
   if [ "$webhook_count" -gt 0 ]; then
     ed25519_pattern="(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)"
     ed25519_refs=$(search_raw_files "$ed25519_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-      | filter_backend_matches "$ed25519_pattern" \
-      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+      | filter_backend_matches "$ed25519_pattern")
     ed25519_count=$(count_matches "$ed25519_refs")
     webhook_parse_pattern="(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])"
     telnyx_webhook_parse=$(search_raw_files "$webhook_parse_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-      | filter_backend_matches "$webhook_parse_pattern" \
-      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+      | filter_backend_matches "$webhook_parse_pattern")
     telnyx_parse_count=$(count_matches "$telnyx_webhook_parse")
     if [ "$telnyx_parse_count" -gt 0 ] && [ "$ed25519_count" -eq 0 ]; then
       lint_issue "webhook_ed25519_missing" \

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -147,15 +147,16 @@ grep_shebang_files() {
 }
 
 # A caller asking for "*.js" means "JavaScript", not "files whose name ends in
-# .js". Node resolves .cjs/.mjs and bundlers resolve .jsx/.tsx/.mts/.cts as the
-# same source language, so a check that only globs the bare extension silently
-# passes any project using them. Expanding here fixes every call site at once;
-# per-call glob lists drift apart as checks are added.
+# .js". Node resolves .cjs/.mjs, bundlers resolve .jsx/.tsx/.mts/.cts, and
+# component frameworks embed JavaScript in .vue/.svelte/.astro files. A check
+# that only globs the bare extension silently passes projects using them.
+# Expanding here fixes every call site at once; per-call glob lists drift apart
+# as checks are added.
 expand_source_globs() {
   local glob
   for glob in "$@"; do
     case "$glob" in
-      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' ;;
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' ;;
       '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
       '*.py') echo '*.py' '*.pyw' ;;
       '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -48,7 +48,7 @@ HYBRID_PRODUCTS=""
 MIGRATED_FILES=""
 JSON_CHECKS="[]"
 
-EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build"
+EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build .next .nuxt coverage .tox"
 EXCLUDE_LOCK_FILES="--exclude=package-lock.json --exclude=yarn.lock --exclude=pnpm-lock.yaml --exclude=Gemfile.lock --exclude=Pipfile.lock --exclude=poetry.lock --exclude=go.sum"
 EXCLUDE_SCAN_FILES="--exclude=twilio-scan.json --exclude=twilio-deep-scan.json --exclude=migration-state.json --exclude=MIGRATION-PLAN.md --exclude=MIGRATION-REPORT.md"
 
@@ -70,21 +70,153 @@ build_exclude_args() {
   done
   args="$args $EXCLUDE_LOCK_FILES"
   args="$args $EXCLUDE_SCAN_FILES"
-  args="$args --exclude=*.md --exclude=*.min.js"
+  args="$args --exclude=*.md --exclude=*.min.js --exclude=*.min.css --exclude=*.bundle.js --exclude=*.chunk.js"
   echo "$args"
 }
 
 GREP_EXCLUDES=""
 
+
+# grep --include globs are case-sensitive; SEND.JS is the same JavaScript as
+# send.js. Rewrite '*.ext' into a character-class glob matching any casing.
+ci_glob() {
+  local glob="$1"
+  case "$glob" in
+    \*.*)
+      local ext="${glob#\*.}" out="*." i c upper
+      for ((i = 0; i < ${#ext}; i++)); do
+        c="${ext:$i:1}"
+        if [[ "$c" == [a-z] ]]; then
+          upper=$(printf '%s' "$c" | tr '[:lower:]' '[:upper:]')
+          out+="[${c}${upper}]"
+        else
+          out+="$c"
+        fi
+      done
+      echo "$out"
+      ;;
+    *) echo "$glob" ;;
+  esac
+}
+
+# Extensionless executables with shebangs (package.json "bin" entry points,
+# repo CLIs) are source files no --include glob can ever match; the Phase-1
+# scanner greps without includes and sees them, so skipping them here made
+# the validator certify trees the scanner had put in migration scope.
+SHEBANG_JS_FILES=""
+SHEBANG_PY_FILES=""
+SHEBANG_RB_FILES=""
+SHEBANG_SH_FILES=""
+
+collect_shebang_files() {
+  local _f _first
+  while IFS= read -r -d '' _f; do
+    IFS= read -r _first < "$_f" 2>/dev/null || _first=""
+    case "$_first" in
+      '#!'*node*)   SHEBANG_JS_FILES="${SHEBANG_JS_FILES}${_f}"$'\n' ;;
+      '#!'*python*) SHEBANG_PY_FILES="${SHEBANG_PY_FILES}${_f}"$'\n' ;;
+      '#!'*ruby*)   SHEBANG_RB_FILES="${SHEBANG_RB_FILES}${_f}"$'\n' ;;
+      '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
+    esac
+  done < <(find "$PROJECT_ROOT" \
+    \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
+       -o -name venv -o -name .venv -o -name dist -o -name build \
+       -o -name .next -o -name .nuxt -o -name coverage -o -name .tox \) -prune \
+    -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
+}
+
+shebang_files_for_glob() {
+  case "$1" in
+    '*.js'|'*.ts') printf '%s' "$SHEBANG_JS_FILES" ;;
+    '*.py')        printf '%s' "$SHEBANG_PY_FILES" ;;
+    '*.rb')        printf '%s' "$SHEBANG_RB_FILES" ;;
+    '*.sh')        printf '%s' "$SHEBANG_SH_FILES" ;;
+  esac
+}
+
+grep_shebang_files() {
+  local pattern="$1"; shift
+  local glob list _f
+  for glob in "$@"; do
+    list=$(shebang_files_for_glob "$glob")
+    [ -z "$list" ] && continue
+    while IFS= read -r _f; do
+      [ -n "$_f" ] && { grep -nH -E "$pattern" "$_f" 2>/dev/null || true; }
+    done <<< "$list"
+  done
+}
+
+# A caller asking for "*.js" means "JavaScript", not "files whose name ends in
+# .js". Node resolves .cjs/.mjs and bundlers resolve .jsx/.tsx/.mts/.cts as the
+# same source language, so a check that only globs the bare extension silently
+# passes any project using them. Expanding here fixes every call site at once;
+# per-call glob lists drift apart as checks are added.
+expand_source_globs() {
+  local glob
+  for glob in "$@"; do
+    case "$glob" in
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' ;;
+      '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
+      '*.py') echo '*.py' '*.pyw' ;;
+      '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;
+      '*.php') echo '*.php' '*.phtml' ;;
+      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' ;;
+      '*.cs') echo '*.cs' '*.cshtml' ;;
+      *) echo "$glob" ;;
+    esac
+  done
+}
+
+# Comment-leading lines are prose, not residual code: '# migrated from
+# twilio' must not fail a completed migration. Live code with a TRAILING
+# comment still matches, since only lines STARTING with a comment marker are
+# stripped.
+strip_comment_lines() {
+  grep -v '^\([^:]*:[0-9]*:\)[[:space:]]*\(#\|//\|/\*\|\*\|--\|%\|<!--\)' || true
+}
+
+# Filter grep hits through the same lexer used by the messaging-profile
+# analyzer.  Line-prefix filters cannot distinguish a trailing dead comment
+# from live code, and syntax checks must not treat a quoted migration note as
+# an executable builder call.  `comments` preserves string literals (needed
+# for imports, URLs, and configuration); `code` masks both comments and
+# strings (needed for identifiers such as VoiceResponse()).
+filter_source_matches() {
+  local mode="$1"
+  local pattern="$2"
+  local scripts_dir
+  scripts_dir=$(cd "$(dirname "$0")" && pwd)
+  python3 -B "$scripts_dir/filter-source-matches.py" \
+    --mode "$mode" --pattern "$pattern" \
+    --analyzer "$scripts_dir/lint-required-messaging-profile.py"
+}
+
+search_live_files() {
+  local mode="$1"
+  local pattern="$2"
+  shift 2
+  search_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
+}
+
 search_files() {
   local pattern="$1"
   shift
   local include_args=""
-  for glob in "$@"; do
-    include_args="$include_args --include=$glob"
+  local glob
+  # shellcheck disable=SC2046
+  # `for glob in $(...)` lets the shell PATHNAME-EXPAND each glob against the
+  # CALLER'S cwd: if a matching file happens to exist there the glob collapses
+  # to that basename, silently restricting grep to it; if none matches the glob
+  # survives. Either way whole languages could stop being scanned. set -f keeps
+  # the patterns literal.
+  set -f
+  for glob in $(expand_source_globs "$@"); do
+    include_args="$include_args --include=$(ci_glob "$glob")"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  set +f
+  grep -rn $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep_shebang_files "$pattern" "$@"
 }
 
 count_matches() {
@@ -231,6 +363,17 @@ while [ $# -gt 0 ]; do
     --product)
       if [ $# -lt 2 ]; then echo "Error: --product requires a value" >&2; usage; fi
       PRODUCT_FILTER="$2"
+      # An unvalidated value silently matches no check_products list, so a typo
+      # skips every product-scoped check and still exits 0 — a silent pass.
+      # Same accepted set as validate-migration.sh.
+      case "$PRODUCT_FILTER" in
+        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup) ;;
+        *)
+          echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
+          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup" >&2
+          exit 2
+          ;;
+      esac
       shift 2
       ;;
     --json)
@@ -288,6 +431,7 @@ fi
 
 PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
 GREP_EXCLUDES=$(build_exclude_args)
+collect_shebang_files
 
 if [ -z "$STATE_FILE" ] && [ -f "$PROJECT_ROOT/migration-state.json" ]; then
   STATE_FILE="$PROJECT_ROOT/migration-state.json"
@@ -326,9 +470,55 @@ fi
 ORIGINAL_HAD_WEBHOOK_VALIDATION="unknown"
 SCAN_PRODUCTS=""
 if [ -n "$SCAN_JSON" ] && [ -f "$SCAN_JSON" ] && command -v jq >/dev/null 2>&1; then
-  ORIGINAL_HAD_WEBHOOK_VALIDATION=$(jq -r '.has_webhook_validation // false' "$SCAN_JSON" 2>/dev/null || echo "unknown")
+  ORIGINAL_HAD_WEBHOOK_VALIDATION=$(jq -r 'if (.summary.has_webhook_validation != null) then .summary.has_webhook_validation elif (.has_webhook_validation != null) then .has_webhook_validation else "unknown" end' "$SCAN_JSON" 2>/dev/null || echo "unknown")
   SCAN_PRODUCTS=$(jq -r '.products_used // [] | map(ascii_downcase) | join(",")' "$SCAN_JSON" 2>/dev/null || true)
 fi
+
+# Hybrid awareness, mirroring validate-migration.sh: a product recorded as
+# kept on Twilio in migration-state.json is a skill-sanctioned deployment
+# state, so residual-Twilio findings for it are expected and must not hard-
+# fail Phase 4 forever.
+if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ] && command -v jq >/dev/null 2>&1; then
+  # Only products with a truthy keep reason stay in hybrid scope. An
+  # operator reverses a decision with `set kept_on_twilio.X false`
+  # (there is no unset command), so false/null/empty means NOT kept.
+  KEPT_ON_TWILIO=$(jq -r '.kept_on_twilio // {} | to_entries | map(select(.value != false and .value != null and .value != "")) | map(.key) | join(",")' "$STATE_FILE" 2>/dev/null || true)
+elif [ -n "$STATE_FILE" ] && [ ! -f "$STATE_FILE" ]; then
+  echo "Warning: --state-file '$STATE_FILE' not found, ignoring" >&2
+fi
+
+# Waive only for the product that is actually KEPT on Twilio.
+#
+# Testing `-n "$KEPT_ON_TWILIO"` alone made ANY hybrid state a GLOBAL waiver: in
+# a `--product messaging` run, a leftover Twilio messaging import was downgraded
+# to a warning - and the linter exited clean - merely because an unrelated
+# product such as voice was kept on Twilio. That is a silent pass on exactly the
+# residue the check exists to find.
+#
+# The product is passed per call site because these checks are not all inside a
+# product-scoped block; the global ones (residual imports, client instantiation,
+# directory names, docs) legitimately span products and pass "any", which waives
+# whenever ANY product is kept - the original behaviour, but now stated at the
+# call site rather than applied silently everywhere.
+kept_on_twilio() {
+  local product="$1"
+  [ -n "$KEPT_ON_TWILIO" ] || return 1
+  [ "$product" = "any" ] && return 0
+  case ",$KEPT_ON_TWILIO," in
+    *",$product,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+lint_issue_or_hybrid_warn() {
+  local product="$1"
+  shift
+  if kept_on_twilio "$product"; then
+    lint_warn "$1" "$2 (hybrid deployment — $KEPT_ON_TWILIO kept on Twilio)" "$3" "${4:-}"
+  else
+    lint_issue "$1" "$2" "$3" "${4:-}"
+  fi
+}
 
 # Helper: returns 0 if a product was detected in the scan (or if no scan data)
 scan_has_product() {
@@ -355,56 +545,78 @@ fi
 if product_applies "messaging"; then
   section_header "Messaging Correctness"
 
-  # Check 1: .messages.create( — Twilio pattern, Telnyx uses .send() or messages.create differently
-  matches=$(search_files '\.messages\.create\(' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
-  count=$(count_matches "$matches")
+  # Check 1: Twilio and Telnyx both expose messages.create() in some SDKs.
+  # Classify the call by its request field: Twilio uses `body`, while Telnyx
+  # uses `text`. Reuse the quote-aware source lexer so strings, comments, URLs,
+  # nested objects, and adjacent calls cannot create false classifications.
+  messaging_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
+  if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$messaging_source_analyzer" ]; then
+    echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
+    exit 2
+  fi
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields "$PROJECT_ROOT"); then
+    echo "Error: Twilio messages.create analysis failed" >&2
+    exit 2
+  fi
+  count=$(count_matches "$twilio_create_calls")
   if [ "$count" -gt 0 ]; then
-    lint_issue "twilio_messages_create" \
-      "Twilio .messages.create() pattern found in $count file(s)" \
-      "Use telnyx.messages.send() (Python) or telnyx.messages.create() with text parameter (JS/Ruby)" \
-      "$(matches_to_json "$matches")"
+    lint_issue_or_hybrid_warn "messaging" "twilio_messages_create" \
+      "Twilio .messages.create() request using body found at $count call site(s)" \
+      "Use telnyx.messages.send() (Python) or telnyx.messages.create() with the text parameter (JavaScript/Ruby)" \
+      "$(matches_to_json "$twilio_create_calls")"
   else
-    lint_pass "twilio_messages_create" "No Twilio .messages.create() pattern found"
+    lint_pass "twilio_messages_create" "No Twilio .messages.create() request using body found"
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  matches=$(search_files '(\.send\(|\.create\().*body[=:]' "*.py" "*.js" "*.ts" "*.rb")
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields "$PROJECT_ROOT"); then
+    echo "Error: messaging body-field analysis failed" >&2
+    exit 2
+  fi
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    # Filter to only lines that also reference telnyx or messaging context
-    telnyx_context=$(echo "$matches" | grep -iE "telnyx|message|sms|mms" || true)
-    tcount=$(count_matches "$telnyx_context")
-    if [ "$tcount" -gt 0 ]; then
-      lint_issue "body_not_text" \
-        "Message send with 'body' parameter found in $tcount file(s)" \
-        "Telnyx uses 'text' not 'body' for message content" \
-        "$(matches_to_json "$telnyx_context")"
-    else
-      lint_pass "body_not_text" "No 'body' parameter in Telnyx messaging context"
-    fi
+    lint_issue "body_not_text" \
+      "Message send with 'body' parameter found at $count call site(s)" \
+      "Telnyx uses 'text' not 'body' for message content" \
+      "$(matches_to_json "$matches")"
   else
     lint_pass "body_not_text" "No 'body' parameter in message send calls"
   fi
 
-  # Check 3: messaging_profile_id missing in send calls (skip if messaging not detected in scan)
-  if scan_has_product "messaging"; then
-    telnyx_send=$(search_files '(telnyx.*message|message.*send|messages\.create)' "*.py" "*.js" "*.ts" "*.rb" "*.go")
-    send_count=$(count_matches "$telnyx_send")
-    if [ "$send_count" -gt 0 ]; then
-      profile_refs=$(search_files 'messaging_profile_id' "*.py" "*.js" "*.ts" "*.rb" "*.go")
-      profile_count=$(count_matches "$profile_refs")
-      if [ "$profile_count" -eq 0 ]; then
-        lint_warn "missing_messaging_profile_id" \
-          "Telnyx messaging calls found but no messaging_profile_id reference" \
-          "Include messaging_profile_id in send calls or set a default on the messaging profile"
-      else
-        lint_pass "missing_messaging_profile_id" "messaging_profile_id referenced in code"
-      fi
-    fi
+  # Check 3: number-pool and alphanumeric-sender sends require a Messaging
+  # Profile ID. Normal phone-number sends may omit it when the sender already
+  # belongs to the intended profile, which source inspection cannot infer.
+  # Run the source analyzer unconditionally inside the messaging section.
+  # The scanner and analyzer intentionally recognize different evidence; using
+  # scanner attribution as a gate let newly-supported URL builders disappear
+  # before the analyzer could evaluate them (a silent false pass).
+  if ! required_profile_analysis=$(python3 -B "$messaging_source_analyzer" "$PROJECT_ROOT"); then
+    echo "Error: required Messaging Profile analysis failed" >&2
+    exit 2
+  fi
+  required_sender_count=$(printf '%s\n' "$required_profile_analysis" | sed -n '1p')
+  case "$required_sender_count" in
+    ''|*[!0-9]*)
+      echo "Error: required Messaging Profile analysis returned an invalid count" >&2
+      exit 2
+      ;;
+  esac
+  missing_profile_calls=$(printf '%s\n' "$required_profile_analysis" | sed '1d; /^$/d')
+  missing_profile_count=$(count_matches "$missing_profile_calls")
+
+  if [ "$missing_profile_count" -gt 0 ]; then
+    lint_issue "required_messaging_profile_id" \
+      "Number-pool or dedicated alphanumeric-sender call sites found without a messaging_profile_id ($missing_profile_count)" \
+      "Include messaging_profile_id for every number-pool or alphanumeric-sender send. Phone-number sends may omit it when from already resolves to the intended Messaging Profile." \
+      "$(matches_to_json "$missing_profile_calls")"
+  elif [ "$required_sender_count" -gt 0 ]; then
+    lint_pass "required_messaging_profile_id" "Every detected required-profile messaging call has a messaging_profile_id"
+  else
+    lint_pass "required_messaging_profile_id" "No dedicated number-pool or alphanumeric-sender call sites detected"
   fi
 
   # Check 4: MessagingResponse builder class (doesn't exist in Telnyx)
-  matches=$(search_files 'MessagingResponse\(' "*.py" "*.js" "*.ts" "*.rb")
+  matches=$(search_live_files code 'MessagingResponse\(' "*.py" "*.js" "*.ts" "*.rb")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     lint_issue "messaging_response_builder" \
@@ -423,7 +635,7 @@ if product_applies "voice"; then
   section_header "Voice Correctness"
 
   # Check 5: VoiceResponse builder (Twilio TwiML — doesn't exist in Telnyx SDK)
-  matches=$(search_files 'VoiceResponse\(' "*.py" "*.js" "*.ts" "*.rb" "*.java" "*.php")
+  matches=$(search_live_files code 'VoiceResponse\(' "*.py" "*.js" "*.ts" "*.rb" "*.java" "*.php")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     lint_issue "voice_response_builder" \
@@ -448,7 +660,7 @@ excluded = {
     ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__",
     "build", "coverage", "dist", "node_modules", "vendor", "venv",
 }
-suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
+  suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
 tag_pattern = re.compile(
     r"<(?P<closing>/)?\s*(?P<tag>[A-Za-z_][\w:.-]*)"
     r"(?P<attrs>(?:\"[^\"]*\"|'[^']*'|[^>])*)>",
@@ -549,7 +761,14 @@ if product_applies "verify"; then
 
   # Check 9: verify_profile_id missing (skip if verify not detected in scan)
   if scan_has_product "verify"; then
-    telnyx_verify=$(search_files '(telnyx.*verif|verif.*telnyx|verify_profile|verification)' "*.py" "*.js" "*.ts" "*.rb" "*.go")
+    # "verification" alone matched WEBHOOK SIGNATURE verification - which every
+    # correctly migrated app now has - so repos with no Verify product at all
+    # were told to add a verify_profile_id. Match the Verify PRODUCT's own API
+    # surface instead, and exclude the signature/webhook sense explicitly.
+    telnyx_verify=$(search_files \
+      '(telnyx.*\bverifications?\b|\bverifications?\b.*telnyx|verify_profile|/v2/verifications|verifications\.(create|by_phone_number)|\bVerifyProfile\b)' \
+      "*.py" "*.js" "*.ts" "*.rb" "*.go" \
+      | grep -v -iE '(webhook|signature|ed25519|unwrap|construct_event|verify_webhook|verification_key|public_key)' || true)
     verify_count=$(count_matches "$telnyx_verify")
     if [ "$verify_count" -gt 0 ]; then
       profile_refs=$(search_files 'verify_profile_id' "*.py" "*.js" "*.ts" "*.rb" "*.go")
@@ -655,7 +874,7 @@ fi
 if product_applies "voice"; then
   section_header "Polly Voice Compatibility"
 
-  # Check 14: Non-Neural Polly voices (may fall back to default voice)
+  # Check 14: Named Polly voices are valid and must retain caller-facing audio.
   polly_refs=$(search_files "Polly\.[A-Z][a-z]+" "*.xml" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
   polly_count=$(count_matches "$polly_refs")
   if [ "$polly_count" -gt 0 ]; then
@@ -679,18 +898,33 @@ section_header "Documentation Updates"
 
 # Check 15: README and docs still referencing Twilio
 doc_files=""
-for f in README.md README README.rst CONTRIBUTING.md; do
-  if [ -f "$PROJECT_ROOT/$f" ]; then
-    twilio_in_doc=$(grep -in "twilio" "$PROJECT_ROOT/$f" 2>/dev/null | grep -v -iE '(migrat|port|formerly|previously|was twilio|from twilio to)' || true)
+while IFS= read -r -d '' doc_path; do
+    # Prose EXPLAINING the migration is not residual Twilio. Two defects here:
+    #  - 'formerly' did not cover 'the former Twilio Verify SID', so an
+    #    operator's mapping note gated a correctly migrated repo with exit 1;
+    #  - bare 'port' matched inside 'support', 'important' and 'export', which
+    #    silently excluded real leftovers. Both are now word-anchored.
+    # A HYBRID deployment also documents its remaining Twilio use on purpose -
+    # the skill mandates recording it - so those lines are expected too.
+    # Upstream repository ownership is historical provenance, not a runtime
+    # dependency. Rewriting a TwilioDevEd badge/clone URL would create a dead
+    # link while leaving the actual migration unchanged.
+    # NOTE: no \b before 'behaviour change'. Markdown bold writes
+    # __Behavior change from the Twilio integration__, and '_' is a WORD
+    # character, so \bbehavior could never match after it - the same
+    # word-boundary trap that made (?<![\w$]) never match $var in shell.
+    doc_exclusions='(\bmigrat|\bported\b|\bporting\b|\bformer|\bpreviousl|\bwas twilio\b|from twilio to|\breplaces?\b|\bno longer\b|\binstead of\b|\bequivalent\b|behaviou?r change|\btwilio integration\b|\bcounterpart\b|\bunlike twilio\b|\bcompared (to|with)\b|\bhybrid\b|\bstill uses? twilio\b|\bno telnyx equivalent\b|github\.com[:/]twiliodeved/)'
+    twilio_in_doc=$(grep -in "twilio" "$doc_path" 2>/dev/null | grep -v -iE "$doc_exclusions" || true)
     if [ -n "$twilio_in_doc" ]; then
-      doc_files+="$PROJECT_ROOT/$f"$'\n'
+      doc_files+="$doc_path"$'\n'
     fi
-  fi
-done
+done < <(find "$PROJECT_ROOT" -maxdepth 1 -type f \
+  \( -iname README -o -iname README.md -o -iname README.rst -o -iname CONTRIBUTING.md \) \
+  -print0 2>/dev/null)
 doc_files=$(echo "$doc_files" | sed '/^$/d')
 doc_count=$(echo "$doc_files" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$doc_count" -gt 0 ]; then
-  lint_issue "docs_still_twilio" \
+  lint_issue_or_hybrid_warn "any" "docs_still_twilio" \
     "Documentation files still reference Twilio (not migration-related references) in $doc_count file(s)" \
     "Update README/docs: replace Twilio service names, env vars, setup instructions, and URLs with Telnyx equivalents" \
     "$(echo "$doc_files" | sed '/^$/d' | head -10 | jq -R -s '{files: (split("\n") | map(select(length > 0)))}' 2>/dev/null || echo '{"files":[]}')"
@@ -704,7 +938,7 @@ fi
 section_header "Residual Twilio Patterns"
 
 # Check 10: Residual Twilio imports still present alongside Telnyx code
-matches=$(search_files '(from twilio|import twilio|require.*twilio|using Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
+matches=$(search_live_files comments '(from twilio|import[ (].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then
@@ -723,7 +957,7 @@ else
 fi
 
 # Check 11: Twilio client instantiation patterns
-matches=$(search_files '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -1008,7 +1008,7 @@ else
 fi
 
 # Check 11: Twilio client instantiation patterns
-matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.|TwilioClient[[:space:]]*\.[[:space:]]*Init[[:space:]]*\()' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -142,38 +142,36 @@ grep_allow_no_match() {
 # repo CLIs) are source files no --include glob can ever match; the Phase-1
 # scanner greps without includes and sees them, so skipping them here made
 # the validator certify trees the scanner had put in migration scope.
-SHEBANG_JS_FILES=""
-SHEBANG_PY_FILES=""
-SHEBANG_RB_FILES=""
-SHEBANG_SH_FILES=""
+SHEBANG_FILES=()
+SHEBANG_CATEGORIES=()
 
 collect_shebang_files() {
-  local _f _first
+  local _f _first _category
   while IFS= read -r -d '' _f; do
-    IFS= read -r _first < "$_f" 2>/dev/null || _first=""
+    _first=""
+    IFS= read -r _first < "$_f" 2>/dev/null || [ -n "$_first" ] || _first=""
     case "$_first" in
-      '#!'*node*)   SHEBANG_JS_FILES="${SHEBANG_JS_FILES}${_f}"$'\n' ;;
-      '#!'*python*) SHEBANG_PY_FILES="${SHEBANG_PY_FILES}${_f}"$'\n' ;;
-      '#!'*ruby*)   SHEBANG_RB_FILES="${SHEBANG_RB_FILES}${_f}"$'\n' ;;
-      '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
+      '#!'*node*)   _category="javascript" ;;
+      '#!'*python*) _category="python" ;;
+      '#!'*ruby*)   _category="ruby" ;;
+      '#!'*sh*)     _category="shell" ;;
+      *)            _category="" ;;
     esac
+    if [ -n "$_category" ]; then
+      # Bash variables cannot contain NUL, and LF-delimited path lists cannot
+      # represent every legal pathname. Indexed arrays retain each `find
+      # -print0` record as one argument all the way through grep.
+      SHEBANG_FILES+=("$_f")
+      SHEBANG_CATEGORIES+=("$_category")
+    fi
   done < <(find "$PROJECT_ROOT" \
     \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
     -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
 }
 
-shebang_files_for_glob() {
-  case "$1" in
-    '*.js'|'*.ts') printf '%s' "$SHEBANG_JS_FILES" ;;
-    '*.py')        printf '%s' "$SHEBANG_PY_FILES" ;;
-    '*.rb')        printf '%s' "$SHEBANG_RB_FILES" ;;
-    '*.sh')        printf '%s' "$SHEBANG_SH_FILES" ;;
-  esac
-}
-
 grep_shebang_files() {
   local pattern="$1"; shift
-  local glob list _f category seen_categories=""
+  local glob _index _f category seen_categories=""
   for glob in "$@"; do
     case "$glob" in
       '*.js'|'*.ts') category="javascript" ;;
@@ -187,11 +185,11 @@ grep_shebang_files() {
       *" $category "*) continue ;;
     esac
     seen_categories="$seen_categories $category"
-    list=$(shebang_files_for_glob "$glob")
-    [ -z "$list" ] && continue
-    while IFS= read -r _f; do
-      [ -n "$_f" ] && grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
-    done <<< "$list"
+    for _index in "${!SHEBANG_FILES[@]}"; do
+      [ "${SHEBANG_CATEGORIES[$_index]}" = "$category" ] || continue
+      _f=${SHEBANG_FILES[$_index]}
+      grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
+    done
   done
 }
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -76,6 +76,18 @@ build_exclude_args() {
 
 GREP_EXCLUDES=""
 
+# Build every find(1) prune expression from the same policy as grep.  Keeping
+# literal copies in each traversal caused generated directories to re-enter
+# through the directory-name and shebang scans after source scanning excluded
+# them.
+FIND_EXCLUDE_EXPR=()
+for excluded_dir in $EXCLUDE_DIRS; do
+  if [ ${#FIND_EXCLUDE_EXPR[@]} -gt 0 ]; then
+    FIND_EXCLUDE_EXPR+=(-o)
+  fi
+  FIND_EXCLUDE_EXPR+=(-name "$excluded_dir")
+done
+
 
 # grep --include globs are case-sensitive; SEND.JS is the same JavaScript as
 # send.js. Rewrite '*.ext' into a character-class glob matching any casing.
@@ -134,9 +146,7 @@ collect_shebang_files() {
       '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
     esac
   done < <(find "$PROJECT_ROOT" \
-    \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
-       -o -name venv -o -name .venv -o -name dist -o -name build \
-       -o -name .next -o -name .nuxt -o -name coverage -o -name .tox \) -prune \
+    \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
     -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
 }
 
@@ -189,7 +199,7 @@ expand_source_globs() {
       '*.rb') echo '*.rb' '*.rake' 'Rakefile' 'rakefile' '*.erb' ;;
       '*.php') echo '*.php' '*.phtml' ;;
       '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' '*.jsp' ;;
-      '*.cs') echo '*.cs' '*.cshtml' ;;
+      '*.cs') echo '*.cs' '*.cshtml' '*.razor' ;;
       *) echo "$glob" ;;
     esac
   done
@@ -648,7 +658,7 @@ if product_applies "voice"; then
   # a documented attribute on a Language child of ConversationRelay. Inspect
   # tag ancestry instead of rejecting every textual occurrence.
   speech_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
-  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" <<'PYEOF'
+  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" "$EXCLUDE_DIRS" <<'PYEOF'
 import importlib.util
 import os
 import re
@@ -663,16 +673,13 @@ if spec is None or spec.loader is None:
 analyzer = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = analyzer
 spec.loader.exec_module(analyzer)
-excluded_dirs = {
-    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__", "build",
-    "coverage", "dist", "node_modules", "vendor", "venv",
-}
+excluded_dirs = set(sys.argv[3].split())
 excluded_files = {
     "MIGRATION-PLAN.md", "MIGRATION-REPORT.md", "migration-state.json",
     "twilio-deep-scan.json", "twilio-scan.json",
 }
 suffixes = {
-    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".dart", ".ejs", ".erb",
+    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".razor", ".dart", ".ejs", ".erb",
     ".ksh", ".zsh", ".go", ".handlebars", ".hbs", ".java", ".jinja",
     ".jinja2", ".cts", ".j2", ".js", ".jsp", ".jsx", ".kt", ".kts",
     ".mjs", ".mts", ".mustache", ".php", ".phtml", ".py", ".pyw",
@@ -1011,8 +1018,7 @@ fi
 
 # Check 12: Directory/path names containing "twilio"
 twilio_dirs=$(find "$PROJECT_ROOT" -mindepth 1 \
-  \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
-     -o -name venv -o -name .venv -o -name dist -o -name build \) -prune \
+  \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
   -o -type d -iname '*twilio*' -print 2>/dev/null || true)
 twilio_dir_count=$(echo "$twilio_dirs" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$twilio_dir_count" -gt 0 ] && [ -n "$(echo "$twilio_dirs" | sed '/^$/d')" ]; then

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -136,8 +136,20 @@ shebang_files_for_glob() {
 
 grep_shebang_files() {
   local pattern="$1"; shift
-  local glob list _f
+  local glob list _f category seen_categories=""
   for glob in "$@"; do
+    case "$glob" in
+      '*.js'|'*.ts') category="javascript" ;;
+      '*.py') category="python" ;;
+      '*.rb') category="ruby" ;;
+      '*.sh') category="shell" ;;
+      *) category="" ;;
+    esac
+    [ -z "$category" ] && continue
+    case " $seen_categories " in
+      *" $category "*) continue ;;
+    esac
+    seen_categories="$seen_categories $category"
     list=$(shebang_files_for_glob "$glob")
     [ -z "$list" ] && continue
     while IFS= read -r _f; do
@@ -156,12 +168,12 @@ expand_source_globs() {
   local glob
   for glob in "$@"; do
     case "$glob" in
-      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' ;;
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' '*.ejs' ;;
       '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
       '*.py') echo '*.py' '*.pyw' ;;
-      '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;
+      '*.rb') echo '*.rb' '*.rake' 'Rakefile' 'rakefile' '*.erb' ;;
       '*.php') echo '*.php' '*.phtml' ;;
-      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' ;;
+      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' '*.jsp' ;;
       '*.cs') echo '*.cs' '*.cshtml' ;;
       *) echo "$glob" ;;
     esac
@@ -192,14 +204,32 @@ filter_source_matches() {
     --analyzer "$scripts_dir/lint-required-messaging-profile.py"
 }
 
+filter_backend_matches() {
+  local pattern="$1"
+  local scripts_dir
+  scripts_dir=$(cd "$(dirname "$0")" && pwd)
+  python3 -B "$scripts_dir/filter-source-matches.py" \
+    --mode comments --region backend --pattern "$pattern" \
+    --analyzer "$scripts_dir/lint-required-messaging-profile.py"
+}
+
 search_live_files() {
   local mode="$1"
   local pattern="$2"
   shift 2
-  search_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
+  search_raw_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
 }
 
 search_files() {
+  local pattern="$1"
+  shift
+  # All source searches share the executable-region/comment contract. This
+  # keeps component markup and server-template prose out of semantic checks;
+  # callers needing identifiers with strings masked use search_live_files code.
+  search_raw_files "$pattern" "$@" | filter_source_matches comments "$pattern"
+}
+
+search_raw_files() {
   local pattern="$1"
   shift
   local include_args=""
@@ -368,10 +398,10 @@ while [ $# -gt 0 ]; do
       # skips every product-scoped check and still exits 0 — a silent pass.
       # Same accepted set as validate-migration.sh.
       case "$PRODUCT_FILTER" in
-        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup) ;;
+        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
         *)
           echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
-          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup" >&2
+          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
           exit 2
           ;;
       esac
@@ -425,8 +455,10 @@ if [ ! -d "$PROJECT_ROOT" ]; then
   exit 2
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "Error: python3 is required for correctness analysis" >&2
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c \
+  'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' \
+  >/dev/null 2>&1; then
+  echo "Error: Python 3.10+ is required for correctness analysis" >&2
   exit 2
 fi
 
@@ -466,7 +498,6 @@ if [ -n "$STATE_FILE" ]; then
     }
   fi
 fi
-
 # Load scan context if provided (for context-aware checks like webhook validation)
 ORIGINAL_HAD_WEBHOOK_VALIDATION="unknown"
 SCAN_PRODUCTS=""
@@ -555,7 +586,7 @@ if product_applies "messaging"; then
     echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
     exit 2
   fi
-  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields "$PROJECT_ROOT"); then
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
     echo "Error: Twilio messages.create analysis failed" >&2
     exit 2
   fi
@@ -570,7 +601,7 @@ if product_applies "messaging"; then
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields "$PROJECT_ROOT"); then
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
     echo "Error: messaging body-field analysis failed" >&2
     exit 2
   fi
@@ -650,18 +681,38 @@ if product_applies "voice"; then
   # Check 6: speechModel must be translated on Gather/Transcription, but it is
   # a documented attribute on a Language child of ConversationRelay. Inspect
   # tag ancestry instead of rejecting every textual occurrence.
-  matches=$(python3 - "$PROJECT_ROOT" <<'PYEOF'
+  speech_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
+  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" <<'PYEOF'
+import importlib.util
 import os
-import pathlib
 import re
 import sys
+from pathlib import Path
 
-root = pathlib.Path(sys.argv[1])
-excluded = {
-    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__",
-    "build", "coverage", "dist", "node_modules", "vendor", "venv",
+root = Path(sys.argv[1])
+analyzer_path = Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("telnyx_source_lexer", analyzer_path)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Could not load {analyzer_path}")
+analyzer = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = analyzer
+spec.loader.exec_module(analyzer)
+excluded_dirs = {
+    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__", "build",
+    "coverage", "dist", "node_modules", "vendor", "venv",
 }
-  suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
+excluded_files = {
+    "MIGRATION-PLAN.md", "MIGRATION-REPORT.md", "migration-state.json",
+    "twilio-deep-scan.json", "twilio-scan.json",
+}
+suffixes = {
+    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".dart", ".ejs", ".erb",
+    ".ksh", ".zsh", ".go", ".handlebars", ".hbs", ".java", ".jinja",
+    ".jinja2", ".cts", ".j2", ".js", ".jsp", ".jsx", ".kt", ".kts",
+    ".mjs", ".mts", ".mustache", ".php", ".phtml", ".py", ".pyw",
+    ".rb", ".rake", ".scala", ".sh", ".svelte", ".swift", ".texml",
+    ".tmpl", ".ts", ".tsx", ".twiml", ".twig", ".vue", ".xml",
+}
 tag_pattern = re.compile(
     r"<(?P<closing>/)?\s*(?P<tag>[A-Za-z_][\w:.-]*)"
     r"(?P<attrs>(?:\"[^\"]*\"|'[^']*'|[^>])*)>",
@@ -670,23 +721,33 @@ tag_pattern = re.compile(
 speech_model = re.compile(r"(?<![\w:.-])speechModel\s*(?:=|:)")
 
 for directory, child_dirs, filenames in os.walk(root):
-    child_dirs[:] = sorted(name for name in child_dirs if name not in excluded)
+    child_dirs[:] = sorted(name for name in child_dirs if name not in excluded_dirs)
     for filename in sorted(filenames):
-        path = pathlib.Path(directory, filename)
-        if path.suffix.lower() not in suffixes:
+        path = Path(directory, filename)
+        if filename in excluded_files or path.suffix.lower() not in suffixes:
             continue
         source = path.read_text(encoding="utf-8", errors="replace")
-        source = re.sub(
-            r"<!--.*?-->|<!\[CDATA\[.*?\]\]>",
+        executable = analyzer.executable_source(path, source)
+        masked_executable = analyzer.lex_source(
+            executable, analyzer.canonical_suffix(path)
+        ).without_comments
+        scan_source = "".join(
+            masked if code != " " or raw in "\r\n" else raw
+            for raw, code, masked in zip(source, executable, masked_executable)
+        )
+        scan_source = re.sub(
+            r"<!--.*?-->|<!\[CDATA\[.*?\]\]>|"
+            r"<%#.*?%>|<%--.*?--%>|"
+            r"\{\{!--.*?--\}\}|\{\{!.*?\}\}|\{#.*?#\}",
             lambda match: "".join(
                 char if char in "\r\n" else " " for char in match.group(0)
             ),
-            source,
+            scan_source,
             flags=re.DOTALL,
         )
         stack = []
         tagged_speech_model = set()
-        for match in tag_pattern.finditer(source):
+        for match in tag_pattern.finditer(scan_source):
             tag = match.group("tag").rsplit(":", 1)[-1]
             if match.group("closing"):
                 if stack and stack[-1] == tag:
@@ -699,20 +760,17 @@ for directory, child_dirs, filenames in os.walk(root):
             tagged_speech_model.update(
                 attr_start + occurrence.start() for occurrence in attr_occurrences
             )
-            if attr_occurrences:
-                if not (tag == "Language" and stack[-1:] == ["ConversationRelay"]):
-                    line = source.count("\n", 0, match.start()) + 1
-                    print(f"{path}:{line}: <{tag}> speechModel")
+            if attr_occurrences and not (
+                tag == "Language" and stack[-1:] == ["ConversationRelay"]
+            ):
+                line = scan_source.count("\n", 0, match.start()) + 1
+                print(f"{path}:{line}: <{tag}> speechModel")
             if not match.group("attrs").rstrip().endswith("/"):
                 stack.append(tag)
-        # Builder/object forms (for example `{speechModel: "phone_call"}`)
-        # are migration-sensitive even when no literal XML tag exists. Only
-        # suppress occurrences already classified inside an XML tag, including
-        # the valid ConversationRelay <Language> form above.
-        for occurrence in speech_model.finditer(source):
+        for occurrence in speech_model.finditer(scan_source):
             if occurrence.start() in tagged_speech_model:
                 continue
-            line = source.count("\n", 0, occurrence.start()) + 1
+            line = scan_source.count("\n", 0, occurrence.start()) + 1
             print(f"{path}:{line}: non-XML speechModel")
 PYEOF
 )
@@ -831,12 +889,24 @@ if product_applies "all"; then
   section_header "Webhook Signature Validation"
 
   # Check 12: Webhook handlers without Ed25519 signature verification
-  webhook_handlers=$(search_files "(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+  # Vue/Svelte/Astro expressions are executable client code, but never server
+  # route declarations. Exclude those component files from this backend-only
+  # cross-file heuristic after applying the normal executable-source filter.
+  webhook_pattern="(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)"
+  webhook_handlers=$(search_raw_files "$webhook_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+    | filter_backend_matches "$webhook_pattern" \
+    | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
   webhook_count=$(count_matches "$webhook_handlers")
   if [ "$webhook_count" -gt 0 ]; then
-    ed25519_refs=$(search_files "(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+    ed25519_pattern="(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)"
+    ed25519_refs=$(search_raw_files "$ed25519_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+      | filter_backend_matches "$ed25519_pattern" \
+      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
     ed25519_count=$(count_matches "$ed25519_refs")
-    telnyx_webhook_parse=$(search_files "(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+    webhook_parse_pattern="(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])"
+    telnyx_webhook_parse=$(search_raw_files "$webhook_parse_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+      | filter_backend_matches "$webhook_parse_pattern" \
+      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
     telnyx_parse_count=$(count_matches "$telnyx_webhook_parse")
     if [ "$telnyx_parse_count" -gt 0 ] && [ "$ed25519_count" -eq 0 ]; then
       lint_issue "webhook_ed25519_missing" \
@@ -939,7 +1009,7 @@ fi
 section_header "Residual Twilio Patterns"
 
 # Check 10: Residual Twilio imports still present alongside Telnyx code
-matches=$(search_live_files comments '(from twilio|import[ (].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
+matches=$(search_live_files comments '(from twilio|import[ (=].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -45,7 +45,7 @@ PROJECT_ROOT=""
 SCAN_JSON=""
 STATE_FILE=""
 HYBRID_PRODUCTS=""
-MIGRATED_FILES=""
+MIGRATED_FILES_JSON="[]"
 JSON_CHECKS="[]"
 
 EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build .next .nuxt coverage .tox"
@@ -75,6 +75,18 @@ build_exclude_args() {
 }
 
 GREP_EXCLUDES=""
+
+# Finding records are LF-delimited, so path identity uses a reversible display
+# encoding. Escape backslashes first to distinguish a literal `\n` filename
+# segment from an actual newline. The Python analyzer and grep adapter use this
+# exact contract too.
+escape_record_path() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\n'/\\n}
+  printf '%s' "$value"
+}
 
 # Build every find(1) prune expression from the same policy as grep.  Keeping
 # literal copies in each traversal caused generated directories to re-enter
@@ -372,12 +384,12 @@ hybrid_waiver_applies() {
     # A retained product never waives a residual inside a file explicitly
     # recorded as migrated. Only downgrade when every matched path is outside
     # that set; mixed or migrated-only results must keep the gate blocking.
-    [ -n "$MIGRATED_FILES" ] || return 0
+    [ "$MIGRATED_FILES_JSON" != "[]" ] || return 0
     while IFS= read -r match; do
       [ -n "$match" ] || continue
-      while IFS= read -r migrated_file; do
+      while IFS= read -r -d '' migrated_file; do
         [ -n "$migrated_file" ] || continue
-        migrated_path="$PROJECT_ROOT/$migrated_file"
+        migrated_path=$(escape_record_path "$PROJECT_ROOT/$migrated_file")
         # Filtered grep output is `<absolute path>:<line>:<text>`. Do not
         # recover the path with a colon regex: POSIX paths may themselves
         # contain `:<digits>:`. Instead compare each complete, known migrated
@@ -392,7 +404,7 @@ hybrid_waiver_applies() {
         if [ "$migrated_path" = "$match" ] || [[ "$migrated_path" = "$match"/* ]]; then
           return 1
         fi
-      done <<<"$MIGRATED_FILES"
+      done < <(printf '%s' "$MIGRATED_FILES_JSON" | jq -j '.[] | ., "\u0000"')
     done <<<"${1:-}"
     return 0
   fi
@@ -507,13 +519,13 @@ if [ -n "$STATE_FILE" ]; then
       echo "Error: --state-file '$STATE_FILE' is not valid migration state JSON" >&2
       exit 2
     }
-    MIGRATED_FILES=$(jq -r --arg root "$PROJECT_ROOT/" '
+    MIGRATED_FILES_JSON=$(jq -c --arg root "$PROJECT_ROOT/" '
       [(.migrated_files? // {}) | .. | arrays | .[]?
        | select(type == "string")
        | if startswith($root) then .[($root | length):]
          elif startswith("./") then .[2:]
          else . end]
-      | unique[]
+      | unique
     ' "$STATE_FILE" 2>/dev/null) || {
       echo "Error: --state-file '$STATE_FILE' has invalid migrated_files" >&2
       exit 2
@@ -1017,9 +1029,12 @@ else
 fi
 
 # Check 12: Directory/path names containing "twilio"
-twilio_dirs=$(find "$PROJECT_ROOT" -mindepth 1 \
+twilio_dirs=""
+while IFS= read -r -d '' twilio_dir; do
+  twilio_dirs+="$(escape_record_path "$twilio_dir")"$'\n'
+done < <(find "$PROJECT_ROOT" -mindepth 1 \
   \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
-  -o -type d -iname '*twilio*' -print 2>/dev/null || true)
+  -o -type d -iname '*twilio*' -print0 2>/dev/null || true)
 twilio_dir_count=$(echo "$twilio_dirs" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$twilio_dir_count" -gt 0 ] && [ -n "$(echo "$twilio_dirs" | sed '/^$/d')" ]; then
   if hybrid_waiver_applies "$twilio_dirs"; then

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -398,10 +398,10 @@ while [ $# -gt 0 ]; do
       # skips every product-scoped check and still exits 0 — a silent pass.
       # Same accepted set as validate-migration.sh.
       case "$PRODUCT_FILTER" in
-        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
+        all|voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
         *)
           echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
-          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
+          echo "Valid products: all, voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
           exit 2
           ;;
       esac
@@ -458,7 +458,7 @@ fi
 if ! command -v python3 >/dev/null 2>&1 || ! python3 -c \
   'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' \
   >/dev/null 2>&1; then
-  echo "Error: Python 3.10+ is required for correctness analysis" >&2
+  echo "Error: python3 is required for correctness analysis; Python 3.10+ is required for correctness analysis" >&2
   exit 2
 fi
 
@@ -506,52 +506,6 @@ if [ -n "$SCAN_JSON" ] && [ -f "$SCAN_JSON" ] && command -v jq >/dev/null 2>&1; 
   SCAN_PRODUCTS=$(jq -r '.products_used // [] | map(ascii_downcase) | join(",")' "$SCAN_JSON" 2>/dev/null || true)
 fi
 
-# Hybrid awareness, mirroring validate-migration.sh: a product recorded as
-# kept on Twilio in migration-state.json is a skill-sanctioned deployment
-# state, so residual-Twilio findings for it are expected and must not hard-
-# fail Phase 4 forever.
-if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ] && command -v jq >/dev/null 2>&1; then
-  # Only products with a truthy keep reason stay in hybrid scope. An
-  # operator reverses a decision with `set kept_on_twilio.X false`
-  # (there is no unset command), so false/null/empty means NOT kept.
-  KEPT_ON_TWILIO=$(jq -r '.kept_on_twilio // {} | to_entries | map(select(.value != false and .value != null and .value != "")) | map(.key) | join(",")' "$STATE_FILE" 2>/dev/null || true)
-elif [ -n "$STATE_FILE" ] && [ ! -f "$STATE_FILE" ]; then
-  echo "Warning: --state-file '$STATE_FILE' not found, ignoring" >&2
-fi
-
-# Waive only for the product that is actually KEPT on Twilio.
-#
-# Testing `-n "$KEPT_ON_TWILIO"` alone made ANY hybrid state a GLOBAL waiver: in
-# a `--product messaging` run, a leftover Twilio messaging import was downgraded
-# to a warning - and the linter exited clean - merely because an unrelated
-# product such as voice was kept on Twilio. That is a silent pass on exactly the
-# residue the check exists to find.
-#
-# The product is passed per call site because these checks are not all inside a
-# product-scoped block; the global ones (residual imports, client instantiation,
-# directory names, docs) legitimately span products and pass "any", which waives
-# whenever ANY product is kept - the original behaviour, but now stated at the
-# call site rather than applied silently everywhere.
-kept_on_twilio() {
-  local product="$1"
-  [ -n "$KEPT_ON_TWILIO" ] || return 1
-  [ "$product" = "any" ] && return 0
-  case ",$KEPT_ON_TWILIO," in
-    *",$product,"*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-lint_issue_or_hybrid_warn() {
-  local product="$1"
-  shift
-  if kept_on_twilio "$product"; then
-    lint_warn "$1" "$2 (hybrid deployment — $KEPT_ON_TWILIO kept on Twilio)" "$3" "${4:-}"
-  else
-    lint_issue "$1" "$2" "$3" "${4:-}"
-  fi
-}
-
 # Helper: returns 0 if a product was detected in the scan (or if no scan data)
 scan_has_product() {
   local product="$1"
@@ -586,13 +540,13 @@ if product_applies "messaging"; then
     echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
     exit 2
   fi
-  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$HYBRID_PRODUCTS" "$PROJECT_ROOT"); then
     echo "Error: Twilio messages.create analysis failed" >&2
     exit 2
   fi
   count=$(count_matches "$twilio_create_calls")
   if [ "$count" -gt 0 ]; then
-    lint_issue_or_hybrid_warn "messaging" "twilio_messages_create" \
+    lint_issue "twilio_messages_create" \
       "Twilio .messages.create() request using body found at $count call site(s)" \
       "Use telnyx.messages.send() (Python) or telnyx.messages.create() with the text parameter (JavaScript/Ruby)" \
       "$(matches_to_json "$twilio_create_calls")"
@@ -601,7 +555,7 @@ if product_applies "messaging"; then
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$HYBRID_PRODUCTS" "$PROJECT_ROOT"); then
     echo "Error: messaging body-field analysis failed" >&2
     exit 2
   fi
@@ -995,7 +949,7 @@ done < <(find "$PROJECT_ROOT" -maxdepth 1 -type f \
 doc_files=$(echo "$doc_files" | sed '/^$/d')
 doc_count=$(echo "$doc_files" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$doc_count" -gt 0 ]; then
-  lint_issue_or_hybrid_warn "any" "docs_still_twilio" \
+  lint_issue "docs_still_twilio" \
     "Documentation files still reference Twilio (not migration-related references) in $doc_count file(s)" \
     "Update README/docs: replace Twilio service names, env vars, setup instructions, and URLs with Telnyx equivalents" \
     "$(echo "$doc_files" | sed '/^$/d' | head -10 | jq -R -s '{files: (split("\n") | map(select(length > 0)))}' 2>/dev/null || echo '{"files":[]}')"

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/preflight-check.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/preflight-check.sh
@@ -240,32 +240,48 @@ echo -e "${BOLD}Twilio SDKs Detected (to be replaced)${NC}"
 
 TWILIO_FOUND=false
 
-# Python
-if python3 -c "import twilio" 2>/dev/null; then
+# Python. With a project root, report project manifests only; a globally
+# installed package belongs to the host and says nothing about this migration.
+if [ -n "$PROJECT_ROOT" ] && find "$PROJECT_ROOT" -maxdepth 3 \
+  \( -name requirements.txt -o -name pyproject.toml -o -name setup.py -o -name Pipfile \) \
+  -exec grep -liE '(^|[^A-Za-z0-9_-])twilio([^A-Za-z0-9_-]|$)' {} + \
+  2>/dev/null | head -1 | grep -q .; then
+  check_info "Python: twilio (declared in project)"
+  TWILIO_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && python3 -c "import twilio" 2>/dev/null; then
   TWILIO_VER=$(python3 -c "import twilio; print(twilio.__version__)" 2>/dev/null || echo "unknown")
   check_info "Python: twilio $TWILIO_VER"
   TWILIO_FOUND=true
-elif python -c "import twilio" 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && python -c "import twilio" 2>/dev/null; then
   check_info "Python: twilio (version unknown)"
   TWILIO_FOUND=true
 fi
 
 # Node.js
-if [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/twilio" ]; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/package.json" ] && \
+  grep -qE '"twilio"[[:space:]]*:' "$PROJECT_ROOT/package.json" 2>/dev/null; then
+  TWILIO_NODE_VER=$(sed -nE 's/.*"twilio"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$PROJECT_ROOT/package.json" | head -1)
+  check_info "Node.js: twilio ${TWILIO_NODE_VER:-version unknown} (declared in project)"
+  TWILIO_FOUND=true
+elif [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/twilio" ]; then
   TWILIO_NODE_VER=$(node -e "console.log(require('$PROJECT_ROOT/node_modules/twilio/package.json').version)" 2>/dev/null || echo "unknown")
   check_info "Node.js: twilio $TWILIO_NODE_VER"
   TWILIO_FOUND=true
-elif [ -d "node_modules/twilio" ] 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && [ -d "node_modules/twilio" ] 2>/dev/null; then
   TWILIO_NODE_VER=$(node -e "console.log(require('twilio/package.json').version)" 2>/dev/null || echo "unknown")
   check_info "Node.js: twilio $TWILIO_NODE_VER"
   TWILIO_FOUND=true
-elif npm list twilio 2>/dev/null | grep -q twilio; then
+elif [ -z "$PROJECT_ROOT" ] && npm list twilio 2>/dev/null | grep -q twilio; then
   check_info "Node.js: twilio (installed globally or in project)"
   TWILIO_FOUND=true
 fi
 
 # Ruby
-if gem list twilio-ruby 2>/dev/null | grep -q twilio-ruby; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/Gemfile" ] && \
+  grep -qE "gem[[:space:]]+['\"]twilio(-ruby)?['\"]" "$PROJECT_ROOT/Gemfile" 2>/dev/null; then
+  check_info "Ruby: twilio-ruby (declared in project Gemfile)"
+  TWILIO_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && gem list twilio-ruby 2>/dev/null | grep -q twilio-ruby; then
   TWILIO_RUBY_VER=$(gem list twilio-ruby 2>/dev/null | grep -o '([^)]*)')
   check_info "Ruby: twilio-ruby $TWILIO_RUBY_VER"
   TWILIO_FOUND=true
@@ -277,13 +293,17 @@ if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/go.mod" ]; then
     check_info "Go: twilio-go (found in project go.mod)"
     TWILIO_FOUND=true
   fi
-elif go list -m github.com/twilio/twilio-go 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && go list -m github.com/twilio/twilio-go 2>/dev/null; then
   check_info "Go: twilio-go (found in go.mod)"
   TWILIO_FOUND=true
 fi
 
-# Java (check for jar in common locations)
+# Java/Kotlin manifests and local jars.
 SEARCH_DIR="${PROJECT_ROOT:-.}"
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" twilio-jvm-declared "$PROJECT_ROOT"; then
+  check_info "Java/Kotlin: Twilio SDK (declared in project)"
+  TWILIO_FOUND=true
+fi
 if find "$SEARCH_DIR" -name "twilio-*.jar" -maxdepth 3 2>/dev/null | grep -q twilio; then
   check_info "Java: twilio jar found in project"
   TWILIO_FOUND=true
@@ -291,7 +311,7 @@ fi
 
 # PHP
 if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/composer.json" ]; then
-  if grep -q "twilio" "$PROJECT_ROOT/composer.json" 2>/dev/null; then
+  if grep -qE '"twilio/sdk"[[:space:]]*:' "$PROJECT_ROOT/composer.json" 2>/dev/null; then
     check_info "PHP: twilio/sdk found in composer.json"
     TWILIO_FOUND=true
   fi
@@ -315,29 +335,50 @@ echo -e "${BOLD}Telnyx SDKs Installed${NC}"
 
 TELNYX_FOUND=false
 
+# Composer declarations belong in require/require-dev, not metadata or scripts.
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" composer "$PROJECT_ROOT"; then
+  check_pass "PHP: telnyx/telnyx-php (declared in project)"
+  TELNYX_FOUND=true
+fi
+
 # Python
-if python3 -c "import telnyx" 2>/dev/null; then
+if [ -n "$PROJECT_ROOT" ] && find "$PROJECT_ROOT" -maxdepth 3 \
+  \( -name requirements.txt -o -name pyproject.toml -o -name setup.py -o -name Pipfile \) \
+  -exec grep -liE '(^|[^A-Za-z0-9_-])telnyx([^A-Za-z0-9_-]|$)' {} + \
+  2>/dev/null | head -1 | grep -q .; then
+  check_pass "Python: telnyx (declared in project)"
+  TELNYX_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && python3 -c "import telnyx" 2>/dev/null; then
   TELNYX_PY_VER=$(python3 -c "import telnyx; print(telnyx.VERSION)" 2>/dev/null || echo "unknown")
   check_pass "Python: telnyx $TELNYX_PY_VER"
   TELNYX_FOUND=true
 fi
 
 # Node.js
-if [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/telnyx" ]; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/package.json" ] && \
+  grep -qE '"telnyx"[[:space:]]*:' "$PROJECT_ROOT/package.json" 2>/dev/null; then
+  TELNYX_NODE_VER=$(sed -nE 's/.*"telnyx"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$PROJECT_ROOT/package.json" | head -1)
+  check_pass "Node.js: telnyx ${TELNYX_NODE_VER:-version unknown} (declared in project)"
+  TELNYX_FOUND=true
+elif [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/telnyx" ]; then
   TELNYX_NODE_VER=$(node -e "console.log(require('$PROJECT_ROOT/node_modules/telnyx/package.json').version)" 2>/dev/null || echo "unknown")
   check_pass "Node.js: telnyx $TELNYX_NODE_VER"
   TELNYX_FOUND=true
-elif [ -d "node_modules/telnyx" ] 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && [ -d "node_modules/telnyx" ] 2>/dev/null; then
   TELNYX_NODE_VER=$(node -e "console.log(require('telnyx/package.json').version)" 2>/dev/null || echo "unknown")
   check_pass "Node.js: telnyx $TELNYX_NODE_VER"
   TELNYX_FOUND=true
-elif npm list telnyx 2>/dev/null | grep -q telnyx; then
+elif [ -z "$PROJECT_ROOT" ] && npm list telnyx 2>/dev/null | grep -q telnyx; then
   check_pass "Node.js: telnyx (installed)"
   TELNYX_FOUND=true
 fi
 
 # Ruby
-if gem list telnyx 2>/dev/null | grep -q "^telnyx "; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/Gemfile" ] && \
+  grep -qE "gem[[:space:]]+['\"]telnyx['\"]" "$PROJECT_ROOT/Gemfile" 2>/dev/null; then
+  check_pass "Ruby: telnyx (declared in project Gemfile)"
+  TELNYX_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && gem list telnyx 2>/dev/null | grep -q "^telnyx "; then
   TELNYX_RUBY_VER=$(gem list telnyx 2>/dev/null | grep "^telnyx " | grep -o '([^)]*)')
   check_pass "Ruby: telnyx $TELNYX_RUBY_VER"
   TELNYX_FOUND=true
@@ -349,8 +390,14 @@ if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/go.mod" ]; then
     check_pass "Go: telnyx-go (found in project go.mod)"
     TELNYX_FOUND=true
   fi
-elif go list -m github.com/telnyx/telnyx-go 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && go list -m all 2>/dev/null | \
+  grep -E '^github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]' >/dev/null; then
   check_pass "Go: telnyx-go (found in go.mod)"
+  TELNYX_FOUND=true
+fi
+
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
+  check_pass "Java/Kotlin: Telnyx SDK (declared in project)"
   TELNYX_FOUND=true
 fi
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/run-discovery.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/run-discovery.sh
@@ -21,7 +21,7 @@
 #
 # Exit codes:
 #   0 — Discovery complete (scan succeeded; preflight may have warnings)
-#   2 — Invalid arguments (project root doesn't exist, etc.)
+#   2 — Invalid arguments or incomplete usage scan
 
 set -uo pipefail
 
@@ -83,11 +83,12 @@ echo -e "  ${BLUE}INFO${NC}  Scanning source code for Twilio patterns (no API ke
 echo ""
 
 SCAN_OUTPUT="$PROJECT_ROOT/twilio-scan.json"
-bash "$SCRIPT_DIR/scan-twilio-usage.sh" "$PROJECT_ROOT" > "$SCAN_OUTPUT" 2>/dev/null
+bash "$SCRIPT_DIR/scan-twilio-usage.sh" "$PROJECT_ROOT" > "$SCAN_OUTPUT"
 SCAN_EXIT=$?
 
 if [ "$SCAN_EXIT" -ne 0 ]; then
-  echo -e "  ${YELLOW}WARN${NC}  Scanner exited with code $SCAN_EXIT"
+  echo -e "  ${RED}ERROR${NC}  Discovery incomplete: scanner exited with code $SCAN_EXIT. Do not use $SCAN_OUTPUT as a complete inventory." >&2
+  exit 2
 fi
 
 if [ -f "$SCAN_OUTPUT" ] && [ -s "$SCAN_OUTPUT" ]; then
@@ -105,7 +106,8 @@ if [ -f "$SCAN_OUTPUT" ] && [ -s "$SCAN_OUTPUT" ]; then
     echo "  Files:      $FILE_COUNT files with Twilio patterns"
   fi
 else
-  echo -e "  ${YELLOW}WARN${NC}  Scan produced no output — the project may have no Twilio code"
+  echo -e "  ${RED}ERROR${NC}  Discovery incomplete: scanner produced no report." >&2
+  exit 2
 fi
 
 echo ""
@@ -143,7 +145,7 @@ DEEP_SCAN_OUTPUT="$PROJECT_ROOT/twilio-deep-scan.json"
 if command -v python3 &>/dev/null; then
   if [ -f "$SCRIPT_DIR/scan-twilio-deep.py" ]; then
     echo -e "  ${BLUE}INFO${NC}  Running scan-twilio-deep.py..."
-    python3 "$SCRIPT_DIR/scan-twilio-deep.py" "$PROJECT_ROOT" > "$DEEP_SCAN_OUTPUT" 2>/dev/null
+    python3 "$SCRIPT_DIR/scan-twilio-deep.py" "$PROJECT_ROOT" > "$DEEP_SCAN_OUTPUT"
     DEEP_EXIT=$?
     if [ "$DEEP_EXIT" -eq 0 ] && [ -f "$DEEP_SCAN_OUTPUT" ] && [ -s "$DEEP_SCAN_OUTPUT" ]; then
       echo -e "  ${GREEN}PASS${NC}  Deep scan results saved to: $DEEP_SCAN_OUTPUT"

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/run-validation.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/run-validation.sh
@@ -138,6 +138,34 @@ fi
 
 echo ""
 
+# --- Step 5.1b: Telnyx Correctness Linter ---
+# This integration belongs with the source-aware analyzer. Without it the full
+# Phase 5 wrapper can certify a required sender that lacks
+# messaging_profile_id even though the standalone linter would block it.
+echo -e "${BOLD}Step 5.1b: Telnyx Correctness${NC}"
+echo "────────────────────────────────"
+
+CORRECTNESS_ARGS=("$PROJECT_ROOT")
+# Discovery records whether the original app intentionally omitted webhook
+# validation. Preserve that context so the wrapper and standalone linter reach
+# the same verdict instead of upgrading an intentional warning to an issue.
+[ -f "$PROJECT_ROOT/twilio-scan.json" ] && \
+  CORRECTNESS_ARGS+=("--scan-json" "$PROJECT_ROOT/twilio-scan.json")
+bash "$SCRIPT_DIR/lint-telnyx-correctness.sh" "${CORRECTNESS_ARGS[@]}"
+CORRECTNESS_EXIT=$?
+if [ "$CORRECTNESS_EXIT" -eq 0 ]; then
+  echo ""
+  echo -e "  ${GREEN}PASS${NC}  Correctness checks passed"
+  RESULTS="${RESULTS}correctness:pass,"
+else
+  echo ""
+  echo -e "  ${RED}FAIL${NC}  Correctness checks failed (exit code: $CORRECTNESS_EXIT)"
+  OVERALL_PASS=false
+  RESULTS="${RESULTS}correctness:fail,"
+fi
+
+echo ""
+
 # --- Step 5.2: TeXML Validation (optional) ---
 if [ "$INCLUDE_TEXML" = true ]; then
   echo -e "${BOLD}Step 5.2: TeXML Validation${NC}"

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/run-validation.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/run-validation.sh
@@ -104,6 +104,9 @@ fi
 if [ -z "$STATE_FILE" ] && [ -f "$PROJECT_ROOT/migration-state.json" ]; then
   STATE_FILE="$PROJECT_ROOT/migration-state.json"
 fi
+if [ -z "$SCAN_JSON" ] && [ -f "$PROJECT_ROOT/twilio-scan.json" ]; then
+  SCAN_JSON="$PROJECT_ROOT/twilio-scan.json"
+fi
 
 OVERALL_PASS=true
 RESULTS=""
@@ -146,11 +149,13 @@ echo -e "${BOLD}Step 5.1b: Telnyx Correctness${NC}"
 echo "────────────────────────────────"
 
 CORRECTNESS_ARGS=("$PROJECT_ROOT")
+# Keep the correctness linter in the same hybrid scope as migration
+# validation. An external state file is not discoverable from PROJECT_ROOT.
+[ -n "$STATE_FILE" ] && CORRECTNESS_ARGS+=("--state-file" "$STATE_FILE")
 # Discovery records whether the original app intentionally omitted webhook
 # validation. Preserve that context so the wrapper and standalone linter reach
 # the same verdict instead of upgrading an intentional warning to an issue.
-[ -f "$PROJECT_ROOT/twilio-scan.json" ] && \
-  CORRECTNESS_ARGS+=("--scan-json" "$PROJECT_ROOT/twilio-scan.json")
+[ -n "$SCAN_JSON" ] && CORRECTNESS_ARGS+=("--scan-json" "$SCAN_JSON")
 bash "$SCRIPT_DIR/lint-telnyx-correctness.sh" "${CORRECTNESS_ARGS[@]}"
 CORRECTNESS_EXIT=$?
 if [ "$CORRECTNESS_EXIT" -eq 0 ]; then

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -181,7 +181,7 @@ GO_EXTENSIONS = {".go"}
 RUBY_EXTENSIONS = {".rb", ".rake"}
 JAVA_EXTENSIONS = {".java", ".kt", ".kts", ".scala"}
 PHP_EXTENSIONS = {".php", ".phtml"}
-CSHARP_EXTENSIONS = {".cs", ".cshtml"}
+CSHARP_EXTENSIONS = {".cs", ".cshtml", ".razor"}
 OTHER_TEXT_EXTENSIONS = {".xml", ".yaml", ".yml"}
 
 # Directories to skip
@@ -794,14 +794,14 @@ _CSHARP_ENV_RE = re.compile(
 _CSHARP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 
 
-def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
+def scan_go_file(filepath: Path, lines: List[str], go_clients: frozenset[str] = frozenset()) -> List[Detection]:
     """Regex-based scanning for Go files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
     source = "\n".join(lines)
     lexed = _ownership.lexed_source(source, ".go")
     lines = lexed.without_comments.split("\n")
-    for line, product in _ownership.contextual_calls(source, ".go"):
+    for line, product in _ownership.contextual_calls(source, ".go", go_clients=go_clients):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
             context=get_context_lines(lines, line), confidence="high", product=product))
@@ -1353,6 +1353,7 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
 
     paths = list(walk_project(project_root))
     global_usings = _ownership.CsharpGlobalUsings(project_root, paths)
+    go_clients = _ownership.GoPackageClients(paths)
     for filepath in paths:
         ext = filepath.suffix.lower()
         name = filepath.name
@@ -1471,11 +1472,12 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
                 text = filepath.read_text(errors="replace")
             except (OSError, PermissionError):
                 continue
-            if "twilio" not in text.lower():
+            package_clients = go_clients.for_file(filepath)
+            if "twilio" not in text.lower() and not package_clients:
                 continue
             lines = text.splitlines()
             rel = str(filepath.relative_to(project_root))
-            go_detections = scan_go_file(filepath, lines)
+            go_detections = scan_go_file(filepath, lines, package_clients)
             if go_detections:
                 fr = FileResult(rel, "go")
                 fr.detections = go_detections

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import importlib.util
 import json
 import os
 import re
@@ -26,6 +27,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 SCAN_VERSION = "1.0.0"
 SCANNER_NAME = "deep"
+
+_ownership_spec = importlib.util.spec_from_file_location(
+    "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+_ownership = importlib.util.module_from_spec(_ownership_spec)
+_ownership_spec.loader.exec_module(_ownership)
 
 # ---------------------------------------------------------------------------
 # Product mapping -- Twilio module path fragment -> product name
@@ -105,6 +111,14 @@ METHOD_PRODUCT_MAP: Dict[str, str] = {
     "CreateVerification": "verify",
     "FetchMessage": "messaging",
     "FetchCall": "voice",
+    "/Messages.json": "messaging",
+    "messaging.twilio.com": "messaging",
+    "/Calls.json": "voice",
+    "verify.twilio.com": "verify",
+    "lookups.twilio.com": "lookup",
+    "video.twilio.com": "video",
+    "fax.twilio.com": "fax",
+    "/IncomingPhoneNumbers.json": "phone-numbers",
 }
 
 # Twilio env var patterns
@@ -161,13 +175,13 @@ DEPENDENCY_FILE_NAMES = {
 }
 
 # File extensions to scan
-PY_EXTENSIONS = {".py"}
-JS_EXTENSIONS = {".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"}
+PY_EXTENSIONS = {".py", ".pyw"}
+JS_EXTENSIONS = {".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs", ".mts", ".cts"}
 GO_EXTENSIONS = {".go"}
-RUBY_EXTENSIONS = {".rb"}
-JAVA_EXTENSIONS = {".java", ".kt", ".scala"}
-PHP_EXTENSIONS = {".php"}
-CSHARP_EXTENSIONS = {".cs"}
+RUBY_EXTENSIONS = {".rb", ".rake"}
+JAVA_EXTENSIONS = {".java", ".kt", ".kts", ".scala"}
+PHP_EXTENSIONS = {".php", ".phtml"}
+CSHARP_EXTENSIONS = {".cs", ".cshtml"}
 OTHER_TEXT_EXTENSIONS = {".xml", ".yaml", ".yml"}
 
 # Directories to skip
@@ -276,8 +290,9 @@ def resolve_product(module_path: str) -> str:
 
 def infer_product_from_text(text: str) -> str:
     """Best-effort product inference from arbitrary text."""
+    lowered = text.lower()
     for pattern, product in METHOD_PRODUCT_MAP.items():
-        if pattern in text:
+        if pattern.lower() in lowered:
             return product
     return "general"
 
@@ -758,10 +773,6 @@ _RUBY_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # Java / Kotlin / Scala patterns
 _JAVA_IMPORT_RE = re.compile(r"import\s+(com\.twilio\.[^\s;]+)", re.IGNORECASE)
 _JAVA_INIT_RE = re.compile(r"Twilio\.init\s*\(", re.IGNORECASE)
-_JAVA_CREATOR_RE = re.compile(
-    r"com\.twilio\.rest\.api\.v2010\.account\.(Call|Message|IncomingPhoneNumber)\.creator",
-    re.IGNORECASE,
-)
 _JAVA_TWIML_RE = re.compile(r"com\.twilio\.twiml\.(VoiceResponse|MessagingResponse)", re.IGNORECASE)
 _JAVA_ENV_RE = re.compile(r'System\.getenv\s*\(\s*"(TWILIO_\w+)"', re.IGNORECASE)
 _JAVA_WEBHOOK_RE = re.compile(r"X-Twilio-Signature|RequestValidator", re.IGNORECASE)
@@ -770,7 +781,6 @@ _JAVA_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # PHP patterns
 _PHP_USE_RE = re.compile(r"use\s+Twilio\\([^\s;]+)", re.IGNORECASE)
 _PHP_CLIENT_RE = re.compile(r"new\s+Client\s*\(\s*\$\w+\s*,\s*\$\w+", re.IGNORECASE)
-_PHP_METHOD_RE = re.compile(r"\$twilio->\s*(\w+)", re.IGNORECASE)
 _PHP_ENV_RE = re.compile(r"""(?:getenv\s*\(\s*['"]|\$_ENV\[['"])(TWILIO_\w+)""", re.IGNORECASE)
 _PHP_WEBHOOK_RE = re.compile(r"RequestValidator", re.IGNORECASE)
 _PHP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
@@ -778,10 +788,6 @@ _PHP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # C# patterns
 _CSHARP_USING_RE = re.compile(r"using\s+(Twilio[^\s;]*)", re.IGNORECASE)
 _CSHARP_INIT_RE = re.compile(r"TwilioClient\.Init\s*\(", re.IGNORECASE)
-_CSHARP_RESOURCE_RE = re.compile(
-    r"(MessageResource|CallResource|IncomingPhoneNumberResource|AccountResource)\.(Create|Read|Update|Fetch)",
-    re.IGNORECASE,
-)
 _CSHARP_ENV_RE = re.compile(
     r'Environment\.GetEnvironmentVariable\s*\(\s*"(TWILIO_\w+)"', re.IGNORECASE
 )
@@ -792,8 +798,18 @@ def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
     """Regex-based scanning for Go files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, ".go")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, ".go"):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
 
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # Import statements
@@ -836,9 +852,10 @@ def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
         stripped = line.strip()
         if stripped.startswith("//"):
             continue
-        # Check for API method calls (e.g. CreateMessage, messages.create)
+        # SDK calls were attributed above. A generic application method name
+        # alone is not ownership evidence; retain explicit Twilio hints only.
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _GO_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -924,11 +941,22 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
 
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # import com.twilio.*
-        m = _JAVA_IMPORT_RE.search(stripped)
+        m = _JAVA_IMPORT_RE.search(syntax_lines[i - 1])
         if m:
             pkg = m.group(1).lower()
             product = "general"
@@ -963,26 +991,6 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
                     context=get_context_lines(lines, i), confidence="high", product="general",
-                )
-            )
-            detected_lines.add(i)
-            continue
-
-        # Creator patterns: Call.creator, Message.creator
-        m = _JAVA_CREATOR_RE.search(stripped)
-        if m:
-            resource = m.group(1).lower()
-            product = "general"
-            if resource == "call":
-                product = "voice"
-            elif resource == "message":
-                product = "messaging"
-            elif resource == "incomingphonenumber":
-                product = "phone-numbers"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
                 )
             )
             detected_lines.add(i)
@@ -1033,7 +1041,7 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _JAVA_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1059,11 +1067,22 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
 
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # use Twilio\* namespace imports
-        m = _PHP_USE_RE.search(stripped)
+        m = _PHP_USE_RE.search(syntax_lines[i - 1])
         if m:
             ns = m.group(1).lower()
             product = "general"
@@ -1106,30 +1125,6 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
             detected_lines.add(i)
             continue
 
-        # $twilio-> method calls
-        m = _PHP_METHOD_RE.search(stripped)
-        if m:
-            method = m.group(1).lower()
-            product = "general"
-            if method in ("messages", "message"):
-                product = "messaging"
-            elif method in ("calls", "call"):
-                product = "voice"
-            elif method in ("verify", "verification"):
-                product = "verify"
-            elif method in ("video",):
-                product = "video"
-            elif method in ("lookups", "lookup"):
-                product = "lookup"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
-                )
-            )
-            detected_lines.add(i)
-            continue
-
         # Env vars: getenv('TWILIO_*'), $_ENV['TWILIO_*']
         m = _PHP_ENV_RE.search(stripped)
         if m:
@@ -1161,7 +1156,7 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("#") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _PHP_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1186,12 +1181,23 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
     """Regex-based scanning for C# files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
 
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # using Twilio* imports
-        m = _CSHARP_USING_RE.search(stripped)
+        m = _CSHARP_USING_RE.search(syntax_lines[i - 1])
         if m:
             ns = m.group(1).lower()
             product = "general"
@@ -1234,26 +1240,6 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
             detected_lines.add(i)
             continue
 
-        # Resource method calls: MessageResource.Create, CallResource.Create, etc.
-        m = _CSHARP_RESOURCE_RE.search(stripped)
-        if m:
-            resource = m.group(1).lower()
-            product = "general"
-            if "message" in resource:
-                product = "messaging"
-            elif "call" in resource:
-                product = "voice"
-            elif "incomingphonenumber" in resource:
-                product = "phone-numbers"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
-                )
-            )
-            detected_lines.add(i)
-            continue
-
         # Env vars: Environment.GetEnvironmentVariable("TWILIO_*")
         m = _CSHARP_ENV_RE.search(stripped)
         if m:
@@ -1274,7 +1260,7 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _CSHARP_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1326,7 +1312,9 @@ def walk_project(root: Path):
     """Yield file paths, skipping common non-source directories."""
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune skip dirs in-place
-        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS and not d.startswith(".")]
+        # Hidden source folders (for example .github/scripts) are still source.
+        # Exclude named generated/tool directories, not every dot-directory.
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
         for fname in filenames:
             yield Path(dirpath) / fname
 
@@ -1523,7 +1511,7 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
             rel = str(filepath.relative_to(project_root))
             java_detections = scan_java_file(filepath, lines)
             if java_detections:
-                lang = "kotlin" if ext == ".kt" else "scala" if ext == ".scala" else "java"
+                lang = "kotlin" if ext in {".kt", ".kts"} else "scala" if ext == ".scala" else "java"
                 fr = FileResult(rel, lang)
                 fr.detections = java_detections
                 file_results.append(fr)

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -945,6 +945,9 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
     lexed = _ownership.lexed_source(source, filepath.suffix)
     syntax_lines = lexed.code.split("\n")
     lines = lexed.without_comments.split("\n")
+    scala_selectors = (_ownership.scala_import_bindings(lexed.code, {
+        "Message": "messaging", "Call": "voice",
+        "IncomingPhoneNumber": "phone-numbers"}) if filepath.suffix == ".scala" else [])
     for line, product in _ownership.contextual_calls(source, filepath.suffix):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
@@ -958,6 +961,21 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
         # import com.twilio.*
         m = _JAVA_IMPORT_RE.search(syntax_lines[i - 1])
         if m:
+            if filepath.suffix == ".scala" and re.search(
+                r"\bimport\s+(?:_root_\.)?com\.twilio\.rest\.api\.v2010\.account\.\s*\{",
+                syntax_lines[i - 1],
+            ):
+                # Selector text is not a package name: Message => _ excludes
+                # Message, while Message => Sms imports it under another name.
+                products = {product for offset, selected, _ in scala_selectors
+                            if source.count("\n", 0, offset) + 1 == i
+                            for product in selected.values() if product}
+                for product in sorted(products or {"general"}):
+                    detections.append(Detection(
+                        pattern=stripped, line=i, detection_method="regex",
+                        context=get_context_lines(lines, i), confidence="high", product=product))
+                detected_lines.add(i)
+                continue
             pkg = m.group(1).lower()
             product = "general"
             if "messaging" in pkg or "message" in pkg:

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -1195,7 +1195,7 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
     return detections
 
 
-def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
+def scan_csharp_file(filepath: Path, lines: List[str], global_using_code: str = "") -> List[Detection]:
     """Regex-based scanning for C# files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
@@ -1203,7 +1203,7 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
     lexed = _ownership.lexed_source(source, filepath.suffix)
     syntax_lines = lexed.code.split("\n")
     lines = lexed.without_comments.split("\n")
-    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+    for line, product in _ownership.contextual_calls(source, filepath.suffix, global_using_code):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
             context=get_context_lines(lines, line), confidence="high", product=product))
@@ -1351,7 +1351,9 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
     method_counts: Dict[str, int] = {"ast": 0, "regex": 0, "heuristic": 0}
     confidence_counts: Dict[str, int] = {"high": 0, "medium": 0, "low": 0}
 
-    for filepath in walk_project(project_root):
+    paths = list(walk_project(project_root))
+    global_usings = _ownership.CsharpGlobalUsings(project_root, paths)
+    for filepath in paths:
         ext = filepath.suffix.lower()
         name = filepath.name
 
@@ -1592,11 +1594,12 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
                 text = filepath.read_text(errors="replace")
             except (OSError, PermissionError):
                 continue
-            if "twilio" not in text.lower():
+            global_using_code = global_usings.for_file(filepath)
+            if "twilio" not in text.lower() and not global_using_code:
                 continue
             lines = text.splitlines()
             rel = str(filepath.relative_to(project_root))
-            csharp_detections = scan_csharp_file(filepath, lines)
+            csharp_detections = scan_csharp_file(filepath, lines, global_using_code)
             if csharp_detections:
                 fr = FileResult(rel, "csharp")
                 fr.detections = csharp_detections

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
@@ -118,6 +118,21 @@ run_grep() {
   grep -rnI "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
+run_source_fixed_grep() {
+  grep -rnI "${EXCLUDE_ARGS[@]}" --exclude='*.razor' --exclude='*.cshtml' "$@" "$PROJECT_ROOT" 2>/dev/null || true
+  # Razor mixes inert markup and executable C#. Recheck candidate lines on
+  # the shared executable view, retaining the original fixed-string semantics.
+  local filter_pattern script_dir filepath locator
+  filter_pattern="$(printf '%s' "$2" | sed 's/[][\\.^$*+?(){}|]/\\&/g')"
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  while IFS= read -r -d '' filepath && IFS= read -r locator; do
+    printf '%s\0%s\n' "$filepath" "$locator" |
+      python3 "$script_dir/filter-source-matches.py" --mode code \
+        --analyzer "$script_dir/lint-required-messaging-profile.py" --pattern "$filter_pattern"
+  done < <(grep -rnIH --null --include='*.razor' --include='*.cshtml' \
+    "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true)
+}
+
 # Detect language from file extension
 detect_language() {
   local f="$1"
@@ -130,7 +145,7 @@ detect_language() {
     *.java)                   echo "java" ;;
     *.php|*.phtml)             echo "php" ;;
     *.scala)                  echo "scala" ;;
-    *.cs|*.cshtml)             echo "csharp" ;;
+    *.cs|*.cshtml|*.razor)     echo "csharp" ;;
     *.sh|*.bash)              echo "shell" ;;
     *.xml)                    echo "xml" ;;
     *.json)                   echo "json" ;;
@@ -340,7 +355,7 @@ for pat in "${SDK_PATTERNS[@]}"; do
         record_file "$rel" "$lang" "$p" "$trimmed"
       done
     fi
-  done < <(run_grep -F "$pat")
+  done < <(run_source_fixed_grep -F "$pat")
 done
 
 for pat in "${SDK_REGEX_PATTERNS[@]}"; do
@@ -427,7 +442,7 @@ for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
     fi
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
-  done < <(run_grep -F "$pat")
+  done < <(run_source_fixed_grep -F "$pat")
 done
 
 # Case-insensitive regex patterns for common method calls

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
@@ -115,21 +115,22 @@ declare -A API_URL_MAP       # url -> comma-separated files
 # Runs grep -rn inside PROJECT_ROOT with standard excludes and returns
 # matching lines (path:lineno:content). Returns 0 even if nothing matched.
 run_grep() {
-  grep -rn "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Detect language from file extension
 detect_language() {
   local f="$1"
   case "$f" in
-    *.py)                     echo "python" ;;
-    *.js|*.mjs|*.cjs)        echo "javascript" ;;
-    *.ts|*.tsx)               echo "typescript" ;;
+    *.py|*.pyw)               echo "python" ;;
+    *.js|*.jsx|*.mjs|*.cjs)    echo "javascript" ;;
+    *.ts|*.tsx|*.mts|*.cts)    echo "typescript" ;;
     *.go)                     echo "go" ;;
-    *.rb)                     echo "ruby" ;;
+    *.rb|*.rake|*/Rakefile|Rakefile) echo "ruby" ;;
     *.java)                   echo "java" ;;
-    *.php)                    echo "php" ;;
-    *.cs)                     echo "csharp" ;;
+    *.php|*.phtml)             echo "php" ;;
+    *.scala)                  echo "scala" ;;
+    *.cs|*.cshtml)             echo "csharp" ;;
     *.sh|*.bash)              echo "shell" ;;
     *.xml)                    echo "xml" ;;
     *.json)                   echo "json" ;;
@@ -179,7 +180,7 @@ pattern_to_products() {
     products="$products fax"
   fi
   # Lookup
-  if echo "$pat" | grep -qiE 'twilio/rest/lookups|PhoneNumber|lookups'; then
+  if echo "$pat" | grep -qiE 'twilio/rest/lookups|lookups'; then
     products="$products lookup"
   fi
   # TeXML (TwiML)
@@ -293,8 +294,8 @@ SDK_PATTERNS=(
   'import com.twilio'
   'com.twilio.'
   # PHP
-  'use Twilio\\'
-  'Twilio\\'
+  "use Twilio\\"
+  "Twilio\\"
   # C# / .NET
   'using Twilio'
   'Twilio.'
@@ -407,8 +408,8 @@ PRODUCT_PATTERNS_FIXED=(
 )
 
 for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
-  pat="${entry%%:*}"
-  product="${entry#*:}"
+  pat="${entry%:*}"
+  product="${entry##*:}"
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     filepath="${line%%:*}"
@@ -416,6 +417,14 @@ for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
     content="${rest#*:}"
     rel="${filepath#"$PROJECT_ROOT"/}"
     lang="$(detect_language "$rel")"
+    # C# resource names can be application-defined. The shared scoped
+    # resolver below attributes these calls; a bare name is not SDK evidence.
+    if [[ "$lang" == csharp && ( "$pat" == MessageResource || "$pat" == CallResource || \
+      "$pat" == VerificationResource || "$pat" == FaxResource || "$pat" == SimResource || \
+      "$pat" == ConversationResource || "$pat" == NotificationResource || \
+      "$pat" == WorkflowResource ) ]]; then
+      continue
+    fi
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
   done < <(run_grep -F "$pat")
@@ -425,6 +434,14 @@ done
 PRODUCT_PATTERNS_REGEX=(
   'messages\.create:messaging'
   'messages\.list:messaging'
+  'api\.twilio\.com/.*/Messages(\.json)?:messaging'
+  'messaging\.twilio\.com:messaging'
+  'api\.twilio\.com/.*/Calls(\.json)?:voice'
+  'verify\.twilio\.com:verify'
+  'lookups\.twilio\.com:lookup'
+  'video\.twilio\.com:video'
+  'fax\.twilio\.com:fax'
+  'api\.twilio\.com/.*/IncomingPhoneNumbers(\.json)?:phone-numbers'
   '\.calls\.create:voice'
   '\.calls\.list:voice'
   'verify\.v2:verify'
@@ -438,7 +455,6 @@ PRODUCT_PATTERNS_REGEX=(
   'twiml\.voice:voice'
   'twiml\.messaging:messaging'
   'VoiceGrant:voice'
-  'SipGrant:voice'
   # SIP trunking
   'twilio\.rest\.trunking:sip'
   'trunking\.v1:sip'
@@ -496,8 +512,8 @@ PRODUCT_PATTERNS_REGEX=(
 )
 
 for entry in "${PRODUCT_PATTERNS_REGEX[@]}"; do
-  pat="${entry%%:*}"
-  product="${entry#*:}"
+  pat="${entry%:*}"
+  product="${entry##*:}"
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     filepath="${line%%:*}"
@@ -507,8 +523,22 @@ for entry in "${PRODUCT_PATTERNS_REGEX[@]}"; do
     lang="$(detect_language "$rel")"
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
-  done < <(run_grep -iE "$pat")
+  done < <(run_grep -iE -- "$pat")
 done
+
+# Ambiguous JVM class names and PHP receivers use the same ownership resolver
+# as deep discovery. NUL records preserve filenames and source text verbatim.
+while IFS= read -r -d '' filepath && IFS= read -r -d '' product && IFS= read -r -d '' content; do
+  rel="${filepath#"$PROJECT_ROOT"/}"
+  lang="$(detect_language "$rel")"
+  record_file "$rel" "$lang" "$product" "$content"
+done < <(python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sdk-source-ownership.py" "$PROJECT_ROOT")
+# A process-substitution failure does not propagate through `set -e`.
+# Do not serialize partial discovery as a successful complete scan.
+if ! wait "$!"; then
+  echo "SDK ownership discovery failed; scan is incomplete" >&2
+  exit 2
+fi
 
 # ---------------------------------------------------------------------------
 # 3. Environment variables

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Shared, bounded SDK ownership for ambiguous JVM/PHP/Go discovery call names.
+
+This is discovery evidence, not a whole-program type checker. A comment, string,
+unrelated import, or receiver name alone never establishes SDK ownership.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+import importlib.util
+from pathlib import Path
+import re
+import os
+import sys
+
+
+@lru_cache(maxsize=None)
+def load_script(name: str):
+    spec = importlib.util.spec_from_file_location(
+        name.replace("-", "_"), Path(__file__).with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def lexed_source(source: str, suffix: str):
+    analyzer = load_script("lint-required-messaging-profile")
+    path = Path("source" + suffix)
+    return analyzer.lex_source(analyzer.executable_source(path, source),
+                               analyzer.canonical_suffix(path), analyzer.source_dialect(path))
+
+
+def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
+    lexed = lexed_source(source, suffix)
+    code = lexed.code
+    if suffix == ".go":
+        return go_contextual_calls(source, lexed)
+    if suffix in {".cs", ".cshtml"}:
+        analyzer = load_script("lint-required-messaging-profile")
+        resolver = analyzer.SourceEndpointResolver(lexed, ".cs")
+        resources = (
+            ("Twilio.Rest.Api.V2010.Account.MessageResource", "messaging"),
+            ("Twilio.Rest.Api.V2010.Account.CallResource", "voice"),
+            ("Twilio.Rest.Api.V2010.Account.IncomingPhoneNumberResource", "phone-numbers"),
+            ("Twilio.Rest.Api.V2010.AccountResource", "general"),
+            ("Twilio.Rest.Verify.V2.Service.VerificationResource", "verify"),
+            ("Twilio.Rest.Fax.V1.FaxResource", "fax"),
+            ("Twilio.Rest.Supersim.V1.SimResource", "iot"),
+            ("Twilio.Rest.Wireless.V1.SimResource", "iot"),
+            ("Twilio.Rest.Conversations.V1.ConversationResource", "conversations"),
+            ("Twilio.Rest.Conversations.V1.Service.ConversationResource", "conversations"),
+            ("Twilio.Rest.Notify.V1.Service.NotificationResource", "notify"),
+            ("Twilio.Rest.Taskrouter.V1.Workspace.WorkflowResource", "taskrouter"),
+        )
+        methods = tuple(
+            method + suffix
+            for method in ("Create", "Read", "Update", "Fetch", "Delete", "List")
+            for suffix in ("", "Async")
+        )
+        return [(source.count("\n", 0, call.start) + 1, product)
+                for target, product in resources
+                for call in analyzer.csharp_twilio_resource_calls(lexed,
+                    target, methods, resolver)]
+    result = []
+    products = {"Message": "messaging", "Call": "voice",
+                "IncomingPhoneNumber": "phone-numbers"}
+    if suffix in {".java", ".kt", ".kts", ".scala"}:
+        analyzer = load_script("lint-required-messaging-profile")
+        resolver = analyzer.SourceEndpointResolver(lexed, ".java")
+        parameter_scopes = []
+        parameter_headers = []
+        if suffix != ".java":
+            # Kotlin/Scala name:type parameters differ from Java Type name.
+            # Keep that dialect distinction local to SDK ownership, without
+            # changing the endpoint resolver's advertised Java contract.
+            for function in re.finditer(r"\b(?:fun|def)\s+\w+\s*\(", code):
+                opening = code.rfind("(", function.start(), function.end())
+                closing = analyzer.matching_delimiter(code, opening, "(", ")")
+                if closing is None:
+                    continue
+                parameter_headers.append((opening, closing))
+                body = code.find("{", closing)
+                if body < 0 or not re.fullmatch(r"\s*(?::[^{}\n=]+)?\s*=?\s*", code[closing + 1:body]):
+                    continue
+                end = analyzer.matching_delimiter(code, body, "{", "}")
+                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
+                if end is not None:
+                    parameter_scopes.append((body, end, names))
+        prefix = "com.twilio.rest.api.v2010.account."
+        imports = {}
+        explicit = {}
+        for match in re.finditer(r"\bimport\s+(com\.twilio\.rest\.api\.v2010\.account\.\*|[\w.]+)(?:\s+as\s+(\w+))?", code):
+            target = match[1]
+            if target == prefix + "*":
+                imports.update(products)
+            elif target.startswith(prefix) and target[len(prefix):] in products:
+                explicit[match[2] or target.rsplit(".", 1)[-1]] = products[target[len(prefix):]]
+            else:
+                explicit[match[2] or target.rsplit(".", 1)[-1]] = None
+        imports.update(explicit)  # Single imports shadow wildcard imports in either order.
+        for match in re.finditer(r"(?<![\w.])([\w.]+)\s*\.\s*creator\s*\(", code):
+            receiver = match[1]
+            first = receiver.split(".", 1)[0]
+            binding_id = resolver.graph.visible_binding(first, resolver.scope_at(match.start()), match.start())
+            if binding_id is not None:
+                binding = resolver.graph.bindings[binding_id]
+                if ((suffix == ".java" or binding.kind != "parameter")
+                        and not any(start < binding.declaration_start < end
+                                    for start, end in parameter_headers)
+                        and analyzer.scope_contains(code, binding.declaration_start, match.start())):
+                    continue
+            if any(start < match.start() < end and first in names
+                   for start, end, names in parameter_scopes):
+                continue
+            product = imports.get(receiver)
+            if receiver.startswith(prefix):
+                product = products.get(receiver[len(prefix):])
+            if product:
+                result.append((source.count("\n", 0, match.start()) + 1, product))
+        return result
+
+    namespaces = list(re.finditer(r"\bnamespace(?:\s+[\w\\]+)?\s*[;{]", code))
+
+    def namespace_at(offset: int) -> int:
+        return next((match.start() for match in reversed(namespaces)
+                     if match.start() < offset), -1)
+
+    def global_namespace(offset: int) -> bool:
+        match = next((match for match in reversed(namespaces) if match.start() < offset), None)
+        return match is None or bool(re.fullmatch(r"namespace\s*\{", match[0]))
+
+    aliases = {}
+    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*;", code, re.I):
+        aliases[(namespace_at(match.start()), (match[2] or match[1]).lower())] = match[1].lower()
+    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\\{([^{};]+)\}\s*;", code, re.I):
+        for member in match[1].split(","):
+            imported = re.fullmatch(
+                r"\s*(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*",
+                member,
+                re.I,
+            )
+            if imported:
+                aliases[(namespace_at(match.start()),
+                         (imported[2] or imported[1]).lower())] = imported[1].lower()
+
+    def kind(type_name: str, offset: int) -> str | None:
+        normalized = type_name.lstrip("\\").lower()
+        if normalized in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"} and (type_name.startswith("\\") or global_namespace(offset)):
+            return normalized.rsplit("\\", 1)[-1]
+        return aliases.get((namespace_at(offset), normalized))
+
+    analyzer = load_script("lint-required-messaging-profile")
+    # Index braces once so bindings cannot leak between functions/classes.
+    braces = {}
+    stack = []
+    for offset, character in enumerate(code):
+        if character == "{":
+            stack.append(offset)
+        elif character == "}" and stack:
+            braces[stack.pop()] = offset
+    functions = []
+    classes = []
+    for pattern, spans in ((r"\bfunction\s*\w*\s*\([^;{]*\)[^;{]*\{", functions),
+                           (r"\bclass\s+\w+[^;{]*\{", classes)):
+        for match in re.finditer(pattern, code):
+            opening = match.end() - 1
+            if opening in braces:
+                spans.append((match.start(), braces[opening]))
+
+    def owner(offset: int, spans: list[tuple[int, int]]):
+        return next((span for span in reversed(spans) if span[0] <= offset < span[1]), None)
+
+    variable = r"\$[A-Za-z_]\w*(?:\s*->\s*[A-Za-z_]\w*)?"
+    assignments = list(re.finditer(r"(" + variable + r")\s*=(?!=|>)\s*([^;\n]+)", code))
+    typed = list(re.finditer(r"(?<![\w\\])([\\\w]+)\s+(\$\w+)\b", code))
+
+    def compact(value: str) -> str:
+        return re.sub(r"\s+", "", value)
+
+    def resolve(expression: str, use: int, seen: frozenset = frozenset()) -> str | None:
+        expression = expression.strip()
+        identity = (expression, use)
+        if identity in seen or len(seen) > 32:
+            return None
+        seen = seen | {identity}
+        constructed = re.match(r"new\s+([\\\w]+)\s*\(", expression, re.I)
+        if constructed:
+            return kind(constructed[1], use)
+        factory = re.match(r"(" + variable + r")\s*->\s*create\s*\(", expression, re.I)
+        if factory:
+            return "client" if resolve(factory[1], use, seen) == "clientfactory" else None
+        if not re.fullmatch(variable, expression):
+            return None
+        name = compact(expression)
+        candidates = []
+        for match in assignments:
+            if compact(match[1]) != name:
+                continue
+            if name.startswith("$this->"):
+                # Only a constructor initializes an instance property for a
+                # later method; arbitrary other method writes are not definite.
+                function = owner(match.start(), functions)
+                same_function = function == owner(use, functions)
+                constructor = function and re.match(r"function\s+__construct\b", code[function[0]:], re.I)
+                if owner(use, classes) is None or owner(use, classes) != owner(match.start(), classes) or not (same_function or constructor):
+                    continue
+                if same_function and match.start() >= use:
+                    continue
+            elif owner(use, functions) != owner(match.start(), functions):
+                continue
+            elif match.start() >= use:
+                continue
+            if namespace_at(match.start()) != namespace_at(use):
+                continue
+            if not name.startswith("$this->") and not analyzer.scope_contains(code, match.start(), use):
+                continue
+            # An assignment in the currently executing method overrides a
+            # constructor initializer regardless of source declaration order.
+            candidates.append((owner(match.start(), functions) == owner(use, functions), match.start(), match[2]))
+        if candidates:
+            _, offset, value = max(candidates)
+            return resolve(value, offset, seen)
+        for match in reversed(typed):
+            if namespace_at(match.start()) != namespace_at(use):
+                continue
+            function = owner(match.start(), functions)
+            # A type hint is in the parameter header, not `return $client` or
+            # another keyword/expression in the function body.
+            parameter = function is not None and match.start() < code.find("{", function[0])
+            if parameter and match.start() < use and compact(match[2]) == name and owner(use, functions) == function:
+                return kind(match[1], match.start())
+            promoted = False
+            if parameter:
+                parameter_start = max(code.rfind("(", function[0], match.start()),
+                                      code.rfind(",", function[0], match.start()))
+                promoted = bool(re.search(
+                    r"\b(?:public|protected|private)\b",
+                    code[parameter_start + 1:match.start()],
+                    re.I,
+                ))
+            if (promoted and name == "$this->" + match[2][1:]
+                    and re.match(r"function\s+__construct\b", code[function[0]:], re.I)
+                    and owner(use, classes) == owner(match.start(), classes)):
+                return kind(match[1], match.start())
+            if name == "$this->" + match[2][1:] and owner(match.start(), functions) is None and owner(use, classes) is not None and owner(use, classes) == owner(match.start(), classes):
+                return kind(match[1], match.start())
+        return None
+
+    php_products = {"messages": "messaging", "calls": "voice", "verify": "verify",
+                    "video": "video", "lookups": "lookup"}
+    for match in re.finditer(r"(" + variable + r")\s*->\s*(messages|calls|verify|video|lookups)\b", code, re.I):
+        if resolve(match[1], match.start()) == "client":
+            result.append((source.count("\n", 0, match.start()) + 1, php_products[match[2].lower()]))
+    return result
+
+
+def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
+    """Attribute standard Go SDK service calls through local client bindings."""
+    analyzer = load_script("lint-required-messaging-profile")
+    code = lexed.code
+    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+    # The shared graph already indexes initialized locals and parameters. Add
+    # Go's uninitialized `var client Type` form so it shadows an outer SDK
+    # binding in exactly the same lexical lookup.
+    for declaration in re.finditer(
+            r"(?m)\bvar\s+([A-Za-z_]\w*)\s+(?![=(])[^=;\n]+(?=;|\n|$)", code):
+        scope = resolver.scope_at(declaration.start())
+        resolver.graph.add_binding(
+            declaration[1], scope, declaration.start(), declaration.start(),
+            "declaration")
+    packages = set()
+    for token in lexed.strings:
+        if token.contents != "github.com/twilio/twilio-go":
+            continue
+        line_start = code.rfind("\n", 0, token.start) + 1
+        prefix = code[line_start:token.start]
+        single = re.fullmatch(r"\s*import\s+(?:(\w+)\s+)?", prefix)
+        grouped = re.fullmatch(r"\s*(?:(\w+)\s+)?", prefix)
+        group_start = code.rfind("import", 0, token.start)
+        in_group = group_start >= 0 and re.match(r"import\s*\(", code[group_start:])
+        if in_group:
+            opening = code.find("(", group_start)
+            closing = analyzer.matching_delimiter(code, opening, "(", ")")
+            in_group = closing is not None and token.start < closing
+        imported = single or (grouped if in_group else None)
+        if imported:
+            packages.add(imported[1] or "twilio")
+    # This shared pattern excludes selector suffixes (`holder.client = ...`),
+    # which are mutations of a different binding.
+    assignments = resolver.root_assignments
+
+    def assignment(name: str, before: int):
+        use_binding = resolver.graph.visible_binding(
+            name, resolver.scope_at(before), before)
+        for match in reversed(assignments):
+            if (match[1].lstrip("$") != name or match.start() >= before
+                    or not analyzer.scope_contains(code, match.start(), before)):
+                continue
+            binding = resolver.assignment_bindings.get(match.start())
+            if binding is None:
+                binding = resolver.graph.visible_binding(
+                    name, resolver.scope_at(match.start()), match.start())
+            if binding == use_binding:
+                value = re.match(r"([^;\n]+)", code[match.end():])
+                return (match, value[1].strip()) if value else None
+        return None
+
+    def client(name: str, before: int, seen: frozenset = frozenset()) -> bool:
+        identity = (name, before)
+        if identity in seen or len(seen) >= 32:
+            return False
+        resolved = assignment(name, before)
+        if resolved is None:
+            return False
+        match, value = resolved
+        created = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", value)
+        if created:
+            package_binding = resolver.graph.visible_binding(
+                created[1], resolver.scope_at(match.start()), match.start())
+            return created[1] in packages and package_binding is None
+        return bool(re.fullmatch(r"\w+", value) and client(value, match.start(), seen | {identity}))
+
+    products = {"Api": {"Message": "messaging", "Call": "voice", "IncomingPhoneNumber": "phone-numbers"},
+                "VerifyV2": {"Verification": "verify"},
+                "LookupsV2": {"PhoneNumber": "lookup"},
+                "VideoV1": {"Room": "video"}}
+    result = []
+    for match in re.finditer(r"\b(\w+)\s*\.\s*(\w+)\s*\.\s*"
+                            r"(?:Create|Fetch|Update|Delete|Read|List)(\w+)\s*\(", code):
+        product = products.get(match[2], {}).get(match[3])
+        if product and client(match[1], match.start()):
+            result.append((source.count("\n", 0, match.start()) + 1, product))
+    return result
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        return 2
+    root = Path(sys.argv[1])
+    scanner = load_script("scan-twilio-deep")
+    failed = False
+    for path in scanner.walk_project(root):
+        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
+            continue
+        try:
+            if not path.stat().st_mode & 0o444 or not os.access(path, os.R_OK):
+                raise OSError("source is not readable")
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            print(f"Cannot inspect SDK ownership in {str(path)!r}: {error}", file=sys.stderr)
+            failed = True
+            continue
+        if "\x00" in source:
+            continue
+        lines = source.splitlines()
+        for line, product in contextual_calls(source, path.suffix):
+            for value in (str(path), product, lines[line - 1].strip()):
+                sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
+    return 2 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -93,7 +93,61 @@ def scala_indent_regions(code: str) -> list[tuple[int, int]]:
     return regions
 
 
-def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
+class CsharpGlobalUsings:
+    """Index unconditional source global usings within project-directory bounds.
+
+    This does not evaluate MSBuild or preprocessor symbols. Conditional imports
+    are not promoted to project-wide evidence. Without a csproj, the scan root
+    is the boundary; nested/sibling csproj directories never share imports.
+    """
+
+    def __init__(self, root: Path, paths: list[Path]):
+        self.root = root
+        self.projects = {path.parent for path in paths if path.suffix.lower() == ".csproj"}
+        self.imports: dict[Path, list[str]] = {}
+        for path in paths:
+            if path.suffix.lower() != ".cs":
+                continue
+            try:
+                source = path.read_text(encoding="utf-8-sig")
+            except (OSError, UnicodeError):
+                continue  # The scanner retains its own read-error policy.
+            if "global" not in source or "\x00" in source:
+                continue
+            code = lexed_source(source, ".cs").code
+            # Preserve offsets while removing conditional regions. A using in
+            # one possible build configuration is not definite ownership.
+            depth, unconditional = 0, []
+            for line in code.splitlines(keepends=True):
+                directive = re.match(r"\s*#\s*(if|endif)\b", line)
+                if directive and directive[1] == "if":
+                    depth += 1
+                unconditional.append("\n" if depth or directive else line)
+                if directive and directive[1] == "endif":
+                    depth = max(0, depth - 1)
+            code = "".join(unconditional)
+            analyzer = load_script("lint-required-messaging-profile")
+            for match in re.finditer(
+                r"\bglobal\s+using\s+(?:static\s+)?(?:\w+\s*=\s*)?"
+                r"(?:global\s*::\s*)?\w+(?:\s*\.\s*\w+)*\s*;", code
+            ):
+                # Global directives are compilation-unit declarations, never
+                # members of a namespace/type body.
+                if analyzer.curly_ancestry(code, match.start()):
+                    continue
+                self.imports.setdefault(self.owner(path), []).append(match[0])
+        self.contexts = {owner: "\n".join(dict.fromkeys(imports))
+                         for owner, imports in self.imports.items()
+                         if any(re.search(r"\bTwilio\s*\.", item) for item in imports)}
+
+    def owner(self, path: Path) -> Path:
+        return next((parent for parent in path.parents if parent in self.projects), self.root)
+
+    def for_file(self, path: Path) -> str:
+        return self.contexts.get(self.owner(path), "")
+
+
+def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
     if suffix == ".go":
@@ -123,7 +177,7 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
         return [(source.count("\n", 0, call.start) + 1, product)
                 for target, product in resources
                 for call in analyzer.csharp_twilio_resource_calls(lexed,
-                    target, methods, resolver)]
+                    target, methods, resolver, global_using_code)]
     result = []
     products = {"Message": "messaging", "Call": "voice",
                 "IncomingPhoneNumber": "phone-numbers"}
@@ -458,7 +512,9 @@ def main() -> int:
     root = Path(sys.argv[1])
     scanner = load_script("scan-twilio-deep")
     failed = False
-    for path in scanner.walk_project(root):
+    paths = list(scanner.walk_project(root))
+    global_usings = CsharpGlobalUsings(root, paths)
+    for path in paths:
         if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
             continue
         try:
@@ -472,7 +528,7 @@ def main() -> int:
         if "\x00" in source:
             continue
         lines = source.splitlines()
-        for line, product in contextual_calls(source, path.suffix):
+        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path)):
             for value in (str(path), product, lines[line - 1].strip()):
                 sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
     return 2 if failed else 0

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -31,6 +31,68 @@ def lexed_source(source: str, suffix: str):
                                analyzer.canonical_suffix(path), analyzer.source_dialect(path))
 
 
+def scala_import_bindings(code: str, products: dict[str, str]) -> list[tuple[int, dict, dict]]:
+    """Read Scala 2/3 selectors, preserving renames and wildcard exclusions.
+
+    Import positions are retained because Scala permits block-local imports.
+    This recognizes literal package imports, not arbitrary stable-path aliases.
+    """
+    analyzer = load_script("lint-required-messaging-profile")
+    prefix = "com.twilio.rest.api.v2010.account"
+    result = []
+    for statement in re.finditer(r"\bimport\s+((?:[.,]\s*\n\s*|[^;\n{}]|\{[^{}]*\})+)", code):
+        for start, end in analyzer.split_arguments(code, statement.start(1), statement.end(1)):
+            expression = code[start:end].strip()
+            grouped = re.fullmatch(r"([\w.]+)\.\s*\{([^{}]*)\}", expression)
+            if grouped:
+                package, selectors = grouped[1], grouped[2].split(",")
+            else:
+                single = re.fullmatch(r"([\w.]+)\.\s*([\w*]+)(?:\s+as\s+(\w+))?", expression)
+                if not single:
+                    continue
+                package = single[1]
+                selectors = [single[2] + (" as " + single[3] if single[3] else "")]
+            package = package.removeprefix("_root_.")
+            explicit, wildcard, excluded = {}, False, set()
+            for selector in selectors:
+                member = re.fullmatch(r"\s*([\w*]+)(?:\s*(?:=>|\bas\b)\s*(\w+))?\s*", selector)
+                if not member:
+                    continue
+                name, alias = member[1], member[2]
+                if name in {"_", "*"} and alias is None:
+                    wildcard = True
+                else:
+                    excluded.add(name)
+                    if alias != "_":
+                        explicit[alias or name] = products.get(name) if package == prefix else None
+            wildcards = ({name: product for name, product in products.items() if name not in excluded}
+                         if wildcard and package == prefix else {})
+            result.append((statement.start(), explicit, wildcards))
+    return result
+
+
+def scala_indent_regions(code: str) -> list[tuple[int, int]]:
+    """Index Scala 3 indentation regions alongside (not instead of) braces."""
+    regions, stack = [], []
+    previous, previous_indent, offset = "", 0, 0
+    for line in code.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped:
+            indent = len(line) - len(line.lstrip(" \t"))
+            while stack and indent < stack[-1][0]:
+                _, start = stack.pop()
+                regions.append((start, offset))
+            if indent > previous_indent and re.search(
+                r"(?::|=|=>|\bthen|\bdo|\bmatch|\btry|\bcatch|\bfinally|\belse|\byield)$",
+                previous,
+            ):
+                stack.append((indent, offset))
+            previous, previous_indent = stripped, indent
+        offset += len(line)
+    regions.extend((start, len(code)) for _, start in stack)
+    return regions
+
+
 def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
@@ -68,6 +130,12 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
     if suffix in {".java", ".kt", ".kts", ".scala"}:
         analyzer = load_script("lint-required-messaging-profile")
         resolver = analyzer.SourceEndpointResolver(lexed, ".java")
+        indent_regions = scala_indent_regions(code) if suffix == ".scala" else []
+
+        def scope_path(offset: int) -> tuple[int, ...]:
+            return tuple(sorted((*analyzer.curly_ancestry(code, offset),
+                                 *(start for start, end in indent_regions if start <= offset < end))))
+
         parameter_scopes = []
         parameter_headers = []
         if suffix != ".java":
@@ -80,11 +148,22 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
                 if closing is None:
                     continue
                 parameter_headers.append((opening, closing))
+                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
+                expression = re.match(r"\s*(?::[^{}\n=]+)?\s*=\s*", code[closing + 1:])
+                if expression:
+                    start = closing + 1 + expression.end()
+                    if start < len(code) and code[start] != "{":
+                        end = analyzer.assignment_end(lexed, start, ".java")
+                        # A multiline indentation body includes following
+                        # expressions, but not a dedented sibling definition.
+                        body_regions = [end for begin, end in indent_regions
+                                        if closing < begin <= start < end]
+                        parameter_scopes.append((start - 1, min(body_regions) if body_regions else end, names))
+                        continue
                 body = code.find("{", closing)
                 if body < 0 or not re.fullmatch(r"\s*(?::[^{}\n=]+)?\s*=?\s*", code[closing + 1:body]):
                     continue
                 end = analyzer.matching_delimiter(code, body, "{", "}")
-                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
                 if end is not None:
                     parameter_scopes.append((body, end, names))
         prefix = "com.twilio.rest.api.v2010.account."
@@ -99,21 +178,48 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
             else:
                 explicit[match[2] or target.rsplit(".", 1)[-1]] = None
         imports.update(explicit)  # Single imports shadow wildcard imports in either order.
+        scala_imports = scala_import_bindings(code, products) if suffix == ".scala" else []
+        scala_objects = list(re.finditer(r"\bobject\s+(\w+)", code)) if suffix == ".scala" else []
         for match in re.finditer(r"(?<![\w.])([\w.]+)\s*\.\s*creator\s*\(", code):
             receiver = match[1]
             first = receiver.split(".", 1)[0]
+            use_scope = scope_path(match.start()) if suffix == ".scala" else ()
             binding_id = resolver.graph.visible_binding(first, resolver.scope_at(match.start()), match.start())
-            if binding_id is not None:
-                binding = resolver.graph.bindings[binding_id]
+            bindings = ([resolver.graph.bindings[index]
+                         for index in resolver.graph.bindings_by_name.get(first, [])]
+                        if suffix == ".scala" else
+                        [resolver.graph.bindings[binding_id]] if binding_id is not None else [])
+            shadowed = False
+            for binding in bindings:
+                binding_scope = scope_path(binding.declaration_start) if suffix == ".scala" else ()
                 if ((suffix == ".java" or binding.kind != "parameter")
                         and not any(start < binding.declaration_start < end
                                     for start, end in parameter_headers)
-                        and analyzer.scope_contains(code, binding.declaration_start, match.start())):
-                    continue
+                        and (use_scope[:len(binding_scope)] == binding_scope if suffix == ".scala"
+                             else analyzer.scope_contains(code, binding.declaration_start, match.start()))):
+                    shadowed = True
+                    break
+            if shadowed or any(obj[1] == first and use_scope[:len(scope_path(obj.start()))] == scope_path(obj.start())
+                               for obj in scala_objects):
+                continue
             if any(start < match.start() < end and first in names
                    for start, end, names in parameter_scopes):
                 continue
             product = imports.get(receiver)
+            if suffix == ".scala":
+                # A deeper lexical scope wins; within a scope, explicit
+                # selectors take precedence over wildcard selectors.
+                candidates = []
+                for position, selected, wildcard in scala_imports:
+                    import_scope = scope_path(position)
+                    if position >= match.start() or use_scope[:len(import_scope)] != import_scope:
+                        continue
+                    depth = len(import_scope)
+                    if receiver in selected:
+                        candidates.append((depth, 1, position, selected[receiver]))
+                    elif receiver in wildcard:
+                        candidates.append((depth, 0, position, wildcard[receiver]))
+                product = max(candidates, key=lambda item: item[:3])[3] if candidates else None
             if receiver.startswith(prefix):
                 product = products.get(receiver[len(prefix):])
             if product:

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -237,24 +237,18 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
         return match is None or bool(re.fullmatch(r"namespace\s*\{", match[0]))
 
     aliases = {}
-    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*;", code, re.I):
-        aliases[(namespace_at(match.start()), (match[2] or match[1]).lower())] = match[1].lower()
-    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\\{([^{};]+)\}\s*;", code, re.I):
-        for member in match[1].split(","):
-            imported = re.fullmatch(
-                r"\s*(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*",
-                member,
-                re.I,
-            )
-            if imported:
-                aliases[(namespace_at(match.start()),
-                         (imported[2] or imported[1]).lower())] = imported[1].lower()
 
     def kind(type_name: str, offset: int) -> str | None:
         normalized = type_name.lstrip("\\").lower()
         if normalized in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"} and (type_name.startswith("\\") or global_namespace(offset)):
             return normalized.rsplit("\\", 1)[-1]
-        return aliases.get((namespace_at(offset), normalized))
+        if not type_name.startswith("\\"):
+            first, separator, rest = normalized.partition("\\")
+            imported = aliases.get((namespace_at(offset), first))
+            expanded = imported + separator + rest if imported else ""
+            if expanded in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"}:
+                return expanded.rsplit("\\", 1)[-1]
+        return None
 
     analyzer = load_script("lint-required-messaging-profile")
     # Index braces once so bindings cannot leak between functions/classes.
@@ -265,6 +259,24 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
             stack.append(offset)
         elif character == "}" and stack:
             braces[stack.pop()] = offset
+    namespace_braces = {match.end() - 1 for match in namespaces if match[0].endswith("{")}
+    for statement in re.finditer(r"\buse\s+([^;()]+);", code, re.I):
+        # Trait uses and closure captures are not namespace imports.
+        if re.match(r"(?:function|const)\b", statement[1], re.I):
+            continue
+        if any(start < statement.start() < end and start not in namespace_braces
+               for start, end in braces.items()):
+            continue
+        for start, end in analyzer.split_arguments(code, statement.start(1), statement.end(1)):
+            item = code[start:end].strip()
+            group = re.fullmatch(r"(\\?[\w\\]+\\)\s*\{([^{}]*)\}", item)
+            members = [(group[1], member) for member in group[2].split(",")] if group else [("", item)]
+            for prefix, member in members:
+                imported = re.fullmatch(r"\s*(\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+([A-Za-z_]\w*))?\s*", member, re.I)
+                if imported:
+                    qualified = (prefix + imported[1]).lstrip("\\").lower()
+                    alias = (imported[2] or imported[1].rsplit("\\", 1)[-1]).lower()
+                    aliases[(namespace_at(statement.start()), alias)] = qualified
     functions = []
     classes = []
     for pattern, spans in ((r"\bfunction\s*\w*\s*\([^;{]*\)[^;{]*\{", functions),

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -147,13 +147,21 @@ class CsharpGlobalUsings:
         return self.contexts.get(self.owner(path), "")
 
 
-def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> list[tuple[int, str]]:
+def contextual_calls(source: str, suffix: str, global_using_code: str = "",
+                     go_clients: frozenset[str] = frozenset()) -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
     if suffix == ".go":
-        return go_contextual_calls(source, lexed)
-    if suffix in {".cs", ".cshtml"}:
+        return go_contextual_calls(source, lexed, go_clients)
+    if suffix in {".cs", ".cshtml", ".razor"}:
         analyzer = load_script("lint-required-messaging-profile")
+        if suffix in {".cshtml", ".razor"}:
+            # Razor @using directives are newline-terminated, unlike C# using
+            # declarations. Only executable lexer output can supply imports.
+            directives = re.findall(
+                r"(?m)^\s*@using\s+((?:static\s+)?(?:\w+\s*=\s*)?"
+                r"(?:global\s*::\s*)?\w+(?:\s*\.\s*\w+)*)\s*;?\s*$", code)
+            global_using_code += "\n" + "\n".join("using " + item + ";" for item in directives)
         resolver = analyzer.SourceEndpointResolver(lexed, ".cs")
         resources = (
             ("Twilio.Rest.Api.V2010.Account.MessageResource", "messaging"),
@@ -427,20 +435,10 @@ def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> l
     return result
 
 
-def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
-    """Attribute standard Go SDK service calls through local client bindings."""
+def go_import_packages(lexed) -> set[str]:
+    """Return file-local names importing the actual Twilio Go SDK."""
     analyzer = load_script("lint-required-messaging-profile")
     code = lexed.code
-    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
-    # The shared graph already indexes initialized locals and parameters. Add
-    # Go's uninitialized `var client Type` form so it shadows an outer SDK
-    # binding in exactly the same lexical lookup.
-    for declaration in re.finditer(
-            r"(?m)\bvar\s+([A-Za-z_]\w*)\s+(?![=(])[^=;\n]+(?=;|\n|$)", code):
-        scope = resolver.scope_at(declaration.start())
-        resolver.graph.add_binding(
-            declaration[1], scope, declaration.start(), declaration.start(),
-            "declaration")
     packages = set()
     for token in lexed.strings:
         if token.contents != "github.com/twilio/twilio-go":
@@ -458,9 +456,117 @@ def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
         imported = single or (grouped if in_group else None)
         if imported:
             packages.add(imported[1] or "twilio")
+    return packages
+
+
+def go_var_declarations(code: str):
+    """Yield Go var bindings; multi-name declarations only establish shadows."""
+    analyzer = load_script("lint-required-messaging-profile")
+    declaration = re.compile(r"([A-Za-z_]\w*)[ \t]*(?:[^=;,\n)]+)?(?P<equals>=)?")
+    for keyword in re.finditer(r"\bvar\s+", code):
+        start = keyword.end()
+        if code[start:start + 1] == "(":
+            end = analyzer.matching_delimiter(code, start, "(", ")")
+            if end is None:
+                continue
+            starts, stack = [start + 1], []
+            for position in range(start + 1, end):
+                char = code[position]
+                if char in "([{":
+                    stack.append(char)
+                elif char in ")]}":
+                    if stack:
+                        stack.pop()
+                elif char in ";\n" and not stack:
+                    starts.append(position + 1)
+        else:
+            starts, end = [start], len(code)
+        for position in starts:
+            while position < end and code[position] in " \t\r":
+                position += 1
+            multiple = re.compile(r"(?:\w+[ \t]*,[ \t]*)+\w+").match(code, position, end)
+            if multiple:
+                yield from re.compile(r"(\w+)(?P<equals>=)?").finditer(code, position, multiple.end())
+                continue
+            match = declaration.match(code, position, end)
+            if match:
+                yield match
+
+
+class GoPackageClients:
+    """Resolve static package client initializers without sharing file imports."""
+
+    def __init__(self, paths: list[Path]):
+        self.keys: dict[Path, tuple[Path, str]] = {}
+        declarations: dict[tuple[Path, str], dict[str, list[tuple[bool, str]]]] = {}
+        analyzer = load_script("lint-required-messaging-profile")
+        for path in paths:
+            if path.suffix != ".go":
+                continue
+            try:
+                source = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            lexed = lexed_source(source, ".go")
+            package = re.search(r"\bpackage\s+(\w+)", lexed.code)
+            if package is None:
+                continue
+            key = (path.parent, package[1])
+            self.keys[path] = key
+            # Test declarations and build-constrained variants must not seed
+            # unconditional ownership in production files.
+            if path.name.endswith("_test.go") or re.search(r"(?m)^\s*//\s*(?:go:build|\+build)\b", source):
+                continue
+            imports = go_import_packages(lexed)
+            resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+            assignments = list(resolver.root_assignments)
+            known_ends = {(match[1], match.end()) for match in assignments}
+            assignments.extend(match for match in go_var_declarations(lexed.code)
+                               if match["equals"] and (match[1], match.end()) not in known_ends)
+            for match in assignments:
+                if analyzer.curly_ancestry(lexed.code, match.start()):
+                    continue
+                value = re.match(r"[^;\n]+", lexed.code[match.end():])
+                if not value:
+                    continue
+                expression = value[0].strip()
+                constructor = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", expression)
+                owned = bool(constructor and constructor[1] in imports)
+                declarations.setdefault(key, {}).setdefault(match[1], []).append((owned, expression))
+        self.clients: dict[tuple[Path, str], frozenset[str]] = {}
+        for key, bindings in declarations.items():
+            known: set[str] = set()
+            for _ in range(len(bindings) + 1):
+                added = {name for name, values in bindings.items() if len(values) == 1
+                         and (values[0][0] or values[0][1] in known)} - known
+                if not added:
+                    break
+                known.update(added)
+            self.clients[key] = frozenset(known)
+
+    def for_file(self, path: Path) -> frozenset[str]:
+        return self.clients.get(self.keys.get(path), frozenset())
+
+
+def go_contextual_calls(source: str, lexed, package_clients: frozenset[str] = frozenset()) -> list[tuple[int, str]]:
+    """Attribute SDK calls through local bindings, then package initializers."""
+    analyzer = load_script("lint-required-messaging-profile")
+    code = lexed.code
+    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+    assignments = list(resolver.root_assignments)
+    known_ends = {(match[1], match.end()) for match in assignments}
+    for declaration in go_var_declarations(code):
+        if declaration["equals"] and (declaration[1], declaration.end()) in known_ends:
+            continue
+        scope = resolver.scope_at(declaration.start())
+        binding = resolver.graph.add_binding(declaration[1], scope, declaration.start(), declaration.start(), "declaration")
+        if declaration["equals"]:
+            assignments.append(declaration)
+            resolver.assignment_bindings[declaration.start()] = binding
+    packages = go_import_packages(lexed)
     # This shared pattern excludes selector suffixes (`holder.client = ...`),
     # which are mutations of a different binding.
-    assignments = resolver.root_assignments
+    assignments.sort(key=lambda match: match.start())
 
     def assignment(name: str, before: int):
         use_binding = resolver.graph.visible_binding(
@@ -484,7 +590,10 @@ def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
             return False
         resolved = assignment(name, before)
         if resolved is None:
-            return False
+            binding = resolver.graph.visible_binding(name, resolver.scope_at(before), before)
+            return name in package_clients and (binding is None or (
+                resolver.graph.bindings[binding].kind != "parameter"
+                and not analyzer.curly_ancestry(code, resolver.graph.bindings[binding].declaration_start)))
         match, value = resolved
         created = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", value)
         if created:
@@ -514,8 +623,9 @@ def main() -> int:
     failed = False
     paths = list(scanner.walk_project(root))
     global_usings = CsharpGlobalUsings(root, paths)
+    go_clients = GoPackageClients(paths)
     for path in paths:
-        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
+        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml", ".razor"}:
             continue
         try:
             if not path.stat().st_mode & 0o444 or not os.access(path, os.R_OK):
@@ -528,7 +638,7 @@ def main() -> int:
         if "\x00" in source:
             continue
         lines = source.splitlines()
-        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path)):
+        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path), go_clients.for_file(path)):
             for value in (str(path), product, lines[line - 1].strip()):
                 sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
     return 2 if failed else 0

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -20,6 +20,7 @@
 #   2 — Usage error
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # --- Colors (disabled if not a terminal) ---
 # shellcheck disable=SC2034  # BLUE reserved for info lines; kept for palette consistency
@@ -204,7 +205,7 @@ search_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Search helper that excludes .md files and minified JS (for config/env var checks)
@@ -217,7 +218,18 @@ search_source_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+}
+
+# Auth-related names are common in unrelated SDKs. Require Telnyx context in
+# the same file before reporting static evidence, not cryptographic assurance.
+search_telnyx_auth_files() {
+  local pattern="$1" file
+  while IFS= read -r -d '' file; do
+    if grep -qiE 'telnyx' "$file"; then
+      grep -nH -E "$pattern" "$file" || true
+    fi
+  done < <(grep -rlI --null $GREP_EXCLUDES --exclude='*.md' -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true)
 }
 
 # Search helper that filters out comment-only lines to reduce false positives.
@@ -407,10 +419,52 @@ fi
 # ============================================================
 section_header "Residual Twilio References"
 
+# Grep suppresses permission errors below; make scan incompleteness visible.
+# Use the same exclusions as the content checks, including caller exclusions.
+unreadable_files=$(python3 - "$PROJECT_ROOT" "$EXCLUDE_DIRS $EXTRA_EXCLUDE_DIRS" "$EXCLUDE_FILES" "$EXCLUDE_LOCK_FILES" <<'PY'
+import fnmatch
+import json
+import os
+import stat
+import sys
+root, excluded_dirs, excluded_files, excluded_locks = sys.argv[1:]
+excluded_dirs = excluded_dirs.split()
+excluded_files = excluded_files.split() + [arg.removeprefix("--exclude=") for arg in excluded_locks.split()]
+unreadable = []
+def excluded(name, patterns):
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+def walk_error(error):
+    unreadable.append(error.filename)
+for directory, dirs, files in os.walk(root, onerror=walk_error):
+    dirs[:] = [name for name in dirs if not excluded(name, excluded_dirs)]
+    for name in files:
+        if excluded(name, excluded_files):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            mode = os.stat(path).st_mode
+            if stat.S_ISREG(mode) and (not mode & 0o444 or not os.access(path, os.R_OK)):
+                unreadable.append(path)
+        except OSError:
+            unreadable.append(path)
+print(json.dumps({"files": unreadable}))
+PY
+)
+if [ "$(jq '.files | length' <<< "$unreadable_files")" -gt 0 ]; then
+  check_fail "source_readability" "Files could not be read; migration validation is incomplete:" "$unreadable_files"
+fi
+
+# Rust is not a supported SDK analyzer. Concrete Twilio imports must not be
+# hidden by an unrelated supported-language Telnyx dependency.
+matches=$(search_code_only '(^|[;[:space:]])(use|extern[[:space:]]+crate)[[:space:]]+twilio([[:space:]:;]|$)' "*.rs")
+if [ -n "$matches" ]; then
+  check_residual_matches_with_hybrid_scope "unsupported_twilio_source" "Twilio Rust source found; this validator cannot analyse Rust SDK migration completeness. Manual review is required:" "$matches"
+fi
+
 # --- Check 1: Twilio SDK imports ---
 # Python
 if product_applies "all"; then
-  matches=$(search_files "(from twilio|import twilio)" "*.py")
+  matches=$(search_files "(from twilio|import twilio)" "*.py" "*.pyw")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_python_imports" "Twilio Python imports found in $count file(s):" "$matches"
@@ -421,7 +475,7 @@ fi
 
 # JavaScript / TypeScript
 if product_applies "all"; then
-  matches=$(search_files "(require\(['\"]twilio['\"]|from ['\"]twilio['\"])" "*.js" "*.ts" "*.jsx" "*.tsx" "*.mjs" "*.cjs")
+  matches=$(search_files "(require\(['\"]twilio['\"]|from ['\"]twilio['\"])" "*.js" "*.ts" "*.jsx" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_js_imports" "Twilio JS/TS imports found in $count file(s):" "$matches"
@@ -443,7 +497,7 @@ fi
 
 # Ruby
 if product_applies "all"; then
-  matches=$(search_files "(require ['\"]twilio-ruby['\"]|require ['\"]twilio['\"])" "*.rb")
+  matches=$(search_files "(require ['\"]twilio-ruby['\"]|require ['\"]twilio['\"])" "*.rb" "*.rake")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_ruby_imports" "Twilio Ruby imports found in $count file(s):" "$matches"
@@ -454,7 +508,7 @@ fi
 
 # Java
 if product_applies "all"; then
-  matches=$(search_files "import com\.twilio\." "*.java" "*.kt" "*.scala")
+  matches=$(search_files "import com\.twilio\." "*.java" "*.kt" "*.kts" "*.scala")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_java_imports" "Twilio Java imports found in $count file(s):" "$matches"
@@ -465,7 +519,7 @@ fi
 
 # PHP
 if product_applies "all"; then
-  matches=$(search_files "(use Twilio|require.*twilio.php)" "*.php")
+  matches=$(search_files "(use Twilio|require.*twilio.php)" "*.php" "*.phtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_php_imports" "Twilio PHP imports found in $count file(s):" "$matches"
@@ -476,7 +530,7 @@ fi
 
 # C#
 if product_applies "all"; then
-  matches=$(search_files "using Twilio" "*.cs")
+  matches=$(search_files "using Twilio" "*.cs" "*.cshtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_csharp_imports" "Twilio C# imports found in $count file(s):" "$matches"
@@ -487,7 +541,7 @@ fi
 
 # --- Check 2: Twilio API URLs (excludes .md docs and minified JS) ---
 if product_applies "all"; then
-  matches=$(search_source_files "(api\.twilio\.com|verify\.twilio\.com|video\.twilio\.com|taskrouter\.twilio\.com|chat\.twilio\.com|conversations\.twilio\.com|sync\.twilio\.com|proxy\.twilio\.com|studio\.twilio\.com)")
+  matches=$(search_source_files "(api\.twilio\.com|verify\.twilio\.com|video\.twilio\.com|taskrouter\.twilio\.com|chat\.twilio\.com|conversations\.twilio\.com|sync\.twilio\.com|proxy\.twilio\.com|studio\.twilio\.com|twimlets\.com)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope \
@@ -549,11 +603,15 @@ if product_applies "all"; then
   # Go
   dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/go.mod 2>/dev/null || true)
   # Java/Kotlin (build.gradle, build.gradle.kts, pom.xml, libs.versions.toml)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 4 \( -name pom.xml -o -name build.gradle -o -name build.gradle.kts -o -name "libs.versions.toml" \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/build/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
+    dep_matches+=$'\nJVM dependency declaration\n'
+  fi
   # iOS (Swift Package Manager — project.pbxproj, Package.swift)
   dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 4 \( -name "project.pbxproj" -o -name "Package.swift" \) -not -path "*/.git/*" -exec grep -l -i "telnyx" {} \; 2>/dev/null || true)
   # PHP
-  dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/composer.json 2>/dev/null || true)
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" composer "$PROJECT_ROOT"; then
+    dep_matches+=$'\nComposer dependency declaration\n'
+  fi
   # C#
   dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name "*.csproj" -exec grep -l "Telnyx" {} \; 2>/dev/null || true)
   # Flutter
@@ -570,7 +628,10 @@ if product_applies "all"; then
   else
     # Before failing, check if Telnyx imports exist in source — if so, SDK is present
     # but in a dependency file we don't recognize (e.g., monorepo, custom build system)
-    source_imports=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/telnyx|@telnyx/|com\.telnyx\.|TelnyxRTC|TelnyxClient)")
+    source_imports=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/(team-)?telnyx|@telnyx/|com\.telnyx\.|TelnyxRTC|TelnyxClient)" \
+      "*.py" "*.pyw" "*.js" "*.jsx" "*.ts" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts" "*.rb" "*.rake" \
+      "*.go" "*.java" "*.kt" "*.kts" "*.scala" "*.php" "*.phtml" "*.cs" "*.cshtml" \
+      "*.swift" "*.dart")
     source_count=$(count_matches "$source_imports")
     if [ "$source_count" -gt 0 ]; then
       check_warn "telnyx_sdk_dependency" "Telnyx SDK not found in standard dependency files, but Telnyx imports found in $source_count source file(s) — likely using a non-standard dependency manager"
@@ -593,9 +654,19 @@ if product_applies "all"; then
   if grep -qE "gem\s+['\"]telnyx['\"].*~>" "$PROJECT_ROOT"/Gemfile 2>/dev/null; then
     version_pinned=true
   fi
+  # Go modules always require an explicit semantic version. Recognize both the
+  # current /v4 module path and an eventual later major-version path.
+  if grep -qE 'github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]+v[0-9]+\.' "$PROJECT_ROOT"/go.mod 2>/dev/null; then
+    version_pinned=true
+  fi
+  # Inspect dependency fields structurally. App/parent/unrelated versions are
+  # not evidence that this SDK dependency has a constrained version.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-pinned "$PROJECT_ROOT"; then
+    version_pinned=true
+  fi
   # If no dependency files found at all, skip the check
   has_deps=false
-  for f in requirements.txt setup.py setup.cfg pyproject.toml Pipfile package.json Gemfile go.mod; do
+  for f in requirements.txt setup.py setup.cfg pyproject.toml Pipfile package.json Gemfile go.mod pom.xml build.gradle build.gradle.kts composer.json; do
     if [ -f "$PROJECT_ROOT/$f" ]; then has_deps=true; break; fi
   done
   if [ "$has_deps" = true ]; then
@@ -637,7 +708,9 @@ fi
 
 # --- Check 7: Telnyx imports in source code ---
 if product_applies "all"; then
-  matches=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/telnyx)")
+  matches=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/(team-)?telnyx|com\.telnyx\.)" \
+    "*.py" "*.pyw" "*.js" "*.jsx" "*.ts" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts" "*.rb" "*.rake" \
+    "*.go" "*.java" "*.kt" "*.kts" "*.scala" "*.php" "*.phtml" "*.cs" "*.cshtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_pass "telnyx_source_imports" "Telnyx imports found in $count source file(s)"
@@ -655,10 +728,10 @@ section_header "Auth Patterns"
 
 # --- Check 8: Bearer auth ---
 if product_applies "all"; then
-  matches=$(search_files "(Authorization.*Bearer|bearer.*auth|Bearer.*TELNYX|TELNYX.*Bearer)")
+  matches=$(search_telnyx_auth_files "(Authorization.*Bearer|bearer.*auth|Bearer.*TELNYX|TELNYX.*Bearer)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    check_pass "bearer_auth" "Bearer auth pattern found in $count file(s)"
+    check_pass "bearer_auth" "Bearer auth pattern found in $count Telnyx-related match(es) (static evidence only)"
   else
     check_pass "bearer_auth" "No explicit Bearer auth pattern (SDK may handle this)"
   fi
@@ -682,10 +755,10 @@ section_header "Webhook Validation"
 
 # --- Check 10: Ed25519 signature validation ---
 if product_applies "voice,messaging,verify,sip,fax"; then
-  matches=$(search_files "(ed25519|Ed25519|telnyx-signature-ed25519|verify_signature|construct_event|webhooks\.unwrap|webhook.*signature.*telnyx)")
+  matches=$(search_telnyx_auth_files "(telnyx-signature-ed25519|verify_signature|construct_event|webhooks\.unwrap|webhook.*signature.*telnyx|ed25519.*[Vv]erify|Ed25519.*[Vv]erify)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    check_pass "ed25519_validation" "Ed25519 webhook signature validation found in $count file(s)"
+    check_pass "ed25519_validation" "Telnyx webhook verification pattern found in $count match(es) (static evidence only; review signature enforcement)"
   else
     # Check if the project has webhook handlers — if so, missing validation is a FAIL
     webhook_handlers=$(search_files "(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|HandleFunc|post '/)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -204,8 +204,10 @@ search_files() {
   for glob in "$@"; do
     include_args="$include_args --include=$glob"
   done
+  # GNU grep defaults unmatched files to included if an exclusion comes first.
+  # Put the allowlist first and exclusions last so both GNU and BSD grep agree.
   # shellcheck disable=SC2086
-  grep -rnI $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Search helper that excludes .md files and minified JS (for config/env var checks)
@@ -218,7 +220,7 @@ search_source_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rnI $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $include_args $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Auth-related names are common in unrelated SDKs. Require Telnyx context in

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -594,14 +594,10 @@ section_header "Telnyx SDK Present"
 # --- Check 6: Telnyx SDK in dependency files ---
 if product_applies "all"; then
   dep_matches=""
-  # Python (root + subdirectories)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 \( -name requirements.txt -o -name setup.py -o -name setup.cfg -o -name pyproject.toml -o -name Pipfile \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/vendor/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
-  # Node (root + subdirectories)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name package.json -not -path "*/node_modules/*" -not -path "*/.git/*" -exec grep -l '"telnyx"\|"@telnyx/' {} \; 2>/dev/null || true)
-  # Ruby
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name Gemfile -not -path "*/vendor/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
-  # Go
-  dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/go.mod 2>/dev/null || true)
+  # Python, Node, Ruby and Go: dependency declarations, not comments or metadata.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" other-declared "$PROJECT_ROOT"; then
+    dep_matches+=$'\nSDK dependency declaration\n'
+  fi
   # Java/Kotlin (build.gradle, build.gradle.kts, pom.xml, libs.versions.toml)
   if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
     dep_matches+=$'\nJVM dependency declaration\n'
@@ -642,26 +638,18 @@ if product_applies "all"; then
 
   # --- Check 6a: Telnyx SDK version pinning ---
   version_pinned=false
-  # Python: check for version constraint (>=, <, ~=, ==)
-  if grep -qE 'telnyx[><=~!]+' "$PROJECT_ROOT"/{requirements.txt,setup.py,setup.cfg,pyproject.toml,Pipfile} 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Node: check package.json for version constraint (^, ~, >=)
-  if grep -qE '"telnyx"\s*:\s*"[\^~>=]' "$PROJECT_ROOT"/package.json 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Ruby: check Gemfile for version constraint (~>)
-  if grep -qE "gem\s+['\"]telnyx['\"].*~>" "$PROJECT_ROOT"/Gemfile 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Go modules always require an explicit semantic version. Recognize both the
-  # current /v4 module path and an eventual later major-version path.
-  if grep -qE 'github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]+v[0-9]+\.' "$PROJECT_ROOT"/go.mod 2>/dev/null; then
+  # Reuse the declaration owners for literal versions and supported ranges.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" other-pinned "$PROJECT_ROOT"; then
     version_pinned=true
   fi
   # Inspect dependency fields structurally. App/parent/unrelated versions are
   # not evidence that this SDK dependency has a constrained version.
   if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-pinned "$PROJECT_ROOT"; then
+    version_pinned=true
+  fi
+  # Composer accepts caret/tilde/range constraints as well as exact versions.
+  # Only require/require-dev links for the SDK count, never unrelated metadata.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" composer-pinned "$PROJECT_ROOT"; then
     version_pinned=true
   fi
   # If no dependency files found at all, skip the check

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/SKILL.md
@@ -10,7 +10,7 @@ user_invocable: true
 metadata:
   author: telnyx
   product: migration
-  compatibility: "Requires bash 4+, jq, curl, python3. macOS ships bash 3.2 — scripts auto-upgrade via Homebrew bash if available (brew install bash). python3 is mandatory: the scanners and the correctness linter exit 2 without it."
+  compatibility: "Requires bash 4+, Python 3.10+, jq, curl. macOS ships bash 3.2 — scripts auto-upgrade via Homebrew bash if available (brew install bash)."
 ---
 
 # Twilio to Telnyx Migration

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Filter ``grep -nH`` matches through the migration source lexer.
+
+The shell validators use grep for breadth, but grep cannot distinguish live
+syntax from comments or quoted prose.  This adapter keeps the shell tools on
+the same lexical contract as the messaging-profile analyzer while preserving
+the familiar ``path:line:text`` output used in reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+MATCH_RE = re.compile(r"^(.*?):([0-9]+):(.*)$")
+
+
+def load_analyzer(path: Path):
+    spec = importlib.util.spec_from_file_location("telnyx_source_contract", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("comments", "code"), default="comments")
+    parser.add_argument("--analyzer", type=Path, required=True)
+    parser.add_argument("--pattern", required=True)
+    args = parser.parse_args()
+
+    analyzer = load_analyzer(args.analyzer)
+    cache: dict[Path, object] = {}
+    for raw in sys.stdin:
+        raw = raw.rstrip("\n")
+        match = MATCH_RE.match(raw)
+        if not match:
+            continue
+        filename, line_number, original = match.groups()
+        path = Path(filename)
+        try:
+            if path not in cache:
+                source = path.read_text(encoding="utf-8", errors="replace")
+                suffix = analyzer.canonical_suffix(path)
+                if (
+                    path.name == ".env"
+                    or path.name.startswith(".env.")
+                    or path.suffix.lower() in {
+                        ".conf",
+                        ".env",
+                        ".ini",
+                        ".properties",
+                        ".toml",
+                        ".yaml",
+                        ".yml",
+                    }
+                ):
+                    suffix = ".sh"
+                cache[path] = analyzer.lex_source(source, suffix)
+            lexed = cache[path]
+            view = lexed.code if args.mode == "code" else lexed.without_comments
+            lines = view.splitlines()
+            index = int(line_number) - 1
+            filtered = lines[index] if 0 <= index < len(lines) else ""
+        except OSError:
+            filtered = original
+        live_match = subprocess.run(
+            ["grep", "-E", "-q", args.pattern],
+            input=filtered,
+            text=True,
+            check=False,
+        ).returncode == 0
+        if filtered.strip() and live_match:
+            print(f"{filename}:{line_number}:{filtered}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -35,6 +35,7 @@ def main() -> int:
     parser.add_argument("--mode", choices=("comments", "code"), default="comments")
     parser.add_argument("--analyzer", type=Path, required=True)
     parser.add_argument("--pattern", required=True)
+    parser.add_argument("--region", choices=("all", "backend"), default="all")
     args = parser.parse_args()
 
     analyzer = load_analyzer(args.analyzer)
@@ -49,6 +50,10 @@ def main() -> int:
         try:
             if path not in cache:
                 source = path.read_text(encoding="utf-8", errors="replace")
+                if args.region == "backend":
+                    source = analyzer.backend_executable_source(path, source)
+                else:
+                    source = analyzer.executable_source(path, source)
                 suffix = analyzer.canonical_suffix(path)
                 if (
                     path.name == ".env"

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -47,7 +47,12 @@ def grep_records(data: bytes) -> Iterator[tuple[Path, int]]:
 def display_path(path: Path) -> str:
     """Keep one finding per output line even for control characters in paths."""
 
-    return str(path).replace("\r", "\\r").replace("\n", "\\n")
+    return (
+        str(path)
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
 
 
 def load_analyzer(path: Path):

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -83,7 +83,13 @@ def main() -> int:
             continue
         try:
             if path not in cache:
-                source = path.read_text(encoding="utf-8", errors="replace")
+                # Preserve physical newlines exactly. grep -n counts LF bytes;
+                # universal-newline translation would turn a preceding bare CR
+                # into a synthetic LF and make the lexer index a different row.
+                with path.open(
+                    "r", encoding="utf-8", errors="replace", newline=""
+                ) as source_file:
+                    source = source_file.read()
                 if args.region == "backend":
                     source = analyzer.backend_executable_source(path, source)
                 else:

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -11,13 +11,43 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import re
+import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterator
 
 
-MATCH_RE = re.compile(r"^(.*?):([0-9]+):(.*)$")
+def grep_records(data: bytes) -> Iterator[tuple[Path, int]]:
+    """Parse ``grep -nH --null`` records without interpreting path bytes.
+
+    Grep terminates the filename with NUL, then writes ``line:text\n``.  A
+    filename may legally contain colons or newlines on POSIX, so neither can be
+    used to find the filename boundary.  Match text cannot contain a newline;
+    grep removes that source delimiter from each emitted record.
+    """
+
+    cursor = 0
+    while cursor < len(data):
+        nul = data.find(b"\0", cursor)
+        if nul < 0:
+            raise ValueError("grep record has no NUL filename delimiter")
+        newline = data.find(b"\n", nul + 1)
+        if newline < 0:
+            newline = len(data)
+        locator = data[nul + 1 : newline]
+        colon = locator.find(b":")
+        if colon <= 0 or not locator[:colon].isdigit():
+            raise ValueError("grep record has no numeric line field")
+        filename = os.fsdecode(data[cursor:nul])
+        yield Path(filename), int(locator[:colon])
+        cursor = newline + 1
+
+
+def display_path(path: Path) -> str:
+    """Keep one finding per output line even for control characters in paths."""
+
+    return str(path).replace("\r", "\\r").replace("\n", "\\n")
 
 
 def load_analyzer(path: Path):
@@ -36,17 +66,21 @@ def main() -> int:
     parser.add_argument("--analyzer", type=Path, required=True)
     parser.add_argument("--pattern", required=True)
     parser.add_argument("--region", choices=("all", "backend"), default="all")
+    parser.add_argument("--exclude-suffix", action="append", default=[])
     args = parser.parse_args()
 
     analyzer = load_analyzer(args.analyzer)
+    try:
+        records = list(grep_records(sys.stdin.buffer.read()))
+    except ValueError as error:
+        print(f"Error: malformed NUL-delimited grep input: {error}", file=sys.stderr)
+        return 2
+
     cache: dict[Path, object] = {}
-    for raw in sys.stdin:
-        raw = raw.rstrip("\n")
-        match = MATCH_RE.match(raw)
-        if not match:
+    excluded_suffixes = {suffix.lower() for suffix in args.exclude_suffix}
+    for path, line_number in records:
+        if path.suffix.lower() in excluded_suffixes:
             continue
-        filename, line_number, original = match.groups()
-        path = Path(filename)
         try:
             if path not in cache:
                 source = path.read_text(encoding="utf-8", errors="replace")
@@ -72,19 +106,27 @@ def main() -> int:
                 cache[path] = analyzer.lex_source(source, suffix)
             lexed = cache[path]
             view = lexed.code if args.mode == "code" else lexed.without_comments
-            lines = view.splitlines()
-            index = int(line_number) - 1
-            filtered = lines[index] if 0 <= index < len(lines) else ""
-        except OSError:
-            filtered = original
-        live_match = subprocess.run(
+            lines = view.split("\n")
+            index = line_number - 1
+            if not 0 <= index < len(lines):
+                raise ValueError(
+                    f"grep line {line_number} is outside the lexed source"
+                )
+            filtered = lines[index]
+        except (OSError, ValueError) as error:
+            print(f"Error: could not filter {display_path(path)}: {error}", file=sys.stderr)
+            return 2
+        match_result = subprocess.run(
             ["grep", "-E", "-q", args.pattern],
             input=filtered,
             text=True,
             check=False,
-        ).returncode == 0
-        if filtered.strip() and live_match:
-            print(f"{filename}:{line_number}:{filtered}")
+        )
+        if match_result.returncode > 1:
+            print("Error: grep could not evaluate the filter pattern", file=sys.stderr)
+            return 2
+        if filtered.strip() and match_result.returncode == 0:
+            print(f"{display_path(path)}:{line_number}:{filtered}")
     return 0
 
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Read local dependency declarations; never resolve packages over the network.
+
+Exit zero only for positive evidence. Unresolved external Maven parents,
+properties, and unsupported Gradle expressions deliberately remain warnings.
+Gradle version catalogs use stdlib tomllib on Python 3.11+; older Python still
+supports Maven, Composer and literal Gradle coordinates without extra packages.
+"""
+from __future__ import annotations
+
+import json
+import importlib.util
+import os
+from pathlib import Path
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+try:
+    import tomllib
+except ImportError:
+    tomllib = None
+
+JVM_ARTIFACTS = {"telnyx", "telnyx-core", "telnyx-client-okhttp"}
+
+
+def version_is_constrained(value: object) -> bool:
+    return isinstance(value, str) and bool(re.fullmatch(
+        r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?", value.strip()
+    ))
+
+
+def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    try:
+        data = json.loads((root / "composer.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and any(
+        isinstance(data.get(section), dict)
+        and isinstance(data[section].get(package), str)
+        and bool(data[section][package].strip())
+        for section in ("require", "require-dev")
+    )
+
+
+def maven_dependencies(path: Path) -> list[tuple[str, str, str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+        # Manifests need no entities. Avoid entity expansion on untrusted input.
+        if "<!DOCTYPE" in text or "<!ENTITY" in text:
+            return []
+        project = ET.fromstring(text)
+    except (OSError, ValueError, ET.ParseError):
+        return []
+    for node in project.iter():
+        node.tag = node.tag.rsplit("}", 1)[-1]
+    if project.tag != "project":
+        return []
+    properties = {node.tag: (node.text or "").strip()
+                  for node in project.findall("./properties/*")}
+
+    def resolve(value: str) -> str:
+        seen = set()
+        while re.fullmatch(r"\$\{[^}]+\}", value) and value not in seen:
+            seen.add(value)
+            value = properties.get(value[2:-1], "")
+        return value
+
+    def field(node: ET.Element, name: str) -> str:
+        return resolve((node.findtext(name) or "").strip())
+
+    managed = {
+        (field(dep, "groupId"), field(dep, "artifactId")): field(dep, "version")
+        for dep in project.findall("./dependencyManagement/dependencies/dependency")
+    }
+    dependencies = []
+    for dep in project.findall("./dependencies/dependency"):
+        group, artifact = field(dep, "groupId"), field(dep, "artifactId")
+        # An explicit unresolved version must not fall back to management.
+        version = (field(dep, "version") if dep.find("version") is not None
+                   else managed.get((group, artifact), ""))
+        dependencies.append((group, artifact, version))
+    return dependencies
+
+
+def maven_pinned(path: Path) -> bool:
+    return any(group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS
+               and version_is_constrained(version)
+               for group, artifact, version in maven_dependencies(path))
+
+
+def groovy_slashy_ranges(source: str, code: str) -> list[tuple[int, int]]:
+    """Exclude Groovy's additional string delimiters from declaration evidence.
+
+    Ordinary quotes/comments are already masked by the shared lexer. Slashy
+    strings are expressions, so a division operator after an operand isn't an
+    opener. This does not evaluate interpolation or arbitrary build programs.
+    """
+    ranges = []
+    end = 0
+    for match in re.finditer(r"\$/|/(?![/*])", code):
+        start = match.start()
+        if start < end:
+            continue
+        dollar = match[0] == "$/"
+        prefix = code[:start].rstrip()
+        if not dollar and prefix and prefix[-1] not in "=(:,[!?{" and not re.search(r"\breturn$", prefix):
+            continue
+        cursor = match.end()
+        while cursor < len(source):
+            if dollar and source.startswith("/$", cursor):
+                cursor += 2
+                break
+            if not dollar and source[cursor] == "/":
+                cursor += 1
+                break
+            if (dollar and source[cursor] == "$" and cursor + 1 < len(source)
+                    and source[cursor + 1] in "$/") or (not dollar and source[cursor] == "\\"):
+                cursor += 2
+            else:
+                cursor += 1
+        end = cursor
+        ranges.append((start, end))
+    return ranges
+
+
+def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tuple[str, str, object]]:
+    spec = importlib.util.spec_from_file_location(
+        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+    ownership = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ownership)
+    analyzer = ownership.load_script("lint-required-messaging-profile")
+    dependencies = []
+    accessors = set()
+    for name in ("build.gradle", "build.gradle.kts"):
+        try:
+            source = (root / name).read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        # Reuse source masking: inline comments and help strings aren't code.
+        lexed = ownership.lexed_source(source, ".kt" if name.endswith(".kts") else ".java")
+        strings = {token.start: token for token in lexed.strings}
+        inert_ranges = groovy_slashy_ranges(source, lexed.code) if name == "build.gradle" else []
+        declaration = r"\b(?:implementation|api|compileOnly|runtimeOnly|testImplementation)\b"
+        for match in re.finditer(declaration, lexed.code):
+            if any(start <= match.start() < end for start, end in inert_ranges):
+                continue
+            prefix = re.match(r"\s*\(?\s*", lexed.without_comments[match.end():])
+            start = match.end() + prefix.end()
+            token = strings.get(start)
+            if token:
+                parts = token.contents.split(":")
+                if len(parts) in {2, 3}:
+                    dependencies.append((parts[0], parts[1], parts[2] if len(parts) == 3 else ""))
+            else:
+                accessor = re.match(r"libs\.([\w.]+)", lexed.code[start:])
+                if accessor:
+                    accessors.add(accessor[1])
+                    continue
+                # Groovy also accepts named-map dependency notation:
+                # implementation group: 'g', name: 'a', version: '1.2.3'
+                # and the equivalent parenthesized call. Read only string
+                # tokens belonging to this declaration, so comments and prose
+                # cannot contribute coordinates.
+                cursor = match.end()
+                while (cursor < len(lexed.code)
+                       and lexed.code[cursor] in " \t\r"):
+                    cursor += 1
+                parenthesized = (cursor < len(lexed.code)
+                                 and lexed.code[cursor] == "(")
+                if parenthesized:
+                    closing = analyzer.matching_delimiter(
+                        lexed.code, cursor, "(", ")")
+                    if closing is None:
+                        continue
+                    argument_start, argument_end = cursor + 1, closing
+                else:
+                    argument_start, argument_end = cursor, len(lexed.code)
+                fields = {}
+                cursor = argument_start
+                continued = parenthesized
+                while cursor < argument_end:
+                    while (cursor < argument_end
+                           and lexed.code[cursor].isspace()
+                           and (continued or lexed.code[cursor] != "\n")):
+                        cursor += 1
+                    field = re.match(r"(group|name|version)\s*:",
+                                     lexed.code[cursor:argument_end])
+                    if field is None:
+                        break
+                    value_start = cursor + field.end()
+                    while (value_start < argument_end
+                           and lexed.without_comments[value_start].isspace()):
+                        value_start += 1
+                    token = strings.get(value_start)
+                    if token and token.end <= argument_end:
+                        fields[field[1]] = token.contents
+                        cursor = token.end
+                    else:
+                        # Dynamic/unsupported values invalidate an earlier
+                        # duplicate literal instead of leaving stale evidence.
+                        fields[field[1]] = None
+                        boundary = re.search(r"[,;\n})]",
+                                             lexed.code[value_start:argument_end])
+                        cursor = (argument_end if boundary is None else
+                                  value_start + boundary.start())
+                    while (cursor < argument_end
+                           and lexed.code[cursor] in " \t\r"):
+                        cursor += 1
+                    if cursor >= argument_end or lexed.code[cursor] != ",":
+                        break
+                    cursor += 1
+                    continued = True
+                if "group" in fields and "name" in fields:
+                    dependencies.append((fields["group"], fields["name"],
+                                         fields.get("version", "")))
+    if tomllib is None:
+        return dependencies
+    try:
+        catalog = tomllib.loads(((catalog_root or root) / "gradle/libs.versions.toml").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return dependencies
+    libraries, versions = catalog.get("libraries", {}), catalog.get("versions", {})
+    if not isinstance(libraries, dict) or not isinstance(versions, dict):
+        return dependencies
+    for alias, entry in libraries.items():
+        accessor = re.sub(r"[-_]", ".", alias)
+        if accessor not in accessors:
+            continue
+        if isinstance(entry, str):
+            parts = entry.split(":")
+            if len(parts) != 3:
+                continue
+            group, artifact, version = parts
+        elif isinstance(entry, dict):
+            module = entry.get("module")
+            if isinstance(module, str) and module.count(":") == 1:
+                group, artifact = module.split(":")
+            else:
+                group, artifact = entry.get("group"), entry.get("name")
+            version = entry.get("version")
+            if isinstance(version, dict):
+                reference = version.get("ref")
+                version = versions.get(reference) if isinstance(reference, str) else None
+        else:
+            continue
+        dependencies.append((group, artifact, version))
+    return dependencies
+
+
+def gradle_pinned(root: Path) -> bool:
+    return any(group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS
+               and version_is_constrained(version)
+               for group, artifact, version in gradle_dependencies(root))
+
+
+def jvm_declared(root: Path, vendor: str) -> bool:
+    for directory, dirs, names in os.walk(root):
+        relative = Path(directory).relative_to(root)
+        dirs[:] = [name for name in dirs if name not in {
+            ".git", "node_modules", "build", "vendor", ".gradle", ".venv"}
+            and len(relative.parts) < 3]
+        path = Path(directory)
+        dependencies = maven_dependencies(path / "pom.xml") if "pom.xml" in names else []
+        if "build.gradle" in names or "build.gradle.kts" in names:
+            dependencies.extend(gradle_dependencies(path, root))
+        if any((group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS)
+               if vendor == "telnyx" else (group == "com.twilio.sdk" and artifact == "twilio")
+               for group, artifact, _ in dependencies):
+            return True
+    return False
+
+
+def main() -> int:
+    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "jvm-pinned", "jvm-declared", "twilio-jvm-declared"}:
+        return 2
+    root = Path(sys.argv[2])
+    mode = sys.argv[1]
+    if mode == "composer":
+        found = composer_declared(root)
+    elif mode.endswith("declared"):
+        found = jvm_declared(root, "twilio" if mode.startswith("twilio") else "telnyx")
+    else:
+        found = maven_pinned(root / "pom.xml") or gradle_pinned(root)
+    return 0 if found else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -9,6 +9,7 @@ on older Python. Gradle catalogs still require tomllib; no packages are installe
 from __future__ import annotations
 
 import ast
+import codecs
 import configparser
 from functools import lru_cache
 import json
@@ -17,6 +18,7 @@ import os
 from pathlib import Path
 import re
 import sys
+import tokenize
 import xml.etree.ElementTree as ET
 
 try:
@@ -43,8 +45,26 @@ def version_is_constrained(value: object) -> bool:
 
 def read_text(path: Path) -> str:
     try:
-        return path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError):
+        # Python source and pip requirements honor PEP 263 declarations. npm's
+        # JSON reader accepts a leading UTF-8 BOM; TOML does not share that rule.
+        if path.name == "setup.py":
+            with tokenize.open(path) as source:
+                return source.read()
+        if path.name == "requirements.txt":
+            data = path.read_bytes()
+            # pip checks BOMs before coding comments, and UTF-32 before UTF-16.
+            for boms, encoding in (((codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE), "utf-32"),
+                                   ((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE), "utf-16"),
+                                   ((codecs.BOM_UTF8,), "utf-8-sig")):
+                if data.startswith(boms):
+                    return data.decode(encoding)
+            for line in data.split(b"\n")[:2]:
+                cookie = re.search(br"coding[:=]\s*([-\w.]+)", line) if line.startswith(b"#") else None
+                if cookie:
+                    return data.decode(cookie[1].decode("ascii"))
+            return data.decode("utf-8")
+        return path.read_text(encoding="utf-8-sig" if path.name == "package.json" else "utf-8")
+    except (OSError, UnicodeError, SyntaxError, LookupError):
         return ""
 
 
@@ -252,6 +272,36 @@ def python_requirement(value: object) -> list[str]:
     return [suffix.split(";", 1)[0].strip().strip("() ")]
 
 
+_SETUP_FUNCTION = object()
+
+
+class _SetupModule:
+    """Static import identity, never an imported or executed Python module."""
+
+
+_SETUP_MODULE = _SetupModule()
+
+
+def setup_import_bindings(statement: ast.Import | ast.ImportFrom) -> dict:
+    """Names replaced by an import; None denotes an unrecognized owner."""
+    result = {}
+    for alias in statement.names:
+        name = alias.asname or alias.name.split(".")[0]
+        result[name] = None
+        if isinstance(statement, ast.Import):
+            if alias.name == "setuptools" or (not alias.asname and alias.name.startswith("setuptools.")):
+                result[name] = _SETUP_MODULE
+        elif not statement.level and statement.module in {"setuptools", "distutils.core"} and alias.name == "setup":
+            result[name] = _SETUP_FUNCTION
+        elif not statement.level and statement.module == "setuptools" and alias.name == "*":
+            # setuptools explicitly exports these names through __all__. Do
+            # not erase unrelated local requirements or aliases on this import.
+            result = dict.fromkeys(("Command", "Distribution", "Extension", "Require",
+                                    "SetuptoolsDeprecationWarning", "find_namespace_packages", "find_packages"))
+            result["setup"] = _SETUP_FUNCTION
+    return result
+
+
 def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
     """Resolve only local literal data, never execute setup code or imports."""
     if depth > 20:
@@ -259,6 +309,8 @@ def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
     resolve = lambda child: setup_literal(child, bindings, depth + 1)
     if isinstance(node, ast.Name):
         return bindings[node.id]
+    if isinstance(node, ast.Attribute) and node.attr == "setup" and isinstance(resolve(node.value), _SetupModule):
+        return _SETUP_FUNCTION
     if isinstance(node, (ast.List, ast.Tuple)):
         values = [resolve(child) for child in node.elts]
         return tuple(values) if isinstance(node, ast.Tuple) else values
@@ -293,29 +345,72 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
         for child in ast.iter_child_nodes(node):
             yield from local_nodes(child)
 
-    def invalidate(names):
+    def invalidate(names, mutation=False):
         # Containers can own aliases too, e.g. config={"requires": requirements}.
         def mutable_objects(value):
-            objects = {id(value)} if isinstance(value, (list, dict)) else set()
+            objects = {id(value)} if isinstance(value, (list, dict, _SetupModule)) else set()
             children = value.values() if isinstance(value, dict) else value if isinstance(value, (list, tuple)) else ()
             for child in children:
                 objects.update(mutable_objects(child))
             return objects
 
         objects = set().union(*(mutable_objects(bindings[name]) for name in names if name in bindings))
+        if mutation and class_outer is not None:
+            # Class-local rebinding stays local; mutating a shared outer module
+            # or container does not. Never restore its stale entry snapshot.
+            for name in list(class_outer):
+                if mutable_objects(class_outer[name]) & objects:
+                    del class_outer[name]
         for name in list(bindings):
             if name in names or mutable_objects(bindings[name]) & objects:
                 del bindings[name]
 
     def preceding(statement):
+        nonlocal bindings
+        common_imports = {}
+        if isinstance(statement, (ast.If, ast.Try)):
+            # Reuse the same statement handling on each alternative, but merge
+            # only import identity -- never conditional literal requirements.
+            paths = []
+            if isinstance(statement, ast.If):
+                paths = [(statement.body, None, []), (statement.orelse, None, [])]
+                headers = [statement.test]
+            else:
+                paths = [(statement.body + statement.orelse, None, statement.finalbody)]
+                paths += [(handler.body, handler.name, statement.finalbody) for handler in statement.handlers]
+                headers = [handler.type for handler in statement.handlers if handler.type is not None]
+            if not any(isinstance(node, (ast.Call, ast.NamedExpr)) for header in headers for node in ast.walk(header)):
+                incoming, alternatives = bindings, []
+                try:
+                    for body, exception_name, finalbody in paths:
+                        bindings = incoming.copy()
+                        if exception_name:
+                            bindings.pop(exception_name, None)
+                        for item in body:
+                            preceding(item)
+                        if exception_name:
+                            bindings.pop(exception_name, None)
+                        for item in finalbody:
+                            preceding(item)
+                        alternatives.append({name: value for name, value in bindings.items()
+                                             if value is _SETUP_FUNCTION or value is _SETUP_MODULE})
+                finally:
+                    bindings = incoming
+                common_imports = {name: value for name, value in alternatives[0].items()
+                                  if all(other.get(name) is value for other in alternatives[1:])}
         nodes = list(local_nodes(statement))
         mutated = set()
         for node in nodes:
             if isinstance(node, ast.Call):
-                mutated.update(item.id for item in ast.walk(node) if isinstance(item, ast.Name))
+                try:
+                    known_setup = setup_literal(node.func, bindings) is _SETUP_FUNCTION
+                except (KeyError, ValueError, TypeError, SyntaxError):
+                    known_setup = False
+                operands = [*node.args, *(kw.value for kw in node.keywords)] if known_setup else [node]
+                mutated.update(item.id for operand in operands for item in ast.walk(operand) if isinstance(item, ast.Name))
             elif isinstance(node, (ast.Attribute, ast.Subscript)) and isinstance(node.ctx, (ast.Store, ast.Del)):
                 mutated.update(item.id for item in ast.walk(node.value) if isinstance(item, ast.Name))
-        invalidate(mutated)
+        invalidate(mutated, mutation=True)
         if isinstance(statement, (ast.Assign, ast.AnnAssign)):
             targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
             try:
@@ -333,13 +428,36 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
             return
         invalidate({node.id for node in nodes if isinstance(node, ast.Name)
                     and isinstance(node.ctx, (ast.Store, ast.Del))})
-        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            bindings.pop(statement.name, None)
+        # Conditional imports/definitions also replace names, even though the
+        # AST represents them without Name(Store) nodes.
+        for node in nodes:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                effects = setup_import_bindings(node)
+                if "*" in effects:
+                    bindings.clear()
+                invalidate(set(effects))
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                bindings.pop(node.name, None)
         if isinstance(statement, (ast.Import, ast.ImportFrom)):
-            for alias in statement.names:
-                bindings.pop(alias.asname or alias.name.split(".")[0], None)
+            bindings.update({name: value for name, value in setup_import_bindings(statement).items() if value is not None})
+        bindings.update(common_imports)
 
+    class_outer = None
     for parent, child in reversed(path):
+        if class_outer is not None and isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            # Only the outermost iterator is evaluated in the class namespace;
+            # the comprehension body has its own enclosing lexical scope.
+            if not any(node is call for node in ast.walk(parent.generators[0].iter)):
+                bindings = class_outer
+                class_outer = None
+        if isinstance(parent, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            # A class body executes with its own locals, but is not a closure
+            # for methods or nested classes. Preserve the outer lexical scope.
+            if class_outer is not None:
+                bindings = class_outer
+                class_outer = None
+            if isinstance(parent, ast.ClassDef):
+                class_outer = bindings.copy()
         if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             # Python locals shadow outer names throughout the function, including
             # before their assignment. Parameters are unknown, not outer literals.
@@ -348,6 +466,12 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
                        for node in local_nodes(statement) if isinstance(node, ast.Name)
                        and isinstance(node.ctx, (ast.Store, ast.Del))}
             locals_.update(node.arg for node in ast.walk(parent.args) if isinstance(node, ast.arg))
+            for statement in statements:
+                for node in local_nodes(statement):
+                    if isinstance(node, (ast.Import, ast.ImportFrom)):
+                        locals_.update(alias.asname or alias.name.split(".")[0] for alias in node.names)
+                    elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                        locals_.add(node.name)
             for name in locals_:
                 bindings.pop(name, None)
         if isinstance(parent, (ast.For, ast.AsyncFor, ast.With, ast.AsyncWith,
@@ -356,13 +480,23 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
             targets = [parent.target] if isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension)) else (
                 [item.optional_vars for item in parent.items if item.optional_vars is not None]
                 if isinstance(parent, (ast.With, ast.AsyncWith)) else [])
+            if isinstance(parent, ast.comprehension) and child is parent.iter:
+                targets = []
             names = {node.id for target in targets for node in ast.walk(target) if isinstance(node, ast.Name)}
             if isinstance(parent, ast.ExceptHandler) and parent.name:
                 names.add(parent.name)
             for name in names:
                 bindings.pop(name, None)
         if isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
-            for generator in parent.generators:
+            visible = parent.generators
+            for index, generator in enumerate(parent.generators):
+                if any(node is call for node in ast.walk(generator.iter)):
+                    visible = parent.generators[:index]
+                    break
+                if any(node is call for condition in generator.ifs for node in ast.walk(condition)):
+                    visible = parent.generators[:index + 1]
+                    break
+            for generator in visible:
                 for node in ast.walk(generator.target):
                     if isinstance(node, ast.Name):
                         bindings.pop(node.id, None)
@@ -372,7 +506,7 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
                 [parent.iter] if isinstance(parent, (ast.For, ast.AsyncFor)) else
                 [item.context_expr for item in parent.items])
             invalidate({name.id for header in headers for node in ast.walk(header)
-                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)})
+                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)}, mutation=True)
         for _, children in ast.iter_fields(parent):
             if isinstance(children, list) and child in children and isinstance(child, ast.stmt):
                 for previous in children[:children.index(child)]:
@@ -439,17 +573,19 @@ def python_dependencies(root: Path) -> list[tuple[str, bool]]:
     try:
         tree = ast.parse(read_text(root / "setup.py"))
         for call in ast.walk(tree):
-            if not isinstance(call, ast.Call) or not (
-                isinstance(call.func, ast.Name) and call.func.id == "setup"
-                or isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name)
-                and call.func.value.id == "setuptools" and call.func.attr == "setup"
-            ):
+            if not isinstance(call, ast.Call):
+                continue
+            bindings = setup_bindings(tree, call)
+            try:
+                if setup_literal(call.func, bindings) is not _SETUP_FUNCTION:
+                    continue
+            except (KeyError, ValueError, TypeError, SyntaxError):
                 continue
             for keyword in call.keywords:
                 if keyword.arg not in {"install_requires", "extras_require"}:
                     continue
                 try:
-                    value = setup_literal(keyword.value, setup_bindings(tree, call))
+                    value = setup_literal(keyword.value, bindings)
                 except (KeyError, ValueError, TypeError, SyntaxError):
                     continue
                 if keyword.arg == "extras_require" and isinstance(value, dict):

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -3,11 +3,14 @@
 
 Exit zero only for positive evidence. Unresolved external Maven parents,
 properties, and unsupported Gradle expressions deliberately remain warnings.
-Gradle version catalogs use stdlib tomllib on Python 3.11+; older Python still
-supports Maven, Composer and literal Gradle coordinates without extra packages.
+TOML manifests use stdlib tomllib on Python 3.11+ and a bounded literal fallback
+on older Python. Gradle catalogs still require tomllib; no packages are installed.
 """
 from __future__ import annotations
 
+import ast
+import configparser
+from functools import lru_cache
 import json
 import importlib.util
 import os
@@ -25,22 +28,650 @@ JVM_ARTIFACTS = {"telnyx", "telnyx-core", "telnyx-client-okhttp"}
 
 
 def version_is_constrained(value: object) -> bool:
-    return isinstance(value, str) and bool(re.fullmatch(
-        r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?", value.strip()
+    """Literal JVM releases and numeric hard requirements, not dynamic selectors."""
+    if not isinstance(value, str):
+        return False
+    release = r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?"
+    value = value.strip()
+    if re.fullmatch(release, value) or re.fullmatch(r"\[" + release + r"\]", value):
+        return True
+    interval = re.fullmatch(r"[\[(]\s*(.*?)\s*,\s*(.*?)\s*[\])]", value)
+    return bool(interval and any(interval.groups()) and all(
+        not bound or re.fullmatch(release, bound) for bound in interval.groups()
     ))
 
 
-def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+
+
+def toml_string(raw: str) -> str:
+    """Decode TOML 1.0 string escapes without Python's extra escape forms."""
+    quote = raw[0]
+    width = 3 if raw.startswith(quote * 3) else 1
+    if not raw.endswith(quote * width):
+        raise ValueError("unterminated TOML string")
+    value = raw[width:-width]
+    if width == 3:
+        value = re.sub(r"^\r?\n", "", value)
+    if re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", value):
+        raise ValueError("control character in TOML string")
+    if width == 1 and ("\n" in value or "\r" in value):
+        raise ValueError("newline in single-line TOML string")
+    if quote == "'":
+        return value
+    escapes = {'b': '\b', 't': '\t', 'n': '\n', 'f': '\f', 'r': '\r', '"': '"', '\\': '\\'}
+
+    def decode(match):
+        escaped = match[0][1:]
+        if escaped in escapes:
+            return escapes[escaped]
+        if re.fullmatch(r"u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}", escaped):
+            number = int(escaped[1:], 16)
+            if number <= 0x10ffff and not 0xd800 <= number <= 0xdfff:
+                return chr(number)
+        if width == 3 and re.fullmatch(r"[ \t]*\r?\n[ \t\r\n]*", escaped):
+            return ""
+        raise ValueError("invalid TOML escape")
+
+    return re.sub(r'\\(?:u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|[ \t]*\r?\n[ \t\r\n]*|.|$)',
+                  decode, value)
+
+
+def literal_toml_mapping(source: str) -> dict:
+    """Python 3.10 fallback: tables, literal strings, arrays and inline tables.
+
+    This is intentionally not a general TOML implementation. It accepts the
+    dependency forms used below without evaluating code. Unsupported
+    values remain unresolved; masked strings cannot introduce table headers.
+    """
+    ownership = source_ownership()
+    analyzer = ownership.load_script("lint-required-messaging-profile")
+    lexed = ownership.lexed_source(source, ".py")
+    strings = {token.start: token for token in lexed.strings}
+    key = r'''(?:[A-Za-z0-9_-]+|"(?:[^"\\\n]|\\.)*"|'[^'\n]*')'''
+    data, cursor = {}, 0
+    table = data
+    headers = set()
+
+    def table_at(parts: list[str]) -> dict | None:
+        target = data
+        for part in parts:
+            if not isinstance(target.setdefault(part, {}), dict):
+                return None
+            target = target[part]
+        return target
+
+    while cursor < len(source):
+        whitespace = re.match(r"\s*", lexed.without_comments[cursor:])
+        cursor += whitespace.end()
+        if cursor >= len(source):
+            break
+        end = source.find("\n", cursor)
+        end = len(source) if end < 0 else end
+        line = lexed.without_comments[cursor:end].strip()
+        if lexed.code[cursor:cursor + 1] == "[":
+            header = re.fullmatch(r"\[\s*(" + key + r"(?:\s*\.\s*" + key + r")*)\s*\]", line)
+            if header:
+                try:
+                    parts = tuple(toml_string(part) if part.startswith(('"', "'")) else part
+                                  for part in re.findall(key, header[1]))
+                except ValueError:
+                    return {}
+                if parts in headers:
+                    return {}
+                headers.add(parts)
+                table = table_at(list(parts))
+            else:
+                table = None
+            cursor = end
+            continue
+        assignment = re.match(r"(" + key + r"(?:\s*\.\s*" + key + r")*)\s*=\s*", lexed.without_comments[cursor:])
+        if assignment is None:
+            cursor = end
+            continue
+        try:
+            parts = [toml_string(part) if part.startswith(('"', "'")) else part
+                     for part in re.findall(key, assignment[1])]
+        except ValueError:
+            return {}
+        start = cursor + assignment.end()
+        token = strings.get(start)
+        if token:
+            end = token.end
+        elif source[start:start + 1] in {"[", "{"}:
+            opening = source[start]
+            closing = analyzer.matching_delimiter(lexed.code, start, opening, "]" if opening == "[" else "}")
+            if closing is None:
+                return {}  # Cannot safely find the next declaration.
+            end = closing + 1
+        expression = lexed.without_comments[start:end]
+        replacements = []
+        supported = True
+        for token in lexed.strings:
+            if start <= token.start < end:
+                try:
+                    decoded = toml_string(source[token.start:token.end])
+                except ValueError:
+                    supported = False
+                    decoded = ""
+                replacements.append((token.start - start, token.end - start, repr(decoded)))
+        code = lexed.code[start:end]
+        if any(character in code for character in "():"):
+            return {}  # Python tuples and JSON colon maps are not TOML.
+        for field in re.finditer(r"\b([A-Za-z_][\w-]*)\s*(?==)", code):
+            replacements.append((field.start(1), field.end(1), repr(field[1])))
+        for equal in re.finditer("=", code):
+            replacements.append((equal.start(), equal.end(), ":"))
+        for boolean in re.finditer(r"\b(true|false)\b", code):
+            replacements.append((boolean.start(), boolean.end(), boolean[1].title()))
+        for first, last, replacement in sorted(replacements, reverse=True):
+            expression = expression[:first] + replacement + expression[last:]
+        cursor = end
+        line_end = source.find("\n", end)
+        line_end = len(source) if line_end < 0 else line_end
+        if lexed.without_comments[end:line_end].strip():
+            cursor = line_end
+            continue  # Do not certify a prefix of an unsupported expression.
+        if table is None or not supported:
+            continue
+        try:
+            tree = ast.parse(expression.strip(), mode="eval")
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Dict):
+                    keys = [ast.literal_eval(key) for key in node.keys]
+                    if not all(isinstance(key, str) for key in keys) or len(keys) != len(set(keys)):
+                        return {}
+            value = ast.literal_eval(tree)
+        except (ValueError, SyntaxError):
+            continue
+        target = table
+        for part in parts[:-1]:
+            target = target.setdefault(part, {})
+            if not isinstance(target, dict):
+                break
+        if isinstance(target, dict):
+            if parts[-1] in target:
+                return {}  # Duplicate keys are invalid TOML, not extra evidence.
+            target[parts[-1]] = value
+    return data
+
+
+def read_mapping(path: Path, toml: bool = False) -> dict:
+    try:
+        if toml:
+            source = read_text(path)
+            data = tomllib.loads(source) if tomllib else literal_toml_mapping(source)
+        else:
+            data = json.loads(read_text(path))
+    except ValueError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def node_dependencies(root: Path) -> list[tuple[str, str]]:
+    data = read_mapping(root / "package.json")
+    return [(name, value.strip())
+            for section in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies")
+            if isinstance(data.get(section), dict)
+            for name, value in data[section].items()
+            if (name == "telnyx" or name.startswith("@telnyx/"))
+            and isinstance(value, str)]
+
+
+def node_version_is_constrained(value: str) -> bool:
+    # Registry versions/ranges only; tags, URLs and workspace expressions stay
+    # warnings. Every OR branch must provide numeric version evidence.
+    release = r"v?\d+(?:\.\d+){0,2}(?:-[A-Za-z0-9.-]+)?(?:\+[A-Za-z0-9.-]+)?"
+    wildcard = r"\d+(?:\.\d+)?\.[xX*]"
+    for branch in value.split("||"):
+        branch = re.sub(r"([~^<>=]+)\s+", r"\1", branch.strip())
+        if re.fullmatch(release + r"\s+-\s+" + release, branch):
+            continue
+        if not branch or not all(re.fullmatch(
+            r"(?:\^|~|>=|<=|>|<|=)?(?:" + release + "|" + wildcard + ")", token)
+            for token in branch.split()):
+            return False
+    return True
+
+
+def python_requirement(value: object) -> list[str]:
+    if not isinstance(value, str):
+        return []
+    requirement = re.fullmatch(r"telnyx\s*(?:\[[\w, -]+\])?\s*(.*)",
+                               value.strip(), re.IGNORECASE)
+    if not requirement:
+        return []
+    suffix = requirement[1]
+    # Do not mistake a different distribution, e.g. telnyx-tools, for Telnyx.
+    if suffix and suffix[0] not in "<>=~!(@;":
+        return []
+    return [suffix.split(";", 1)[0].strip().strip("() ")]
+
+
+def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
+    """Resolve only local literal data, never execute setup code or imports."""
+    if depth > 20:
+        raise ValueError("literal binding depth")
+    resolve = lambda child: setup_literal(child, bindings, depth + 1)
+    if isinstance(node, ast.Name):
+        return bindings[node.id]
+    if isinstance(node, (ast.List, ast.Tuple)):
+        values = [resolve(child) for child in node.elts]
+        return tuple(values) if isinstance(node, ast.Tuple) else values
+    if isinstance(node, ast.Dict) and all(key is not None for key in node.keys):
+        return {resolve(key): resolve(value) for key, value in zip(node.keys, node.values)}
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left, right = resolve(node.left), resolve(node.right)
+        if type(left) is type(right) and isinstance(left, (str, list, tuple)):
+            return left + right
+        raise ValueError("nonliteral concatenation")
+    return ast.literal_eval(node)
+
+
+def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
+    """Snapshot preceding straight-line assignments in the call's own scopes.
+
+    Conditional writes and unknown mutations invalidate evidence. In particular,
+    never borrow a later assignment or a binding from an unrelated function.
+    """
+    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
+    path, child = [], call
+    while child in parents:
+        parent = parents[child]
+        path.append((parent, child))
+        child = parent
+    bindings = {}
+
+    def local_nodes(node):
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            return
+        for child in ast.iter_child_nodes(node):
+            yield from local_nodes(child)
+
+    def invalidate(names):
+        # Containers can own aliases too, e.g. config={"requires": requirements}.
+        def mutable_objects(value):
+            objects = {id(value)} if isinstance(value, (list, dict)) else set()
+            children = value.values() if isinstance(value, dict) else value if isinstance(value, (list, tuple)) else ()
+            for child in children:
+                objects.update(mutable_objects(child))
+            return objects
+
+        objects = set().union(*(mutable_objects(bindings[name]) for name in names if name in bindings))
+        for name in list(bindings):
+            if name in names or mutable_objects(bindings[name]) & objects:
+                del bindings[name]
+
+    def preceding(statement):
+        nodes = list(local_nodes(statement))
+        mutated = set()
+        for node in nodes:
+            if isinstance(node, ast.Call):
+                mutated.update(item.id for item in ast.walk(node) if isinstance(item, ast.Name))
+            elif isinstance(node, (ast.Attribute, ast.Subscript)) and isinstance(node.ctx, (ast.Store, ast.Del)):
+                mutated.update(item.id for item in ast.walk(node.value) if isinstance(item, ast.Name))
+        invalidate(mutated)
+        if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+            try:
+                value = setup_literal(statement.value, bindings)
+                resolved = True
+            except (KeyError, ValueError, TypeError, SyntaxError):
+                resolved = False
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    bindings.pop(target.id, None)
+                    if resolved:
+                        bindings[target.id] = value
+                else:
+                    invalidate({node.id for node in ast.walk(target) if isinstance(node, ast.Name)})
+            return
+        invalidate({node.id for node in nodes if isinstance(node, ast.Name)
+                    and isinstance(node.ctx, (ast.Store, ast.Del))})
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bindings.pop(statement.name, None)
+        if isinstance(statement, (ast.Import, ast.ImportFrom)):
+            for alias in statement.names:
+                bindings.pop(alias.asname or alias.name.split(".")[0], None)
+
+    for parent, child in reversed(path):
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            # Python locals shadow outer names throughout the function, including
+            # before their assignment. Parameters are unknown, not outer literals.
+            statements = parent.body if isinstance(parent.body, list) else []
+            locals_ = {node.id for statement in statements
+                       for node in local_nodes(statement) if isinstance(node, ast.Name)
+                       and isinstance(node.ctx, (ast.Store, ast.Del))}
+            locals_.update(node.arg for node in ast.walk(parent.args) if isinstance(node, ast.arg))
+            for name in locals_:
+                bindings.pop(name, None)
+        if isinstance(parent, (ast.For, ast.AsyncFor, ast.With, ast.AsyncWith,
+                               ast.ExceptHandler, ast.comprehension)):
+            # These names are rebound by the header, before its body executes.
+            targets = [parent.target] if isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension)) else (
+                [item.optional_vars for item in parent.items if item.optional_vars is not None]
+                if isinstance(parent, (ast.With, ast.AsyncWith)) else [])
+            names = {node.id for target in targets for node in ast.walk(target) if isinstance(node, ast.Name)}
+            if isinstance(parent, ast.ExceptHandler) and parent.name:
+                names.add(parent.name)
+            for name in names:
+                bindings.pop(name, None)
+        if isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            for generator in parent.generators:
+                for node in ast.walk(generator.target):
+                    if isinstance(node, ast.Name):
+                        bindings.pop(node.id, None)
+        if isinstance(parent, (ast.If, ast.While, ast.For, ast.AsyncFor, ast.With, ast.AsyncWith)):
+            # Calls in a control-flow header may mutate the incoming data.
+            headers = [parent.test] if isinstance(parent, (ast.If, ast.While)) else (
+                [parent.iter] if isinstance(parent, (ast.For, ast.AsyncFor)) else
+                [item.context_expr for item in parent.items])
+            invalidate({name.id for header in headers for node in ast.walk(header)
+                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)})
+        for _, children in ast.iter_fields(parent):
+            if isinstance(children, list) and child in children and isinstance(child, ast.stmt):
+                for previous in children[:children.index(child)]:
+                    if isinstance(previous, ast.stmt):
+                        preceding(previous)
+    return bindings
+
+
+def python_dependencies(root: Path) -> list[tuple[str, bool]]:
+    """Read declared literal requirements; never execute setup.py or imports."""
+    result = []
+
+    def requirements(values: object) -> None:
+        if isinstance(values, (list, tuple)):
+            for value in values:
+                result.extend((constraint, False) for constraint in python_requirement(value))
+
+    def package_table(table: object, poetry: bool = False) -> None:
+        if not isinstance(table, dict):
+            return
+        for name, value in table.items():
+            if name.lower() == "telnyx":
+                if isinstance(value, dict):
+                    value = value.get("version", "")
+                if isinstance(value, str):
+                    result.append((value.strip(), poetry))
+
+    # pip joins physical lines before removing comments. Per-requirement options
+    # belong to pip, not to the PEP 440 version constraint (nor another package).
+    source = re.sub(r"\\\r?\n", "", read_text(root / "requirements.txt"))
+    requirements([re.split(r"\s+--(?:hash|config-settings)(?==|\s|$)",
+                          re.sub(r"(^|\s+)#.*", "", line), maxsplit=1)[0]
+                  for line in source.splitlines()])
+    pipfile = read_mapping(root / "Pipfile", toml=True)
+    for section in ("packages", "dev-packages"):
+        package_table(pipfile.get(section))
+    project = read_mapping(root / "pyproject.toml", toml=True)
+    metadata = project.get("project", {})
+    if isinstance(metadata, dict):
+        requirements(metadata.get("dependencies"))
+        optional = metadata.get("optional-dependencies", {})
+        if isinstance(optional, dict):
+            for values in optional.values():
+                requirements(values)
+    tool = project.get("tool", {})
+    poetry = tool.get("poetry", {}) if isinstance(tool, dict) else {}
+    if isinstance(poetry, dict):
+        for section in ("dependencies", "dev-dependencies"):
+            package_table(poetry.get(section), poetry=True)
+        groups = poetry.get("group", {})
+        if isinstance(groups, dict):
+            for group in groups.values():
+                if isinstance(group, dict):
+                    package_table(group.get("dependencies"), poetry=True)
+    config = configparser.ConfigParser(interpolation=None)
+    try:
+        config.read_string(read_text(root / "setup.cfg"))
+        requirements(config.get("options", "install_requires", fallback="").splitlines())
+        if config.has_section("options.extras_require"):
+            for _, values in config.items("options.extras_require"):
+                requirements(values.splitlines())
+    except configparser.Error:
+        pass
+    try:
+        tree = ast.parse(read_text(root / "setup.py"))
+        for call in ast.walk(tree):
+            if not isinstance(call, ast.Call) or not (
+                isinstance(call.func, ast.Name) and call.func.id == "setup"
+                or isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "setuptools" and call.func.attr == "setup"
+            ):
+                continue
+            for keyword in call.keywords:
+                if keyword.arg not in {"install_requires", "extras_require"}:
+                    continue
+                try:
+                    value = setup_literal(keyword.value, setup_bindings(tree, call))
+                except (KeyError, ValueError, TypeError, SyntaxError):
+                    continue
+                if keyword.arg == "extras_require" and isinstance(value, dict):
+                    for values in value.values():
+                        requirements(values)
+                elif keyword.arg == "install_requires":
+                    requirements(value)
+    except (ValueError, SyntaxError):
+        pass
+    return result
+
+
+def python_version_is_constrained(value: str, poetry: bool = False) -> bool:
+    """Bounded PEP 440 specifiers, with Poetry's table-only caret/tilde syntax."""
+    numeric = r"(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*"
+    release = (r"v?" + numeric
+               + r"(?:[-_.]?(?:a|b|c|rc|alpha|beta|pre|preview)[-_.]?[0-9]*)?"
+               + r"(?:-[0-9]+|[-_.]?(?:post|rev|r)[-_.]?[0-9]*)?"
+               + r"(?:[-_.]?dev[-_.]?[0-9]*)?")
+    local = r"(?:\+[a-z0-9]+(?:[-_.][a-z0-9]+)*)?"
+    for token in value.split(","):
+        match = re.fullmatch(r"(===|==|~=|>=|<=|!=|>|<|\^|~)?\s*(\S+)", token.strip())
+        if not match:
+            return False
+        operator, version = match.groups()
+        if operator == "===":
+            continue  # PEP 440 explicitly permits arbitrary equality strings.
+        if operator in {None, "^", "~"} and not poetry:
+            return False
+        if re.fullmatch(numeric + r"\.\*", version):
+            if operator not in ({None, "==", "!="} if poetry else {"==", "!="}):
+                return False
+            continue
+        if not re.fullmatch(release + local, version, re.IGNORECASE):
+            return False
+        if "+" in version and operator not in {None, "==", "!="}:
+            return False
+        if operator == "~=" and not re.match(r"v?(?:[0-9]+!)?[0-9]+\.[0-9]+", version):
+            return False
+    return True
+
+
+@lru_cache(maxsize=1)
+def source_ownership():
+    spec = importlib.util.spec_from_file_location(
+        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+    ownership = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ownership)
+    return ownership
+
+
+def ruby_dependencies(root: Path) -> list[str]:
+    """Literal gem calls, bounded by arguments rather than whole source lines."""
+    source = read_text(root / "Gemfile")
+    if not source:
+        return []
+    ownership = source_ownership()
+    lexed = ownership.lexed_source(source, ".rb")
+    strings = {token.start: token for token in lexed.strings}
+    result = []
+
+    def literal(token) -> bool:
+        raw = source[token.start:token.end]
+        return (raw.startswith(("'", '"', "%q", "%Q"))
+                and "#{" not in token.contents and "\\" not in token.contents)
+
+    def skip_space(cursor: int) -> int:
+        # The shared lexer masks percent strings even in without_comments.
+        # Stop at their token boundary rather than eating the literal as space.
+        while cursor < len(source) and cursor not in strings and lexed.without_comments[cursor].isspace():
+            cursor += 1
+        return cursor
+
+    for call in re.finditer(r"(?<![\w.:])gem\b", lexed.code):
+        cursor = skip_space(call.end())
+        if source[cursor:cursor + 1] == "(":
+            cursor = skip_space(cursor + 1)
+        token = strings.get(cursor)
+        if token is None or not literal(token) or token.contents != "telnyx":
+            continue
+        if not re.match(r"[ \t]*(?=[,;\n)]|(?:if|unless)\b|$)", lexed.without_comments[token.end:]):
+            continue  # The package name is an expression, not this literal.
+        cursor, constraints = token.end, []
+        while True:
+            comma = re.match(r"[ \t]*(?:\r?\n[ \t]*)?,", lexed.without_comments[cursor:])
+            if comma is None:
+                break
+            token = strings.get(skip_space(cursor + comma.end()))
+            if token is None or not literal(token):
+                break
+            if not re.match(r"[ \t]*(?=[,;\n)]|(?:if|unless)\b|$)", lexed.without_comments[token.end:]):
+                break
+            constraints.append(token.contents)
+            cursor = token.end
+        result.append(",".join(constraints))
+    return result
+
+
+def ruby_version_is_constrained(value: str) -> bool:
+    return bool(value and all(re.fullmatch(
+        r"(?:~>|>=|<=|!=|>|<|=)?\s*\d+(?:\.[0-9A-Za-z]+)*(?:-[0-9A-Za-z.-]+)?",
+        token.strip()) for token in value.split(",")))
+
+
+def go_dependencies(root: Path) -> list[str]:
+    source = read_text(root / "go.mod")
+    result, block = [], False
+    for line in source.splitlines():
+        line = line.split("//", 1)[0].strip()
+        if re.fullmatch(r"require\s*\(", line):
+            block = True
+            continue
+        if line == ")":
+            block = False
+            continue
+        if not block:
+            match = re.match(r"require\s+(.+)", line)
+            if not match:
+                continue
+            line = match[1]
+        dependency = re.fullmatch(
+            r'"?github\.com/team-telnyx/telnyx-go(?:/v[0-9]+)?"?\s+"?(v[^"\s]+)"?', line)
+        if dependency:
+            result.append(dependency[1])
+    return result
+
+
+def other_declared(root: Path) -> bool:
+    # Match the validator's existing root + two directory levels for these
+    # manifests. Version checking remains root-scoped, as before.
+    for directory, dirs, _ in os.walk(root):
+        path = Path(directory)
+        dirs[:] = [name for name in dirs if name not in {
+            ".git", "node_modules", "vendor", ".venv", "build"}
+            and len(path.relative_to(root).parts) < 2]
+        if python_dependencies(path) or node_dependencies(path) or ruby_dependencies(path):
+            return True
+    return bool(go_dependencies(root))
+
+
+def other_pinned(root: Path) -> bool:
+    return (any(python_version_is_constrained(value, poetry) for value, poetry in python_dependencies(root))
+            or any(name == "telnyx" and node_version_is_constrained(value)
+                   for name, value in node_dependencies(root))
+            or any(ruby_version_is_constrained(value) for value in ruby_dependencies(root))
+            or any(re.fullmatch(r"v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?", value)
+                   for value in go_dependencies(root)))
+
+
+def composer_constraints(root: Path, package: str = "telnyx/telnyx-php") -> list[str]:
+    """Read only real dependency links, shared by presence and version checks."""
     try:
         data = json.loads((root / "composer.json").read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return False
-    return isinstance(data, dict) and any(
-        isinstance(data.get(section), dict)
+        return []
+    if not isinstance(data, dict):
+        return []
+    return [
+        data[section][package].strip()
+        for section in ("require", "require-dev")
+        if isinstance(data.get(section), dict)
         and isinstance(data[section].get(package), str)
         and bool(data[section][package].strip())
-        for section in ("require", "require-dev")
-    )
+    ]
+
+
+def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    return bool(composer_constraints(root, package))
+
+
+def composer_version_is_constrained(value: object) -> bool:
+    """Recognize common Composer constraints, not resolve or solve them.
+
+    Exact releases, numeric ranges/wildcards, and explicit dev branches supply
+    version evidence. Bare wildcards and stability-only flags do not. Every OR
+    alternative must constrain a version; an AND may contain a neutral wildcard.
+    Unsupported syntax (including inline aliases) conservatively stays a warning.
+    A constraint is not a lockfile or a guarantee against breaking upgrades.
+    See https://getcomposer.org/doc/articles/versions.md and the schema's links.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return False
+    release = (r"v?[0-9]+(?:\.[0-9]+){0,3}"
+               r"(?:[._-]?(?:stable|alpha|a|beta|b|RC|patch|pl|p)"
+               r"(?:[.-]?[0-9]+(?:[.-][0-9]+)*)?)?(?:[.-]?dev)?"
+               r"(?:\+[A-Za-z0-9.-]+)?")
+    wildcard = r"v?[0-9]+(?:\.[0-9]+){0,2}(?:\.[x*]){1,3}"
+    stability = r"@(dev|stable|alpha|beta|RC)$"
+
+    def atom(token: str) -> bool | None:
+        if not token:
+            return None
+        token = re.sub(stability, "", token, flags=re.IGNORECASE)
+        if not token or re.fullmatch(r"[x*](?:\.[x*])*", token, re.IGNORECASE):
+            return False
+        if re.fullmatch(r"(?:dev-[A-Za-z0-9_][A-Za-z0-9_./-]*|"
+                        + wildcard + r"-dev)(?:#[A-Za-z0-9]+)?",
+                        token, re.IGNORECASE):
+            return True
+        if re.fullmatch(r"(?:\^|~|>=|<=|!=|<>|==|=|>|<)?" + release,
+                        token, re.IGNORECASE):
+            return True
+        if re.fullmatch(wildcard, token, re.IGNORECASE):
+            return True
+        return None
+
+    for alternative in re.split(r"\|\|?", value.strip()):
+        alternative = alternative.strip()
+        if re.fullmatch(release + r"\s+-\s+" + release,
+                        alternative, re.IGNORECASE):
+            continue
+        # Whitespace after an operator belongs to that atom, not to an AND.
+        alternative = re.sub(r"([~^<>=!]+)\s+", r"\1", alternative)
+        atoms = [atom(token) for token in re.split(r"\s*,\s*|\s+", alternative)]
+        if None in atoms or not any(atoms):
+            return False
+    return True
+
+
+def composer_pinned(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    return any(composer_version_is_constrained(value)
+               for value in composer_constraints(root, package))
 
 
 def maven_dependencies(path: Path) -> list[tuple[str, str, str]]:
@@ -125,10 +756,7 @@ def groovy_slashy_ranges(source: str, code: str) -> list[tuple[int, int]]:
 
 
 def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tuple[str, str, object]]:
-    spec = importlib.util.spec_from_file_location(
-        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
-    ownership = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(ownership)
+    ownership = source_ownership()
     analyzer = ownership.load_script("lint-required-messaging-profile")
     dependencies = []
     accessors = set()
@@ -241,7 +869,12 @@ def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tu
             version = entry.get("version")
             if isinstance(version, dict):
                 reference = version.get("ref")
-                version = versions.get(reference) if isinstance(reference, str) else None
+                if isinstance(reference, str):
+                    version = versions.get(reference)
+                if isinstance(version, dict):
+                    # Rich catalog versions are still attached to the consumed
+                    # library. Preferences alone are not a hard requirement.
+                    version = version.get("strictly", version.get("require"))
         else:
             continue
         dependencies.append((group, artifact, version))
@@ -272,12 +905,18 @@ def jvm_declared(root: Path, vendor: str) -> bool:
 
 
 def main() -> int:
-    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "jvm-pinned", "jvm-declared", "twilio-jvm-declared"}:
+    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "composer-pinned", "jvm-pinned", "jvm-declared", "twilio-jvm-declared", "other-declared", "other-pinned"}:
         return 2
     root = Path(sys.argv[2])
     mode = sys.argv[1]
-    if mode == "composer":
+    if mode == "other-declared":
+        found = other_declared(root)
+    elif mode == "other-pinned":
+        found = other_pinned(root)
+    elif mode == "composer":
         found = composer_declared(root)
+    elif mode == "composer-pinned":
+        found = composer_pinned(root)
     elif mode.endswith("declared"):
         found = jvm_declared(root, "twilio" if mode.startswith("twilio") else "telnyx")
     else:

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -14552,6 +14552,7 @@ def csharp_twilio_message_calls(
 def csharp_twilio_resource_calls(
     lexed: LexedSource, target: str, methods: tuple[str, ...],
     source: SourceEndpointResolver | None = None,
+    global_using_code: str = "",
 ) -> list[Call]:
     """Resolve the SDK resource's C# using/alias forms before checking its body.
 
@@ -14567,27 +14568,54 @@ def csharp_twilio_resource_calls(
         return max((span for span in namespaces if span[0] < offset < span[1]),
                    key=lambda span: span[0], default=None)
 
-    imports = []
-    for match in re.finditer(
+    using_pattern = re.compile(
         r"\b(?:global\s+)?using\s+(?:(?P<static>static)\s+)?"
         r"(?:(?P<alias>\w+)\s*=\s*)?(?:global\s*::\s*)?"
-        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;", code
-    ):
+        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;"
+    )
+    global_imports = [(match, re.sub(r"\s+", "", match.group("target")))
+                      for match in using_pattern.finditer(global_using_code)]
+    imports = []
+    for match in using_pattern.finditer(code):
         imports.append((match, re.sub(r"\s+", "", match.group("target")),
                         namespace_at(match.start())))
     candidates = calls_matching(lexed, re.compile(
         r"(?<![\w$.])(?:global\s*::\s*)?(?:\w+\s*\.\s*)*(?:"
         + "|".join(re.escape(method) for method in methods) + r")\s*\("
     ))
+    # Unqualified static imports lose to local methods/delegates. Keep method
+    # declarations out of call evidence and retain their enclosing scope.
+    local_methods = []
+    for candidate in candidates:
+        if not re.fullmatch(r"\w+", code[candidate.start:candidate.open_paren].strip()):
+            continue
+        closing = matching_delimiter(code, candidate.open_paren, "(", ")")
+        if closing is None:
+            continue
+        tail = code[closing + 1:]
+        prefix = code[max(0, candidate.start - 100):candidate.start]
+        if (re.match(r"\s*(?:\{|=>)", tail)
+                and re.search(r"\b[\w<>?\[\].]+\s+$", prefix)
+                and not re.search(r"\bnew\s+$", prefix)):
+            local_methods.append(candidate)
     result = []
     for call in candidates:
         head = re.sub(r"\s+", "", code[call.start:call.open_paren])
         receiver = head.rsplit(".", 1)[0] if "." in head else ""
+        if not receiver:
+            if re.search(r"\bnew\s+$", code[max(0, call.start - 100):call.start]):
+                continue
+            if any(code[item.start:item.open_paren].strip() == head
+                   and scope_contains(code, item.start, call.start)
+                   for item in local_methods):
+                continue
+            if source.graph.visible_binding(head, source.scope_at(call.start), call.start) is not None:
+                continue
         if receiver.startswith("global::"):
             if receiver.removeprefix("global::") == target:
                 result.append(call)
             continue
-        visible = [(match, name) for match, name, scope in imports
+        visible = global_imports + [(match, name) for match, name, scope in imports
                    if scope is None or scope[0] < call.start < scope[1]]
         aliases = {match.group("alias"): name for match, name in visible
                    if match.group("alias")}

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1520,33 +1520,6 @@ _HEREDOC_OPENER_RE = re.compile(
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
-_SHELL_HEREDOC_REDIRECTION_RE = re.compile(
-    r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
-    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"\\])*\"|"
-    r"(?:\\.|[^\\ \t\r\n;<>&|])+)",
-)
-
-
-def _shell_heredoc_redirection_tail(tail: str) -> bool:
-    """Accept only shell redirections after a heredoc delimiter.
-
-    A delimiter need not end the physical command: `cat <<EOF >out 2>&1` is
-    valid shell.  The lexer must mask that body, while still rejecting an
-    arbitrary expression containing `<< WORD`.  Consuming a sequence of
-    concrete redirections keeps that boundary explicit.
-    """
-
-    position = 0
-    while position < len(tail):
-        if tail[position:].strip() == "":
-            return True
-        if tail[position:].lstrip().startswith("#"):
-            return True
-        match = _SHELL_HEREDOC_REDIRECTION_RE.match(tail, position)
-        if match is None or match.end() == position:
-            return False
-        position = match.end()
-    return True
 
 
 def _heredoc_opener_at(
@@ -1561,15 +1534,19 @@ def _heredoc_opener_at(
     match = _HEREDOC_OPENER_RE.match(source, index)
     if match is None:
         return None
+    # In shell, three opening angle brackets introduce an inline here-string,
+    # not a multiline heredoc body. Treating `<<<WORD` as an opener can mask
+    # every request below it when no line contains the pseudo terminator.
+    if suffix == ".sh" and (
+        source.startswith("<<<", index)
+        or (index > 0 and source[index - 1] == "<")
+    ):
+        return None
     line_start = source.rfind("\n", 0, index) + 1
     line_end = source.find("\n", match.end())
     if line_end < 0:
         line_end = len(source)
-    tail = source[match.end():line_end]
-    if suffix == ".sh":
-        if not _shell_heredoc_redirection_tail(tail):
-            return None
-    elif tail.strip():
+    if suffix != ".sh" and source[match.end():line_end].strip():
         return None
     if suffix == ".rb":
         if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
@@ -1578,7 +1555,139 @@ def _heredoc_opener_at(
 
 
 def _heredoc_langs(suffix: str) -> bool:
-    return suffix in {".sh", ".php", ".rb"}
+    return suffix in {".php", ".rb"}
+
+
+def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
+    """Return shell heredoc body ranges in one command-aware linear pass.
+
+    The scan follows quotes, arithmetic contexts and backslash continuations,
+    collects every delimiter in one logical command, then consumes their
+    bodies in declaration order. It intentionally does not parse shell
+    expressions beyond the boundaries needed to distinguish heredocs from
+    arithmetic shifts and here-strings.
+    """
+
+    ranges: list[tuple[int, int]] = []
+    pending: list[tuple[str, bool]] = []
+    quote = ""
+    escaped = False
+    parenthesis_depth = 0
+    bracket_depth = 0
+    comment_start: int | None = None
+    command_start = 0
+    index = 0
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif quote == '"' and character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if parenthesis_depth:
+            if character == "(":
+                parenthesis_depth += 1
+            elif character == ")":
+                parenthesis_depth -= 1
+            index += 1
+            continue
+        if bracket_depth:
+            if character == "[":
+                bracket_depth += 1
+            elif character == "]":
+                bracket_depth -= 1
+            index += 1
+            continue
+        if source.startswith("$((", index):
+            parenthesis_depth = 2
+            index += 3
+            continue
+        if source.startswith("((", index):
+            parenthesis_depth = 2
+            index += 2
+            continue
+        if source.startswith("$[", index):
+            bracket_depth = 1
+            index += 2
+            continue
+        if character == "\\":
+            if index + 1 < len(source) and source[index + 1] == "\n":
+                index += 2
+            else:
+                index += 2
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            index += 1
+            continue
+        if character == "#" and (
+            index == command_start or source[index - 1].isspace()
+        ):
+            comment_start = index
+            newline = source.find("\n", index + 1)
+            index = len(source) if newline < 0 else newline
+            continue
+        if source.startswith("<<<", index):
+            index += 3
+            continue
+        opener = _HEREDOC_OPENER_RE.match(source, index)
+        if opener is not None and (
+            index == 0 or source[index - 1] != "<"
+        ):
+            pending.append((opener.group("tag"), "<<-" in opener.group(0)))
+            index = opener.end()
+            continue
+        if character != "\n":
+            index += 1
+            continue
+
+        command_end = index if comment_start is None else comment_start
+        command = source[command_start:command_end].rstrip()
+        comment_start = None
+        if command.endswith(("|", "&&")):
+            index += 1
+            continue
+        if not pending:
+            index += 1
+            command_start = index
+            continue
+
+        body_start = index + 1
+        for tag, strips_tabs in pending:
+            cursor = body_start
+            terminator_start: int | None = None
+            terminator_end: int | None = None
+            while cursor <= len(source):
+                line_end = source.find("\n", cursor)
+                line_end = len(source) if line_end < 0 else line_end
+                line = source[cursor:line_end].removesuffix("\r")
+                delimiter = line.lstrip("\t") if strips_tabs else line
+                if delimiter == tag:
+                    terminator_start = cursor
+                    terminator_end = line_end
+                    break
+                if line_end == len(source):
+                    break
+                cursor = line_end + 1
+            body_end = len(source) if terminator_start is None else terminator_start
+            if body_start < body_end:
+                ranges.append((body_start, body_end))
+            if terminator_end is None:
+                body_start = len(source)
+                break
+            body_start = (
+                len(source)
+                if terminator_end == len(source)
+                else terminator_end + 1
+            )
+        pending.clear()
+        index = body_start
+        command_start = index
+    return ranges
 
 
 _JS_REGEX_PREFIX_WORDS = {
@@ -1762,10 +1871,29 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     c_line_comments = suffix in JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
     c_block_comments = c_line_comments
     hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
+    shell_heredoc_ranges = _shell_heredoc_ranges(source) if suffix == ".sh" else []
+    shell_heredoc_index = 0
     index = 0
     last_js_opaque_end = 0
 
     while index < len(source):
+        while (
+            shell_heredoc_index < len(shell_heredoc_ranges)
+            and shell_heredoc_ranges[shell_heredoc_index][1] <= index
+        ):
+            shell_heredoc_index += 1
+        if shell_heredoc_index < len(shell_heredoc_ranges):
+            body_start, body_end = shell_heredoc_ranges[shell_heredoc_index]
+            if body_start <= index < body_end:
+                _blank(code, body_start, body_end)
+                strings.append(
+                    StringToken(
+                        body_start, body_end, source[body_start:body_end]
+                    )
+                )
+                index = body_end
+                shell_heredoc_index += 1
+                continue
         if (
             suffix in JS_TS_SUFFIXES
             and source[index] == "/"
@@ -1879,21 +2007,35 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         # and masked the send that followed.
         heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
         if heredoc is not None:
-            tag = heredoc.group("tag")
             body_start = source.find("\n", heredoc.end())
             if body_start < 0:
                 index = heredoc.end()
                 continue
             body_start += 1
-            terminator = re.compile(rf"^[ \t]*{re.escape(tag)}\b", re.M).search(
-                source, body_start
-            )
-            body_end = len(source) if terminator is None else terminator.start()
-            _blank(code, body_start, body_end)
-            strings.append(
-                StringToken(body_start, body_end, source[body_start:body_end])
-            )
-            index = body_end
+            openers = [heredoc]
+            for opener in openers:
+                tag = opener.group("tag")
+                terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
+                terminator = re.compile(terminator_pattern, re.M).search(
+                    source, body_start
+                )
+                body_end = (
+                    len(source) if terminator is None else terminator.start()
+                )
+                _blank(code, body_start, body_end)
+                strings.append(
+                    StringToken(
+                        body_start, body_end, source[body_start:body_end]
+                    )
+                )
+                if terminator is None:
+                    body_start = len(source)
+                    break
+                terminator_end = source.find("\n", terminator.end())
+                body_start = (
+                    len(source) if terminator_end < 0 else terminator_end + 1
+                )
+            index = body_start
             continue
 
         quote = source[index]
@@ -4220,22 +4362,41 @@ def request_object_is_executed(
     tail = lexed.code[call.end:]
     ruby_spans = _ruby_function_spans(lexed.code) if suffix == ".rb" else []
     for name in names:
-        execution = re.search(pattern.format(name=re.escape(name)), tail)
-        if execution is None:
-            continue
-        execution_offset = call.end + execution.start()
-        if suffix == ".rb" and not _same_ruby_function_scope(
-            lexed.code, call.start, execution_offset, ruby_spans
-        ):
-            continue
-        # A new reaching definition supersedes this request object. A later
-        # execution of the same variable must not retroactively execute the
-        # discarded constructor.
-        rebound = re.search(
-            rf"(?<![\w@$]){re.escape(name)}\s*=(?!=)", tail[:execution.start()]
+        execution_pattern = pattern.format(name=re.escape(name))
+        # Ruby member assignments such as `self.req = ...` do not rebind the
+        # local `req`. Include member/namespace separators in the boundary so
+        # a suffix match cannot discard the local request object.
+        binding_boundary = (
+            r"(?<![\w@$.])(?<!::)" if suffix == ".rb" else r"(?<![\w@$])"
         )
-        if rebound is None:
-            return True
+        rebound_pattern = re.compile(
+            rf"{binding_boundary}{re.escape(name)}\s*=(?!=)"
+        )
+        for execution in re.finditer(execution_pattern, tail):
+            execution_offset = call.end + execution.start()
+            # Ruby locals belong to one method/top-level scope. Instance,
+            # class and global variables retain their identity across methods.
+            local_ruby_binding = suffix == ".rb" and not name.startswith(
+                ("@", "$")
+            )
+            if local_ruby_binding and not _same_ruby_function_scope(
+                lexed.code, call.start, execution_offset, ruby_spans
+            ):
+                continue
+            # A new reaching definition supersedes this request object. Check
+            # every exact-binding assignment before THIS execution; for Ruby
+            # locals, assignments in unrelated methods do not rebind it.
+            rebound = False
+            for candidate in rebound_pattern.finditer(tail, 0, execution.start()):
+                candidate_offset = call.end + candidate.start()
+                if local_ruby_binding and not _same_ruby_function_scope(
+                    lexed.code, call.start, candidate_offset, ruby_spans
+                ):
+                    continue
+                rebound = True
+                break
+            if not rebound:
+                return True
     return False
 
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -2644,8 +2644,14 @@ def finding_row(path: Path, line: int, detail: str) -> str:
     # The analyzer-to-shell protocol is LF-delimited. POSIX permits CR and LF
     # in filenames, so emitting a raw path can turn one finding into several
     # records and inflate both counts and details.files. Escape only the record
-    # delimiters; keep the rest of the path byte-for-byte displayable.
-    display_path = str(path).replace("\r", "\\r").replace("\n", "\\n")
+    # delimiters. Escape backslashes first so a literal `\n` path segment and
+    # an actual newline cannot collapse to the same display identity.
+    display_path = (
+        str(path)
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
     return f"{display_path}:{line}:{detail}"
 
 
@@ -11365,12 +11371,53 @@ def external_static_values(
     return resolved
 
 
-def external_reference_names(source: str, suffix: str) -> set[str]:
+def _matches_js_alias_key(module: str, key: str) -> bool:
+    pattern = re.escape(key).replace(r"\*", ".*")
+    return re.fullmatch(pattern, module) is not None
+
+
+def _js_module_has_local_provenance(module: str, project_root: Path) -> bool:
+    """Return whether a JS module spelling denotes project-controlled code."""
+
+    if module.startswith((".", "@/", "~/", "#")):
+        return True
+    for filename in ("tsconfig.json", "jsconfig.json"):
+        try:
+            config = json.loads((project_root / filename).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(config, dict):
+            continue
+        compiler_options = config.get("compilerOptions", {})
+        if not isinstance(compiler_options, dict):
+            continue
+        paths = compiler_options.get("paths", {})
+        if isinstance(paths, dict) and any(
+            isinstance(key, str) and _matches_js_alias_key(module, key)
+            for key in paths
+        ):
+            return True
+    try:
+        package = json.loads((project_root / "package.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        package = {}
+    imports = package.get("imports", {}) if isinstance(package, dict) else {}
+    return isinstance(imports, dict) and any(
+        isinstance(key, str) and _matches_js_alias_key(module, key)
+        for key in imports
+    )
+
+
+def external_reference_names(
+    source: str, suffix: str, project_root: Path
+) -> set[str]:
     """Return local names whose values originate outside the current file.
 
-    Exact static exports are resolved separately. This index covers the wider
-    language-level import boundary so an unresolved mutating request fails
-    closed instead of silently passing. Sentinels are intentionally narrow:
+    Exact relative static exports are resolved separately. This index covers
+    the wider language-level import boundary—including configured aliases
+    such as ``@/``, ``~/``, tsconfig paths, and package
+    ``imports``—so an unresolved mutating request fails closed instead of
+    silently passing. Sentinels are intentionally narrow:
     uppercase constants after require/include, qualified package/class members,
     and shell variables only when a source command is present.
     """
@@ -11383,16 +11430,23 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
             for match in re.finditer(
                 r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
                 r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
-                r"from\s*(['\"])\.[^'\"]*\2",
+                r"from\s*(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         for match in re.finditer(
             r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
             r"\{(?P<members>[^{}]*)\}\s*from\s*"
-            r"(['\"])\.[^'\"]*\2",
+            r"(['\"])(?P<module>[^'\"]+)\2",
             visible,
         ):
+            if not _js_module_has_local_provenance(
+                match.group("module"), project_root
+            ):
+                continue
             for member in match.group("members").split(","):
                 parsed = re.fullmatch(
                     r"\s*([A-Za-z_$]\w*)(?:\s+as\s+([A-Za-z_$]\w*))?\s*",
@@ -11405,23 +11459,33 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
             for match in re.finditer(
                 r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
                 r"\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
-                r"(['\"])\.[^'\"]*\2",
+                r"(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         names.update(
             match.group(1)
             for match in re.finditer(
                 r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
-                r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+                r"require\s*\(\s*(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         for match in re.finditer(
             r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
-            r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+            r"require\s*\(\s*(['\"])(?P<module>[^'\"]+)\2",
             visible,
         ):
+            if not _js_module_has_local_provenance(
+                match.group("module"), project_root
+            ):
+                continue
             for member in match.group("members").split(","):
                 parsed = re.fullmatch(
                     r"\s*([A-Za-z_$]\w*)(?:\s*:\s*([A-Za-z_$]\w*))?\s*",
@@ -11499,7 +11563,7 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
         lexed,
         suffix,
         external_static_values(path, project_root, source, suffix),
-        external_reference_names(source, suffix),
+        external_reference_names(source, suffix, project_root),
     )
     profile_resolver = PayloadStateResolver(
         lexed,

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1,0 +1,10277 @@
+#!/usr/bin/env python3
+"""Find required-profile messaging calls whose own payload omits the profile.
+
+This is intentionally a small lexer, not a language parser. It preserves byte
+offsets while masking comments and string literals, which is enough to match
+call/assignment boundaries without confusing URLs, comment markers, or
+semicolons inside strings for source syntax. Payload variables are resolved to
+their nearest real assignment in the same file.
+"""
+
+from __future__ import annotations
+
+import bisect
+import json
+import os
+import posixpath
+import re
+import shlex
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, TypeAlias
+from urllib.parse import urljoin, urlsplit
+
+
+# Node module-system extensions (.cjs/.mjs) and the TypeScript equivalents
+# (.cts/.mts) are the same language as .js/.ts. SKILL.md documents a CommonJS
+# flow, and scan-twilio-deep.py already treats them as JavaScript, so omitting
+# them here made the two tools disagree about what counts as source.
+JS_TS_SUFFIXES = {
+    ".cjs",
+    ".cts",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".mts",
+    ".ts",
+    ".tsx",
+}
+TYPESCRIPT_SUFFIXES = {".ts", ".tsx", ".mts", ".cts"}
+# Keys a request-style config object may carry its URL under. Shared so the
+# named-argument path and the config-object path cannot recognise different
+# spellings, which is how `uri` came to work as a named argument but not as
+# an object member.
+URL_MEMBER_NAMES = ("url", "uri", "requestUri", "request_uri")
+# Extensions that are aliases of a language this linter already analyses, not
+# new languages. A `.bash` file is a shell script and a `.phtml` file is PHP,
+# but every downstream check compares against the canonical suffix, so an
+# alias was read as an unknown language and silently produced no findings.
+# Normalising in one place beats widening each comparison: there are dozens.
+SUFFIX_LANGUAGE_ALIASES = {
+    ".bash": ".sh",
+    ".ksh": ".sh",
+    ".zsh": ".sh",
+    ".phtml": ".php",
+    ".pyw": ".py",
+    ".rake": ".rb",
+    ".cshtml": ".cs",
+    ".scala": ".java",
+    # Kotlin shares Java's grammar for everything this linter models - the
+    # OkHttp/java.net.http builder chains, the braced control-flow arms, the
+    # execution links. Three branches already name `.kt`/`.kts` explicitly, but
+    # the discovery layer never yielded such a file, so a Kotlin migration was
+    # scanned as zero files and passed silently no matter what it contained.
+    ".kt": ".java",
+    ".kts": ".java",
+    # Single-file components and server templates embed the SAME JS/Ruby a
+    # sibling .js/.rb file would hold, but the allow-list excluded the whole
+    # file type, so a number-pool send inside a Vue/Svelte/Astro component or
+    # an ERB view was never opened at all. The lexer already stops a single
+    # quote at end of line for JS, so surrounding markup prose does not mask
+    # the script blocks.
+    ".vue": ".js",
+    ".svelte": ".js",
+    ".astro": ".js",
+    ".erb": ".rb",
+}
+INCLUDED_SUFFIXES = {
+    ".cs",
+    ".go",
+    ".java",
+    ".php",
+    ".py",
+    ".rb",
+    ".sh",
+} | JS_TS_SUFFIXES | set(SUFFIX_LANGUAGE_ALIASES)
+
+
+# package.json "bin" entry points and repo CLIs are extensionless; the
+# shebang is their file identity. The Phase-1 scanner greps without include
+# filters and reports them, so refusing to open them here let the pipeline
+# contradict itself on the same tree.
+SHEBANG_LANGUAGE_SUFFIXES = (
+    ("node", ".js"),
+    ("python", ".py"),
+    ("ruby", ".rb"),
+    ("bash", ".sh"),
+    ("zsh", ".sh"),
+    ("ksh", ".sh"),
+    ("sh", ".sh"),
+)
+
+
+def shebang_suffix(path: Path) -> str | None:
+    """Return the canonical suffix an extensionless executable maps to."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            first_line = handle.readline(200)
+    except OSError:
+        return None
+    if not first_line.startswith("#!"):
+        return None
+    for token, suffix in SHEBANG_LANGUAGE_SUFFIXES:
+        if token in first_line:
+            return suffix
+    return None
+
+
+def canonical_suffix(path: Path) -> str:
+    """Return the language suffix a file should be analysed as."""
+    suffix = path.suffix.lower()
+    if not suffix:
+        return shebang_suffix(path) or ""
+    return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
+# Kept in step with the EXCLUDE_DIRS list in scan-twilio-usage.sh. Generated
+# output belongs here as much as node_modules: a stale compiled bundle under
+# .next carrying a pre-fix number-pool send would fail Phase 4 after the
+# source had already been corrected, and the scanner that produced the plan
+# never looked at it.
+EXCLUDED_DIRS = {
+    ".git",
+    ".next",
+    ".nuxt",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "vendor",
+    "venv",
+}
+EXCLUDED_FILES = {
+    "Gemfile.lock",
+    "Pipfile.lock",
+    "migration-state.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "twilio-deep-scan.json",
+    "twilio-scan.json",
+    "yarn.lock",
+}
+
+PROFILE_NAMES = (
+    "messaging_profile_id",
+    "messagingProfileId",
+    "messagingProfileID",
+    "MessagingProfileId",
+    "MessagingProfileID",
+)
+PROFILE_NAME_PATTERN = "|".join(map(re.escape, PROFILE_NAMES))
+PROFILE_IDENTIFIER_RE = re.compile(
+    rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
+)
+PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
+SDK_CALL_RE = re.compile(
+    r"(?:\?\.|\.|->)\s*(?:"
+    r"sendNumberPool|send_number_pool|SendNumberPool|"
+    r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
+    r"SendWithAlphanumericSender"
+    r")\s*(?:\?\.)?\s*\("
+)
+FETCH_CALL_RE = re.compile(
+    r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
+    # curl_init($url) is the documented one-liner that sets CURLOPT_URL
+    # directly. Listing only the setopt spellings made that whole shape
+    # invisible: no endpoint resolved, so the send was never counted and the
+    # fail-safe could not fire - the linter reported "no number-pool call sites
+    # detected" on a number-pool POST.
+    # Net::HTTP::Post.new(uri) is the ONLY Net::HTTP form that can set request
+    # headers (an Authorization header, for instance), so it is what real
+    # migrated Ruby uses. Modelling only Net::HTTP.post made the whole shape
+    # invisible: zero sends detected, so the fail-safe could not fire either.
+    r"Net::HTTP::(?:Post|Put|Patch)\s*\.\s*new|"
+    r"NewRequest|curl_setopt_array|curl_setopt|curl_init|"
+    r"HttpRequestMessage|RestRequest|Request|open|file_get_contents|"
+    r"axios\s*\.\s*post|axios)\s*\("
+)
+TWILIO_MESSAGE_CREATE_RE = re.compile(
+    r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
+    r"create\s*(?:\?\.)?\s*\("
+)
+MESSAGE_BODY_CALL_RE = re.compile(
+    r"(?:"
+    r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
+    r"(?:create|send|send_)\s*(?:\?\.)?\s*\("
+    r"|(?:\?\.|\.|->)\s*Messages\s*(?:\?\.|\.|->)\s*"
+    r"Send\s*\("
+    r"|(?:\?\.|\.|->)\s*messages\s*\(\s*\)\s*"
+    r"(?:\?\.|\.|->)\s*send\s*\("
+    r")"
+)
+SIMPLE_VARIABLE_RE = re.compile(r"(?:\.\.\.|\*\*|[&*])?\s*(\$?[A-Za-z_]\w*)\s*$")
+STRINGIFIED_VARIABLE_RE = re.compile(
+    r"(?:JSON\s*\.\s*stringify|json\s*\.\s*dumps|json\s*\.\s*Marshal|"
+    r"json_encode|JsonSerializer\s*\.\s*Serialize|"
+    r"JsonConvert\s*\.\s*SerializeObject)\s*\(\s*"
+    r"(\$?[A-Za-z_]\w*)\s*\)"
+)
+NAMED_PAYLOAD_VARIABLE_RE = re.compile(
+    r"(?:\bbody|\bdata|\bjson|\bpayload)\s*[:=]\s*(\$?[A-Za-z_]\w*)"
+)
+SOURCE_IDENTIFIER_RE = re.compile(r"(?<![\w$.])(\$?[A-Za-z_]\w*)(?!\w)")
+SPREAD_VARIABLE_RE = re.compile(r"\.\.\.\s*(\$?[A-Za-z_]\w*)")
+# Matched against RAW source offsets, so it has to tolerate the leading
+# whitespace a member span keeps after `{ a, ...base }` is split.
+SPREAD_MEMBER_RE = re.compile(r"\s*(?:\.\.\.|\*\*)\s*")
+VARIABLE_ASSIGNMENT_RE = re.compile(
+    r"(?<![\w$.>])(\$?[A-Za-z_]\w*)(?!\w)"
+    r"(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+)
+SHELL_VARIABLE_RE = re.compile(r"^\$(?:\{([A-Za-z_]\w*)\}|([A-Za-z_]\w*))$")
+SHELL_STATIC_REFERENCE_RE = re.compile(
+    r"\$(?:\{([A-Za-z_]\w*)(?:\[([^\]]+)\])?\}|([A-Za-z_]\w*))"
+)
+SHELL_CURL_RE = re.compile(r"(?<![\w-])(curl)(?=\s|$)")
+SHELL_DATA_OPTIONS = {
+    "-d",
+    "--data",
+    "--data-ascii",
+    "--data-binary",
+    "--data-raw",
+    "--data-urlencode",
+    "--json",
+}
+SHELL_FORM_OPTIONS = {"-F", "--form", "--form-string"}
+SHELL_UPLOAD_OPTIONS = {"-T", "--upload-file"}
+SHELL_CURL_URL_OPTIONS = {"--url"}
+SHELL_CURL_SHORT_VALUE_OPTIONS = set("AbcCdDeEFHKmoPqrtTuUwXxyzY")
+SHELL_CURL_VALUE_OPTIONS = (
+    SHELL_DATA_OPTIONS
+    | SHELL_FORM_OPTIONS
+    | SHELL_UPLOAD_OPTIONS
+    | SHELL_CURL_URL_OPTIONS
+    | {
+        "-A",
+        "--cacert",
+        "--cert",
+        "--connect-timeout",
+        "-H",
+        "--header",
+        "--key",
+        "--max-time",
+        "-o",
+        "--output",
+        "--proxy",
+        "--resolve",
+        "--retry",
+        "--retry-delay",
+        "-u",
+        "--user",
+        "-w",
+        "--write-out",
+        "-X",
+        "--request",
+    }
+)
+SHELL_ASSIGNMENT_TOKEN_RE = re.compile(r"[A-Za-z_]\w*=.*")
+MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH"})
+
+
+@dataclass(frozen=True)
+class StringToken:
+    start: int
+    end: int
+    contents: str
+
+
+@dataclass(frozen=True)
+class LexedSource:
+    original: str
+    code: str
+    without_comments: str
+    strings: tuple[StringToken, ...]
+
+
+@dataclass(frozen=True)
+class Call:
+    start: int
+    open_paren: int
+    end: int
+    parenthesized: bool = True
+
+
+EndpointReference = tuple[str, ...]
+
+
+REQUIRED = "required"
+SAFE = "safe"
+UNKNOWN = "unknown"
+MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class EndpointValue:
+    kind: str
+    exact: str | None = None
+
+
+UNKNOWN_VALUE = EndpointValue(UNKNOWN)
+MISSING_VALUE = EndpointValue(MISSING)
+
+
+@dataclass(frozen=True)
+class EndpointLiteral:
+    value: str
+
+
+@dataclass(frozen=True)
+class EndpointUnknown:
+    reason: str = "unsupported"
+
+
+@dataclass(frozen=True)
+class EndpointRef:
+    binding_id: int
+    members: EndpointReference = ()
+
+
+@dataclass(frozen=True)
+class EndpointObject:
+    entries: tuple[tuple[str, "EndpointExpression"], ...]
+
+
+@dataclass(frozen=True)
+class EndpointArray:
+    items: tuple["EndpointExpression", ...]
+
+
+@dataclass(frozen=True)
+class EndpointDefault:
+    primary: "EndpointExpression"
+    fallback: "EndpointExpression"
+
+
+@dataclass(frozen=True)
+class EndpointConcat:
+    parts: tuple["EndpointExpression", ...]
+
+
+@dataclass(frozen=True)
+class EndpointProjected:
+    expression: "EndpointExpression"
+    members: EndpointReference
+
+
+EndpointExpression: TypeAlias = (
+    EndpointLiteral
+    | EndpointUnknown
+    | EndpointRef
+    | EndpointObject
+    | EndpointArray
+    | EndpointDefault
+    | EndpointConcat
+    | EndpointProjected
+)
+
+
+@dataclass(frozen=True)
+class IndexedScope:
+    id: int
+    parent: int | None
+    start: int
+    end: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class IndexedBinding:
+    id: int
+    name: str
+    scope_id: int
+    declaration_start: int
+    visibility_start: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class IndexedDefinition:
+    binding_id: int
+    member_path: EndpointReference
+    start: int
+    expression: EndpointExpression
+    scope_id: int
+    execution_scope: int
+    kind: str
+    guarded: bool = False
+
+
+@dataclass(frozen=True)
+class EndpointAccessState:
+    binding_id: int
+    path: EndpointReference
+    before: int
+    use_scope: int
+
+
+@dataclass(frozen=True)
+class EndpointExpressionState:
+    expression: EndpointExpression
+    projection: EndpointReference
+    before: int
+    use_scope: int
+
+
+EndpointState: TypeAlias = EndpointAccessState | EndpointExpressionState
+
+
+@dataclass
+class EndpointExpansion:
+    dependencies: tuple[EndpointState, ...] = ()
+    combine: Callable[[tuple[EndpointValue, ...]], EndpointValue] | None = None
+    immediate: EndpointValue | None = None
+
+
+@dataclass
+class EndpointFrame:
+    state: EndpointState
+    expansion: EndpointExpansion | None = None
+    next_dependency: int = 0
+    values: list[EndpointValue] = field(default_factory=list)
+
+
+def _blank(buffer: list[str], start: int, end: int) -> None:
+    for index in range(start, end):
+        if buffer[index] != "\n":
+            buffer[index] = " "
+
+
+# Heredoc openers: shell/ruby `<<TAG`, `<<-TAG`, `<<~TAG`, `<<'TAG'`; PHP
+# `<<<TAG` / `<<<'TAG'`. The body is data and must be masked like a string.
+# NO whitespace is permitted between `<<`/`<<<` and the tag in any of these
+# languages. Allowing it made Ruby's append operator (`audit_log << recipient`),
+# PHP's left shift (`1 << OFFSET`) and shell arithmetic (`$((1 << SHIFT))`) parse
+# as heredoc openers, and since no later line matched the pseudo-tag the "body"
+# ran to EOF and blanked every send below it - a silent pass.
+_HEREDOC_OPENER_RE = re.compile(
+    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)[ \t]*(?=\r?\n|$)"
+)
+# Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
+# singleton-class syntax `class <<self` also puts a bare word straight after
+# `<<` at end of line, so it parsed as a heredoc opening a body that never
+# closed - blanking the rest of the file and silently passing every send below
+# it. That is the same defect the end-of-line anchor was added to fix, one
+# spelling sideways, so the opener needs its LEFT context checked too.
+_NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+
+
+def _heredoc_opener_at(
+    source: str, index: int, suffix: str
+) -> "re.Match[str] | None":
+    """Match a heredoc opener at `index`, rejecting Ruby's `class <<self`.
+
+    Scoped to Ruby: `class` is not a keyword before `<<` in shell or PHP, so
+    applying the rejection there would disable heredoc masking on any opener
+    line that merely ENDS with the word `class` (`echo class <<EOT`).
+    """
+    match = _HEREDOC_OPENER_RE.match(source, index)
+    if match is None:
+        return None
+    if suffix == ".rb":
+        line_start = source.rfind("\n", 0, index) + 1
+        if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
+            return None
+    return match
+
+
+def _heredoc_langs(suffix: str) -> bool:
+    return suffix in {".sh", ".php", ".rb"}
+
+
+def lex_source(source: str, suffix: str) -> LexedSource:
+    """Mask comments and strings while preserving offsets and newlines."""
+
+    code = list(source)
+    without_comments = list(source)
+    strings: list[StringToken] = []
+    c_line_comments = suffix in JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
+    c_block_comments = c_line_comments
+    hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
+    index = 0
+
+    while index < len(source):
+        if c_block_comments and source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            end = len(source) if end < 0 else end + 2
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        if c_line_comments and source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            end = len(source) if end < 0 else end
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        if hash_comments and source[index] == "#":
+            if suffix == ".sh" and index == 0 and source.startswith("#!", index):
+                end = source.find("\n", index + 2)
+                index = len(source) if end < 0 else end
+                continue
+            end = source.find("\n", index + 1)
+            end = len(source) if end < 0 else end
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        # Ruby block comments. Without this, `=begin ... =end` prose was lexed
+        # as code, so one apostrophe in it opened a string that swallowed the
+        # sends below (the fail-safe above cannot help when the stray quote
+        # finds a LATER quote to pair with).
+        if (
+            suffix == ".rb"
+            and source.startswith("=begin", index)
+            and (index == 0 or source[index - 1] == "\n")
+        ):
+            terminator = re.search(r"^=end\b.*$", source[index:], re.M)
+            end = (
+                len(source)
+                if terminator is None
+                else index + terminator.end()
+            )
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        # Heredoc bodies are DATA, not code. They were lexed as code, so an
+        # apostrophe inside one ("Don't edit by hand") paired with a later quote
+        # and masked the send that followed.
+        heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
+        if heredoc is not None:
+            tag = heredoc.group("tag")
+            body_start = source.find("\n", heredoc.end())
+            if body_start < 0:
+                index = heredoc.end()
+                continue
+            body_start += 1
+            terminator = re.compile(rf"^[ \t]*{re.escape(tag)}\b", re.M).search(
+                source, body_start
+            )
+            body_end = len(source) if terminator is None else terminator.start()
+            _blank(code, body_start, body_end)
+            strings.append(
+                StringToken(body_start, body_end, source[body_start:body_end])
+            )
+            index = body_end
+            continue
+
+        quote = source[index]
+        if quote not in {"'", '"', "`"}:
+            index += 1
+            continue
+
+        delimiter = quote
+        if quote in {"'", '"'} and source.startswith(quote * 3, index):
+            delimiter = quote * 3
+        string_start = index
+        index += len(delimiter)
+        contents_start = index
+        # A backtick delimits a Go RAW string, which has no escape sequences, so
+        # a literal `\` inside one previously consumed the closing backtick and
+        # ran the "string" to end of file.
+        honours_escapes = not (suffix == ".go" and delimiter == "`")
+        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
+            JS_TS_SUFFIXES | {".py"}
+        )
+        terminated = False
+        while index < len(source):
+            if source.startswith(delimiter, index):
+                contents_end = index
+                index += len(delimiter)
+                terminated = True
+                break
+            if honours_escapes and source[index] == "\\":
+                index = min(len(source), index + 2)
+                continue
+            if source[index] == "\n" and line_bounded:
+                # A single/double-quoted JS/TS or Python literal cannot contain a
+                # raw newline, so hitting one means the quote never opened a
+                # string at all (an apostrophe in JSX text, prose, or a comment).
+                # Stop here rather than pairing it with some LATER quote, which
+                # masked every send in between.
+                break
+            index += 1
+        else:
+            contents_end = len(source)
+
+        if not terminated:
+            # FAIL SAFE. An unterminated quote used to blank everything to EOF,
+            # so a single apostrophe in JSX text, a heredoc body, or a Ruby
+            # =begin comment deleted every send below it and the file was
+            # reported clean. Treat the lone quote as ordinary code and resume
+            # immediately after it: the damage is one character, not the file.
+            index = string_start + 1
+            continue
+
+        _blank(code, string_start, index)
+        strings.append(
+            StringToken(string_start, index, source[contents_start:contents_end])
+        )
+
+    return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
+
+
+def matching_delimiter(code: str, opening: int, left: str, right: str) -> int | None:
+    depth = 0
+    for index in range(opening, len(code)):
+        character = code[index]
+        if character == left:
+            depth += 1
+        elif character == right:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def calls_matching(lexed: LexedSource, pattern: re.Pattern[str]) -> list[Call]:
+    calls: list[Call] = []
+    for match in pattern.finditer(lexed.code):
+        opening = lexed.code.rfind("(", match.start(), match.end())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None:
+            closing = lexed.code.find("\n", opening)
+            closing = len(lexed.code) - 1 if closing < 0 else closing
+        calls.append(Call(match.start(), opening, closing + 1))
+    return calls
+
+
+def serialized_payload_string(
+    lexed: LexedSource, token: StringToken, region_start: int
+) -> bool:
+    prefix_start = max(region_start, token.start - 120)
+    code_prefix = lexed.code[prefix_start : token.start]
+    source_prefix = lexed.without_comments[prefix_start : token.start]
+    return bool(
+        re.search(r"(?:\bbody|\bdata)\s*[:=]\s*$", code_prefix)
+        or re.search(
+            r"(?:^|\s)(?:-d|--data(?:-raw|-binary)?)\s*$", source_prefix
+        )
+    )
+
+
+def structural_depth(code: str, start: int, offset: int) -> tuple[int, int, int]:
+    round_depth = square_depth = curly_depth = 0
+    for character in code[start:offset]:
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+    return round_depth, square_depth, curly_depth
+
+
+def curly_ancestry(code: str, offset: int) -> tuple[int, ...]:
+    """Return the unmatched opening-brace positions containing offset."""
+
+    ancestry: list[int] = []
+    for index, character in enumerate(code[:offset]):
+        if character == "{":
+            ancestry.append(index)
+        elif character == "}" and ancestry:
+            ancestry.pop()
+    return tuple(ancestry)
+
+
+def scope_contains(code: str, binding: int, use: int) -> bool:
+    """Return true when binding's lexical brace path contains use."""
+
+    binding_scope = curly_ancestry(code, binding)
+    use_scope = curly_ancestry(code, use)
+    return use_scope[: len(binding_scope)] == binding_scope
+
+
+def payload_root_depth(code: str, start: int, end: int) -> tuple[int, int, int]:
+    """Return the direct-member depth for an object payload or argument list."""
+
+    round_depth = square_depth = curly_depth = 0
+    named_value = False
+    for character in code[start:end]:
+        at_argument_root = round_depth == square_depth == curly_depth == 0
+        if at_argument_root and character == ",":
+            return 0, 0, 0
+        if at_argument_root and character in {":", "="}:
+            named_value = True
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+            if not named_value:
+                return round_depth, square_depth, curly_depth
+            return 0, 0, 0
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+            if not named_value:
+                return round_depth, square_depth, curly_depth
+            return 0, 0, 0
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+    return 0, 0, 0
+
+
+def at_payload_root(
+    code: str,
+    start: int,
+    end: int,
+    offset: int,
+) -> bool:
+    return structural_depth(code, start, offset) == payload_root_depth(code, start, end)
+
+
+def serialized_json_has_profile(value: str) -> bool:
+    candidates = [value]
+    try:
+        decoded_literal = json.loads(f'"{value}"')
+    except (TypeError, ValueError):
+        pass
+    else:
+        if decoded_literal != value:
+            candidates.append(decoded_literal)
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict) and any(
+            _is_usable_profile_value(payload.get(name))
+            for name in PROFILE_NAMES
+            if name in payload
+        ):
+            return True
+    return False
+
+
+def _is_usable_profile_value(value: Any) -> bool:
+    """Return whether a decoded JSON profile value is usable.
+
+    `value not in {None, ""}` raised TypeError on a dict or list value, and
+    nothing between here and main() caught it, so ONE payload carrying
+    `"messaging_profile_id": {...}` aborted the entire scan - every other file
+    in the project went unanalysed and the run reported nothing at all.
+    A non-scalar is also not a usable profile id, so it is simply False.
+    """
+    return isinstance(value, (str, int)) and not isinstance(value, bool) and str(value).strip() != ""
+
+
+def token_is_entire_expression(
+    lexed: LexedSource, token: StringToken, start: int, end: int
+) -> bool:
+    """Return true when a string token is the assignment value, not nested data."""
+
+    return not (
+        lexed.code[start:token.start].strip()
+        or lexed.code[token.end:end].strip()
+    )
+
+
+def region_has_profile(
+    lexed: LexedSource,
+    start: int,
+    end: int,
+    *,
+    serialized_assignment: bool = False,
+    allow_js_shorthand: bool = False,
+) -> bool:
+    code_region = lexed.code[start:end]
+    if PROFILE_CLI_RE.search(code_region):
+        return True
+    for match in PROFILE_IDENTIFIER_RE.finditer(lexed.code, start, end):
+        if not at_payload_root(lexed.code, start, end, match.start()):
+            continue
+        after = lexed.code[match.end():end]
+        if re.match(r"\s*(?::|=(?!=)|\()", after):
+            return True
+        if allow_js_shorthand and re.match(r"\s*(?=[,}])", after):
+            return True
+
+    for token in lexed.strings:
+        if token.start < start or token.end > end:
+            continue
+        after = lexed.without_comments[token.end:end]
+        if (
+            token.contents in PROFILE_NAMES
+            and at_payload_root(lexed.code, start, end, token.start)
+            and re.match(r"\s*(?::|=>|=(?!=))", after)
+        ):
+            return True
+        serialized_value = serialized_payload_string(lexed, token, start) or (
+            serialized_assignment
+            and token_is_entire_expression(lexed, token, start, end)
+        )
+        if serialized_value and serialized_json_has_profile(token.contents):
+            return True
+    return False
+
+
+def split_arguments(code: str, start: int, end: int) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    segment_start = start
+    round_depth = square_depth = curly_depth = 0
+    for index in range(start, end):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == "," and not (round_depth or square_depth or curly_depth):
+            spans.append((segment_start, index))
+            segment_start = index + 1
+    spans.append((segment_start, end))
+    return spans
+
+
+def entry_value_end(code: str, start: int, limit: int) -> int:
+    """End of one `key => value` entry inside an enclosing literal.
+
+    The entry stops at its own top-level `,`/`;` or at the first closer that
+    belongs to the CONTAINER rather than to the value, so a nested literal
+    value is kept whole while a trailing `]]);` is not swallowed.
+    """
+    depth = 0
+    for index in range(start, limit):
+        character = code[index]
+        if character in "([{":
+            depth += 1
+        elif character in ")]}":
+            if depth == 0:
+                return index
+            depth -= 1
+        elif depth == 0 and character in ",;":
+            return index
+    return limit
+
+
+def named_payload_spans(
+    code: str,
+    spans: list[tuple[int, int]],
+    *,
+    allow_js_shorthand: bool = False,
+) -> list[tuple[int, int]]:
+    """Return only body/data/json/payload values from argument/object spans."""
+
+    payloads: list[tuple[int, int]] = []
+    name_pattern = re.compile(r"\s*(?:body|data|json|payload)\s*[:=](?!=)")
+    shorthand_pattern = re.compile(r"\s*(?:body|data|json|payload)\s*$")
+    for start, end in spans:
+        match = name_pattern.match(code, start, end)
+        if match is not None:
+            payloads.append((match.end(), end))
+            continue
+        if allow_js_shorthand and shorthand_pattern.fullmatch(code, start, end):
+            payloads.append((start, end))
+            continue
+        opening = code.find("{", start, end)
+        if opening < 0:
+            continue
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is None or closing >= end:
+            continue
+        for member_start, member_end in split_arguments(code, opening + 1, closing):
+            member_match = name_pattern.match(code, member_start, member_end)
+            if member_match is not None:
+                payloads.append((member_match.end(), member_end))
+            elif allow_js_shorthand and shorthand_pattern.fullmatch(
+                code, member_start, member_end
+            ):
+                payloads.append((member_start, member_end))
+    return payloads
+
+
+def assigned_payload_member_span(
+    lexed: LexedSource,
+    variable: str,
+    after: int,
+    before: int,
+    suffix: str,
+) -> list[tuple[int, int]]:
+    """Return the latest body-like property assigned to an options variable."""
+
+    escaped = re.escape(variable)
+    pattern = re.compile(
+        rf"(?<![\w$.>]){escaped}(?!\w)\s*(?:\.|->)\s*"
+        r"(?:body|data|json|payload)\s*(?::=|=(?!=|>))"
+    )
+    matches = list(pattern.finditer(lexed.code, after, before))
+    if not matches:
+        return []
+    latest = matches[-1]
+    return [(latest.end(), assignment_end(lexed, latest.end(), suffix))]
+
+
+def assigned_named_payload_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> list[tuple[int, int]]:
+    """Resolve an options variable and return only its request-body member."""
+
+    candidate = lexed.code[span[0] : span[1]].strip()
+    variable_match = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+    if variable_match is None:
+        return []
+    variable = variable_match.group(1)
+    if variable in seen:
+        return []
+    matches = assignment_matches(lexed.code, variable, before)
+    if not matches:
+        return []
+    assignment = matches[-1]
+    rhs_start = assignment.end()
+    rhs_end = assignment_end(lexed, rhs_start, suffix)
+    named = named_payload_spans(
+        lexed.code,
+        [(rhs_start, rhs_end)],
+        allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+    )
+    mutation = assigned_payload_member_span(
+        lexed, variable, rhs_end, before, suffix
+    )
+    if mutation:
+        return mutation
+    if named:
+        return named
+    return assigned_named_payload_spans(
+        lexed,
+        (rhs_start, rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def argument_string_value(
+    lexed: LexedSource, span: tuple[int, int]
+) -> str | None:
+    """Return a sole string literal argument's value."""
+
+    tokens = [
+        token
+        for token in lexed.strings
+        if span[0] <= token.start and token.end <= span[1]
+    ]
+    if len(tokens) != 1 or lexed.code[span[0] : span[1]].strip():
+        return None
+    return tokens[0].contents
+
+
+_KTOR_BODY_LINK_RE = re.compile(r"\b(?:setBody|body)\s*(?:\(|=)")
+
+
+def _trailing_lambda_span(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Span of a Kotlin trailing lambda immediately following `call`."""
+    tail = lexed.code[call.end:call.end + 40]
+    brace = re.match(r"\s*\{", tail)
+    if brace is None:
+        return None
+    opening = call.end + brace.end() - 1
+    closing = matching_delimiter(lexed.code, opening, "{", "}")
+    return None if closing is None else (opening, closing)
+
+
+def ktor_trailing_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Body attached inside a Ktor builder lambda: `post(url) { setBody(x) }`.
+
+    Ktor's send takes the ENDPOINT as its only argument and configures the body
+    in the trailing lambda, so neither the argument list nor any earlier chain
+    link carries the payload.
+    """
+    block = _trailing_lambda_span(lexed, call)
+    if block is None:
+        return None
+    inner_text = lexed.code[block[0]:block[1]]
+    link = _KTOR_BODY_LINK_RE.search(inner_text)
+    if link is None:
+        return None
+    base = block[0] + link.end()
+    if inner_text[link.end() - 1] == "(":
+        closing = matching_delimiter(lexed.code, base - 1, "(", ")")
+        if closing is None:
+            return None
+        arguments = split_arguments(lexed.code, base, closing)
+        span = payload_argument(lexed, arguments) if arguments else None
+    else:
+        end = lexed.code.find("\n", base)
+        span = (base, end if end > 0 else block[1])
+    if span is None:
+        return None
+    return resolve_wrapped_payload(lexed, span, span[0], suffix)
+
+
+def ruby_request_body_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Body assigned to a Ruby request object after construction.
+
+    `req = Net::HTTP::Post.new(uri)` carries only the endpoint; the payload
+    arrives in a later statement as `req.body = ...`, so the constructor's own
+    arguments never reveal it.
+    """
+    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    binding = re.search(
+        r"([A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+    )
+    if binding is None:
+        return []
+    name = re.escape(binding.group(1))
+    match = re.search(
+        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*", lexed.code[call.end:]
+    )
+    if match is None:
+        return []
+    start = call.end + match.end()
+    end = lexed.code.find("\n", start)
+    span = (start, end if end > 0 else len(lexed.code))
+    return [resolve_wrapped_payload(lexed, span, span[0], suffix)]
+
+
+def rest_payload_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select request-body expressions without accepting query/config fields."""
+
+    args_start = call.open_paren + 1
+    args_end = max(args_start, call.end - 1)
+    arguments = split_arguments(lexed.code, args_start, args_end)
+    if not arguments:
+        return []
+
+    # Guzzle's canonical body shape is an options array with a quoted `json`
+    # key: `$client->post($url, ['json' => ['messaging_profile_id' => $mp]])`.
+    # Quoted keys are blanked in `lexed.code`, so the generic named-member
+    # regex cannot recover them. Project the literal container through the
+    # lexer's token-aware key resolver instead.
+    if suffix == ".php":
+        for argument in arguments[1:]:
+            projected = literal_value_span(
+                lexed, argument[0], argument[1], ("json",), suffix
+            )
+            if projected is not None:
+                return [projected]
+
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    if suffix == ".php" and callee == "file_get_contents":
+        region = php_stream_context_region(lexed, call, suffix)
+        if region is None:
+            return []
+        key = re.search(
+            r"[\'\"]content[\'\"]\s*=>", lexed.original[region[0]:region[1]]
+        )
+        if key is None:
+            return []
+        start = region[0] + key.end()
+        # `region[1]` is the end of the whole stream_context_create(...)
+        # statement, so an unbounded span reads `$json]]);` rather than the
+        # entry's value: no variable is recognised, the hop to the body is lost
+        # and a compliant send is reported as missing the profile. Bound the
+        # value at the entry's own `,`/`]` first.
+        end = entry_value_end(lexed.code, start, region[1])
+        return [resolve_wrapped_payload(lexed, (start, end), start, suffix)]
+    if suffix in JS_TS_SUFFIXES and callee.split(".")[-1] == "open":
+        body = xhr_send_body_span(lexed, call, suffix)
+        return [body] if body else []
+    if suffix == ".py" and callee.split(".")[-1] == "Request":
+        data = named_argument_spans(lexed, arguments, "data")
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in data[-1:]
+        ]
+    if callee in {"HttpRequestMessage", "RestRequest"}:
+        body = csharp_request_body_span(lexed, call, suffix)
+        return [body] if body else []
+    if suffix == ".go" and callee in {"Post", "Put", "Patch"} and len(arguments) == 1:
+        body = builder_body_span(lexed, call, "SetBody|SetJSONBody|SetFormData")
+        return [resolve_wrapped_payload(lexed, body, body[0], suffix)] if body else []
+    if suffix == ".go" and callee == "Post" and len(arguments) >= 3:
+        # net/http.Post(url, contentType, body) carries the request body in
+        # its third argument, unlike the common post(url, body, config) form.
+        # Gating on the receiver being literally "http" missed every
+        # (*http.Client).Post call — client.Post(...), httpClient.Post(...),
+        # http.DefaultClient.Post(...) — which fell through to the generic
+        # rule and had its content-type string inspected as the payload,
+        # reporting a compliant body as missing messaging_profile_id.
+        receiver = (call_receiver(lexed, call) or "").lower()
+        second = lexed.code[arguments[1][0]:arguments[1][1]].strip()
+        looks_like_content_type = bool(
+            re.fullmatch(r"""["'][A-Za-z0-9.+-]+/[A-Za-z0-9.+;=\s-]+["']""", second)
+        )
+        if (
+            receiver == "http"
+            or receiver.endswith("client")
+            or looks_like_content_type
+        ):
+            # Follow reader/stringifier wrappers to the literal, as the curl
+            # branch does. Returning the raw span only worked when the literal
+            # sat textually inside it: the idiomatic
+            # `body := []byte(...); http.Post(url, ct, bytes.NewBuffer(body))`
+            # left the span at the wrapper, so a compliant body was reported as
+            # missing messaging_profile_id.
+            return [
+                resolve_wrapped_payload(
+                    lexed, arguments[2], arguments[2][0], suffix
+                )
+            ]
+    if callee == "fetch":
+        inline = named_payload_spans(
+            lexed.code,
+            arguments[1:2],
+            allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+        )
+        if inline:
+            return inline
+        if len(arguments) > 1:
+            return assigned_named_payload_spans(
+                lexed, arguments[1], call.start, suffix
+            )
+        return []
+    if callee == "axios.post":
+        return arguments[1:2]
+    if callee == "axios":
+        inline = named_payload_spans(
+            lexed.code,
+            arguments[:1],
+            allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+        )
+        if inline:
+            return inline
+        return assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+    named = named_payload_spans(
+        lexed.code,
+        arguments,
+        allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+    )
+    if named:
+        return named
+    if callee == "request" and len(arguments) >= 3:
+        method = argument_string_value(lexed, arguments[0])
+        if method is None or method.upper() in MUTATING_HTTP_METHODS:
+            return arguments[2:3]
+
+    if callee == "NewRequest" and len(arguments) >= 3:
+        # http.NewRequest(method, url, body): the body is the third argument,
+        # normally wrapped (bytes.NewBuffer(json.Marshal output)).
+        return [
+            resolve_wrapped_payload(lexed, arguments[2], call.start, suffix)
+        ]
+    if callee.split(".")[-1] == "post_form":
+        # Net::HTTP.post_form(uri, k => v, ...): every pair after the URI is
+        # form data. Returning only the first pair would report a compliant
+        # send whose profile arrives in a later pair.
+        return arguments[1:]
+    if callee.endswith("new") and "Net::HTTP::" in callee:
+        # The endpoint is this call's argument (handled in request_url_spans);
+        # the BODY arrives later as `req.body = ...` on the binding, exactly
+        # like the C# `req.Content = ...` shape.
+        return ruby_request_body_spans(lexed, call, suffix)
+    if callee == "curl_init":
+        # `$ch = curl_init($url)` names its handle on the LEFT of the
+        # assignment, not in the argument list, so the sibling
+        # CURLOPT_POSTFIELDS lookup needs the binding. Without it the endpoint
+        # resolved but the body never did, and a COMPLIANT send was reported as
+        # missing the profile.
+        line_start = lexed.code.rfind("\n", 0, call.start) + 1
+        binding = re.search(
+            r"(\$[A-Za-z_]\w*)\s*=\s*$",
+            lexed.code[line_start:call.start].rstrip()[-120:] + "=",
+        ) or re.search(
+            r"(\$[A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+        )
+        if binding is None:
+            return []
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in curl_postfields_spans(
+                lexed, binding.group(1), call.start, suffix
+            )
+        ]
+    if callee == "curl_setopt" and len(arguments) >= 3:
+        option = lexed.code[arguments[1][0]:arguments[1][1]].strip()
+        if option != "CURLOPT_URL":
+            return []
+        handle = lexed.code[arguments[0][0]:arguments[0][1]].strip()
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in curl_postfields_spans(
+                lexed, handle, call.start, suffix
+            )
+        ]
+    if callee == "curl_setopt_array" and len(arguments) >= 2:
+        # The array form carries the body in the SAME literal as the URL, and
+        # may also have been set by earlier per-option calls on the handle.
+        handle = lexed.code[arguments[0][0]:arguments[0][1]].strip()
+        spans = curl_option_array_value_spans(
+            lexed, arguments[1], suffix, "CURLOPT_POSTFIELDS"
+        ) or curl_postfields_spans(lexed, handle, call.start, suffix)
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in spans
+        ]
+    # `.kt`/`.kts` are CANONICALISED to `.java` before reaching here, so this
+    # must test the canonical suffix - keying on ".kt" meant the branch never
+    # ran. Gating on the trailing lambda keeps it Kotlin-only in practice:
+    # Java has no trailing-lambda call syntax for this shape.
+    if suffix in {".java", ".kt", ".kts", ".scala"} and callee.lower() in {
+        "post", "put", "patch", "request", "submitform"
+    }:
+        ktor_body = ktor_trailing_body_span(lexed, call, suffix)
+        if ktor_body is not None:
+            return [ktor_body]
+    if (
+        callee.lower() == "post"
+        and suffix in {".java", ".kt", ".kts", ".scala"}
+        # ONE argument only. Both idioms below pass the body alone, because the
+        # endpoint came from an earlier `.uri(...)`/`.url(...)` link. A
+        # positional two-argument `post(url, body)` - the shape used by Ktor and
+        # by most thin JVM wrappers - puts the ENDPOINT first, so taking
+        # argument 0 as the payload read the URL as the body and reported
+        # compliant code as missing the profile. Matching on the case-insensitive
+        # verb widened this branch to exactly those calls, so it must now check
+        # the arity the branch actually assumes.
+        and len(arguments) == 1
+        # Ktor spells the send `client.post(url) { setBody(json) }` - ONE
+        # argument, but that argument is the ENDPOINT and the body lives in the
+        # trailing lambda. The arity gate alone still read the URL as the
+        # payload, so a compliant Kotlin send was flagged. A trailing lambda
+        # means the single argument is not the body.
+        and _trailing_lambda_span(lexed, call) is None
+    ):
+        # .POST(HttpRequest.BodyPublishers.ofString(json)) for java.net.http and
+        # .post(RequestBody.create(json, TYPE)) for OkHttp — in both the payload
+        # is the wrapper's inner argument, not the wrapper itself.
+        # The canonical OkHttp idiom binds the body first — `RequestBody body =
+        # RequestBody.create(json, MediaType.parse(...)); ....post(body)` — and
+        # `unwrap_body_publisher` returns a bare variable untouched, leaving the
+        # whole `create(json, mediaType)` right-hand side to be inspected as the
+        # payload, where the media-type string won and a compliant send was
+        # reported as missing the profile. Resolve the variable hop first.
+        return [
+            unwrap_body_publisher(
+                lexed, resolve_wrapped_payload(lexed, span, span[0], suffix)
+            )
+            for span in arguments[:1]
+        ]
+    if callee == "request" and len(arguments) == 1:
+        resolved = assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+        if resolved:
+            return resolved
+        # Node core http(s).request: the body never rides in the options
+        # object — it is written afterwards via <handle>.write(payload).
+        written = request_write_payload_spans(lexed, call)
+        if written:
+            return written
+        return []
+
+    if callee.split(".")[-1].lower() in {"post", "postasync"}:
+        # Request-style config object held in a variable:
+        #   const cfg = {url: ..., json: {...}}; request.post(cfg)
+        # The inline form is already covered by named_payload_spans above,
+        # which reads json/body/data straight out of the literal. Once the URL
+        # side learned to resolve the variable, this side had to as well —
+        # otherwise the call was recognised as targeting the endpoint but its
+        # body could never be proven compliant, turning a silent miss into a
+        # false report on exactly the shape that was just fixed.
+        #
+        # Only returned when a body member is actually found. For
+        # post(urlVariable, bodyVariable) the first argument resolves to a
+        # string with no body member, so this yields nothing and the
+        # positional rule below still applies.
+        resolved = assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+        if resolved:
+            return resolved
+
+    # For post(url, payload, config)-style clients, only the second positional
+    # argument is request data. Later arguments are transport/query options.
+    return arguments[1:2]
+
+
+def payload_variables(
+    lexed: LexedSource, start: int, end: int, *, sdk_call: bool = False
+) -> list[str]:
+    variables: list[str] = []
+    for arg_start, arg_end in reversed(split_arguments(lexed.code, start, end)):
+        argument = lexed.code[arg_start:arg_end].strip()
+        match = SIMPLE_VARIABLE_RE.fullmatch(argument)
+        if match:
+            variables.append(match.group(1))
+        for nested in STRINGIFIED_VARIABLE_RE.finditer(argument):
+            variables.append(nested.group(1))
+        if not sdk_call:
+            for named in NAMED_PAYLOAD_VARIABLE_RE.finditer(argument):
+                variables.append(named.group(1))
+    for spread in SPREAD_VARIABLE_RE.finditer(lexed.code, start, end):
+        depth = structural_depth(lexed.code, start, spread.start())
+        if depth[2] and depth == payload_root_depth(lexed.code, start, end):
+            variables.append(spread.group(1))
+    variables = list(dict.fromkeys(variables))
+    if not sdk_call:
+        return variables
+
+    non_payload_names = {
+        "cancellationToken",
+        "context",
+        "ctx",
+        "options",
+        "requestOptions",
+    }
+    return [
+        variable
+        for variable in variables
+        if variable.lstrip("$") not in non_payload_names
+    ][:1]
+
+
+def assignment_matches(code: str, variable: str, before: int) -> list[re.Match[str]]:
+    escaped = re.escape(variable)
+    # The optional annotation covers TypeScript/Python declarations without
+    # allowing the search to cross a statement boundary.
+    pattern = re.compile(
+        rf"(?<![\w$.>]){escaped}(?!\w)(?:\s*,\s*\$?[A-Za-z_]\w*)*"
+        rf"(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+    )
+    return list(pattern.finditer(code, 0, before))
+
+
+def assignment_end(lexed: LexedSource, rhs_start: int, suffix: str) -> int:
+    code = lexed.code
+    round_depth = square_depth = curly_depth = 0
+    c_style = suffix in JS_TS_SUFFIXES | {".cs", ".java", ".php"}
+    for index in range(rhs_start, len(code)):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == "}" and not (round_depth or square_depth or curly_depth):
+            return index
+        elif character == ";" and not (round_depth or square_depth or curly_depth):
+            return index
+        elif character == "\n" and not (round_depth or square_depth or curly_depth):
+            if c_style:
+                next_line = code[index + 1 :].lstrip(" \t")
+                if next_line.startswith((".", "?")):
+                    continue
+            return index
+    return len(code)
+
+
+def shell_jq_assignment_has_profile(
+    lexed: LexedSource, start: int, end: int
+) -> bool:
+    """Recognize a top-level profile key emitted by a jq command substitution."""
+
+    try:
+        shell_source = re.sub(
+            r"\\\r?\n", "", lexed.original[start:end]
+        )
+        tokens = shlex.split(
+            shell_source, comments=True, posix=True
+        )
+    except ValueError:
+        return False
+
+    jq_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if token.lstrip("$(").rsplit("/", 1)[-1] == "jq"
+        ),
+        None,
+    )
+    if jq_index is None:
+        return False
+
+    two_value_options = {
+        "--arg",
+        "--argjson",
+        "--slurpfile",
+        "--rawfile",
+    }
+    one_value_options = {
+        "-f",
+        "--from-file",
+        "-L",
+        "--library-path",
+        "--indent",
+    }
+    index = jq_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in two_value_options:
+            index += 3
+            continue
+        if token in one_value_options:
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    if index >= len(tokens):
+        return False
+
+    program = tokens[index]
+    program_lexed = lex_source(program, ".sh")
+    return region_has_profile(program_lexed, 0, len(program))
+
+
+def shell_curl_get_mode(tokens: list[str]) -> bool:
+    """Return curl's final -G/--get state without reading option values as flags."""
+
+    enabled = False
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        option, separator, _ = token.partition("=")
+        if separator and option in SHELL_CURL_VALUE_OPTIONS:
+            index += 1
+            continue
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            index += 2
+            continue
+        if token == "--get":
+            enabled = True
+        elif token == "--no-get":
+            enabled = False
+        elif token.startswith("-") and not token.startswith("--"):
+            for short_option in token[1:]:
+                if short_option == "G":
+                    enabled = True
+                if short_option in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                    break
+        index += 1
+    return enabled
+
+
+def shell_curl_http_method(lexed: LexedSource, call: Call) -> str | None:
+    """Return curl's effective HTTP method, or None when it is dynamic.
+
+    curl defaults to GET, switches to POST for data/form options and PUT for
+    uploads, while an explicit request method wins.  A dynamic -X value stays
+    unresolved so callers can conservatively keep the request in scope.
+    """
+
+    try:
+        tokens = shlex.split(
+            lexed.original[call.start:call.end], comments=True, posix=True
+        )
+    except ValueError:
+        return None
+    curl_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if re.search(r"(?:^|[/$(])curl$", token)
+        ),
+        None,
+    )
+    if curl_index is None:
+        return None
+
+    explicit: str | None = None
+    inferred = "GET"
+    index = curl_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"-X", "--request"}:
+            if index + 1 >= len(tokens):
+                return None
+            explicit = tokens[index + 1]
+            index += 2
+            continue
+        if token.startswith("--request="):
+            explicit = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token.startswith("-X") and len(token) > 2:
+            explicit = token[2:]
+            index += 1
+            continue
+        option = token.split("=", 1)[0]
+        if (
+            option in SHELL_DATA_OPTIONS | SHELL_FORM_OPTIONS
+            or token.startswith("-d") and len(token) > 2
+            or token.startswith("-F") and len(token) > 2
+        ):
+            inferred = "POST"
+        elif (
+            option in SHELL_UPLOAD_OPTIONS
+            or token.startswith("-T") and len(token) > 2
+        ):
+            inferred = "PUT"
+        elif option in {"-I", "--head"}:
+            inferred = "HEAD"
+        elif option in {"-G", "--get"}:
+            inferred = "GET"
+        elif (
+            token.startswith("-")
+            and not token.startswith("--")
+            and len(token) > 1
+        ):
+            # BUNDLED short options: `curl -fsSd '<json>' <url>` means -f -s -S
+            # -d. Only a bare or `-d<value>` form was inferred as POST, so a
+            # clustered -d left the method at GET and the send was dropped
+            # from the scan entirely.
+            for short_option in token[1:]:
+                if short_option not in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                    continue
+                if short_option == "d":
+                    inferred = "POST"
+                elif short_option == "F":
+                    inferred = "POST"
+                elif short_option == "T":
+                    inferred = "PUT"
+                break
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            index += 2
+        else:
+            index += 1
+
+    if explicit is None:
+        return "GET" if shell_curl_get_mode(tokens[curl_index + 1:]) else inferred
+    if re.search(r"[$`{}()]", explicit):
+        return None
+    return explicit.upper()
+
+
+def shell_payload_values(source: str, start: int, end: int) -> list[str]:
+    """Return curl request-body arguments without executing shell syntax."""
+
+    try:
+        tokens = shlex.split(source[start:end], comments=True, posix=True)
+    except ValueError:
+        return []
+    if shell_curl_get_mode(tokens):
+        return []
+
+    values: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in SHELL_DATA_OPTIONS:
+            if index + 1 < len(tokens):
+                values.append(tokens[index + 1])
+                index += 2
+                continue
+        for option in sorted(SHELL_DATA_OPTIONS, key=len, reverse=True):
+            separator = "=" if token.startswith(f"{option}=") else ""
+            if separator:
+                values.append(token[len(option) + 1 :])
+                break
+            if option == "-d" and token.startswith("-d") and len(token) > 2:
+                values.append(token[2:])
+                break
+        else:
+            # BUNDLED short options: `curl -fsSd '<json>' <url>` is the same as
+            # `-f -s -S -d '<json>'`. Only a bare `-d` or a `-d<value>` prefix
+            # was recognised, so a clustered -d hid the body entirely and the
+            # send was never treated as carrying a payload.
+            if (
+                token.startswith("-")
+                and not token.startswith("--")
+                and len(token) > 1
+            ):
+                for position, short_option in enumerate(token[1:], start=1):
+                    if short_option not in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                        continue
+                    if short_option == "d":
+                        inline = token[position + 1:]
+                        if inline:
+                            values.append(inline)
+                        elif index + 1 < len(tokens):
+                            values.append(tokens[index + 1])
+                            index += 1
+                    break  # a value-taking option consumes the rest
+        index += 1
+    return values
+
+
+def shell_payload_variable(value: str) -> str | None:
+    candidate = value[1:] if value.startswith("@") else value
+    match = SHELL_VARIABLE_RE.fullmatch(candidate)
+    if match is None:
+        return None
+    return match.group(1) or match.group(2)
+
+
+def shell_payload_file_has_profile(
+    value: str, source_path: Path, project_root: Path
+) -> bool:
+    if not value.startswith("@") or "$" in value or value == "@-":
+        return False
+    relative = Path(value[1:])
+    candidates = (
+        relative if relative.is_absolute() else source_path.parent / relative,
+        project_root / relative,
+    )
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+            resolved.relative_to(project_root)
+        except (OSError, ValueError):
+            continue
+        if not resolved.is_file():
+            continue
+        try:
+            payload = resolved.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if serialized_json_has_profile(payload[:1_000_000]):
+            return True
+    return False
+
+
+def _parses_as_json_object(value: str) -> bool:
+    """Return whether the text is a complete JSON object we can judge by value."""
+    try:
+        return isinstance(json.loads(value), dict)
+    except (TypeError, ValueError):
+        return False
+
+
+def shell_inline_payload_has_profile(value: str) -> bool:
+    """Recognize a literal JSON object passed through a curl data option."""
+    return serialized_json_has_profile(value)
+
+
+def payload_spans(
+    lexed: LexedSource,
+    call: Call,
+    suffix: str,
+    mode: str,
+) -> list[tuple[int, int]]:
+    """Select the payload for each supported official request signature."""
+
+    start = call.open_paren + 1
+    end = max(start, call.end - 1 if call.parenthesized else call.end)
+    if mode == "rest":
+        return rest_payload_spans(lexed, call, suffix)
+    arguments = split_arguments(lexed.code, start, end)
+    if suffix == ".go":
+        # Idiomatic Go passes a context first, so the payload is the second
+        # argument - but a single-argument send has its payload in the ONLY
+        # argument. Reading argument 1 there yields no span at all, and a
+        # compliant send is reported missing.
+        return arguments[1:2] or arguments[:1]
+    if suffix in {".py", ".rb", ".php"}:
+        spans = [(start, end)]
+        if mode == "body" and suffix == ".php" and len(arguments) > 1:
+            # twilio-php declares `create(string $to, array $options = [])`
+            # (twilio/twilio-php MessageList::create), so the canonical send
+            # keeps `body` inside the trailing options array - one level below
+            # the argument list this region covers.
+            spans.append(arguments[-1])
+        return spans
+    return arguments[:1]
+
+
+def call_has_profile(
+    lexed: LexedSource,
+    call: Call,
+    suffix: str,
+    source_path: Path,
+    project_root: Path,
+    *,
+    sdk_call: bool,
+    resolver: PayloadStateResolver | None = None,
+) -> bool:
+    resolver = resolver or PayloadStateResolver(
+        lexed, suffix, PROFILE_NAMES, require_value=True
+    )
+    if suffix == ".sh" and not sdk_call:
+        for value in shell_payload_values(lexed.original, call.start, call.end):
+            variable = shell_payload_variable(value)
+            if variable is not None and resolver.presence_for_name(
+                variable, call.start
+            ).state == PRESENT:
+                return True
+            if shell_payload_file_has_profile(value, source_path, project_root):
+                return True
+            # When the body is parseable JSON its VALUE can be checked, so that
+            # verdict is authoritative. text_presence only sees the key, so a
+            # structurally-present but unusable value - `"messaging_profile_id":
+            # {"id": "x"}` - was accepted and the send certified.
+            if _parses_as_json_object(value):
+                if serialized_json_has_profile(value):
+                    return True
+                continue
+            if resolver.text_presence(value).state == PRESENT:
+                return True
+        return False
+    return any(
+        resolver.span_presence(start, end, call.start).state == PRESENT
+        for start, end in payload_spans(
+            lexed, call, suffix, "sdk" if sdk_call else "rest"
+        )
+    )
+
+
+def line_number(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def line_bounds(source: str, offset: int) -> tuple[int, int]:
+    start = source.rfind("\n", 0, offset) + 1
+    end = source.find("\n", offset)
+    return start, len(source) if end < 0 else end
+
+
+def finding_row(path: Path, line: int, detail: str) -> str:
+    """Format ONE findings row - the single site that decides the path shape.
+
+    Every row the analyzer prints goes through here, so the whole run uses one
+    path convention: the path exactly as `iter_source_files` yielded it. Callers
+    depend on that - lint-telnyx-correctness.sh copies these strings verbatim
+    into both `details.files[]` and the printed bullets, so mixing conventions
+    in one run leaves a consumer unable to group, dedupe or open by file.
+    """
+
+    return f"{path}:{line}:{detail}"
+
+
+def call_detail(path: Path, lexed: LexedSource, call: Call) -> str:
+    line_start, line_end = line_bounds(lexed.original, call.start)
+    code_line = lexed.code[line_start:line_end]
+    relative = call.start - line_start
+    statement_start = code_line.rfind(";", 0, relative) + 1
+    statement_end = code_line.find(";", relative)
+    statement_end = len(code_line) if statement_end < 0 else statement_end + 1
+    detail = " ".join(
+        lexed.original[line_start + statement_start : line_start + statement_end].split()
+    )
+    return finding_row(path, line_number(lexed.original, call.start), detail)
+
+
+def static_references(
+    lexed: LexedSource, start: int, end: int
+) -> list[EndpointReference]:
+    """Return identifier/member chains whose property names are static."""
+
+    references: list[EndpointReference] = []
+    strings = {token.start: token for token in lexed.strings}
+    for match in SOURCE_IDENTIFIER_RE.finditer(lexed.code, start, end):
+        if re.search(r"(?:\.|->)\s*$", lexed.code[start:match.start()]):
+            continue
+        parts = [match.group(1)]
+        cursor = match.end()
+        while cursor < end:
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            bracket = False
+            if lexed.code.startswith("?.", cursor):
+                cursor += 2
+                while cursor < end and lexed.code[cursor].isspace():
+                    cursor += 1
+                bracket = cursor < end and lexed.code[cursor] == "["
+            elif lexed.code.startswith("->", cursor):
+                cursor += 2
+            elif cursor < end and lexed.code[cursor] == ".":
+                cursor += 1
+            elif cursor < end and lexed.code[cursor] == "[":
+                bracket = True
+            else:
+                break
+
+            if bracket:
+                cursor += 1
+                while (
+                    cursor < end
+                    and cursor not in strings
+                    and lexed.code[cursor].isspace()
+                ):
+                    cursor += 1
+                token = strings.get(cursor)
+                if token is not None:
+                    key = token.contents
+                    cursor = token.end
+                else:
+                    numeric = re.match(r"\d+", lexed.code[cursor:end])
+                    symbol = re.match(
+                        r":\s*([A-Za-z_]\w*)", lexed.code[cursor:end]
+                    )
+                    if numeric is not None:
+                        key = numeric.group(0)
+                        cursor += len(numeric.group(0))
+                    elif symbol is not None:
+                        key = symbol.group(1)
+                        cursor += len(symbol.group(0))
+                    else:
+                        break
+                while cursor < end and lexed.code[cursor].isspace():
+                    cursor += 1
+                if cursor >= end or lexed.code[cursor] != "]":
+                    break
+                parts.append(key)
+                cursor += 1
+                continue
+
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            member = re.match(r"[A-Za-z_]\w*", lexed.code[cursor:end])
+            if member is None:
+                break
+            member_name = member.group(0)
+            cursor += len(member_name)
+            lookup_cursor = cursor
+            while lookup_cursor < end and lexed.code[lookup_cursor].isspace():
+                lookup_cursor += 1
+            if (
+                member_name in {"fetch", "get", "Get"}
+                and lookup_cursor < end
+                and lexed.code[lookup_cursor] == "("
+            ):
+                closing = matching_delimiter(
+                    lexed.code, lookup_cursor, "(", ")"
+                )
+                if closing is None or closing >= end:
+                    break
+                key = static_lookup_key(
+                    lexed, lookup_cursor + 1, closing
+                )
+                if key is None:
+                    break
+                parts.append(key)
+                cursor = closing + 1
+            else:
+                parts.append(member_name)
+        references.append(tuple(parts))
+
+    for token in lexed.strings:
+        if (
+            token.start < start
+            or token.end > end
+            or lexed.original[token.start] != "`"
+        ):
+            continue
+        for interpolation in re.finditer(r"\$\{([^{}]+)\}", token.contents):
+            expression = interpolation.group(1).strip()
+            root = re.match(r"(\$?[A-Za-z_]\w*)", expression)
+            if root is None:
+                continue
+            parts = [root.group(1)]
+            cursor = root.end()
+            valid = True
+            while cursor < len(expression):
+                whitespace = re.match(r"\s*", expression[cursor:])
+                cursor += len(whitespace.group(0)) if whitespace else 0
+                dot = re.match(
+                    r"(?:\?\.|\.)\s*([A-Za-z_]\w*)",
+                    expression[cursor:],
+                )
+                bracket = re.match(
+                    r"\[\s*(?:['\"]([^'\"]+)['\"]|(\d+))\s*\]",
+                    expression[cursor:],
+                )
+                if dot is not None:
+                    parts.append(dot.group(1))
+                    cursor += len(dot.group(0))
+                elif bracket is not None:
+                    parts.append(bracket.group(1) or bracket.group(2))
+                    cursor += len(bracket.group(0))
+                else:
+                    valid = False
+                    break
+            if valid:
+                references.append(tuple(parts))
+    return references
+
+
+def direct_member_assignments(
+    lexed: LexedSource, before: int, suffix: str
+) -> list[tuple[EndpointReference, int, int, int]]:
+    """Return assignments to static dot/bracket member chains."""
+
+    target = (
+        r"(\$?[A-Za-z_]\w*(?:(?:\s*(?:\.|->)\s*[A-Za-z_]\w*)|"
+        r"(?:\s*\[\s*(?:\"[^\"]*\"|'[^']*'|`[^`]*`|"
+        r":\s*[A-Za-z_]\w*|\d+)\s*\]))+)"
+    )
+    pattern = re.compile(target + r"\s*(?::=|=(?!=|>))")
+    assignments: list[tuple[EndpointReference, int, int, int]] = []
+    for match in pattern.finditer(lexed.without_comments, 0, before):
+        if lexed.code[match.start(1)].isspace():
+            continue
+        references = static_references(lexed, match.start(1), match.end(1))
+        if not references:
+            continue
+        rhs_start = match.end()
+        assignments.append(
+            (
+                references[0],
+                match.start(),
+                rhs_start,
+                assignment_end(lexed, rhs_start, suffix),
+            )
+        )
+    return assignments
+
+
+def top_level_colon(code: str, start: int, end: int) -> int | None:
+    round_depth = square_depth = curly_depth = 0
+    for index in range(start, end):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == ":" and not (round_depth or square_depth or curly_depth):
+            return index
+    return None
+
+
+def static_object_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    code = lexed.code[start:end].strip()
+    if re.fullmatch(r"[A-Za-z_]\w*", code):
+        return code
+    if re.fullmatch(r"\d+", code):
+        return code
+    symbol = re.fullmatch(r":\s*([A-Za-z_]\w*)", code)
+    if symbol is not None:
+        return symbol.group(1)
+    tokens = [
+        token for token in lexed.strings
+        if start <= token.start and token.end <= end
+    ]
+    if len(tokens) != 1:
+        return None
+    residual = (
+        lexed.code[start:tokens[0].start] + lexed.code[tokens[0].end:end]
+    ).strip()
+    return tokens[0].contents if residual in {"", "[]"} else None
+
+
+def static_lookup_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    """Return only literal lookup keys, never a runtime identifier."""
+
+    code = lexed.code[start:end].strip()
+    if re.fullmatch(r"\d+", code):
+        return code
+    symbol = re.fullmatch(r":\s*([A-Za-z_]\w*)", code)
+    if symbol is not None:
+        return symbol.group(1)
+    tokens = [
+        token for token in lexed.strings
+        if start <= token.start and token.end <= end
+    ]
+    if len(tokens) != 1:
+        return None
+    residual = (
+        lexed.code[start:tokens[0].start] + lexed.code[tokens[0].end:end]
+    ).strip()
+    return tokens[0].contents if not residual else None
+
+
+def top_level_assignment_separator(
+    code: str, start: int, end: int
+) -> tuple[int, int] | None:
+    round_depth = square_depth = curly_depth = 0
+    index = start
+    while index < end:
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif not (round_depth or square_depth or curly_depth):
+            if code.startswith("=>", index):
+                return index, index + 2
+            if (
+                character == "="
+                and not code.startswith(("==", "=>"), index)
+                and (index == start or code[index - 1] not in "!<>=")
+            ):
+                return index, index + 1
+        index += 1
+    return None
+
+
+def matching_opening(
+    code: str, closing: int, left: str, right: str
+) -> int | None:
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == right:
+            depth += 1
+        elif code[index] == left:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def first_argument_is_object(
+    lexed: LexedSource, span: tuple[int, int]
+) -> bool:
+    """Return whether an argument span is an object/dict literal."""
+    text = lexed.code[span[0]:span[1]].strip()
+    return text.startswith("{")
+
+
+def resolved_config_object_span(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> tuple[int, int] | None:
+    """Return the object literal behind an inline or local config alias."""
+
+    if first_argument_is_object(lexed, span):
+        return span
+
+    candidate = lexed.code[span[0]:span[1]].strip()
+    variable_match = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+    if variable_match is None:
+        return None
+    variable = variable_match.group(1)
+    if variable in seen:
+        return None
+    matches = assignment_matches(lexed.code, variable, before)
+    if not matches:
+        return None
+    assignment = matches[-1]
+    rhs_start = assignment.end()
+    rhs_end = assignment_end(lexed, rhs_start, suffix)
+    return resolved_config_object_span(
+        lexed,
+        (rhs_start, rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def config_object_member_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    names: tuple[str, ...],
+) -> list[tuple[int, int]]:
+    """Return selected members of an inline or aliased config object."""
+
+    resolved = resolved_config_object_span(
+        lexed, span, before, suffix
+    )
+    return (
+        named_object_member_spans(lexed, resolved, names)
+        if resolved is not None
+        else []
+    )
+
+
+def config_object_url_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> list[tuple[int, int]]:
+    """Return the URL member of a request-style config object."""
+
+    return config_object_member_spans(
+        lexed, span, before, suffix, URL_MEMBER_NAMES
+    )
+
+
+def named_object_member_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    name: str | tuple[str, ...],
+) -> list[tuple[int, int]]:
+    names = (name,) if isinstance(name, str) else name
+    opening = lexed.code.find("{", span[0], span[1])
+    if opening < 0:
+        return []
+    closing = matching_delimiter(lexed.code, opening, "{", "}")
+    if closing is None or closing >= span[1]:
+        return []
+    values: list[tuple[int, int]] = []
+    for member_start, member_end in split_arguments(
+        lexed.code, opening + 1, closing
+    ):
+        colon = top_level_colon(lexed.code, member_start, member_end)
+        if colon is None:
+            shorthand = lexed.code[member_start:member_end].strip()
+            if shorthand in names:
+                values.append((member_start, member_end))
+            continue
+        if (
+            static_object_key(lexed, member_start, colon) in names
+        ):
+            values.append((colon + 1, member_end))
+    return values
+
+
+def named_argument_spans(
+    lexed: LexedSource,
+    spans: list[tuple[int, int]],
+    name: str,
+) -> list[tuple[int, int]]:
+    """Return top-level keyword/named-argument value spans."""
+
+    values: list[tuple[int, int]] = []
+    for start, end in spans:
+        separator = top_level_assignment_separator(lexed.code, start, end)
+        if separator is None:
+            colon = top_level_colon(lexed.code, start, end)
+            separator = (colon, colon + 1) if colon is not None else None
+        if separator is None:
+            continue
+        separator_start, value_start = separator
+        if lexed.code[start:separator_start].strip().lstrip("$") == name:
+            values.append((value_start, end))
+    return values
+
+
+def call_receiver(lexed: LexedSource, call: Call) -> str | None:
+    # The optional `?` covers optional chaining - JS `client?.post(...)` and
+    # PHP nullsafe `$client?->post(...)`. Without it the receiver reads as
+    # anonymous and the send is discarded by the anonymous-receiver guard,
+    # which is a false negative on a defensive but perfectly ordinary send.
+    match = re.search(
+        r"(\$?[A-Za-z_]\w*)\s*\??\s*(?:\.|->|::)\s*$",
+        lexed.code[max(0, call.start - 120):call.start],
+    )
+    return match.group(1).lstrip("$") if match is not None else None
+
+
+# Factory methods that build an HTTP client which then sends. A `.post()` on
+# such a factory (requests.Session().post, httpx.Client().post,
+# axios.create(...).post) is a real send; a `.post()` on a mock/assertion
+# factory (nock, expect) is not. Distinguishing on the factory method keeps
+# the mocks out of scope without dropping the clients.
+HTTP_CLIENT_FACTORY_METHODS = frozenset(
+    {
+        "Session",
+        "session",  # requests.session() is the documented lowercase alias
+        "Client",
+        "AsyncClient",
+        # aiohttp's client class is named ClientSession, not Client or
+        # Session, so `aiohttp.ClientSession().post(url, json=...)` fell
+        # through the allowlist and the send was discarded entirely.
+        "ClientSession",
+        "create",
+        "Http",
+        "HTTP",
+        # resty builds the request through a chain - client.R().SetBody(x).Post(url)
+        # - so the IMMEDIATE receiver of the send is the last builder link, not
+        # the client. Each link must be recognised or the send is discarded by
+        # the anonymous-receiver guard.
+        "R",
+        "SetBody",
+        "SetJSONBody",
+        "SetFormData",
+        "SetHeader",
+        "SetHeaders",
+        "SetQueryParam",
+        "SetResult",
+    }
+)
+
+
+def factory_receiver_method(lexed: LexedSource, call: Call) -> str | None:
+    """Return the method name of a factory-call receiver, or None.
+
+    For `axios.create(...).post(...)` the receiver is the call `create(...)`,
+    so `call_receiver` returns None; this recovers `create`. For a receiver
+    that is not a call (`foo.post`) it returns None.
+    """
+    prefix = lexed.code[:call.start]
+    accessor = re.search(r"(?:\.|->|::)\s*$", prefix)
+    if accessor is None:
+        return None
+    before = prefix[: accessor.start()].rstrip()
+    if not before.endswith(")"):
+        return None
+    # Walk back to the matching '(' of the factory call.
+    depth = 0
+    index = len(before) - 1
+    while index >= 0:
+        char = before[index]
+        if char == ")":
+            depth += 1
+        elif char == "(":
+            depth -= 1
+            if depth == 0:
+                break
+        index -= 1
+    if index < 0:
+        return None
+    # The factory method sits immediately before the call parens:
+    # requests.Session() -> "Session", axios.create(...) -> "create",
+    # new Client() -> "Client". A receiver wrapped in an extra paren group,
+    # e.g. PHP `(new Client())`, is not recovered here and stays skipped
+    # rather than risking a misread; that shape is left to a future change.
+    name = re.search(r"([A-Za-z_]\w*)\s*$", before[:index])
+    return name.group(1) if name is not None else None
+
+
+def static_method_value(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> str | None:
+    value = argument_string_value(lexed, span)
+    if value is not None:
+        return value.upper()
+    member_constant = re.fullmatch(
+        r"\s*(?:[A-Za-z_]\w*\s*\.\s*)*(?:Http|Request)?Method"
+        r"\s*\.?\s*(Get|Head|Options|Delete|Post|Put|Patch)\s*",
+        lexed.code[slice(*span)],
+        re.IGNORECASE,
+    )
+    if member_constant is not None:
+        return member_constant.group(1).upper()
+    symbol = re.fullmatch(r"\s*:\s*([A-Za-z_]\w*)\s*", lexed.code[slice(*span)])
+    if symbol is not None:
+        return symbol.group(1).upper()
+    variable_match = re.fullmatch(
+        r"\s*(\$?[A-Za-z_]\w*)\s*", lexed.code[slice(*span)]
+    )
+    if variable_match is None or variable_match.group(1) in seen:
+        return None
+    variable = variable_match.group(1)
+    assignments = assignment_matches(lexed.code, variable, before)
+    if not assignments:
+        return None
+    assignment = assignments[-1]
+    rhs_end = assignment_end(lexed, assignment.end(), suffix)
+    return static_method_value(
+        lexed,
+        (assignment.end(), rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def static_string_value(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> str | None:
+    """Resolve a string literal through a bounded local alias chain."""
+
+    value = argument_string_value(lexed, span)
+    if value is not None:
+        return value
+    variable_match = re.fullmatch(
+        r"\s*(\$?[A-Za-z_]\w*)\s*", lexed.code[slice(*span)]
+    )
+    if variable_match is None or variable_match.group(1) in seen:
+        return None
+    variable = variable_match.group(1)
+    assignments = assignment_matches(lexed.code, variable, before)
+    if not assignments:
+        return None
+    assignment = assignments[-1]
+    rhs_end = assignment_end(lexed, assignment.end(), suffix)
+    return static_string_value(
+        lexed,
+        (assignment.end(), rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+_CSHARP_BODY_RE = re.compile(
+    r"\.\s*(?:Content\s*=|AddJsonBody\s*\(|AddStringBody\s*\(|AddBody\s*\()"
+)
+
+
+# A request OBJECT is not a request. Each client has an explicit execution step;
+# without it the object is constructed and discarded (a builder in a factory, a
+# test fixture, dead code), and reporting it is a false positive.
+_EXECUTION_LINK_RE = {
+    # OkHttp executes via newCall(req).execute()/.enqueue(); java.net.http via
+    # client.send(req, ...) / sendAsync(req, ...).
+    # `\??\s*\.` accepts Kotlin's null-safe call: the .kt/.kts files that now
+    # reach this table spell the same link `client?.newCall(req)?.execute()`,
+    # and requiring a plain dot dropped the send entirely - a silent pass on
+    # idiomatic Kotlin.
+    # `(?:\?|!!)?` accepts both Kotlin null-handling spellings between the call
+    # and the link - `client?.newCall(req)?.execute()` and the non-null
+    # assertion `client!!.newCall(req)!!.execute()`. Requiring a plain dot
+    # dropped the send entirely on idiomatic Kotlin, a silent pass.
+    ".java": (
+        r"newCall\s*\(\s*{name}\s*\)\s*(?:\?|!!)?\s*\.\s*(?:execute|enqueue)\s*\("
+        r"|(?:send|sendAsync)\s*\(\s*{name}\b"
+    ),
+    ".cs": (
+        r"(?:SendAsync|Send)\s*\(\s*{name}\b"
+        r"|Execute\w*\s*(?:<[^>()]*>)?\s*\(\s*(?:[A-Za-z_]\w*\s*,\s*)?{name}\b"
+    ),
+    ".py": r"urlopen\s*\(\s*{name}\b",
+    ".go": r"\.\s*Do\s*\(\s*{name}\b",
+}
+_INLINE_EXECUTION_RE = re.compile(
+    # The constructor may be namespaced inside the execution call, as in
+    # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
+    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do)\s*\(\s*"
+    r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
+)
+
+
+def request_object_is_executed(
+    lexed: LexedSource, call: Call, suffix: str
+) -> bool:
+    """Return whether a constructed request object is actually sent.
+
+    OkHttp needs newCall(req).execute()/.enqueue(), HttpRequestMessage needs
+    SendAsync(req), RestSharp needs Execute*/ExecuteAsync*, urllib needs
+    urlopen(req) and net/http needs client.Do(req). Construction alone is not a
+    send.
+    """
+    canonical = ".java" if suffix in {".kt", ".kts", ".scala"} else suffix
+    pattern = _EXECUTION_LINK_RE.get(canonical)
+    if pattern is None:
+        return True
+
+    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)).
+    prefix = lexed.code[max(0, call.start - 160):call.start]
+    if _INLINE_EXECUTION_RE.search(prefix):
+        return True
+
+    # Otherwise the object must be bound and that binding executed. The bound
+    # name is searched for SPECIFICALLY so two request objects in one scope
+    # cannot borrow each other's execution.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        chain_newline_boundary(lexed.code, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    ) + 1
+    head = lexed.code[statement_start:call.start]
+    assignment = re.search(r"^(.*?)(?::=|=(?!=))", head, re.S)
+    if assignment is None:
+        # An UNBOUND chain can still be executed inline:
+        #   client.send(HttpRequest.newBuilder()...build(), handler)
+        return re.search(
+            r"(?:send|sendAsync|newCall|execute|enqueue|urlopen|Do)\s*\(", head
+        ) is not None
+    # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
+    # never the one executed, so every candidate must be tried.
+    names = [
+        name
+        for name in re.findall(r"[A-Za-z_]\w*", assignment.group(1))
+        if name != "_"
+    ]
+    return any(
+        re.search(pattern.format(name=re.escape(name)), lexed.code[statement_start:])
+        for name in names
+    )
+
+
+def php_stream_context_region(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the stream-context array backing a file_get_contents() call.
+
+    `$ctx = stream_context_create(["http" => ["method" => "POST", "content" =>
+    $json]]); file_get_contents($url, false, $ctx);` - the verb and the body live
+    in the CONTEXT, not in the call, so the call alone looks like a plain read.
+    """
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    if len(args) < 3:
+        return None
+    text = lexed.code[args[2][0]:args[2][1]].strip()
+    if "stream_context_create" in text:
+        return args[2]
+    name = re.fullmatch(r"\$?([A-Za-z_]\w*)", text)
+    if name is None:
+        return None
+    # A PHP variable is written `$ctx`, and assignment_matches' lookbehind
+    # rejects a leading `$`, so the bare name alone never resolves.
+    candidates = [
+        match
+        for form in (text, name.group(1))
+        for match in assignment_matches(lexed.code, form, call.start)
+    ]
+    for assignment in sorted(candidates, key=lambda m: m.start(), reverse=True):
+        start = assignment.end()
+        end = assignment_end(lexed, start, suffix)
+        if "stream_context_create" in lexed.code[start:end]:
+            return (start, end)
+    return None
+
+
+def xhr_send_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the body passed to `.send(...)` after an XHR `.open(...)`.
+
+    XMLHttpRequest splits one request across two calls on the same object:
+    `x.open('POST', url)` carries the endpoint and method, `x.send(body)` the
+    payload. Neither call alone describes the send.
+    """
+    receiver = call_receiver(lexed, call)
+    if receiver is None:
+        return None
+    # `call_receiver` strips a leading `$` (PHP/JS sigil), so the name is
+    # searched back into source that still spells it `$xhr`. Keeping `$` in the
+    # lookbehind without allowing the sigil made every `$`-prefixed JS
+    # identifier ($xhr, $http) unmatchable, losing the `.send(...)` body and
+    # reporting a compliant send as missing the profile.
+    match = re.search(
+        rf"(?<![\w$])\$?{re.escape(receiver)}\s*(?:\?\.|\.)\s*send\s*\(",
+        lexed.code[call.end:],
+    )
+    if match is None:
+        return None
+    open_paren = call.end + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    if not inner:
+        return None
+    return resolve_wrapped_payload(lexed, inner[0], inner[0][0], suffix)
+
+
+def csharp_request_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the body attached to a C# request object after construction.
+
+    `new HttpRequestMessage(HttpMethod.Post, url)` and `new RestRequest(url,
+    Method.Post)` carry only the endpoint; the body arrives in a LATER statement
+    (`req.Content = new StringContent(json)`, `req.AddJsonBody(...)`), so the
+    constructor's own arguments never reveal it.
+    """
+    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    assigned = re.search(
+        r"([A-Za-z_][\w]*)\s*=\s*$", lexed.code[line_start:call.start].rstrip()[:200]
+    ) or re.search(
+        r"(?:var|[A-Za-z_][\w<>\[\]]*)\s+([A-Za-z_][\w]*)\s*=",
+        lexed.code[line_start:call.start],
+    )
+    if assigned is None:
+        return None
+    name = assigned.group(1)
+    for match in re.finditer(
+        rf"(?<![\w]){re.escape(name)}\s*(?=\.)", lexed.code[call.end:]
+    ):
+        tail = lexed.code[call.end + match.end():]
+        body = _CSHARP_BODY_RE.match(tail)
+        if body is None:
+            continue
+        base = call.end + match.end() + body.end()
+        if tail[body.end() - 1] == "(":
+            closing = matching_delimiter(lexed.code, base - 1, "(", ")")
+            if closing is None:
+                continue
+            inner = split_arguments(lexed.code, base, closing)
+            span = inner[0] if inner else None
+        else:
+            end = lexed.code.find(";", base)
+            span = (base, end if end > 0 else len(lexed.code))
+        if span is not None:
+            return resolve_wrapped_payload(lexed, span, span[0], suffix)
+    return None
+
+
+# A wrapped fluent chain is ONE statement written two ways. Go (and Python
+# inside brackets) puts the dot at the END of the previous line; Java, Kotlin,
+# C#, JavaScript and TypeScript put it at the START of the next one, which is
+# by far the more common formatting:
+#
+#     Request r = new Request.Builder().url(URL)
+#         .post(body).build();
+#
+# Only the trailing-dot half used to be recognised, so every window bounded by
+# a newline was truncated at the first wrap. That cost the chain its own
+# binding (`Request r =`), which is what the execution-link check searches for
+# - so a multi-line OkHttp builder was unresolvable while the byte-identical
+# single-line spelling resolved fine, and the fail-safe backstop then reported
+# a correct send as "could not verify".
+#
+# The leading-dot form requires the identifier to touch the dot (`.post`, never
+# `. post`). That is how fluent chains are written, and it keeps shell's `.`
+# source command (`. env.sh`) from reading as a continuation.
+_LEADING_CHAIN_LINK_RE = re.compile(r"\.[A-Za-z_]")
+
+
+def newline_continues_chain(code: str, newline: int) -> bool:
+    """Whether the newline at `newline` is a chain wrap rather than a boundary.
+
+    Both halves look only at the text either side of the newline itself. An
+    earlier draft bounded the lookahead at the CALLER's position, which for the
+    leading-dot form is the dot itself - so the identifier that proves it is a
+    chain link sat outside the window and the test could never fire.
+    """
+    if code[max(0, newline - 200):newline].rstrip().endswith("."):
+        return True
+    following = code[newline:newline + 200].lstrip()
+    return bool(_LEADING_CHAIN_LINK_RE.match(following))
+
+
+def chain_newline_boundary(code: str, position: int) -> int:
+    """Index of the newline that really ends the statement before `position`.
+
+    Walks back over newlines that only wrap a fluent chain. Callers combine
+    this with `rfind(";")`/`rfind("{")` under `max()`, so a genuine terminator
+    on an earlier line still wins and the widened window cannot swallow a
+    preceding statement.
+    """
+    index = code.rfind("\n", 0, position)
+    while index > 0 and newline_continues_chain(code, index):
+        index = code.rfind("\n", 0, index)
+    return index
+
+
+def _go_block_brace(code: str, start: int) -> int:
+    """Index of the `{` that opens a Go statement BODY, scanning from `start`.
+
+    Go headers are brace-ambiguous: a composite literal (`cfg{A: 1}`,
+    `map[string]int{...}`, `[]T{...}`) puts a brace in the header that does not
+    open the block. A literal's brace is always preceded by a type expression -
+    an identifier, or the `]` closing a slice/map type - whereas a block's brace
+    follows an operator, a paren, or nothing. Balanced runs of `()`/`[]` are
+    skipped so a brace nested inside them is never mistaken for either.
+
+    Returns -1 when no body brace is found before the statement ends.
+    """
+    index, depth = start, 0
+    while index < len(code):
+        char = code[index]
+        if char in "([":
+            depth += 1
+        elif char in ")]":
+            depth -= 1
+            if depth < 0:
+                return -1
+        elif char == "}" and depth == 0:
+            return -1
+        elif char == "{" and depth == 0:
+            # ADJACENCY is the discriminator, not the preceding token class:
+            # `switch mode {` also puts an identifier before the brace, so
+            # testing the token alone classified every ordinary switch as a
+            # composite literal. Go composite literals are written with the
+            # brace touching the type (`cfg{`, `map[string]int{`), and a block
+            # brace is always separated by whitespace.
+            prefix = code[max(0, index - 200):index]
+            if prefix and (prefix[-1].isalnum() or prefix[-1] in "_]"):
+                # A composite literal: skip its balanced body and keep looking.
+                closing = matching_delimiter(code, index, "{", "}")
+                if closing is None:
+                    return -1
+                index = closing
+            else:
+                return index
+        index += 1
+    return -1
+
+
+def _top_level_ternary(
+    code: str, start: int, end: int
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    """Split `cond ? a : b` into its two arms, or None if this is not a ternary.
+
+    Skips balanced brackets so a `?` inside an argument list is not mistaken for
+    the operator, and ignores JS optional chaining (`?.`) and nullish
+    coalescing (`??`).
+    """
+    depth = question = -1
+    depth = 0
+    for index in range(start, end):
+        char = code[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "?" and depth == 0:
+            if code[index + 1:index + 2] in (".", "?"):
+                continue
+            question = index
+            break
+    if question < 0:
+        return None
+    depth = 0
+    for index in range(question + 1, end):
+        char = code[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == ":" and depth == 0:
+            return (question + 1, index), (index + 1, end)
+    return None
+
+
+def chain_statement_start(code: str, position: int) -> int:
+    """Index of the statement boundary preceding a chained call.
+
+    A raw `rfind` for `;`/`{`/newline stops inside the chain's own arguments:
+    `SetBody(map[string]string{...}).Post(url)` puts a `{` between the body
+    link and the send, so the search window began AFTER the very link being
+    looked for. Scan backwards instead, skipping balanced `()`/`{}`/`[]` runs,
+    and treat a newline as a boundary only when it is not a chain wrap in
+    either of the two spellings above.
+    """
+    depth = 0
+    index = position - 1
+    while index >= 0:
+        char = code[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth == 0:
+                return index
+            depth -= 1
+        elif depth == 0 and char in ";\n":
+            if char == "\n" and newline_continues_chain(code, index):
+                index -= 1
+                continue
+            return index
+        index -= 1
+    return -1
+
+
+def builder_body_span(
+    lexed: LexedSource, call: Call, methods: str
+) -> tuple[int, int] | None:
+    """Return the body argument set by an earlier link of the same chain.
+
+    resty spells it `client.R().SetBody(payload).Post(url)`: the endpoint is the
+    send call's argument while the BODY was attached upstream, the mirror image
+    of the java/OkHttp builders.
+    """
+    statement_start = chain_statement_start(lexed.code, call.start)
+    window = lexed.code[statement_start + 1:call.start]
+    last = None
+    for match in re.finditer(rf"\.\s*(?:{methods})\s*\(", window):
+        last = match
+    if last is None:
+        return None
+    open_paren = statement_start + 1 + last.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > call.start:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else None
+
+
+def builder_uri_span(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Return the .uri(...)/.url(...) argument preceding a builder send call.
+
+    java.net.http uses `.uri(URI.create(URL))`; OkHttp uses `.url(URL)`. Both
+    put the endpoint in an EARLIER link of the same chain than the call that
+    performs the send, so the send argument alone never reveals the endpoint.
+    """
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    )
+    window = lexed.code[statement_start + 1:call.start]
+    last = None
+    matched_link = None
+    for match in re.finditer(r"\.\s*(?:uri|url)\s*\(", window):
+        last = match
+        matched_link = "url" if "url" in match.group(0) else "uri"
+    if last is None:
+        return None
+    open_paren = statement_start + 1 + last.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > call.start:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    if not inner:
+        return None
+    _BUILDER_LINK_KIND[(id(lexed), call.start)] = matched_link
+    return inner[0]
+
+
+# Which builder link supplied the endpoint for a given call: "uri" for
+# java.net.http, "url" for OkHttp. Recorded rather than re-sniffed, because a
+# substring search for ".url" in the preceding source also matches an unrelated
+# `this.url` / `cfg.url` and silently rerouted java.net.http chains into the
+# OkHttp branch, where the execution-link requirement then discarded the send.
+_BUILDER_LINK_KIND: dict[tuple[int, int], str | None] = {}
+
+
+PAYLOAD_WRAPPER_RE = re.compile(
+    # `new` is optional so the C# constructor forms below match the same way
+    # the static factories above do.
+    r"^\s*(?:new\s+)?(?:bytes\s*\.\s*NewBuffer|bytes\s*\.\s*NewReader|"
+    r"strings\s*\.\s*NewReader|json\s*\.\s*Marshal|json_encode|"
+    r"RequestBody\s*\.\s*create|okhttp3\s*\.\s*RequestBody\s*\.\s*create|"
+    # C# attaches the body as `req.Content = new StringContent(json, ...)`.
+    # `csharp_request_body_span` already resolved that span, but without the
+    # wrapper listed here the presence check ran against the CONSTRUCTOR text
+    # rather than the JSON inside it - so a compliant HttpRequestMessage send
+    # was reported as missing the profile, and a non-compliant one was flagged
+    # for the wrong reason.
+    r"StringContent|JsonContent\s*\.\s*Create|"
+    # .NET serializers. Without these the resolver stopped at
+    # `JsonSerializer.Serialize(payload)` and never reached the payload
+    # variable, so every field written via Dictionary.Add was invisible and a
+    # compliant C# send was reported as missing the profile.
+    r"JsonSerializer\s*\.\s*Serialize|JsonConvert\s*\.\s*SerializeObject)"
+    r"\s*\("
+)
+
+
+# A wrapper's payload is not always its FIRST argument. OkHttp ships both
+# `RequestBody.create(body, mediaType)` and the deprecated
+# `RequestBody.create(mediaType, body)` - and Kotlin code overwhelmingly uses
+# the latter. Taking argument 0 unconditionally resolved the MEDIA TYPE as the
+# payload, so `messaging_profile_id` was invisible and a compliant send was
+# reported as missing it.
+#
+# Selection is POSITIVE - identify the argument that looks like a BODY - rather
+# than a deny-list of media-type spellings. An earlier draft enumerated the
+# media-type factories instead, and each spelling it did not list reopened the
+# same false positive: a bound `static final MediaType JSON` constant (the
+# spelling in OkHttp's own README), and Kotlin's `"application/json"
+# .toMediaType()`. Enumerating producers cannot terminate; asking what a
+# payload looks like can.
+_MEDIA_TYPE_FACTORY_RE = re.compile(
+    r"(?:[\w.]*\bMediaType\s*\.\s*(?:parse|get)\s*\(|\bContentType\s*\.|"
+    r"\.\s*toMediaTypeOrNull\s*\(|\.\s*toMediaType\s*\(|"
+    r"\bMediaTypeHeaderValue\s*\()"
+)
+# A MIME literal is `type/subtype` with an optional parameter tail, and nothing
+# else. A JSON body is never shaped like that, so a real payload cannot be
+# skipped by this test.
+_MIME_LITERAL_RE = re.compile(
+    r"""^\s*(["'])[\w.+-]+/[\w.+-]+(?:\s*;[^"']*)?\1\s*$"""
+)
+# A body announces itself: a quoted literal whose content opens a JSON object or
+# array, or an inline object/array/map literal.
+_BODY_LITERAL_RE = re.compile(r"""^\s*(?:["'`]\s*[\{\[]|[\{\[])""")
+# Last-resort tiebreak only (see payload_argument). Names that read as a content
+# type rather than a payload. Deliberately narrow: it must not match a name a
+# real body would plausibly carry, so `body`, `payload`, `data` and `content`
+# are absent - `content` in particular appears in `StringContent`, a body.
+_CONTENT_TYPE_NAME_RE = re.compile(
+    r"(?i)(?:\bmedia[_]?type|\bmime\b|\bcontent[_]?type|\bJSON_TYPE\b|\bTYPE\b)"
+)
+# Postfix wrapper: the payload is the RECEIVER. Kotlin/OkHttp 4 spells body
+# construction this way (`json.toRequestBody(contentType)`), the mirror image of
+# every prefix wrapper above.
+# Anchored on the CALL, with the receiver taken as everything before it. A
+# pattern that tried to capture the receiver directly matched the blanks inside
+# a masked string literal instead: lex_source blanks the quotes as well as the
+# content, so on `"{...}".toRequestBody(...)` the receiver is indistinguishable
+# from whitespace in `lexed.code` and must be delimited by offset, not by shape.
+_POSTFIX_PAYLOAD_WRAPPER_RE = re.compile(
+    r"\.\s*(?:toRequestBody|toResponseBody)\s*\("
+)
+# `new X(...)` is NOT evidence of a body: `new MediaTypeHeaderValue("application
+# /json")` and `new StringContent(...)` are both spelled that way, so accepting
+# every constructor let a CONTENT-TYPE argument win the positive body test and
+# outrank the real payload. Only composite literals - Go maps and struct/object
+# literals, which are brace-initialised - count here; a constructor has to earn
+# it through PAYLOAD_WRAPPER_RE like every other wrapper.
+_MAP_LITERAL_RE = re.compile(r"^\s*(?:map\[|new\s+\w[\w.<>\[\]]*\s*\{|\w+\s*\{)")
+
+
+def _is_media_type_argument(
+    lexed: LexedSource, span: tuple[int, int], before: int
+) -> bool:
+    """Whether an argument denotes a CONTENT TYPE rather than a payload."""
+    code_text = lexed.code[span[0]:span[1]]
+    if _MEDIA_TYPE_FACTORY_RE.search(code_text):
+        return True
+    if _MIME_LITERAL_RE.match(lexed.original[span[0]:span[1]]):
+        return True
+    # An identifier reveals nothing by itself; resolve what it was assigned.
+    # `static final MediaType JSON = MediaType.parse(...)` is the OkHttp README
+    # spelling, and without this hop the constant read as the payload. The name
+    # may be QUALIFIED (`HttpConstants.JSON`, `this.jsonType`, `Companion.JSON`)
+    # - resolving only the bare form left every qualified constant unclassified,
+    # so it fell through as "not a media type" and won the argument.
+    bare = code_text.strip().rsplit(".", 1)[-1].strip()
+    variable = SIMPLE_VARIABLE_RE.fullmatch(bare)
+    if variable is None:
+        return False
+    # Searched across the WHOLE file, not just above the send. A media-type
+    # constant is conventionally declared at the BOTTOM of the class in Kotlin
+    # (`companion object { val JSON = ... }`) and in Java, so bounding the
+    # lookup at the call site left those unclassified and the media type won the
+    # argument. Safe here because the result only decides which argument is the
+    # CONTENT TYPE - it never decides whether a profile value is present.
+    matches = assignment_matches(lexed.code, variable.group(1), len(lexed.code))
+    if not matches:
+        matches = assignment_matches(lexed.code, variable.group(1), before)
+    if not matches:
+        return False
+    rhs_start = matches[-1].end()
+    rhs_code = lexed.code[rhs_start:rhs_start + 200]
+    if _MEDIA_TYPE_FACTORY_RE.search(rhs_code.split("\n")[0]):
+        return True
+    rhs_original = lexed.original[rhs_start:rhs_start + 200].split("\n")[0]
+    return bool(_MIME_LITERAL_RE.match(rhs_original.strip().rstrip(";,")))
+
+
+def _is_body_argument(lexed: LexedSource, span: tuple[int, int]) -> bool:
+    """Whether an argument positively looks like a request payload."""
+    if _BODY_LITERAL_RE.match(lexed.original[span[0]:span[1]]):
+        return True
+    code_text = lexed.code[span[0]:span[1]]
+    if _BODY_LITERAL_RE.match(code_text) or _MAP_LITERAL_RE.match(code_text):
+        return True
+    return bool(PAYLOAD_WRAPPER_RE.match(code_text) or
+                STRINGIFIED_VARIABLE_RE.search(code_text))
+
+
+def payload_argument(
+    lexed: LexedSource, inner: list[tuple[int, int]]
+) -> tuple[int, int] | None:
+    """Pick the argument carrying the BODY, skipping content-type arguments."""
+    if len(inner) <= 1:
+        return inner[0] if inner else None
+    before = inner[0][0]
+    bodies = [span for span in inner if _is_body_argument(lexed, span)]
+    if bodies:
+        return bodies[0]
+    for span in inner:
+        if not _is_media_type_argument(lexed, span, before):
+            return span
+    # Nothing was positively identified either way. That happens when both
+    # arguments are plain identifiers and the media-type constant could not be
+    # resolved - a qualified name whose last segment collides with an unrelated
+    # variable, or a declaration in another file. Falling through to argument 0
+    # then picked the MEDIA TYPE for the deprecated
+    # `RequestBody.create(mediaType, body)` order. As a last resort only, prefer
+    # the argument whose NAME does not read as a content type. This is a
+    # tiebreak, never an override: any positively identified body above wins.
+    named = [
+        span for span in inner
+        if not _CONTENT_TYPE_NAME_RE.search(lexed.code[span[0]:span[1]])
+    ]
+    if named:
+        return named[0]
+    return inner[0]
+
+
+def resolve_wrapped_payload(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> tuple[int, int]:
+    """Follow reader/stringifier wrappers and variables to the payload.
+
+    bytes.NewBuffer(body) -> body -> json.Marshal(payload) -> payload -> the
+    map literal. The literal is where messaging_profile_id is provably
+    present or absent; stopping at any earlier hop reports compliant code as
+    missing the profile.
+    """
+    for _ in range(6):
+        text = lexed.code[span[0]:span[1]]
+        # Kotlin/OkHttp 4 wraps the body as an EXTENSION on it -
+        # `body.toRequestBody(mediaType)` - so the payload is the receiver, not
+        # an argument. Every wrapper above is prefix-shaped, so without this the
+        # whole expression was treated as the payload and the JSON inside it was
+        # never inspected.
+        postfix = _POSTFIX_PAYLOAD_WRAPPER_RE.search(text)
+        if postfix is not None and postfix.start() > 0:
+            start, end = span[0], span[0] + postfix.start()
+            # Trim against the ORIGINAL: a masked literal is blank in `code`,
+            # so trimming there would consume the payload itself.
+            while start < end and lexed.original[start].isspace():
+                start += 1
+            while end > start and lexed.original[end - 1].isspace():
+                end -= 1
+            if end > start:
+                span = (start, end)
+                continue
+        wrapper = PAYLOAD_WRAPPER_RE.match(text)
+        if wrapper is not None:
+            open_paren = span[0] + wrapper.end() - 1
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None or closing > span[1]:
+                return span
+            inner = split_arguments(lexed.code, open_paren + 1, closing)
+            if not inner:
+                return span
+            chosen = payload_argument(lexed, inner)
+            if chosen is None:
+                return span
+            span = chosen
+            continue
+        candidate = text.strip()
+        variable = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+        if variable is None:
+            return span
+        matches = assignment_matches(lexed.code, variable.group(1), before)
+        if not matches:
+            return span
+        assignment = matches[-1]
+        rhs_start = assignment.end()
+        rhs = (rhs_start, assignment_end(lexed, rhs_start, suffix))
+        rhs_text = lexed.code[rhs[0]:rhs[1]]
+        # The postfix wrapper counts as a wrapper hop too. Kotlin binds the body
+        # first as often as it inlines it (`val body = json.toRequestBody(type)`
+        # then `.post(body)`), and recognising only prefix wrappers here left the
+        # variable unresolved, so a compliant Kotlin/OkHttp-4 send was always
+        # reported as missing the profile.
+        if (
+            PAYLOAD_WRAPPER_RE.match(rhs_text) is None
+            and _POSTFIX_PAYLOAD_WRAPPER_RE.search(rhs_text) is None
+        ):
+            # Only serializer/reader hops need chasing: the resolver cannot see
+            # through json.Marshal/json_encode. Collapsing a plain variable to
+            # its declaration literal instead DISCARDS every later mutation
+            # (`payload["messaging_profile_id"] = ""`), certifying a send whose
+            # profile was emptied. Stop here and let the mutation-aware
+            # resolver evaluate the variable itself.
+            return span
+        span = rhs
+        before = assignment.start()
+    return span
+
+
+BODY_PUBLISHER_RE = re.compile(
+    r"^\s*(?:(?:HttpRequest\s*\.\s*)?BodyPublishers\s*\.\s*of\w+"
+    r"|(?:okhttp3\s*\.\s*)?RequestBody\s*\.\s*create)\s*\("
+)
+
+
+def unwrap_body_publisher(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel BodyPublishers.ofString(...) down to the payload expression."""
+    text = lexed.code[span[0]:span[1]]
+    match = BODY_PUBLISHER_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else span
+
+
+def php_curl_transaction_bounds(
+    lexed: LexedSource, handle: str, anchor: int
+) -> tuple[int, int]:
+    """Bound the handle transaction containing a URL-setting call."""
+
+    exec_pattern = re.compile(
+        r"curl_exec\s*\(\s*" + re.escape(handle) + r"\s*\)"
+    )
+    previous_exec = list(exec_pattern.finditer(lexed.code, 0, anchor))
+    start = previous_exec[-1].end() if previous_exec else 0
+    next_exec = exec_pattern.search(lexed.code, anchor)
+    return start, next_exec.start() if next_exec is not None else len(lexed.code)
+
+
+def curl_postfields_spans(
+    lexed: LexedSource, handle: str, anchor: int, suffix: str
+) -> list[tuple[int, int]]:
+    """Return POSTFIELDS spans from the same curl handle transaction."""
+
+    transaction_start, transaction_end = php_curl_transaction_bounds(
+        lexed, handle, anchor
+    )
+    pattern = re.compile(
+        r"curl_setopt\s*\(\s*" + re.escape(handle)
+        + r"\s*,\s*CURLOPT_POSTFIELDS\s*,"
+    )
+    # The two curl option forms mix freely on one handle. Reading only the
+    # per-option form here made the body invisible whenever the URL arrived
+    # through curl_setopt(CURLOPT_URL) but the body through
+    # curl_setopt_array() - a compliant send was then reported as missing its
+    # profile. Spans are ordered by position so the last write still wins.
+    array_pattern = re.compile(
+        r"curl_setopt_array\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+
+    def collect(start: int, end: int) -> list[tuple[int, int]]:
+        found: list[tuple[int, tuple[int, int]]] = []
+        for match in pattern.finditer(lexed.code, start, end):
+            open_paren = lexed.code.index("(", match.start())
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None:
+                continue
+            arguments = split_arguments(lexed.code, open_paren + 1, closing)
+            if len(arguments) >= 3:
+                found.append((open_paren, arguments[2]))
+        for match in array_pattern.finditer(lexed.code, start, end):
+            open_paren = lexed.code.index("(", match.start())
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None:
+                continue
+            arguments = split_arguments(lexed.code, open_paren + 1, closing)
+            if len(arguments) >= 2:
+                found.extend(
+                    (open_paren, span)
+                    for span in curl_option_array_value_spans(
+                        lexed, arguments[1], suffix, "CURLOPT_POSTFIELDS"
+                    )
+                )
+        return [span for _, span in sorted(found)]
+
+    spans = collect(transaction_start, transaction_end)
+    if not spans:
+        # POSTFIELDS persists on the handle across exec until overwritten or
+        # reset, so a transaction that only changes CURLOPT_URL still sends the
+        # body set earlier. Fall back to the most recent carried value.
+        state_start = php_curl_handle_state_start(lexed, handle, anchor)
+        carried = collect(state_start, transaction_start)
+        if carried:
+            spans = carried[-1:]
+    return spans
+
+
+_CURL_ARRAY_OPTION_RE = re.compile(
+    r"\s*['\"]?(CURLOPT_[A-Z_]+)['\"]?\s*=>"
+)
+
+
+def curl_option_array_value_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    suffix: str,
+    option: str,
+) -> list[tuple[int, int]]:
+    """Return the value spans for one option inside a curl option ARRAY.
+
+    curl_setopt_array($ch, [CURLOPT_URL => ..., CURLOPT_POSTFIELDS => ...]) is
+    as idiomatic as repeated curl_setopt() calls, but only the per-option call
+    form was recognized, so a number-pool send configured this way was never
+    visited at all. Keys are read from the ORIGINAL source (the masked view
+    blanks string contents); values stay offset-accurate for the resolvers.
+    """
+    container = root_literal_container(lexed, span[0], span[1], suffix)
+    if container is None:
+        return []
+    _, opening, closing = container
+    spans: list[tuple[int, int]] = []
+    for element in split_arguments(lexed.code, opening + 1, closing):
+        match = _CURL_ARRAY_OPTION_RE.match(
+            lexed.original, element[0], element[1]
+        )
+        if match is not None and match.group(1) == option:
+            spans.append((match.end(), element[1]))
+    return spans
+
+
+def php_curl_handle_state_start(
+    lexed: LexedSource, handle: str, anchor: int
+) -> int:
+    """Return where the handle's CARRIED option state begins.
+
+    ext-curl options persist on a handle across curl_exec() until they are
+    overwritten or curl_reset() is called — they are NOT cleared by the exec.
+    State therefore begins at the last curl_reset()/curl_init() before the
+    anchor, not after the previous exec.
+    """
+    latest = 0
+    for pattern in (
+        r"curl_reset\s*\(\s*" + re.escape(handle) + r"\s*\)",
+        re.escape(handle) + r"\s*=\s*curl_init\s*\(",
+    ):
+        matches = list(re.finditer(pattern, lexed.code, 0))
+        for match in matches:
+            if match.end() <= anchor and match.end() > latest:
+                latest = match.end()
+    return latest
+
+
+def php_curl_handle_method(
+    lexed: LexedSource, handle: str, url_call_start: int, suffix: str
+) -> str | None:
+    """Return the method used by the handle's next curl_exec transaction."""
+
+    transaction_start, transaction_end = php_curl_transaction_bounds(
+        lexed, handle, url_call_start
+    )
+    # Options set before an earlier exec are STILL IN EFFECT unless overwritten
+    # or reset, so a handle that posted once and then only changes CURLOPT_URL
+    # is still POSTing. Scanning from the previous exec made that second
+    # transaction look like a fresh GET, and the required send escaped.
+    state_start = php_curl_handle_state_start(lexed, handle, url_call_start)
+    if state_start < transaction_start:
+        transaction_start = state_start
+    setter_pattern = re.compile(
+        r"curl_setopt\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+    array_pattern = re.compile(
+        r"curl_setopt_array\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+
+    # Both option forms must be applied in SOURCE ORDER so that later settings
+    # win. Scanning only curl_setopt() left the array form's method invisible,
+    # so an array-configured GET looked like a required send.
+    events: list[tuple[int, str, tuple[int, int]]] = []
+    for match in setter_pattern.finditer(
+        lexed.code, transaction_start, transaction_end
+    ):
+        opening = lexed.code.index("(", match.start())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None or closing > transaction_end:
+            continue
+        arguments = split_arguments(lexed.code, opening + 1, closing)
+        if len(arguments) < 3:
+            continue
+        events.append(
+            (match.start(), lexed.code[slice(*arguments[1])].strip(), arguments[2])
+        )
+    for match in array_pattern.finditer(
+        lexed.code, transaction_start, transaction_end
+    ):
+        opening = lexed.code.index("(", match.start())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None or closing > transaction_end:
+            continue
+        arguments = split_arguments(lexed.code, opening + 1, closing)
+        if len(arguments) < 2:
+            continue
+        container = root_literal_container(
+            lexed, arguments[1][0], arguments[1][1], suffix
+        )
+        if container is None:
+            continue
+        _, array_open, array_close = container
+        for element in split_arguments(lexed.code, array_open + 1, array_close):
+            key = _CURL_ARRAY_OPTION_RE.match(
+                lexed.original, element[0], element[1]
+            )
+            if key is not None:
+                events.append(
+                    (element[0], key.group(1), (key.end(), element[1]))
+                )
+
+    method = "GET"
+    custom_method: str | None = None
+    for position, option, value_span in sorted(events, key=lambda event: event[0]):
+        value = lexed.code[slice(*value_span)].strip().lower()
+        if option == "CURLOPT_CUSTOMREQUEST":
+            resolved = static_method_value(
+                lexed, value_span, position, suffix
+            )
+            if resolved is None:
+                return None
+            custom_method = resolved
+        elif option == "CURLOPT_POSTFIELDS":
+            method = "POST"
+        elif option == "CURLOPT_POST":
+            if value in {"true", "1"}:
+                method = "POST"
+            elif value in {"false", "0"}:
+                method = "GET"
+            else:
+                return None
+        elif option == "CURLOPT_HTTPGET" and value in {"true", "1"}:
+            method = "GET"
+        elif option == "CURLOPT_NOBODY" and value in {"true", "1"}:
+            method = "HEAD"
+        elif option in {"CURLOPT_UPLOAD", "CURLOPT_PUT"}:
+            if value in {"true", "1"}:
+                method = "PUT"
+            elif value not in {"false", "0"}:
+                return None
+    return custom_method or method
+
+
+ASSIGNED_HANDLE_RE = re.compile(
+    r"([A-Za-z_$][\w$]*)\s*=\s*(?:new\s+)?(?:[A-Za-z_$][\w$]*\s*\.\s*)?$"
+)
+
+
+def request_write_payload_spans(
+    lexed: LexedSource, call: Call
+) -> list[tuple[int, int]]:
+    """Return <handle>.write(...) payload spans after a request(...) call."""
+    prefix = lexed.code[max(0, call.start - 160):call.start]
+    match = ASSIGNED_HANDLE_RE.search(prefix)
+    if match is None:
+        return []
+    handle = match.group(1)
+    write_re = re.compile(
+        r"(?<![\w$])" + re.escape(handle) + r"\s*\.\s*write\s*\("
+    )
+    spans: list[tuple[int, int]] = []
+    for found in write_re.finditer(lexed.code, call.end):
+        open_paren = lexed.code.index("(", found.end() - 1)
+        closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+        if closing is None:
+            continue
+        arguments = split_arguments(lexed.code, open_paren + 1, closing)
+        if arguments:
+            spans.append(arguments[0])
+    return spans
+
+
+URL_CONSTRUCTOR_RE = re.compile(
+    r"^\s*(?:new\s+)?(?:URI|URL)(?:\s*\.\s*(?:create|parse|join))?\s*\("
+)
+
+
+def unwrap_url_constructor(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel URI(...) / URI.create(...) / new URL(...) down to the URL itself.
+
+    Ruby's Net::HTTP and Java's HttpRequest REQUIRE the wrapped form, so a
+    resolver that only reads bare strings treated the mandatory spelling as
+    an unknown expression and dropped the call entirely.
+    """
+    text = lexed.code[span[0]:span[1]]
+    match = URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else span
+
+
+def unwrap_bound_url_constructor(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel a URI/URL constructor held in a BINDING's right-hand side.
+
+    `uri = URI(URL); Net::HTTP.post(uri, body)` is as idiomatic as the inline
+    spelling, but unwrapping only ran on the call-argument span, so the binding
+    stayed an unknown expression and the send resolved to nothing.
+
+    Narrower than `unwrap_url_constructor` on purpose: a binding carries no
+    companion base lookup, so the two-argument `new URL(path, base)` form must
+    stay unresolved rather than collapse to its (safe-looking) path, and a
+    trailing member call (`URI.create(u).resolve(x)`) must not be discarded.
+    """
+    text = lexed.code[span[0]:span[1]]
+    match = URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing >= span[1]:
+        return span
+    if lexed.code[closing + 1:span[1]].strip():
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if len(inner) == 1 else span
+
+
+# Only JS/TS `new URL(path, base)` — the WHATWG constructor whose second
+# argument is a base. Java/Python `URI(...)` multi-argument constructors have
+# different semantics (Java's two-arg form is (scheme, ssp), NOT (path, base)),
+# so combining their arguments would misclassify unrelated calls.
+_JS_URL_CONSTRUCTOR_RE = re.compile(r"^\s*(?:new\s+)?URL\s*\(")
+
+
+def url_constructor_base(
+    lexed: LexedSource, span: tuple[int, int], suffix: str
+) -> str | None:
+    """Return the static base of a JS/TS `new URL(path, base)` span."""
+    if suffix not in JS_TS_SUFFIXES:
+        return None
+    text = lexed.code[span[0]:span[1]]
+    match = _JS_URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return None
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return None
+    arguments = split_arguments(lexed.code, open_paren + 1, closing)
+    if len(arguments) < 2:
+        return None
+    base_start, base_end = arguments[1]
+    for token in lexed.strings:
+        if base_start <= token.start and token.end <= base_end:
+            return token.contents
+    # `new URL(path, BASE)` with the base held in a constant is the idiomatic
+    # spelling; reading only a raw string token left the whole send
+    # unresolvable. Resolve the alias chain the same way every other base does.
+    return static_string_value(lexed, arguments[1], span[0], suffix)
+
+
+# A base URL carried by a client factory: axios.create({baseURL: '...'}),
+# httpx.Client(base_url='...'). The request path is then relative, so the
+# effective endpoint is base + path. The KEY name is code (preserved), but the
+# value is a string whose contents the lexer masks, so it is read from the
+# string token rather than from the masked code.
+# Stops at the separator: the lexer masks the value string to blanks, so a
+# trailing \s* would run past it and miss the token.
+# The left boundary excludes `\w` and `-` so the bare `url` alternative cannot
+# match the TAIL of an unrelated key (`callback_url:`, `'X-Callback-Url' =>`),
+# whose value would otherwise be read as the client's base. `$` is deliberately
+# NOT excluded: PHP's `$base_url =` must still match.
+_BASE_URL_KEY_RE = re.compile(
+    r"(?<![\w\-])(?:base[_]?url|base_uri|BaseAddress|url)['\"]?\s*(?::|=>|=)",
+    re.I,
+)
+_CLIENT_FACTORY_CALL_RE = re.compile(
+    r"(?:\.\s*create|\bClient|\bAsyncClient|\bHttpClient|\bSession|"
+    r"\bsession|\bFaraday\s*\.\s*new)\s*\("
+)
+
+
+def _paren_group_span_before_accessor(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Return the offset span inside the receiver's trailing call parens."""
+    accessor = re.search(r"(?:\.|->|::)\s*$", lexed.code[: call.start])
+    if accessor is None:
+        return None
+    end = len(lexed.code[: accessor.start()].rstrip())
+    if end == 0 or lexed.code[end - 1] != ")":
+        return None
+    depth = 0
+    index = end - 1
+    while index >= 0:
+        if lexed.code[index] == ")":
+            depth += 1
+        elif lexed.code[index] == "(":
+            depth -= 1
+            if depth == 0:
+                break
+        index -= 1
+    if index < 0:
+        return None
+    return index + 1, end - 1
+
+
+def _base_url_in_region(
+    lexed: LexedSource, region: tuple[int, int]
+) -> str | None:
+    """Return the base URL string literal declared within an offset region."""
+    start, end = region
+    # Some languages commonly quote option keys (`'base_uri' =>` in PHP),
+    # which the masked-code view deliberately blanks. Key syntax is safe to
+    # inspect in the original source here; the value still comes from the
+    # lexer's string-token table rather than from regex parsing.
+    key = _BASE_URL_KEY_RE.search(lexed.original, start, end)
+    if key is None:
+        return None
+    value_start = key.end()
+    value_end = _option_value_end(lexed, value_start, end)
+    following = [
+        token
+        for token in lexed.strings
+        if value_start <= token.start and token.end <= value_end
+    ]
+    if not following:
+        return None
+    return min(following, key=lambda token: token.start).contents
+
+
+def _option_value_end(lexed: LexedSource, start: int, limit: int) -> int:
+    """End of ONE option's value: the next separator at its own nesting depth.
+
+    Without this bound the scan took the first string ANYWHERE after the key,
+    so a non-literal base (`url: base`, `baseURL: process.env.X`) silently
+    adopted the next option's value - `headers: {'X-Doc' => '<base>'}` became
+    the base URL and a relative path was joined against it.
+    """
+    depth = 0
+    cursor = start
+    while cursor < limit:
+        char = lexed.code[cursor]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            if depth == 0:
+                return cursor
+            depth -= 1
+        elif char in ",;" and depth == 0:
+            return cursor
+        cursor += 1
+    return limit
+
+
+# An Axios METHOD HELPER takes a per-request config whose baseURL overrides the
+# instance one (axios.post(url, data, {baseURL}) / api.post(url, data, {baseURL})).
+# Body-carrying helpers put that config third; the rest put it second.
+_AXIOS_HELPER_CONFIG_INDEX = {
+    "post": 2,
+    "put": 2,
+    "patch": 2,
+    "get": 1,
+    "delete": 1,
+    "head": 1,
+    "options": 1,
+}
+
+
+def config_object_base_url(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> str | None:
+    """Resolve a static baseURL/base_uri from an inline or aliased config."""
+
+    base_spans = config_object_member_spans(
+        lexed, span, before, suffix, ("baseURL", "baseUrl", "base_uri")
+    )
+    if not base_spans:
+        return None
+    return static_string_value(
+        lexed, base_spans[-1], before, suffix
+    )
+
+
+def client_base_url(lexed: LexedSource, call: Call, suffix: str) -> str | None:
+    """Return the static base URL of the client a `.post()` is sent through.
+
+    Handles the client created inline —
+    axios.create({baseURL: '...'}).post(path) — and bound to a variable —
+    const api = axios.create({baseURL: '...'}); api.post(path). The idiomatic
+    variable form is as common as the inline one, so both must resolve or a
+    base-URL send is silently classified as safe.
+    """
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren]).lower()
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    receiver = call_receiver(lexed, call)
+    if (
+        callee in {"axios", "axios.request"}
+        or (callee == "request" and receiver == "axios")
+    ) and args:
+        return config_object_base_url(
+            lexed, args[0], call.start, suffix
+        )
+
+    # A per-request config on a method helper — axios.post(url, data, {baseURL})
+    # or api.post(url, data, {baseURL}) — sets the effective base and OVERRIDES
+    # the instance baseURL. Only the one-shot axios(config) form was read, so a
+    # required send addressed this way resolved to the bare path and was
+    # silently classified as safe. Checked first for that precedence.
+    # Member access differs by language (obj.post, $obj->post, Obj::post).
+    method_name = re.split(r"->|::|\.", callee)[-1]
+    config_index = _AXIOS_HELPER_CONFIG_INDEX.get(method_name)
+    if config_index is not None and len(args) > config_index:
+        base = config_object_base_url(
+            lexed, args[config_index], call.start, suffix
+        )
+        if base is not None:
+            return base
+
+    if receiver is None:
+        region = _paren_group_span_before_accessor(lexed, call)
+        return _base_url_in_region(lexed, region) if region is not None else None
+
+    # C# commonly configures HttpClient in a separate member assignment:
+    # `client.BaseAddress = new Uri("..."); client.PostAsync(path, ...)`.
+    member_base_pattern = re.compile(
+        rf"\b{re.escape(receiver)}\s*\.\s*BaseAddress\s*="
+    )
+    member_base = list(
+        member_base_pattern.finditer(lexed.code, 0, call.start)
+    )
+    if member_base:
+        start = member_base[-1].end()
+        end = assignment_end(lexed, start, suffix)
+        values = [
+            token.contents
+            for token in lexed.strings
+            if start <= token.start and token.end <= end
+        ]
+        if values:
+            return values[0]
+
+    for assignment in reversed(assignment_matches(lexed.code, receiver, call.start)):
+        rhs_start = assignment.end()
+        rhs_end = assignment_end(lexed, rhs_start, suffix)
+        if _CLIENT_FACTORY_CALL_RE.search(lexed.code, rhs_start, rhs_end):
+            base = _base_url_in_region(lexed, (rhs_start, rhs_end))
+            if base is not None:
+                return base
+    return None
+
+
+def join_base_and_path(base: str, path: str) -> str:
+    return base.rstrip("/") + "/" + path.lstrip("/")
+
+
+def request_url_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select URL expressions, unwrapping URI/URL constructor spellings."""
+    return [
+        unwrap_url_constructor(lexed, span)
+        for span in _request_url_spans(lexed, call, suffix)
+    ]
+
+
+def _request_url_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select URL expressions for the supported REST client signatures."""
+
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    if not args:
+        return []
+    callee = re.sub(
+        r"\s+", "", lexed.code[call.start:call.open_paren]
+    )
+    callee_lower = callee.lower()
+    receiver = call_receiver(lexed, call)
+    explicit_receiver = bool(
+        re.search(r"(?:\.|->|::)\s*$", lexed.code[:call.start])
+    )
+    if callee_lower == "post" and suffix in {".java", ".kt", ".kts", ".scala"}:
+        # Builder chain: the endpoint is set by an EARLIER link in the same
+        # statement — .uri(URI.create(url)) for java.net.http, .url(url) for
+        # OkHttp — so the send call's own arguments never carry it. The chain
+        # has no simple receiver, so this must run before the anonymous-receiver
+        # guard below or the call is discarded exactly because it is a builder.
+        # Keyed on the PRESENCE of that link rather than on the method's case,
+        # since java.net.http spells it .POST and OkHttp spells it .post.
+        uri_span = builder_uri_span(lexed, call)
+        if uri_span is not None:
+            # The execution-link requirement applies to OkHttp (`.url(...)` +
+            # newCall/enqueue), which is newly modelled here. java.net.http
+            # (`.uri(...)`) keeps its existing contract, where the builder chain
+            # itself is treated as the send - changing that is out of scope for
+            # this fix and its behaviour is pinned by existing tests.
+            okhttp_style = _BUILDER_LINK_KIND.get((id(lexed), call.start)) == "url"
+            if not okhttp_style or request_object_is_executed(
+                lexed, call, suffix
+            ):
+                return [uri_span]
+            return []
+        if callee == "POST":
+            return []
+    # A `.post()` whose receiver is not a simple identifier is a factory call.
+    # Two kinds exist: HTTP-client factories that DO send —
+    # requests.Session().post(...), httpx.Client().post(...),
+    # axios.create(...).post(...) — and mock/assertion factories that do NOT —
+    # nock(API).post(...), expect(x)... . Skipping every anonymous receiver
+    # missed the real clients (a common shape); analysing every one flags the
+    # mocks. Discriminate on the factory METHOD name: analyse only the known
+    # client factories, keep skipping the rest.
+    if (
+        callee_lower in {"post", "postasync", "request"}
+        and explicit_receiver
+        and receiver is None
+        and factory_receiver_method(lexed, call) not in HTTP_CLIENT_FACTORY_METHODS
+    ):
+        return []
+    if callee_lower in {"post", "postasync"} and receiver in {
+        "app", "console", "expect", "nock", "router"
+    }:
+        return []
+    if callee_lower in {"axios", "axios.request"}:
+        return config_object_url_spans(
+            lexed, args[0], call.start, suffix
+        )
+    named_method = named_argument_spans(lexed, args, "method")
+    named_url = [
+        span
+        for name in URL_MEMBER_NAMES
+        for span in named_argument_spans(lexed, args, name)
+    ]
+    if callee_lower in {"post", "postasync"} and named_url:
+        return named_url[-1:]
+    if suffix == ".php" and callee == "file_get_contents" and args:
+        region = php_stream_context_region(lexed, call, suffix)
+        if region is None:
+            return []
+        blob = lexed.original[region[0]:region[1]]
+        verb = re.search(r"[\'\"]method[\'\"]\s*=>\s*[\'\"](\w+)[\'\"]", blob)
+        if verb is None or verb.group(1).upper() not in MUTATING_HTTP_METHODS:
+            return []
+        return args[0:1]
+    if (
+        suffix in JS_TS_SUFFIXES
+        and callee.split(".")[-1] == "open"
+        and len(args) >= 2
+    ):
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        if method is None or method.upper() not in MUTATING_HTTP_METHODS:
+            return []
+        return args[1:2]
+    if suffix == ".py" and callee.split(".")[-1] == "Request" and args:
+        # urllib.request.Request(url, data=..., method="POST") - the stdlib
+        # client. Default method is GET unless data= is present or method=
+        # names a mutating verb.
+        blob = lexed.original[call.start:call.end]
+        method = re.search(r"method\s*=\s*[\'\"](\w+)[\'\"]", blob)
+        if method is not None:
+            if method.group(1).upper() not in MUTATING_HTTP_METHODS:
+                return []
+        elif not re.search(r"(?<![\w])data\s*=", blob):
+            return []
+        if not request_object_is_executed(lexed, call, suffix):
+            return []
+        return args[0:1]
+    if callee in {"HttpRequestMessage", "RestRequest"} and args:
+        # HttpRequestMessage(HttpMethod.Post, url) puts the endpoint SECOND;
+        # RestRequest(url, Method.Post) puts it FIRST. Only a mutating method
+        # makes the request a send.
+        blob = lexed.original[call.start:call.end]
+        mutating = re.search(
+            r"(?:HttpMethod|Method)\s*\.\s*(?:Post|Put|Patch)", blob
+        ) is not None
+        if not mutating:
+            # The verb may be assigned AFTER construction:
+            #   var req = new RestRequest(url);  req.Method = Method.Post;
+            # Treating the constructor alone as authoritative made that a
+            # silent pass.
+            statement_start = max(
+                lexed.code.rfind(";", 0, call.start),
+                chain_newline_boundary(lexed.code, call.start),
+            ) + 1
+            binding = re.search(
+                r"([A-Za-z_]\w*)\s*=(?!=)", lexed.code[statement_start:call.start]
+            )
+            if binding is None:
+                return []
+            mutating = re.search(
+                rf"(?<![\w]){re.escape(binding.group(1))}\s*\.\s*Method\s*="
+                r"\s*(?:HttpMethod|Method)\s*\.\s*(?:Post|Put|Patch)\b",
+                lexed.code[call.end:],
+            ) is not None
+            if not mutating:
+                return []
+        if not request_object_is_executed(lexed, call, suffix):
+            return []
+        return args[1:2] if callee == "HttpRequestMessage" else args[0:1]
+    if suffix == ".go" and callee in {"Post", "Put", "Patch"} and len(args) == 1:
+        # resty: client.R().SetBody(...).Post(url) - a single argument is the
+        # ENDPOINT, unlike net/http.Post(url, contentType, body). Without this
+        # the whole send was invisible.
+        return args[0:1]
+    if callee == "NewRequest" and len(args) >= 2:
+        # Go net/http: http.NewRequest(method, url, body) + client.Do(req).
+        # The idiomatic non-shortcut form; only mutating methods matter here.
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return []
+        # NOTE: http.NewRequest is NOT gated on a client.Do(req) execution link.
+        # An existing contract (test_http_method_gate_is_consistent_across_
+        # transports, fixture go-method-post.go) pins the behaviour that
+        # NewRequest alone counts as a required send. Adding the gate here was a
+        # behaviour change beyond the scope of this work, so it is left as-is;
+        # the execution requirement applies only to the clients newly modelled
+        # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
+        return args[1:2]
+    if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
+        return args[0:1]
+    if callee == "curl_init" and len(args) >= 1:
+        # `curl_init($url)` sets CURLOPT_URL directly - it is the documented
+        # one-liner form and is at least as common as the setopt spelling.
+        # Modelling only curl_setopt(CURLOPT_URL) made the whole send invisible:
+        # the endpoint was never resolved, so the call was not counted as a send
+        # and the fail-safe could not fire either. The linter reported "no
+        # number-pool call sites detected" on a number-pool POST.
+        return args[0:1]
+    if callee == "curl_setopt" and len(args) >= 3:
+        # PHP ext-curl is stateful: the URL and the payload arrive in
+        # separate curl_setopt calls on the same handle. The CURLOPT_URL call
+        # carries the endpoint; rest_payload_spans finds the sibling
+        # CURLOPT_POSTFIELDS for the same handle. Every other option is not
+        # an HTTP send and is skipped outright.
+        option = lexed.code[args[1][0]:args[1][1]].strip()
+        return args[2:3] if option == "CURLOPT_URL" else []
+    if callee == "curl_setopt_array" and len(args) >= 2:
+        # Same statefulness, one literal: curl_setopt_array($ch, [CURLOPT_URL
+        # => ..., CURLOPT_POSTFIELDS => ...]). The URL comes from the array,
+        # and the same method gate applies — an array that configures a GET is
+        # not a send and must not be reported.
+        url_spans = curl_option_array_value_spans(
+            lexed, args[1], suffix, "CURLOPT_URL"
+        )[-1:]
+        if not url_spans:
+            return []
+        handle = lexed.code[args[0][0]:args[0][1]].strip()
+        method = php_curl_handle_method(lexed, handle, call.start, suffix)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return []
+        return url_spans
+    if callee_lower in {"post", "postasync"} and not named_url:
+        # Request-style config object: post({url: ..., json: {...}}), with or
+        # without a trailing callback — request.post(options, cb) is the
+        # library's classic form. The URL lives in a member rather than a
+        # named argument, so named_url stays empty and the fallback below
+        # evaluated the whole object, meaning a number-pool send missing
+        # messaging_profile_id was never seen as a required call at all.
+        #
+        # Resolved from the FIRST argument only, never from any argument
+        # carrying a url-ish key: in post(url, {callback_url: ...}) the
+        # endpoint is the positional string and a url-shaped key inside the
+        # body must not displace it. A base-URL client passing only a body
+        # object has no URL member and keeps its existing treatment.
+        object_url = config_object_url_spans(
+            lexed, args[0], call.start, suffix
+        )
+        if object_url:
+            return object_url[-1:]
+    if callee_lower == "request" and named_method and named_url:
+        method = static_method_value(
+            lexed, named_method[-1], call.start, suffix
+        )
+        return (
+            []
+            if method is not None and method not in MUTATING_HTTP_METHODS
+            else named_url[-1:]
+        )
+    if callee_lower == "request":
+        first_config = resolved_config_object_span(
+            lexed, args[0], call.start, suffix
+        )
+        if first_config is not None:
+            members = config_object_url_spans(
+                lexed, args[0], call.start, suffix
+            )
+            if members:
+                return members[-1:]
+            path_members = named_object_member_spans(
+                lexed, first_config, ("path",)
+            )
+            host_members = named_object_member_spans(
+                lexed, first_config, ("hostname", "host")
+            )
+            return path_members[-1:] if path_members and host_members else []
+        if len(args) > 1 and resolved_config_object_span(
+            lexed, args[1], call.start, suffix
+        ) is not None:
+            # request(url, options[, callback]) is URL-first. Method gating
+            # is binding-aware in SourceEndpointResolver.
+            return args[:1]
+    if callee_lower == "request" and len(args) > 1:
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        return (
+            []
+            if method is not None and method not in MUTATING_HTTP_METHODS
+            else args[1:2]
+        )
+    if callee_lower == "request" and len(args) == 1:
+        members = config_object_url_spans(lexed, args[0], call.start, suffix)
+        if members:
+            return members[-1:]
+        # Node core http(s).request splits the endpoint into hostname + path.
+        # The path alone identifies the required endpoint (the normalizer
+        # accepts relative "/v2/messages/number_pool"), so a host member plus
+        # a path member is enough to place the call.
+        path_members = named_object_member_spans(lexed, args[0], ("path",))
+        host_members = named_object_member_spans(
+            lexed, args[0], ("hostname", "host")
+        )
+        if path_members and host_members:
+            return path_members[-1:]
+        return []
+    return args[:1]
+
+
+def selected_members_after_container(
+    lexed: LexedSource, closing: int, end: int
+) -> EndpointReference | None:
+    """Return a static selection chain, or None for a dynamic selector."""
+
+    members: list[str] = []
+    strings = {token.start: token for token in lexed.strings}
+    cursor = closing + 1
+    while cursor < end:
+        while cursor < end and (
+            lexed.code[cursor].isspace() or lexed.code[cursor] == ")"
+        ):
+            cursor += 1
+        bracket = False
+        if lexed.code.startswith("?.", cursor):
+            cursor += 2
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            bracket = cursor < end and lexed.code[cursor] == "["
+        elif cursor < end and lexed.code[cursor] == ".":
+            cursor += 1
+        elif lexed.code.startswith("->", cursor):
+            cursor += 2
+        elif cursor < end and lexed.code[cursor] == "[":
+            bracket = True
+        else:
+            break
+
+        if bracket:
+            cursor += 1
+            while (
+                cursor < end
+                and cursor not in strings
+                and lexed.code[cursor].isspace()
+            ):
+                cursor += 1
+            token = strings.get(cursor)
+            if token is not None:
+                key = token.contents
+                cursor = token.end
+            else:
+                numeric = re.match(r"\d+", lexed.code[cursor:end])
+                symbol = re.match(
+                    r":\s*([A-Za-z_]\w*)", lexed.code[cursor:end]
+                )
+                if numeric is not None:
+                    key = numeric.group(0)
+                    cursor += len(numeric.group(0))
+                elif symbol is not None:
+                    key = symbol.group(1)
+                    cursor += len(symbol.group(0))
+                else:
+                    return None
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            if cursor >= end or lexed.code[cursor] != "]":
+                return None
+            members.append(key)
+            cursor += 1
+            continue
+
+        while cursor < end and lexed.code[cursor].isspace():
+            cursor += 1
+        member = re.match(r"[A-Za-z_]\w*", lexed.code[cursor:end])
+        if member is None:
+            return None
+        member_name = member.group(0)
+        cursor += len(member_name)
+        lookup_cursor = cursor
+        while lookup_cursor < end and lexed.code[lookup_cursor].isspace():
+            lookup_cursor += 1
+        if (
+            member_name in {"fetch", "get", "Get"}
+            and lookup_cursor < end
+            and lexed.code[lookup_cursor] == "("
+        ):
+            lookup_closing = matching_delimiter(
+                lexed.code, lookup_cursor, "(", ")"
+            )
+            if lookup_closing is None or lookup_closing >= end:
+                return None
+            key = static_lookup_key(
+                lexed, lookup_cursor + 1, lookup_closing
+            )
+            if key is None:
+                return None
+            members.append(key)
+            cursor = lookup_closing + 1
+        else:
+            members.append(member_name)
+    return tuple(members)
+
+
+STATIC_REFERENCE_EXPRESSION_RE = re.compile(
+    r"\s*\$?[A-Za-z_]\w*"
+    r"(?:\s*(?:"
+    r"(?:\?\.|\.|->)\s*[A-Za-z_]\w*"
+    r"|(?:\?\.)?\s*\[\s*(?:\"[^\"]*\"|'[^']*'|`[^`]*`|"
+    r":\s*[A-Za-z_]\w*|\d+)\s*\]"
+    r"|(?:\.|->)\s*(?:get|Get|fetch)\s*\(\s*"
+    r"(?:\"[^\"]*\"|'[^']*'|`[^`]*`|:\s*[A-Za-z_]\w*|\d+)"
+    r"\s*\)"
+    r"))*\s*"
+)
+
+
+def strip_expression_parentheses(
+    lexed: LexedSource, start: int, end: int
+) -> tuple[int, int]:
+    while True:
+        while start < end and lexed.original[start].isspace():
+            start += 1
+        while end > start and lexed.original[end - 1].isspace():
+            end -= 1
+        if start >= end or lexed.code[start] != "(":
+            return start, end
+        closing = matching_delimiter(lexed.code, start, "(", ")")
+        if closing != end - 1:
+            return start, end
+        start += 1
+        end -= 1
+
+
+def static_reference_expression(
+    lexed: LexedSource, start: int, end: int
+) -> EndpointReference | None:
+    start, end = strip_expression_parentheses(lexed, start, end)
+    if not STATIC_REFERENCE_EXPRESSION_RE.fullmatch(
+        lexed.original[start:end]
+    ):
+        return None
+    references = static_references(lexed, start, end)
+    return references[0] if references else None
+
+
+def root_literal_container(
+    lexed: LexedSource, start: int, end: int, suffix: str
+) -> tuple[str, int, int] | None:
+    """Return a literal container rooted in one bounded expression."""
+
+    start, end = strip_expression_parentheses(lexed, start, end)
+    call_forms: tuple[tuple[str, str], ...] = ()
+    if suffix == ".java":
+        call_forms = (
+            (r"\bMap\s*\.\s*of\s*\(", "pairs"),
+            (r"\b(?:List\s*\.\s*of|Arrays\s*\.\s*asList)\s*\(", "array"),
+        )
+    elif suffix == ".php":
+        call_forms = ((r"\barray\s*\(", "members"),)
+    for pattern, kind in call_forms:
+        match = re.search(pattern, lexed.code[start:end])
+        if match is None:
+            continue
+        absolute_end = start + match.end()
+        opening = lexed.code.rfind("(", start, absolute_end)
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is not None and closing < end:
+            return kind, opening, closing
+
+    delimiters = "{" if suffix in {".cs", ".go", ".java"} else "[{"
+    candidates: list[int] = []
+    for index in range(start, end):
+        if lexed.code[index] not in delimiters:
+            continue
+        prefix = lexed.code[start:index].strip()
+        prefix = prefix.strip("() \t\r\n")
+        if not prefix or (
+            suffix in {".cs", ".go", ".java"}
+            and re.fullmatch(
+                r"(?:new\s+)?(?:[A-Za-z_]\w*(?:\s*<[^{}]+>)?"
+                r"(?:\s*\[[^{}]*\])?|map\s*\[[^{}]*\]\s*[A-Za-z_]\w*"
+                r"|\[[^{}]*\]\s*[A-Za-z_]\w*)",
+                prefix,
+            )
+        ):
+            candidates.append(index)
+    if not candidates:
+        return None
+    opening = candidates[0]
+    left = lexed.code[opening]
+    right = "}" if left == "{" else "]"
+    closing = matching_delimiter(lexed.code, opening, left, right)
+    return (
+        ("members", opening, closing)
+        if closing is not None and closing < end
+        else None
+    )
+
+
+def literal_value_span(
+    lexed: LexedSource,
+    start: int,
+    end: int,
+    path: EndpointReference,
+    suffix: str,
+) -> tuple[int, int] | None:
+    """Project a static key/index through nested bounded literals."""
+
+    current_start, current_end = start, end
+    for selected_key in path:
+        container = root_literal_container(
+            lexed, current_start, current_end, suffix
+        )
+        if container is None:
+            return None
+        kind, opening, closing = container
+        members = split_arguments(lexed.code, opening + 1, closing)
+        candidates: list[tuple[str, tuple[int, int]]] = []
+        if kind == "pairs":
+            for index in range(1, len(members), 2):
+                key = static_object_key(lexed, *members[index - 1])
+                if key is not None:
+                    candidates.append((key, members[index]))
+        else:
+            separators = [
+                (
+                    (colon, colon + 1)
+                    if (colon := top_level_colon(
+                        lexed.code, member_start, member_end
+                    )) is not None
+                    else top_level_assignment_separator(
+                        lexed.code, member_start, member_end
+                    )
+                )
+                for member_start, member_end in members
+            ]
+            keyed = any(
+                separator is not None for separator in separators
+            )
+            for index, ((member_start, member_end), separator) in enumerate(
+                zip(members, separators)
+            ):
+                if keyed:
+                    if separator is None:
+                        key = static_object_key(
+                            lexed, member_start, member_end
+                        )
+                        if key is not None:
+                            candidates.append(
+                                (key, (member_start, member_end))
+                            )
+                        continue
+                    separator_start, value_start = separator
+                    key = static_object_key(
+                        lexed, member_start, separator_start
+                    )
+                    if key is not None:
+                        candidates.append(
+                            (key, (value_start, member_end))
+                        )
+                else:
+                    candidates.append(
+                        (str(index), (member_start, member_end))
+                    )
+        # Object/hash duplicate keys use their last value.
+        selected = next(
+            (
+                span
+                for key, span in reversed(candidates)
+                if key == selected_key
+            ),
+            None,
+        )
+        if selected is None:
+            return None
+        current_start, current_end = selected
+    return strip_expression_parentheses(lexed, current_start, current_end)
+
+
+def class_field_regions(
+    lexed: LexedSource, suffix: str
+) -> list[tuple[int, int]]:
+    """Top-level regions of JS/TS class BODIES - where fields are declared.
+
+    A class field (`class S { payload = {…} }`) declares a MEMBER, not a
+    reassignment of a same-named outer variable, but the assignment pattern
+    cannot tell them apart. The field's value overwrote an outer `payload`
+    that already carried messaging_profile_id, and the send that used the outer
+    one was reported as missing the profile. Method bodies sit at depth > 0 and
+    are deliberately excluded, so real locals inside them still bind.
+    """
+
+    if suffix not in JS_TS_SUFFIXES:
+        return []
+    code = lexed.code
+    regions: list[tuple[int, int]] = []
+    for match in re.finditer(r"\bclass\b[^{};()]*\{", code):
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is None:
+            continue
+        depth = 0
+        span_start = opening + 1
+        for index in range(opening + 1, closing):
+            character = code[index]
+            if character in "([{":
+                if depth == 0:
+                    regions.append((span_start, index))
+                depth += 1
+            elif character in ")]}" and depth:
+                depth -= 1
+                if depth == 0:
+                    span_start = index + 1
+        regions.append((span_start, closing))
+    return regions
+
+
+def c_function_headers(
+    lexed: LexedSource, suffix: str
+) -> dict[int, tuple[int, int]]:
+    """Index common C-family function/method/closure braces and parameters."""
+
+    supported = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
+    if suffix not in supported:
+        return {}
+    headers: dict[int, tuple[int, int]] = {}
+    controls = {
+        "catch", "checked", "fixed", "for", "foreach", "if", "lock",
+        "switch", "synchronized", "try", "unchecked", "using", "while",
+        "with",
+    }
+    for opening in (index for index, char in enumerate(lexed.code) if char == "{"):
+        statement_start = max(
+            lexed.code.rfind(";", 0, opening),
+            lexed.code.rfind("{", 0, opening),
+            lexed.code.rfind("}", 0, opening),
+            lexed.code.rfind("\n", 0, opening),
+        ) + 1
+        statement_start = max(statement_start, opening - 512)
+        header = lexed.code[statement_start:opening]
+        trimmed = header.rstrip()
+
+        arrow_token = None
+        if suffix in JS_TS_SUFFIXES | {".cs"}:
+            arrow_token = "=>"
+        elif suffix == ".java":
+            arrow_token = "->"
+        if arrow_token and trimmed.endswith(arrow_token):
+            arrow_start = statement_start + len(trimmed) - 2
+            cursor = arrow_start - 1
+            while cursor >= statement_start and lexed.code[cursor].isspace():
+                cursor -= 1
+            if cursor >= statement_start and lexed.code[cursor] == ")":
+                params_open = matching_opening(
+                    lexed.code, cursor, "(", ")"
+                )
+                if params_open is not None and params_open >= statement_start:
+                    headers[opening] = (params_open + 1, cursor)
+                continue
+            parameter = re.search(
+                r"(?:^|[^\w$])([$A-Za-z_]\w*)\s*$",
+                lexed.code[statement_start:arrow_start],
+            )
+            if parameter is not None:
+                headers[opening] = (
+                    statement_start + parameter.start(1),
+                    statement_start + parameter.end(1),
+                )
+            continue
+
+        pairs: list[tuple[int, int]] = []
+        depth = 0
+        params_open = -1
+        for index in range(statement_start, opening):
+            if lexed.code[index] == "(":
+                if depth == 0:
+                    params_open = index
+                depth += 1
+            elif lexed.code[index] == ")" and depth:
+                depth -= 1
+                if depth == 0:
+                    pairs.append((params_open, index))
+        if not pairs:
+            continue
+
+        keyword = re.search(r"\b(function|func)\b", header)
+        if keyword is not None:
+            keyword_end = statement_start + keyword.end()
+            candidates = [pair for pair in pairs if pair[0] >= keyword_end]
+            if not candidates:
+                continue
+            selected = candidates[0]
+            if suffix == ".go" and len(candidates) > 1:
+                before_first = lexed.code[keyword_end:selected[0]].strip()
+                between = lexed.code[selected[1] + 1:candidates[1][0]].strip()
+                if not before_first and re.fullmatch(
+                    r"[A-Za-z_]\w*", between
+                ):
+                    selected = candidates[1]
+            headers[opening] = (selected[0] + 1, selected[1])
+            continue
+        if suffix in {".go", ".php"}:
+            continue
+
+        for candidate_open, candidate_close in pairs:
+            prefix = lexed.code[statement_start:candidate_open]
+            name_match = re.search(r"([A-Za-z_]\w*)\s*$", prefix)
+            if name_match is None:
+                continue
+            name = name_match.group(1)
+            if name in controls:
+                continue
+            before_name = prefix[:name_match.start(1)]
+            if re.search(
+                rf"\b(?:{'|'.join(sorted(controls))})\b[^{{}};]*$",
+                before_name,
+            ):
+                continue
+            if re.search(r"(?:\.|->|::)\s*$", before_name):
+                continue
+            if re.search(
+                r"\b(?:new|return|throw)\b[^{};]*$", before_name
+            ) or re.search(r"\bclass\b[^{};]*\bextends\b", before_name):
+                continue
+            tail = lexed.code[candidate_close + 1:opening].strip()
+            if suffix == ".java" and tail and not tail.startswith("throws"):
+                continue
+            if suffix == ".cs" and tail and not re.fullmatch(
+                r":\s*(?:base|this)\s*\([\s\S]*\)", tail
+            ):
+                continue
+            if suffix in JS_TS_SUFFIXES and tail:
+                if not tail.startswith(":"):
+                    continue
+            if suffix == ".sh":
+                if lexed.code[candidate_open + 1:candidate_close].strip():
+                    continue
+                shell_prefix = prefix.strip()
+                if not re.fullmatch(
+                    rf"(?:function\s+)?{re.escape(name)}\s*", shell_prefix
+                ):
+                    continue
+            headers[opening] = (candidate_open + 1, candidate_close)
+            break
+    return headers
+
+
+def conditional_curly_scopes(code: str) -> set[int]:
+    # The prefix runs back to the previous brace, not a fixed 160 characters:
+    # `[^{}]*` already bounds the search there, and a LONG condition pushed its
+    # `if` outside the window, so the block opened no scope at all and a
+    # block-scoped `const payload` inside it leaked into the enclosing scope -
+    # shadowing the outer payload the send actually uses.
+    guarded: set[int] = set()
+    head = re.compile(
+        r"(?:\b(?:if|else|for|foreach|while|switch|case|catch|try)\b[^{}]*)$"
+    )
+    boundary = 0
+    for index, character in enumerate(code):
+        if character not in "{}":
+            continue
+        if character == "{" and head.search(code[boundary:index]):
+            guarded.add(index)
+        boundary = index + 1
+    return guarded
+
+
+def required_endpoint(value: str) -> bool:
+    # urlsplit RAISES on a malformed authority (an unclosed IPv6 bracket, an
+    # invalid port), and this runs on every endpoint-shaped literal in the tree
+    # - including ones inside test fixtures and documentation. An exception here
+    # aborted the whole FILE, so one unparsable string turned every send in it
+    # into "could not verify". Fall back to plain string handling instead.
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        parsed = None
+    path = (
+        (parsed.path if parsed is not None else "")
+        or value.split("?", 1)[0].split("#", 1)[0]
+    )
+    # Clients configured with a base URL (axios baseURL, requests Session
+    # mounts) pass RELATIVE paths such as "messages/number_pool"; a trailing-
+    # slash base joined with a relative path also leaves INTERIOR "." / ".."
+    # segments, because axios combineURLs does no normalization (baseURL
+    # ".../v2/messages/" + "./number_pool" -> ".../v2/messages/./number_pool",
+    # and ".../v2/messages/foo/" + "../number_pool" -> "...foo/../number_pool").
+    # Resolve all dot segments the way the HTTP layer does before comparing, so
+    # neither the base-URL form nor an interior dot segment is silently missed.
+    if not path.startswith("/"):
+        path = "/" + path
+    path = posixpath.normpath(path)
+    # posixpath.normpath PRESERVES a leading "//" (POSIX reserves it), so
+    # "https://api.telnyx.com//v2/messages/number_pool" kept a "//v2/..." path
+    # and matched nothing. Interior runs are already collapsed by normpath;
+    # collapse the leading run the same way an HTTP router does.
+    path = "/" + path.lstrip("/")
+    if path.startswith("/v2/") or path == "/v2":
+        path = path[3:] or "/"
+    return path.rstrip("/") in {
+        "/messages/number_pool",
+        "/messages/alphanumeric_sender_id",
+    }
+
+
+def required_endpoint_literal_signal(value: str) -> bool:
+    """Whether a URL-expression literal proves a required endpoint suffix.
+
+    Format strings often carry an unknown host prefix (`%s/v2/...`) that is
+    not itself a valid URL/path, but their static suffix is still definitive.
+    Keep this separate from `required_endpoint`, whose exact-path contract is
+    intentionally stricter for fully resolved URLs.
+    """
+    clean = value.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+    return bool(
+        re.search(
+            r"(?:^|/)messages/(?:number_pool|alphanumeric_sender_id)$",
+            clean,
+        )
+    )
+
+
+def endpoint_literal_value(value: str) -> EndpointValue:
+    return EndpointValue(REQUIRED if required_endpoint(value) else SAFE, value)
+
+
+def _default_endpoint_value(
+    values: tuple[EndpointValue, ...]
+) -> EndpointValue:
+    """Combine a `primary, fallback` pair (`get(k, d)`, `{a = d} = o`).
+
+    Only a MISSING primary selects the fallback - that is the one case where the
+    default is provably taken. EVERY other primary, UNRESOLVABLE included, is
+    returned as-is, so a dynamic lookup does NOT promote a REQUIRED literal
+    default. See the comment below for why that stays out of scope here.
+    """
+    primary, fallback = values[0], values[1]
+    if primary.kind == MISSING:
+        return fallback
+    # An UNRESOLVABLE primary deliberately does NOT promote a REQUIRED default.
+    # Treating it as required was tried and reverted: the documented contract
+    # (test_endpoint_resolver_common_static_syntax_corpus, fixture
+    # runtime-primary-default.js) places fail-closed dynamic lookups OUTSIDE
+    # this non-parser's finite grammar, so `const {pool: e = REQUIRED} = r`
+    # with a dynamic `r` is not provably a required send. Changing that is a
+    # behaviour change that needs its own justification, not a side effect.
+    return primary
+
+
+def join_endpoint_values(values: Iterable[EndpointValue]) -> EndpointValue:
+    values = tuple(values)
+    if not values:
+        return UNKNOWN_VALUE
+    kinds = {value.kind for value in values}
+    exacts = {value.exact for value in values}
+    # A JOIN is over branches that may ALL execute (a conditional reassignment,
+    # a guarded arm). If ANY branch reaches the required endpoint the send can
+    # reach it at runtime, so the join must stay REQUIRED. Collapsing the mixed
+    # case to UNKNOWN silently dropped conditionally-assigned number_pool sends:
+    # the surrounding call was still recognised, so the fail-safe backstop had
+    # nothing left to report either.
+    if REQUIRED in kinds:
+        return EndpointValue(
+            REQUIRED, exacts.pop() if len(exacts) == 1 else None
+        )
+    if len(kinds) != 1 or UNKNOWN in kinds:
+        return UNKNOWN_VALUE
+    return EndpointValue(
+        values[0].kind, exacts.pop() if len(exacts) == 1 else None
+    )
+
+
+class EndpointGraph:
+    """Iterative abstract interpreter over pre-indexed endpoint definitions."""
+
+    def __init__(self, source_length: int, state_budget: int = 10_000) -> None:
+        self.scopes: dict[int, IndexedScope] = {
+            0: IndexedScope(0, None, 0, source_length, "module")
+        }
+        self.bindings: dict[int, IndexedBinding] = {}
+        self.bindings_by_name: dict[str, list[int]] = {}
+        self.definitions: dict[int, list[IndexedDefinition]] = {}
+        self.definition_offsets: dict[int, list[int]] = {}
+        self._next_scope = 1
+        self._next_binding = 1
+        self.state_budget = state_budget
+        self._memo: dict[EndpointState, EndpointValue] = {}
+
+    def add_scope(
+        self, parent: int, start: int, end: int, kind: str
+    ) -> int:
+        scope_id = self._next_scope
+        self._next_scope += 1
+        self.scopes[scope_id] = IndexedScope(
+            scope_id, parent, start, end, kind
+        )
+        return scope_id
+
+    def ancestors(self, scope_id: int) -> tuple[int, ...]:
+        result: list[int] = []
+        current: int | None = scope_id
+        while current is not None:
+            result.append(current)
+            current = self.scopes[current].parent
+        return tuple(result)
+
+    def execution_scope(self, scope_id: int) -> int:
+        for candidate in self.ancestors(scope_id):
+            if self.scopes[candidate].kind in {"function", "module"}:
+                return candidate
+        return 0
+
+    def visible_binding(
+        self, name: str, use_scope: int, before: int
+    ) -> int | None:
+        ancestry = self.ancestors(use_scope)
+        depth = {scope_id: index for index, scope_id in enumerate(ancestry)}
+        candidates = [
+            self.bindings[binding_id]
+            for binding_id in self.bindings_by_name.get(name, ())
+            if self.bindings[binding_id].scope_id in depth
+            and self.bindings[binding_id].visibility_start <= before
+        ]
+        if not candidates:
+            return None
+        candidates.sort(
+            key=lambda binding: (
+                depth[binding.scope_id],
+                -binding.declaration_start,
+            )
+        )
+        return candidates[0].id
+
+    def add_binding(
+        self,
+        name: str,
+        scope_id: int,
+        declaration_start: int,
+        visibility_start: int,
+        kind: str,
+    ) -> int:
+        binding_id = self._next_binding
+        self._next_binding += 1
+        binding = IndexedBinding(
+            binding_id,
+            name,
+            scope_id,
+            declaration_start,
+            visibility_start,
+            kind,
+        )
+        self.bindings[binding_id] = binding
+        self.bindings_by_name.setdefault(name, []).append(binding_id)
+        return binding_id
+
+    def add_definition(
+        self,
+        binding_id: int,
+        path: EndpointReference,
+        expression: EndpointExpression,
+        offset: int,
+        scope_id: int,
+        kind: str,
+        guarded: bool = False,
+    ) -> None:
+        self._memo.clear()
+        definition = IndexedDefinition(
+            binding_id,
+            path,
+            offset,
+            expression,
+            scope_id,
+            self.execution_scope(scope_id),
+            kind,
+            guarded,
+        )
+        offsets = self.definition_offsets.setdefault(binding_id, [])
+        definitions = self.definitions.setdefault(binding_id, [])
+        index = bisect.bisect_right(offsets, offset)
+        offsets.insert(index, offset)
+        definitions.insert(index, definition)
+
+    def _definition_reaches(
+        self, definition: IndexedDefinition, state: EndpointAccessState
+    ) -> bool:
+        if definition.kind in {"declaration", "parameter"}:
+            return definition.scope_id in self.ancestors(state.use_scope)
+        return definition.execution_scope == self.execution_scope(
+            state.use_scope
+        )
+
+    def _matching_definitions(
+        self, state: EndpointAccessState
+    ) -> list[IndexedDefinition]:
+        offsets = self.definition_offsets.get(state.binding_id, ())
+        stop = bisect.bisect_left(offsets, state.before)
+        return [
+            definition
+            for definition in self.definitions.get(state.binding_id, ())[:stop]
+            if state.path[: len(definition.member_path)]
+            == definition.member_path
+            and self._definition_reaches(definition, state)
+        ]
+
+    @staticmethod
+    def _concat(values: tuple[EndpointValue, ...]) -> EndpointValue:
+        if not values:
+            return UNKNOWN_VALUE
+        if all(value.exact is not None for value in values):
+            return endpoint_literal_value(
+                "".join(value.exact or "" for value in values)
+            )
+        suffix_parts: list[str] = []
+        for value in reversed(values):
+            if value.exact is None:
+                break
+            suffix_parts.append(value.exact)
+        suffix = "".join(reversed(suffix_parts))
+        if required_endpoint(suffix):
+            return EndpointValue(REQUIRED)
+        # A dynamic QUERY STRING (".../messages/number_pool?ref=" + id) leaves
+        # no exact trailing run at all, so the suffix scan above saw nothing and
+        # the send was silently classified as safe. Once the exact PREFIX has
+        # reached a "?" or "#" the path is already closed: whatever follows is
+        # query or fragment and cannot change the endpoint.
+        prefix_parts: list[str] = []
+        for value in values:
+            if value.exact is None:
+                break
+            prefix_parts.append(value.exact)
+        prefix = "".join(prefix_parts)
+        if ("?" in prefix or "#" in prefix) and required_endpoint(prefix):
+            return EndpointValue(REQUIRED)
+        return UNKNOWN_VALUE
+
+    def _definition_dependency(
+        self,
+        definition: IndexedDefinition,
+        state: EndpointAccessState,
+    ) -> EndpointExpressionState:
+        remainder = state.path[len(definition.member_path):]
+        live_container_alias = (
+            bool(remainder)
+            and isinstance(definition.expression, EndpointRef)
+            and not definition.expression.members
+        )
+        return EndpointExpressionState(
+            definition.expression,
+            remainder,
+            state.before if live_container_alias else definition.start,
+            state.use_scope if live_container_alias else definition.scope_id,
+        )
+
+    def _expand_access(
+        self, state: EndpointAccessState
+    ) -> EndpointExpansion:
+        definitions = self._matching_definitions(state)
+        if not definitions:
+            return EndpointExpansion(immediate=UNKNOWN_VALUE)
+        last_unguarded = -1
+        use_ancestry = set(self.ancestors(state.use_scope))
+        for index, definition in enumerate(definitions):
+            if not definition.guarded or definition.scope_id in use_ancestry:
+                last_unguarded = index
+        if last_unguarded < 0:
+            selected = definitions
+            baseline = (UNKNOWN_VALUE,)
+        else:
+            selected = [definitions[last_unguarded]] + [
+                definition
+                for definition in definitions[last_unguarded + 1:]
+                if definition.guarded
+                and definition.scope_id not in use_ancestry
+            ]
+            baseline = ()
+        dependencies = tuple(
+            self._definition_dependency(definition, state)
+            for definition in selected
+        )
+        return EndpointExpansion(
+            dependencies,
+            lambda values: join_endpoint_values(baseline + values),
+        )
+
+    def _expand_expression(
+        self, state: EndpointExpressionState
+    ) -> EndpointExpansion:
+        expression = state.expression
+        if isinstance(expression, EndpointUnknown):
+            return EndpointExpansion(immediate=UNKNOWN_VALUE)
+        if isinstance(expression, EndpointLiteral):
+            return EndpointExpansion(
+                immediate=(
+                    UNKNOWN_VALUE
+                    if state.projection
+                    else endpoint_literal_value(expression.value)
+                )
+            )
+        if isinstance(expression, EndpointRef):
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointAccessState(
+                        expression.binding_id,
+                        expression.members + state.projection,
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointObject):
+            if not state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            key, remainder = state.projection[0], state.projection[1:]
+            candidates = [
+                value for entry_key, value in expression.entries
+                if entry_key == key
+            ]
+            if not candidates:
+                return EndpointExpansion(immediate=MISSING_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        candidates[-1], remainder, state.before, state.use_scope
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointArray):
+            if not state.projection or not state.projection[0].isdigit():
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            index = int(state.projection[0])
+            if index >= len(expression.items):
+                return EndpointExpansion(immediate=MISSING_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.items[index],
+                        state.projection[1:],
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointDefault):
+            if state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.primary, (), state.before, state.use_scope
+                    ),
+                    EndpointExpressionState(
+                        expression.fallback, (), state.before, state.use_scope
+                    ),
+                ),
+                combine=_default_endpoint_value,
+            )
+        if isinstance(expression, EndpointConcat):
+            if state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            return EndpointExpansion(
+                dependencies=tuple(
+                    EndpointExpressionState(
+                        part, (), state.before, state.use_scope
+                    )
+                    for part in expression.parts
+                ),
+                combine=self._concat,
+            )
+        if isinstance(expression, EndpointProjected):
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.expression,
+                        expression.members + state.projection,
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        return EndpointExpansion(immediate=UNKNOWN_VALUE)
+
+    def _expand(self, state: EndpointState) -> EndpointExpansion:
+        return (
+            self._expand_access(state)
+            if isinstance(state, EndpointAccessState)
+            else self._expand_expression(state)
+        )
+
+    def evaluate(self, state: EndpointState) -> EndpointValue:
+        memo: dict[EndpointState, EndpointValue] = dict(self._memo)
+        visiting: set[EndpointState] = set()
+        stack = [EndpointFrame(state)]
+        expanded_states = 0
+        while stack:
+            frame = stack[-1]
+            if frame.state in memo:
+                value = memo[frame.state]
+                stack.pop()
+                if stack:
+                    stack[-1].values.append(value)
+                    stack[-1].next_dependency += 1
+                continue
+            if frame.expansion is None:
+                expanded_states += 1
+                if expanded_states > self.state_budget:
+                    return UNKNOWN_VALUE
+                frame.expansion = self._expand(frame.state)
+                if frame.expansion.immediate is not None:
+                    memo[frame.state] = frame.expansion.immediate
+                    continue
+                visiting.add(frame.state)
+            dependencies = frame.expansion.dependencies
+            if frame.next_dependency < len(dependencies):
+                dependency = dependencies[frame.next_dependency]
+                if dependency in visiting:
+                    frame.values.append(UNKNOWN_VALUE)
+                    frame.next_dependency += 1
+                elif dependency in memo:
+                    frame.values.append(memo[dependency])
+                    frame.next_dependency += 1
+                else:
+                    stack.append(EndpointFrame(dependency))
+                continue
+            visiting.discard(frame.state)
+            assert frame.expansion.combine is not None
+            memo[frame.state] = frame.expansion.combine(tuple(frame.values))
+        self._memo.update(memo)
+        return memo[state]
+
+
+class SourceEndpointResolver:
+    """Compile one source file into a call-centric endpoint value graph."""
+
+    JAVASCRIPT_SUFFIXES = JS_TS_SUFFIXES
+    C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
+
+    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+        self.lexed = lexed
+        self.suffix = suffix
+        self.graph = EndpointGraph(len(lexed.code))
+        self.c_headers = c_function_headers(lexed, suffix)
+        self.class_fields = class_field_regions(lexed, suffix)
+        self.conditional_openings = conditional_curly_scopes(lexed.code)
+        self.scope_ranges: list[tuple[int, int, int]] = []
+        self.scope_by_opening: dict[int, int] = {}
+        self.expression_parameters: list[tuple[int, int, int, int]] = []
+        self.assignment_bindings: dict[int, int] = {}
+        self.destructuring: list[
+            tuple[int, int, int, int, list[tuple[str, EndpointReference, tuple[int, int] | None]]]
+        ] = []
+        self.destructure_mutations: set[int] = set()
+        self._build_scopes()
+        self._find_destructuring()
+        self.root_assignments = [
+            match
+            for match in VARIABLE_ASSIGNMENT_RE.finditer(lexed.code)
+            if not self._inside_destructuring_lhs(match.start())
+            and not self._inside_parameter_list(match.start())
+            and not self._inside_class_field(match.start())
+        ]
+        self._build_bindings()
+        self._index_node_path_join_bindings()
+        self._build_definitions()
+
+    def _index_node_path_join_bindings(self) -> None:
+        """Index only live bindings that originate from Node's path.join.
+
+        The builder parser must distinguish a real destructured/imported
+        ``path.join`` from an unrelated local function with the same name.
+        Binding IDs make parameter/block shadowing explicit; origin offsets
+        let later assignments invalidate a mutable CommonJS alias.
+        """
+
+        self.node_path_join_origins: dict[int, int] = {}
+        self.node_path_join_imports: dict[str, int] = {}
+        self.node_path_module_origins: dict[int, int] = {}
+        self.node_path_module_imports: dict[str, int] = {}
+        source = self.lexed.without_comments
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?(?!\s*\.)",
+            source,
+        ):
+            name = match.group(1)
+            binding_id = self.graph.visible_binding(
+                name, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_module_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+
+        for match in re.finditer(
+            r"\bimport\s+(?:\*\s+as\s+)?([A-Za-z_$]\w*)\s+from\s*"
+            r"['\"](?:node:)?path['\"]",
+            source,
+        ):
+            self.node_path_module_imports[match.group(1)] = match.start()
+
+        commonjs = re.compile(
+            r"\b(?:const|let|var)\s*\{([^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?"
+        )
+        for match in commonjs.finditer(source):
+            opening = source.find("{", match.start(), match.end())
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*join\s*(?::\s*([A-Za-z_$]\w*))?\s*", member
+                )
+                if parsed is None:
+                    continue
+                name = parsed.group(1) or "join"
+                binding_id = self.destructure_bindings.get((opening, name))
+                if binding_id is not None:
+                    self.node_path_join_origins[binding_id] = opening
+
+        for match in re.finditer(
+            r"\bimport\s*\{([^{}]*)\}\s*from\s*"
+            r"['\"](?:node:)?path['\"]",
+            source,
+        ):
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*join\s*(?:as\s+([A-Za-z_$]\w*))?\s*", member
+                )
+                if parsed is not None:
+                    self.node_path_join_imports[parsed.group(1) or "join"] = (
+                        match.start()
+                    )
+
+        # Destructuring or copying `.join` from a previously bound path
+        # module is equivalent to destructuring it directly from require().
+        for opening, _, rhs_start, rhs_end, leaves in self.destructuring:
+            rhs = source[rhs_start:rhs_end].strip()
+            module = re.fullmatch(r"([A-Za-z_$]\w*)", rhs)
+            if module is None or not self._is_node_path_module_alias(
+                module.group(1), self.scope_at(opening), opening
+            ):
+                continue
+            for name, members, _ in leaves:
+                if members == ("join",):
+                    binding_id = self.destructure_bindings.get((opening, name))
+                    if binding_id is not None:
+                        self.node_path_join_origins[binding_id] = opening
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"([A-Za-z_$]\w*)\s*\.\s*join\b",
+            source,
+        ):
+            alias, module = match.groups()
+            if not self._is_node_path_module_alias(
+                module, self.scope_at(match.start()), match.start()
+            ):
+                continue
+            binding_id = self.graph.visible_binding(
+                alias, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_join_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?\s*\.\s*join\b",
+            source,
+        ):
+            name = match.group(1)
+            binding_id = self.graph.visible_binding(
+                name, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_join_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+            else:
+                self.node_path_join_imports[name] = match.start()
+
+    def _is_node_path_module_alias(
+        self, name: str, scope_id: int, before: int
+    ) -> bool:
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        if binding_id is None:
+            return self.node_path_module_imports.get(name, before + 1) < before
+        origin = self.node_path_module_origins.get(binding_id)
+        if origin is None:
+            return False
+        return not any(
+            origin < offset < before and assigned == binding_id
+            for offset, assigned in self.assignment_bindings.items()
+        )
+
+    def _is_node_path_join_alias(
+        self, name: str, scope_id: int, before: int
+    ) -> bool:
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        if binding_id is None:
+            return self.node_path_join_imports.get(name, before + 1) < before
+        origin = self.node_path_join_origins.get(binding_id)
+        if origin is None:
+            return False
+        # A mutable alias stops identifying path.join after any later plain
+        # or destructuring assignment that reaches the same binding.
+        if any(
+            origin < offset < before and assigned == binding_id
+            for offset, assigned in self.assignment_bindings.items()
+        ):
+            return False
+        if any(
+            origin < opening < before
+            and self.destructure_bindings.get((opening, name)) == binding_id
+            for opening in self.destructure_mutations
+        ):
+            return False
+        return True
+
+    def _build_scopes(self) -> None:
+        if self.suffix in self.C_SUFFIXES:
+            stack: list[tuple[int, int, int]] = []
+            for opening, character in enumerate(self.lexed.code):
+                if character != "{":
+                    continue
+                statement_start = max(
+                    self.lexed.code.rfind(";", 0, opening),
+                    self.lexed.code.rfind("\n", 0, opening),
+                    self.lexed.code.rfind("}", 0, opening),
+                ) + 1
+                prefix = self.lexed.code[statement_start:opening].strip()
+                code_block = (
+                    opening in self.c_headers
+                    or opening in self.conditional_openings
+                    or not prefix
+                    or bool(
+                        re.search(
+                            r"\b(?:else|try|finally|do|class|namespace|"
+                            r"interface|struct|enum|synchronized|using|lock|"
+                            r"fixed|checked|unchecked)\b[^{}]*$",
+                            prefix,
+                        )
+                    )
+                )
+                if not code_block:
+                    continue
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "{", "}"
+                )
+                if closing is None:
+                    continue
+                while stack and opening > stack[-1][1]:
+                    stack.pop()
+                parent = stack[-1][2] if stack else 0
+                kind = (
+                    "function"
+                    if opening in self.c_headers
+                    else "conditional"
+                    if opening in self.conditional_openings
+                    else "block"
+                )
+                scope_id = self.graph.add_scope(
+                    parent, opening, closing + 1, kind
+                )
+                self.scope_by_opening[opening] = scope_id
+                self.scope_ranges.append((opening, closing + 1, scope_id))
+                stack.append((opening, closing, scope_id))
+            self._build_expression_lambda_scopes()
+            return
+        if self.suffix == ".py":
+            self._build_python_scopes()
+            return
+        if self.suffix == ".rb":
+            self._build_ruby_scopes()
+
+    def _build_expression_lambda_scopes(self) -> None:
+        token = "->" if self.suffix == ".java" else "=>"
+        if self.suffix not in JS_TS_SUFFIXES | {".cs", ".java"}:
+            return
+        for arrow in re.finditer(re.escape(token), self.lexed.code):
+            body_start = arrow.end()
+            while (
+                body_start < len(self.lexed.code)
+                and self.lexed.code[body_start].isspace()
+            ):
+                body_start += 1
+            if (
+                body_start >= len(self.lexed.code)
+                or self.lexed.code[body_start] == "{"
+            ):
+                continue
+            cursor = arrow.start() - 1
+            while cursor >= 0 and self.lexed.code[cursor].isspace():
+                cursor -= 1
+            if cursor >= 0 and self.lexed.code[cursor] == ")":
+                params_open = matching_opening(
+                    self.lexed.code, cursor, "(", ")"
+                )
+                if params_open is None:
+                    continue
+                params_start, params_end = params_open + 1, cursor
+            else:
+                parameter = re.search(
+                    r"([$A-Za-z_]\w*)\s*$",
+                    self.lexed.code[:arrow.start()],
+                )
+                if parameter is None:
+                    continue
+                params_start, params_end = parameter.span(1)
+
+            round_depth = square_depth = curly_depth = 0
+            body_end = len(self.lexed.code)
+            for index in range(body_start, len(self.lexed.code)):
+                character = self.lexed.code[index]
+                if character == "(":
+                    round_depth += 1
+                elif character == "[":
+                    square_depth += 1
+                elif character == "{":
+                    curly_depth += 1
+                elif character == ")":
+                    if not round_depth:
+                        body_end = index
+                        break
+                    round_depth -= 1
+                elif character == "]":
+                    if not square_depth:
+                        body_end = index
+                        break
+                    square_depth -= 1
+                elif character == "}":
+                    if not curly_depth:
+                        body_end = index
+                        break
+                    curly_depth -= 1
+                elif (
+                    character in {";", "\n", ","}
+                    and not (round_depth or square_depth or curly_depth)
+                ):
+                    body_end = index
+                    break
+            parent = self.scope_at(arrow.start())
+            scope_id = self.graph.add_scope(
+                parent, body_start, body_end, "function"
+            )
+            self.scope_ranges.append((body_start, body_end, scope_id))
+            self.expression_parameters.append(
+                (scope_id, params_start, params_end, arrow.start())
+            )
+
+    def _build_python_scopes(self) -> None:
+        lines = self.lexed.code.splitlines(keepends=True)
+        stack: list[tuple[int, str, int, int]] = []
+        records: list[list[int | str]] = []
+        cursor = 0
+        row = 0
+        while row < len(lines):
+            line = lines[row]
+            consumed = 1
+            stripped = line.lstrip(" \t")
+            if stripped.strip():
+                indent = len(line) - len(stripped)
+                while stack and indent <= stack[-1][0]:
+                    _, _, record_index, _ = stack.pop()
+                    records[record_index][2] = cursor
+                match = None
+                if re.match(r"(?:async\s+)?(?:def|class)\b", stripped):
+                    # A def/class signature may WRAP across lines, leaving its
+                    # ':' on a continuation row. Only a one-line header was
+                    # recognised, so the function opened no scope at all and a
+                    # local `payload` reassignment inside it read as a
+                    # module-level one - hiding a send that never got the
+                    # profile. Join continuation rows until the brackets close.
+                    joined = stripped
+                    while (
+                        re.search(r":\s*$", joined) is None
+                        and row + consumed < len(lines)
+                        and sum(joined.count(character) for character in "([{")
+                        > sum(joined.count(character) for character in ")]}")
+                    ):
+                        joined += lines[row + consumed]
+                        consumed += 1
+                    match = re.fullmatch(
+                        r"(?:async\s+)?(def|class)\b[\s\S]*:\s*", joined
+                    )
+                if match is not None:
+                    kind = "function" if match.group(1) == "def" else "class"
+                    parent = stack[-1][3] if stack else 0
+                    if kind == "function" and stack and stack[-1][1] == "class":
+                        parent = 0
+                    records.append([cursor, kind, len(self.lexed.code), parent])
+                    record_index = len(records) - 1
+                    # The graph id is filled after ranges are known; retain a
+                    # temporary negative record id in the stack.
+                    stack.append((indent, kind, record_index, -(record_index + 1)))
+            cursor += sum(
+                len(lines[row + offset]) for offset in range(consumed)
+            )
+            row += consumed
+        while stack:
+            _, _, record_index, _ = stack.pop()
+            records[record_index][2] = len(self.lexed.code)
+
+        id_by_record: dict[int, int] = {}
+        for index, (start, kind, end, parent_token) in enumerate(records):
+            parent = (
+                id_by_record[-int(parent_token) - 1]
+                if int(parent_token) < 0
+                else int(parent_token)
+            )
+            scope_id = self.graph.add_scope(
+                parent, int(start), int(end), str(kind)
+            )
+            id_by_record[index] = scope_id
+            self.scope_ranges.append((int(start), int(end), scope_id))
+
+    def _build_ruby_scopes(self) -> None:
+        stack: list[tuple[str, int | None, int]] = []
+        records: list[list[int | str]] = []
+        cursor = 0
+        for line in self.lexed.code.splitlines(keepends=True):
+            stripped = line.strip()
+            if re.match(r"end\b", stripped) and stack:
+                _, record_index, _ = stack.pop()
+                if record_index is not None:
+                    records[record_index][2] = cursor + len(line)
+            else:
+                match = re.match(r"(def|class|module)\b", stripped)
+                if match is not None:
+                    kind = "function" if match.group(1) == "def" else "class"
+                    parent_token = stack[-1][2] if stack else 0
+                    if kind == "function" and stack:
+                        parent_token = 0
+                    records.append(
+                        [cursor, kind, len(self.lexed.code), parent_token]
+                    )
+                    record_index = len(records) - 1
+                    stack.append((kind, record_index, -(record_index + 1)))
+                elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
+                    parent_token = stack[-1][2] if stack else 0
+                    records.append(
+                        [cursor, "block", len(self.lexed.code), parent_token]
+                    )
+                    record_index = len(records) - 1
+                    stack.append(("block", record_index, -(record_index + 1)))
+                elif re.match(
+                    r"(?:if|unless|case|begin|for|while|until)\b", stripped
+                ):
+                    parent_token = stack[-1][2] if stack else 0
+                    stack.append(("control", None, parent_token))
+            cursor += len(line)
+        id_by_record: dict[int, int] = {}
+        for index, (start, kind, end, parent_token) in enumerate(records):
+            parent = (
+                id_by_record[-int(parent_token) - 1]
+                if int(parent_token) < 0
+                else int(parent_token)
+            )
+            scope_id = self.graph.add_scope(
+                parent, int(start), int(end), str(kind)
+            )
+            id_by_record[index] = scope_id
+            self.scope_ranges.append((int(start), int(end), scope_id))
+
+    def scope_at(self, offset: int) -> int:
+        candidates = [
+            (end - start, scope_id)
+            for start, end, scope_id in self.scope_ranges
+            if start <= offset < end
+        ]
+        return min(candidates)[1] if candidates else 0
+
+    def _inside_parameter_list(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end in self.c_headers.values())
+
+    def _inside_class_field(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end in self.class_fields)
+
+    def _inside_destructuring_lhs(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end, _, _, _ in self.destructuring)
+
+    def _destructure_leaves(
+        self,
+        start: int,
+        end: int,
+        prefix: EndpointReference = (),
+    ) -> list[tuple[str, EndpointReference, tuple[int, int] | None]]:
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end or self.lexed.code.startswith("...", start):
+            return []
+        if self.lexed.code[start] not in "[{":
+            default = top_level_assignment_separator(
+                self.lexed.code, start, end
+            )
+            leaf_end = default[0] if default is not None else end
+            leaf = self.lexed.code[start:leaf_end].strip()
+            match = re.fullmatch(r"\$?([A-Za-z_]\w*)", leaf)
+            return (
+                [(match.group(1), prefix, (default[1], end) if default else None)]
+                if match is not None
+                else []
+            )
+        left = self.lexed.code[start]
+        right = "}" if left == "{" else "]"
+        closing = matching_delimiter(self.lexed.code, start, left, right)
+        if closing is None:
+            return []
+        leaves: list[
+            tuple[str, EndpointReference, tuple[int, int] | None]
+        ] = []
+        for index, (member_start, member_end) in enumerate(
+            split_arguments(self.lexed.code, start + 1, closing)
+        ):
+            if not self.lexed.code[member_start:member_end].strip():
+                continue
+            if left == "[":
+                leaves.extend(
+                    self._destructure_leaves(
+                        member_start,
+                        member_end,
+                        prefix + (str(index),),
+                    )
+                )
+                continue
+            colon = top_level_colon(
+                self.lexed.code, member_start, member_end
+            )
+            if colon is not None:
+                key = static_object_key(
+                    self.lexed, member_start, colon
+                )
+                if key is not None:
+                    leaves.extend(
+                        self._destructure_leaves(
+                            colon + 1,
+                            member_end,
+                            prefix + (key,),
+                        )
+                    )
+                continue
+            default = top_level_assignment_separator(
+                self.lexed.code, member_start, member_end
+            )
+            key_end = default[0] if default is not None else member_end
+            key = static_object_key(
+                self.lexed, member_start, key_end
+            )
+            if key is not None:
+                leaves.append(
+                    (
+                        key,
+                        prefix + (key,),
+                        (default[1], member_end) if default else None,
+                    )
+                )
+        return leaves
+
+    def _find_destructuring(self) -> None:
+        if self.suffix not in self.JAVASCRIPT_SUFFIXES:
+            return
+        code = self.lexed.code
+        for opening, character in enumerate(code):
+            if character not in "[{":
+                continue
+            boundary = max(
+                code.rfind(";", 0, opening),
+                code.rfind("\n", 0, opening),
+            ) + 1
+            prefix = code[boundary:opening]
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            assignment = declaration is None and re.fullmatch(
+                r"\s*\(*\s*", prefix
+            )
+            if declaration is None and not assignment:
+                continue
+            right = "}" if character == "{" else "]"
+            closing = matching_delimiter(code, opening, character, right)
+            if closing is None:
+                continue
+            round_depth = square_depth = curly_depth = 0
+            equals = None
+            for cursor in range(closing + 1, len(code)):
+                current = code[cursor]
+                if current == "(":
+                    round_depth += 1
+                elif current == ")" and round_depth:
+                    round_depth -= 1
+                elif current == "[":
+                    square_depth += 1
+                elif current == "]" and square_depth:
+                    square_depth -= 1
+                elif current == "{":
+                    curly_depth += 1
+                elif current == "}" and curly_depth:
+                    curly_depth -= 1
+                elif not (round_depth or square_depth or curly_depth):
+                    if current in ";\n":
+                        break
+                    if (
+                        current == "="
+                        and not code.startswith(("==", "=>"), cursor)
+                        and (cursor == 0 or code[cursor - 1] not in "!<>=")
+                    ):
+                        equals = cursor
+                        break
+            if equals is None:
+                continue
+            residual = code[closing + 1:equals]
+            if residual.strip() and not re.fullmatch(
+                r"\s*:\s*[^=;\n]+\s*", residual
+            ):
+                continue
+            leaves = self._destructure_leaves(opening, closing + 1)
+            if not leaves:
+                continue
+            rhs_start = equals + 1
+            rhs_end = assignment_end(self.lexed, rhs_start, self.suffix)
+            if assignment:
+                wrapper = opening - 1
+                while wrapper >= boundary and code[wrapper].isspace():
+                    wrapper -= 1
+                if wrapper >= boundary and code[wrapper] == "(":
+                    wrapper_closing = matching_delimiter(
+                        code, wrapper, "(", ")"
+                    )
+                    if wrapper_closing is not None:
+                        rhs_end = min(rhs_end, wrapper_closing)
+                self.destructure_mutations.add(opening)
+            self.destructuring.append(
+                (opening, equals, rhs_start, rhs_end, leaves)
+            )
+
+    def _parameter_names(
+        self, start: int, end: int
+    ) -> list[str]:
+        names: list[str] = []
+        for span_start, span_end in split_arguments(
+            self.lexed.code, start, end
+        ):
+            source = self.lexed.code[span_start:span_end]
+            if not source.strip() or source.lstrip().startswith(("{", "[")):
+                continue
+            identifiers = re.findall(r"\$?([A-Za-z_]\w*)", source)
+            if not identifiers:
+                continue
+            if self.suffix == ".go":
+                name = identifiers[0]
+            elif self.suffix in self.JAVASCRIPT_SUFFIXES or self.suffix == ".php":
+                name = identifiers[0]
+            else:
+                name = identifiers[-1]
+            if name not in {"self", "this"}:
+                names.append(name)
+        return names
+
+    def _add_parameter_binding(
+        self, name: str, scope_id: int, offset: int
+    ) -> int:
+        existing = [
+            binding
+            for binding in self.graph.bindings.values()
+            if binding.name == name
+            and binding.scope_id == scope_id
+            and binding.kind == "parameter"
+        ]
+        if existing:
+            return existing[0].id
+        scope_start = self.graph.scopes[scope_id].start
+        binding_id = self.graph.add_binding(
+            name, scope_id, offset, scope_start, "parameter"
+        )
+        self.graph.add_definition(
+            binding_id,
+            (),
+            EndpointUnknown("parameter"),
+            scope_start,
+            scope_id,
+            "parameter",
+        )
+        return binding_id
+
+    def _build_parameter_bindings(self) -> None:
+        for opening, (start, end) in self.c_headers.items():
+            scope_id = self.scope_by_opening.get(opening)
+            if scope_id is None:
+                continue
+            for name in self._parameter_names(start, end):
+                self._add_parameter_binding(name, scope_id, opening)
+        for scope_id, start, end, offset in self.expression_parameters:
+            for name in self._parameter_names(start, end):
+                self._add_parameter_binding(name, scope_id, offset)
+        if self.suffix in self.C_SUFFIXES:
+            for match in re.finditer(
+                r"\b(catch|for|foreach)\s*\(", self.lexed.code
+            ):
+                params_open = self.lexed.code.rfind(
+                    "(", match.start(), match.end()
+                )
+                params_close = matching_delimiter(
+                    self.lexed.code, params_open, "(", ")"
+                )
+                if params_close is None:
+                    continue
+                brace = self.lexed.code.find("{", params_close)
+                if brace < 0 or self.lexed.code[params_close + 1:brace].strip():
+                    continue
+                scope_id = self.scope_by_opening.get(brace)
+                if scope_id is None:
+                    continue
+                source = self.lexed.code[params_open + 1:params_close]
+                if match.group(1) == "catch":
+                    identifiers = re.findall(r"\$?([A-Za-z_]\w*)", source)
+                    names = identifiers[-1:] if identifiers else []
+                else:
+                    declaration = re.search(
+                        r"\b(?:const|let|var|final|String|string|var)\s+"
+                        r"\$?([A-Za-z_]\w*)",
+                        source,
+                    )
+                    names = [declaration.group(1)] if declaration else []
+                for name in names:
+                    self._add_parameter_binding(name, scope_id, match.start())
+        if self.suffix == ".py":
+            pattern = re.compile(r"(?:async\s+)?def\s+\w+\s*\(")
+            for match in pattern.finditer(self.lexed.code):
+                opening = self.lexed.code.rfind("(", match.start(), match.end())
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                if closing is None:
+                    continue
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(opening + 1, closing):
+                    self._add_parameter_binding(name, scope_id, match.start())
+        if self.suffix == ".rb":
+            for match in re.finditer(
+                r"\bdef\s+\w+\s*(?:\(([^)]*)\)|([^\n]*))",
+                self.lexed.code,
+            ):
+                start, end = (
+                    match.span(1) if match.group(1) is not None else match.span(2)
+                )
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(start, end):
+                    self._add_parameter_binding(name, scope_id, match.start())
+            for match in re.finditer(
+                r"\bdo\s*\|([^|]*)\|", self.lexed.code
+            ):
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(*match.span(1)):
+                    self._add_parameter_binding(name, scope_id, match.start())
+
+    def _declaration_spec(
+        self, assignment: re.Match[str]
+    ) -> tuple[int, int, str, tuple[object, ...]] | None:
+        name = assignment.group(1).lstrip("$")
+        scope_id = self.scope_at(assignment.start())
+        execution = self.graph.execution_scope(scope_id)
+        line_start = max(
+            self.lexed.code.rfind("\n", 0, assignment.start()),
+            self.lexed.code.rfind(";", 0, assignment.start()),
+            self.lexed.code.rfind("{", 0, assignment.start()),
+        ) + 1
+        prefix = self.lexed.code[line_start:assignment.start()]
+        assignment_text = self.lexed.code[
+            assignment.start():assignment.end()
+        ]
+        if self.suffix in self.JAVASCRIPT_SUFFIXES:
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            if declaration is None:
+                return None
+            keyword = declaration.group(1)
+            owner = execution if keyword == "var" else scope_id
+            visibility = (
+                self.graph.scopes[owner].start
+                if keyword == "var"
+                else assignment.start()
+            )
+            key = ("js-var", owner, name) if keyword == "var" else (
+                "js-block", assignment.start()
+            )
+            return owner, visibility, "declaration", key
+        if self.suffix == ".go":
+            declared = ":=" in assignment_text or re.search(r"\bvar\s*$", prefix)
+            if not declared:
+                return None
+            return scope_id, assignment.start(), "declaration", (
+                "go", assignment.start()
+            )
+        if self.suffix in {".java", ".cs"}:
+            declared = re.search(
+                r"(?:^|[;{}])\s*(?:(?:public|private|protected|static|final|"
+                r"readonly|volatile)\s+)*(?:var|string|String|Uri|URI|URL|"
+                r"[A-Za-z_]\w*(?:\s*<[^;=]+>)?(?:\[\])?)\s*$",
+                prefix,
+            )
+            if declared is None:
+                return None
+            return scope_id, assignment.start(), "declaration", (
+                "c-block", assignment.start()
+            )
+        if self.suffix == ".py":
+            kind = self.graph.scopes[scope_id].kind
+            owner = scope_id if kind in {"function", "class"} else execution
+            visibility = (
+                self.graph.scopes[owner].start
+                if self.graph.scopes[owner].kind == "function"
+                else assignment.start()
+            )
+            return owner, visibility, "declaration", ("py", owner, name)
+        if self.suffix == ".rb":
+            owner = execution
+            return (
+                owner,
+                self.graph.scopes[owner].start,
+                "declaration",
+                ("rb", owner, name),
+            )
+        if self.suffix == ".php":
+            return (
+                execution,
+                self.graph.scopes[execution].start,
+                "declaration",
+                ("php", execution, name),
+            )
+        if self.suffix == ".sh":
+            return (
+                execution,
+                self.graph.scopes[execution].start,
+                "declaration",
+                ("sh", execution, name),
+            )
+        return None
+
+    def _build_bindings(self) -> None:
+        self._build_parameter_bindings()
+        grouped: dict[tuple[object, ...], int] = {}
+        for assignment in self.root_assignments:
+            name = assignment.group(1).lstrip("$")
+            spec = self._declaration_spec(assignment)
+            if spec is None:
+                continue
+            scope_id, visibility, kind, key = spec
+            binding_id = grouped.get(key)
+            if binding_id is None:
+                binding_id = self.graph.add_binding(
+                    name,
+                    scope_id,
+                    assignment.start(),
+                    visibility,
+                    kind,
+                )
+                grouped[key] = binding_id
+            self.assignment_bindings[assignment.start()] = binding_id
+
+        self.destructure_bindings: dict[tuple[int, str], int] = {}
+        for opening, _, _, _, leaves in self.destructuring:
+            prefix = self.lexed.code[
+                max(0, self.lexed.code.rfind("\n", 0, opening) + 1):opening
+            ]
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            scope_id = self.scope_at(opening)
+            if declaration is None:
+                for name, _, _ in leaves:
+                    binding_id = self.graph.visible_binding(
+                        name, scope_id, opening
+                    )
+                    if binding_id is None:
+                        candidates = list(
+                            re.compile(
+                                rf"\b(let|var|const)\s+{re.escape(name)}\b"
+                            ).finditer(self.lexed.code, 0, opening)
+                        )
+                        if candidates:
+                            candidate = candidates[-1]
+                            candidate_scope = self.scope_at(candidate.start())
+                            keyword = candidate.group(1)
+                            owner = (
+                                self.graph.execution_scope(candidate_scope)
+                                if keyword == "var"
+                                else candidate_scope
+                            )
+                            binding_id = self.graph.add_binding(
+                                name,
+                                owner,
+                                candidate.start(),
+                                (
+                                    self.graph.scopes[owner].start
+                                    if keyword == "var"
+                                    else candidate.start()
+                                ),
+                                "declaration",
+                            )
+                    if binding_id is not None:
+                        self.destructure_bindings[(opening, name)] = binding_id
+                continue
+            keyword = declaration.group(1)
+            owner = (
+                self.graph.execution_scope(scope_id)
+                if keyword == "var"
+                else scope_id
+            )
+            for name, _, _ in leaves:
+                key = (
+                    ("js-var", owner, name)
+                    if keyword == "var"
+                    else ("destructure", opening, name)
+                )
+                binding_id = grouped.get(key)
+                if binding_id is None:
+                    binding_id = self.graph.add_binding(
+                        name,
+                        owner,
+                        opening,
+                        (
+                            self.graph.scopes[owner].start
+                            if keyword == "var"
+                            else opening
+                        ),
+                        "declaration",
+                    )
+                    grouped[key] = binding_id
+                self.destructure_bindings[(opening, name)] = binding_id
+
+        # Plain assignments with no visible declaration create one bounded
+        # implicit binding in their execution scope.
+        for assignment in self.root_assignments:
+            if assignment.start() in self.assignment_bindings:
+                continue
+            name = assignment.group(1).lstrip("$")
+            scope_id = self.scope_at(assignment.start())
+            binding_id = self.graph.visible_binding(
+                name, scope_id, assignment.start()
+            )
+            if binding_id is None:
+                owner = self.graph.execution_scope(scope_id)
+                key = ("implicit", owner, name)
+                binding_id = grouped.get(key)
+                if binding_id is None:
+                    binding_id = self.graph.add_binding(
+                        name,
+                        owner,
+                        assignment.start(),
+                        self.graph.scopes[owner].start,
+                        "implicit",
+                    )
+                    grouped[key] = binding_id
+            self.assignment_bindings[assignment.start()] = binding_id
+
+    def _top_level_plus_spans(
+        self, start: int, end: int
+    ) -> list[tuple[int, int]]:
+        spans: list[tuple[int, int]] = []
+        segment = start
+        round_depth = square_depth = curly_depth = 0
+        for index in range(start, end):
+            character = self.lexed.code[index]
+            if character == "(":
+                round_depth += 1
+            elif character == ")" and round_depth:
+                round_depth -= 1
+            elif character == "[":
+                square_depth += 1
+            elif character == "]" and square_depth:
+                square_depth -= 1
+            elif character == "{":
+                curly_depth += 1
+            elif character == "}" and curly_depth:
+                curly_depth -= 1
+            elif (
+                character == "+"
+                or (
+                    # PHP concatenates with '.', and member access there is
+                    # '->' / '::', so a top-level dot is unambiguous. Guard
+                    # against decimals in a numeric literal.
+                    character == "."
+                    and self.suffix == ".php"
+                    and not (
+                        index > start
+                        and self.lexed.code[index - 1].isdigit()
+                        and index + 1 < end
+                        and self.lexed.code[index + 1].isdigit()
+                    )
+                )
+            ) and not (
+                round_depth or square_depth or curly_depth
+            ):
+                spans.append((segment, index))
+                segment = index + 1
+        if spans:
+            spans.append((segment, end))
+        return spans
+
+    def _typescript_assertion_start(
+        self, start: int, end: int
+    ) -> int | None:
+        if self.suffix not in TYPESCRIPT_SUFFIXES:
+            return None
+        round_depth = square_depth = curly_depth = 0
+        for match in re.finditer(r"\b(?:as|satisfies)\b", self.lexed.code[start:end]):
+            offset = start + match.start()
+            for character in self.lexed.code[start:offset]:
+                if character == "(":
+                    round_depth += 1
+                elif character == ")" and round_depth:
+                    round_depth -= 1
+                elif character == "[":
+                    square_depth += 1
+                elif character == "]" and square_depth:
+                    square_depth -= 1
+                elif character == "{":
+                    curly_depth += 1
+                elif character == "}" and curly_depth:
+                    curly_depth -= 1
+            if round_depth or square_depth or curly_depth:
+                round_depth = square_depth = curly_depth = 0
+                continue
+            tail = self.lexed.original[start + match.end():end].strip()
+            if tail and re.fullmatch(
+                r"(?:const|readonly\s+)?[A-Za-z_$][\w$<>.,\[\]\s|&?:]*",
+                tail,
+            ):
+                return offset
+            round_depth = square_depth = curly_depth = 0
+        return None
+
+    @staticmethod
+    def _project_expression(
+        expression: EndpointExpression, members: EndpointReference
+    ) -> EndpointExpression:
+        if not members:
+            return expression
+        if isinstance(expression, EndpointRef):
+            return EndpointRef(
+                expression.binding_id, expression.members + members
+            )
+        if isinstance(expression, EndpointProjected):
+            return EndpointProjected(
+                expression.expression, expression.members + members
+            )
+        return EndpointProjected(expression, members)
+
+    def _static_key_from_span(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> str | None:
+        literal = static_lookup_key(self.lexed, start, end)
+        if literal is not None:
+            return literal
+        source = self.lexed.original[start:end].strip()
+        if not source or re.fullmatch(r"-\d+", source):
+            return None
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is None or len(reference) != 1:
+            return None
+        binding_id = self.graph.visible_binding(
+            reference[0].lstrip("$"), scope_id, before
+        )
+        if binding_id is None:
+            return None
+        value = self.graph.evaluate(
+            EndpointAccessState(binding_id, (), before, scope_id)
+        )
+        return value.exact
+
+    def _parse_access_expression(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression | None:
+        cursor = start
+        if self.lexed.code[cursor] == "(":
+            closing = matching_delimiter(
+                self.lexed.code, cursor, "(", ")"
+            )
+            if closing is None or closing >= end:
+                return None
+            expression = self._parse_expression(
+                cursor + 1, closing, scope_id, before
+            )
+            cursor = closing + 1
+        else:
+            root = re.match(r"\$?[A-Za-z_]\w*", self.lexed.code[cursor:end])
+            if root is None:
+                return None
+            name = root.group(0).lstrip("$")
+            binding_id = self.graph.visible_binding(name, scope_id, before)
+            expression = (
+                EndpointRef(binding_id)
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{name}")
+            )
+            cursor += len(root.group(0))
+
+        default_methods = {
+            ".py": {"get"},
+            ".rb": {"fetch"},
+            ".java": {"getOrDefault"},
+            ".cs": {"GetValueOrDefault"},
+        }
+        lookup_methods = {"get", "Get", "fetch"}
+        while True:
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            if (
+                self.suffix in TYPESCRIPT_SUFFIXES
+                and cursor < end
+                and self.lexed.code[cursor] == "!"
+            ):
+                cursor += 1
+                continue
+            if cursor >= end:
+                return expression
+
+            if self.lexed.code.startswith("?.", cursor):
+                cursor += 2
+                while cursor < end and self.lexed.code[cursor].isspace():
+                    cursor += 1
+                if cursor < end and self.lexed.code[cursor] == "[":
+                    closing = matching_delimiter(
+                        self.lexed.code, cursor, "[", "]"
+                    )
+                    if closing is None or closing >= end:
+                        return EndpointUnknown("dynamic selector")
+                    key = self._static_key_from_span(
+                        cursor + 1, closing, scope_id, before
+                    )
+                    if key is None:
+                        return EndpointUnknown("dynamic selector")
+                    expression = self._project_expression(expression, (key,))
+                    cursor = closing + 1
+                    continue
+            elif self.lexed.code.startswith("->", cursor):
+                cursor += 2
+            elif self.lexed.code[cursor] == ".":
+                cursor += 1
+            elif self.lexed.code[cursor] == "[":
+                closing = matching_delimiter(
+                    self.lexed.code, cursor, "[", "]"
+                )
+                if closing is None or closing >= end:
+                    return EndpointUnknown("dynamic selector")
+                key = self._static_key_from_span(
+                    cursor + 1, closing, scope_id, before
+                )
+                if key is None:
+                    return EndpointUnknown("dynamic selector")
+                expression = self._project_expression(expression, (key,))
+                cursor = closing + 1
+                continue
+            else:
+                return None
+
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            member = re.match(r"[A-Za-z_]\w*", self.lexed.code[cursor:end])
+            if member is None:
+                return EndpointUnknown("dynamic member")
+            member_name = member.group(0)
+            cursor += len(member_name)
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            if cursor >= end or self.lexed.code[cursor] != "(":
+                expression = self._project_expression(
+                    expression, (member_name,)
+                )
+                continue
+
+            closing = matching_delimiter(
+                self.lexed.code, cursor, "(", ")"
+            )
+            if closing is None or closing >= end:
+                return EndpointUnknown("invalid lookup")
+            arguments = split_arguments(
+                self.lexed.code, cursor + 1, closing
+            )
+            if self.suffix == ".rb" and member_name == "dig":
+                keys = [
+                    self._static_key_from_span(
+                        argument_start,
+                        argument_end,
+                        scope_id,
+                        before,
+                    )
+                    for argument_start, argument_end in arguments
+                ]
+                if not keys or any(key is None for key in keys):
+                    return EndpointUnknown("dynamic dig")
+                expression = self._project_expression(
+                    expression, tuple(key for key in keys if key is not None)
+                )
+                cursor = closing + 1
+                continue
+            supported_defaults = default_methods.get(self.suffix, set())
+            if member_name not in lookup_methods | supported_defaults:
+                return EndpointUnknown("unsupported call")
+            if not arguments or len(arguments) > 2:
+                return EndpointUnknown("invalid lookup")
+            key = self._static_key_from_span(
+                arguments[0][0], arguments[0][1], scope_id, before
+            )
+            if key is None:
+                return EndpointUnknown("dynamic lookup")
+            primary = self._project_expression(expression, (key,))
+            expression = (
+                EndpointDefault(
+                    primary,
+                    self._parse_expression(
+                        arguments[1][0],
+                        arguments[1][1],
+                        scope_id,
+                        before,
+                    ),
+                )
+                if len(arguments) == 2 and member_name in supported_defaults
+                else primary
+            )
+            cursor = closing + 1
+
+    def _parse_reference_text(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        temporary = lex_source(source, self.suffix)
+        reference = static_reference_expression(
+            temporary, 0, len(temporary.code)
+        )
+        if reference is None:
+            return EndpointUnknown("dynamic interpolation")
+        name = reference[0].lstrip("$")
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        return (
+            EndpointRef(binding_id, reference[1:])
+            if binding_id is not None
+            else EndpointUnknown(f"unbound:{name}")
+        )
+
+    def _shell_text_expression(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        parts: list[EndpointExpression] = []
+        cursor = 0
+        for match in SHELL_STATIC_REFERENCE_RE.finditer(source):
+            key: str | None = None
+            if match.group(2):
+                selector = match.group(2).strip()
+                if selector.startswith("$"):
+                    temporary = lex_source(selector, ".sh")
+                    reference = static_reference_expression(
+                        temporary, 0, len(temporary.code)
+                    )
+                    if reference is None or len(reference) != 1:
+                        return EndpointUnknown("dynamic shell selector")
+                    key_binding = self.graph.visible_binding(
+                        reference[0].lstrip("$"), scope_id, before
+                    )
+                    if key_binding is None:
+                        return EndpointUnknown("dynamic shell selector")
+                    key = self.graph.evaluate(
+                        EndpointAccessState(
+                            key_binding, (), before, scope_id
+                        )
+                    ).exact
+                elif re.fullmatch(r"(?:[A-Za-z_]\w*|\d+)", selector) or (
+                    len(selector) >= 2
+                    and selector[0] == selector[-1]
+                    and selector[0] in {"'", '"'}
+                ):
+                    key = shell_static_key(selector)
+                if key is None:
+                    return EndpointUnknown("dynamic shell selector")
+            if match.start() > cursor:
+                parts.append(EndpointLiteral(source[cursor:match.start()]))
+            root = match.group(1) or match.group(3)
+            binding_id = self.graph.visible_binding(root, scope_id, before)
+            parts.append(
+                EndpointRef(binding_id, (key,) if key is not None else ())
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{root}")
+            )
+            cursor = match.end()
+        if cursor < len(source):
+            parts.append(EndpointLiteral(source[cursor:]))
+        return EndpointConcat(tuple(parts)) if parts else EndpointLiteral(source)
+
+    def _parse_shell_array(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        try:
+            tokens = shlex.split(source[1:-1], comments=True, posix=True)
+        except ValueError:
+            return EndpointUnknown("invalid shell array")
+        keyed = bool(tokens) and all(
+            re.match(r"^\[[^]]+\]=", token) for token in tokens
+        )
+        if keyed:
+            entries: list[tuple[str, EndpointExpression]] = []
+            for token in tokens:
+                match = re.match(r"^\[([^]]+)\]=(.*)$", token, re.S)
+                if match is None:
+                    return EndpointUnknown("invalid shell member")
+                key = shell_static_key(match.group(1))
+                if key is None:
+                    return EndpointUnknown("dynamic shell key")
+                entries.append(
+                    (
+                        key,
+                        self._shell_text_expression(
+                            match.group(2), scope_id, before
+                        ),
+                    )
+                )
+            return EndpointObject(tuple(entries))
+        return EndpointArray(
+            tuple(
+                self._shell_text_expression(token, scope_id, before)
+                for token in tokens
+            )
+        )
+
+    def _parse_template(
+        self,
+        token: StringToken,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        contents = token.contents
+        patterns = (
+            r"\$\{([^{}]+)\}"
+            if self.suffix in self.JAVASCRIPT_SUFFIXES
+            else r"#\{([^{}]+)\}"
+            if self.suffix == ".rb"
+            else r"\{\s*(\$[A-Za-z_]\w*)\s*\}"
+            if self.suffix == ".php"
+            else r"\{([^{}]+)\}"
+        )
+        parts: list[EndpointExpression] = []
+        cursor = 0
+        for match in re.finditer(patterns, contents):
+            if match.start() > cursor:
+                parts.append(EndpointLiteral(contents[cursor:match.start()]))
+            parts.append(
+                self._parse_reference_text(
+                    match.group(1).strip(), scope_id, before
+                )
+            )
+            cursor = match.end()
+        if cursor < len(contents):
+            parts.append(EndpointLiteral(contents[cursor:]))
+        return (
+            EndpointConcat(tuple(parts))
+            if parts
+            else EndpointLiteral(contents)
+        )
+
+    def _parse_container(
+        self,
+        kind: str,
+        opening: int,
+        closing: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        members = split_arguments(self.lexed.code, opening + 1, closing)
+        if kind == "pairs":
+            entries: list[tuple[str, EndpointExpression]] = []
+            for index in range(1, len(members), 2):
+                key = static_object_key(self.lexed, *members[index - 1])
+                if key is not None:
+                    entries.append(
+                        (
+                            key,
+                            self._parse_expression(
+                                *members[index], scope_id, before
+                            ),
+                        )
+                    )
+            return EndpointObject(tuple(entries))
+        separators = [
+            (
+                (colon, colon + 1)
+                if (colon := top_level_colon(
+                    self.lexed.code, member_start, member_end
+                )) is not None
+                else top_level_assignment_separator(
+                    self.lexed.code, member_start, member_end
+                )
+            )
+            for member_start, member_end in members
+        ]
+        declared_map = bool(
+            re.search(
+                r"(?:\bDictionary\b|\bMap\b|\bmap\s*\[)",
+                self.lexed.code[max(0, opening - 160):opening],
+            )
+        )
+        keyed = any(separator is not None for separator in separators) or (
+            self.lexed.code[opening] == "{"
+            and (
+                self.suffix not in {".cs", ".go", ".java"}
+                or declared_map
+            )
+        )
+        if not keyed:
+            return EndpointArray(
+                tuple(
+                    self._parse_expression(
+                        member_start, member_end, scope_id, before
+                    )
+                    for member_start, member_end in members
+                    if self.lexed.original[member_start:member_end].strip()
+                )
+            )
+        entries = []
+        for (member_start, member_end), separator in zip(members, separators):
+            if separator is None:
+                key = static_object_key(
+                    self.lexed, member_start, member_end
+                )
+                if key is not None:
+                    entries.append(
+                        (
+                            key,
+                            self._parse_expression(
+                                member_start, member_end, scope_id, before
+                            ),
+                        )
+                    )
+                continue
+            separator_start, value_start = separator
+            key = static_object_key(
+                self.lexed, member_start, separator_start
+            )
+            if key is not None:
+                entries.append(
+                    (
+                        key,
+                        self._parse_expression(
+                            value_start, member_end, scope_id, before
+                        ),
+                    )
+                )
+        return EndpointObject(tuple(entries))
+
+    def _parse_expression(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        raw_start, raw_end = start, end
+        while raw_start < raw_end and self.lexed.original[raw_start].isspace():
+            raw_start += 1
+        while raw_end > raw_start and self.lexed.original[raw_end - 1].isspace():
+            raw_end -= 1
+        if self.suffix == ".sh":
+            raw_source = self.lexed.original[raw_start:raw_end]
+            if raw_source.startswith("(") and raw_source.endswith(")"):
+                return self._parse_shell_array(
+                    raw_source, scope_id, before
+                )
+            if (
+                len(raw_source) >= 2
+                and raw_source[0] == raw_source[-1]
+                and raw_source[0] in {"'", '"'}
+            ):
+                if raw_source[0] == "'":
+                    return EndpointLiteral(raw_source[1:-1])
+                return self._shell_text_expression(
+                    raw_source[1:-1], scope_id, before
+                )
+            if re.fullmatch(r"[A-Za-z_]\w*", raw_source):
+                return EndpointLiteral(raw_source)
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end:
+            return EndpointUnknown("empty")
+        # `new URL(...)` is routinely stringified before use - `u.toString()`,
+        # `u.href`, `String(u)`. Those wrappers are not part of the endpoint, so
+        # peel them before resolving or the binding reads as an unknown
+        # expression and the send disappears.
+        # A TERNARY selecting the endpoint - `flag ? POOL_URL : OTHER` - was not
+        # modelled at all, so the whole expression read as unknown and the send
+        # vanished: not counted, so the fail-safe could not fire either. The
+        # byte-equivalent if/else form was caught. Resolve BOTH arms and treat a
+        # required endpoint in EITHER as required, which is the safe direction:
+        # the send may take that branch at runtime.
+        ternary = _top_level_ternary(self.lexed.code, start, end)
+        if ternary is not None:
+            for arm_start, arm_end in ternary:
+                arm = self._parse_expression(arm_start, arm_end, scope_id, before)
+                if isinstance(arm, EndpointLiteral) and required_endpoint(arm.value):
+                    return arm
+
+        text_for_peel = self.lexed.code[start:end]
+        # SUFFIX forms: u.toString() / u.href / u.toJSON()
+        stringified = re.match(
+            r"^\s*(.+?)\s*(?:\.\s*(?:toString\s*\(\s*\)|href|toJSON\s*\(\s*\)))\s*$",
+            text_for_peel, re.S,
+        )
+        if stringified is not None and stringified.start(1) != stringified.end(1):
+            inner_end = start + stringified.end(1)
+            if inner_end > start and (start, inner_end) != (start, end):
+                return self._parse_expression(start, inner_end, scope_id, before)
+        # PREFIX and TEMPLATE forms: String(u) and `${u}`. An earlier comment
+        # claimed String(u) was covered while the pattern only matched suffix
+        # member access, so `fetch(String(u), ...)` resolved to UNKNOWN - and
+        # because an unknown endpoint is not counted as a send at all, the
+        # fail-safe could not fire either and the linter reported CLEAN.
+        prefix_peel = re.match(
+            r"^\s*(?:String|globalThis\s*\.\s*String)\s*\(\s*(.+?)\s*\)\s*$",
+            text_for_peel, re.S,
+        ) or re.match(r"^\s*`\s*\$\{\s*(.+?)\s*\}\s*`\s*$", text_for_peel, re.S)
+        if prefix_peel is not None:
+            inner_start = start + prefix_peel.start(1)
+            inner_end = start + prefix_peel.end(1)
+            if inner_end > inner_start and (inner_start, inner_end) != (start, end):
+                return self._parse_expression(inner_start, inner_end, scope_id, before)
+
+        # A BOUND two-argument `new URL(path, base)` must be combined here, the
+        # same way the inline spelling is combined at the call site. Leaving it
+        # unresolved was deliberate, but the consequence was a SILENT PASS, not
+        # a caveat: neither `number_pool` nor the base is a required endpoint on
+        # its own, so the fail-safe backstop never fires either and
+        # `const u = new URL('number_pool', BASE); fetch(u, ...)` certified
+        # clean while the byte-identical inline form was correctly flagged.
+        constructor_base = url_constructor_base(self.lexed, (start, end), self.suffix)
+        if constructor_base is not None:
+            constructed = unwrap_url_constructor(self.lexed, (start, end))
+            if constructed != (start, end):
+                inner = self._parse_expression(
+                    constructed[0], constructed[1], scope_id, before
+                )
+                if isinstance(inner, EndpointLiteral):
+                    return EndpointLiteral(urljoin(constructor_base, inner.value))
+
+        constructed = unwrap_bound_url_constructor(self.lexed, (start, end))
+        if constructed != (start, end):
+            return self._parse_expression(
+                constructed[0], constructed[1], scope_id, before
+            )
+        assertion = self._typescript_assertion_start(start, end)
+        if assertion is not None:
+            return self._parse_expression(start, assertion, scope_id, before)
+        plus_spans = self._top_level_plus_spans(start, end)
+        if plus_spans:
+            return EndpointConcat(
+                tuple(
+                    self._parse_expression(
+                        part_start, part_end, scope_id, before
+                    )
+                    for part_start, part_end in plus_spans
+                )
+            )
+
+        # Common URL/string builders. Restrict literal-suffix rescue to these
+        # named producers; applying it to every unsupported expression makes
+        # an unrelated object member or callback URL displace the real request
+        # URL and creates false positives.
+        builder_source = self.lexed.original[start:end]
+        python_percent_format = (
+            self.suffix == ".py"
+            and re.search(r"%(?:\s*\([^)]*\))?[#0 +\-]?[0-9.*]*[a-zA-Z]", builder_source)
+            is not None
+            and re.search(r"%", self.lexed.code[start:end]) is not None
+        )
+        local_builder = re.match(
+            r"\s*([A-Za-z_$]\w*)\s*\(", self.lexed.code[start:end]
+        )
+        node_join_alias = (
+            self.suffix in JS_TS_SUFFIXES
+            and local_builder is not None
+            and self._is_node_path_join_alias(
+                local_builder.group(1), scope_id, start
+            )
+        )
+        if python_percent_format or node_join_alias or re.search(
+            r"(?:\bfmt\s*\.\s*Sprintf\s*\(|\.\s*format\s*\("
+            r"|\burljoin\s*\(|\bencodeURI(?:Component)?\s*\("
+            r"|\.\s*(?:concat|join)\s*\()",
+            builder_source,
+        ):
+            builder_tokens = [
+                token.contents
+                for token in self.lexed.strings
+                if start <= token.start and token.end <= end
+            ]
+            builder_candidates = builder_tokens + [
+                "".join(builder_tokens),
+                "/".join(builder_tokens),
+            ]
+            # A FORMAT builder substitutes later arguments INTO the first
+            # token, so concatenating tokens in source order yields garbage
+            # ("%snumber_pool" + base). Substitute instead, which is what the
+            # runtime does: "%snumber_pool" % base -> ".../messages/number_pool".
+            if len(builder_tokens) >= 2:
+                remaining = list(builder_tokens[1:])
+                substituted = re.sub(
+                    r"%(?:\([^)]*\))?[#0 +\-]?[0-9.*]*[a-zA-Z]|\{\d*\}",
+                    lambda _match: remaining.pop(0) if remaining else "",
+                    builder_tokens[0],
+                )
+                builder_candidates.append(substituted)
+            required = next(
+                (
+                    candidate
+                    for candidate in builder_candidates
+                    if required_endpoint(candidate)
+                    or required_endpoint_literal_signal(candidate)
+                ),
+                None,
+            )
+            if required is not None:
+                suffix_match = re.search(
+                    r"/messages/(?:number_pool|alphanumeric_sender_id)/?$",
+                    required.split("?", 1)[0].split("#", 1)[0],
+                )
+                return EndpointLiteral(
+                    suffix_match.group(0) if suffix_match else required
+                )
+
+        if self.suffix == ".py":
+            python_tokens = [
+                token
+                for token in self.lexed.strings
+                if start <= token.start and token.end <= end
+            ]
+            if len(python_tokens) == 1:
+                token = python_tokens[0]
+                prefix = self.lexed.original[start:token.start].strip().lower()
+                suffix_text = self.lexed.original[token.end:end].strip()
+                if "f" in prefix and not suffix_text and "{" in token.contents:
+                    return self._parse_template(token, scope_id, before)
+
+        container = root_literal_container(
+            self.lexed, start, end, self.suffix
+        )
+        if container is not None:
+            kind, opening, closing = container
+            selected = selected_members_after_container(
+                self.lexed, closing, end
+            )
+            trailing = self.lexed.code[closing + 1:end].strip(" )\t\r\n")
+            if trailing:
+                if selected is None or not selected:
+                    return EndpointUnknown("dynamic container selector")
+                value_span = literal_value_span(
+                    self.lexed, start, end, selected, self.suffix
+                )
+                return (
+                    self._parse_expression(
+                        value_span[0], value_span[1], scope_id, before
+                    )
+                    if value_span is not None
+                    else EndpointUnknown("missing container member")
+                )
+            return self._parse_container(
+                kind, opening, closing, scope_id, before
+            )
+
+        access = self._parse_access_expression(
+            start, end, scope_id, before
+        )
+        if access is not None:
+            return access
+
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is not None:
+            name = reference[0].lstrip("$")
+            binding_id = self.graph.visible_binding(
+                name, scope_id, before
+            )
+            return (
+                EndpointRef(binding_id, reference[1:])
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{name}")
+            )
+
+        if self.suffix == ".rb":
+            symbol = re.fullmatch(
+                r"\s*:\s*([A-Za-z_]\w*)\s*",
+                self.lexed.original[start:end],
+            )
+            if symbol is not None:
+                return EndpointLiteral(symbol.group(1))
+
+        tokens = [
+            token
+            for token in self.lexed.strings
+            if start <= token.start and token.end <= end
+        ]
+        if len(tokens) == 1:
+            token = tokens[0]
+            residual = (
+                self.lexed.code[start:token.start]
+                + self.lexed.code[token.end:end]
+            ).strip()
+            if self.suffix == ".py":
+                format_match = re.fullmatch(
+                    r"\s*\.\s*format\s*\((.*)\)\s*",
+                    self.lexed.original[token.end:end],
+                    re.S,
+                )
+                if format_match is not None:
+                    opening = self.lexed.code.find("(", token.end, end)
+                    closing = matching_delimiter(
+                        self.lexed.code, opening, "(", ")"
+                    )
+                    arguments = (
+                        split_arguments(
+                            self.lexed.code, opening + 1, closing
+                        )
+                        if closing is not None
+                        else []
+                    )
+                    pieces = token.contents.split("{}")
+                    if len(pieces) == len(arguments) + 1:
+                        parts: list[EndpointExpression] = []
+                        for index, piece in enumerate(pieces):
+                            if piece:
+                                parts.append(EndpointLiteral(piece))
+                            if index < len(arguments):
+                                parts.append(
+                                    self._parse_expression(
+                                        arguments[index][0],
+                                        arguments[index][1],
+                                        scope_id,
+                                        before,
+                                    )
+                                )
+                        return EndpointConcat(tuple(parts))
+            is_template = (
+                self.lexed.original[token.start] == "`"
+                or (self.suffix == ".rb" and "#{" in token.contents)
+                or (self.suffix == ".php" and "{$" in token.contents)
+                or (
+                    self.suffix == ".cs"
+                    and "$" in residual
+                    and "{" in token.contents
+                )
+                or (
+                    self.suffix == ".py"
+                    and "f" in residual.lower()
+                    and "{" in token.contents
+                )
+            )
+            if is_template:
+                return self._parse_template(token, scope_id, before)
+            if (
+                self.suffix == ".sh"
+                and self.lexed.original[token.start] == '"'
+                and "$" in token.contents
+            ):
+                return self._shell_text_expression(
+                    token.contents, scope_id, before
+                )
+            if residual.lower() in {"", "f", "r", "u", "b", "fr", "rf"}:
+                return EndpointLiteral(token.contents)
+        return EndpointUnknown("unsupported expression")
+
+    def _guard_scope(self, scope_id: int) -> int | None:
+        for candidate in self.graph.ancestors(scope_id):
+            if self.graph.scopes[candidate].kind == "conditional":
+                return candidate
+            if self.graph.scopes[candidate].kind in {"function", "module"}:
+                break
+        return None
+
+    def _definition_scope(self, scope_id: int) -> tuple[int, bool]:
+        guard = self._guard_scope(scope_id)
+        return (guard, True) if guard is not None else (scope_id, False)
+
+    def _container_origin_binding(
+        self, binding_id: int, before: int
+    ) -> int:
+        seen: set[int] = set()
+        current = binding_id
+        cutoff = before
+        while current not in seen:
+            seen.add(current)
+            definitions = [
+                definition
+                for definition in self.graph.definitions.get(current, ())
+                if definition.start < cutoff and not definition.member_path
+            ]
+            if not definitions:
+                return current
+            latest = definitions[-1]
+            if not (
+                isinstance(latest.expression, EndpointRef)
+                and not latest.expression.members
+            ):
+                return current
+            current = latest.expression.binding_id
+            cutoff = latest.start
+        return binding_id
+
+    def _add_member_definition(
+        self,
+        binding_id: int,
+        path: EndpointReference,
+        expression: EndpointExpression,
+        offset: int,
+        scope_id: int,
+        guarded: bool,
+    ) -> None:
+        targets = {binding_id, self._container_origin_binding(binding_id, offset)}
+        for target in targets:
+            self.graph.add_definition(
+                target,
+                path,
+                expression,
+                offset,
+                scope_id,
+                "mutation",
+                guarded,
+            )
+
+    def _build_definitions(self) -> None:
+        for assignment in self.root_assignments:
+            binding_id = self.assignment_bindings[assignment.start()]
+            scope_id = self.scope_at(assignment.start())
+            rhs_end = assignment_end(
+                self.lexed, assignment.end(), self.suffix
+            )
+            expression = self._parse_expression(
+                assignment.end(), rhs_end, scope_id, assignment.start()
+            )
+            binding = self.graph.bindings[binding_id]
+            kind = (
+                "declaration"
+                if binding.declaration_start == assignment.start()
+                else "mutation"
+            )
+            definition_scope, guarded = self._definition_scope(scope_id)
+            self.graph.add_definition(
+                binding_id,
+                (),
+                expression,
+                assignment.start(),
+                definition_scope,
+                kind,
+                guarded,
+            )
+
+        for reference, start, rhs_start, rhs_end in direct_member_assignments(
+            self.lexed, len(self.lexed.code), self.suffix
+        ):
+            root = reference[0].lstrip("$")
+            scope_id = self.scope_at(start)
+            binding_id = self.graph.visible_binding(root, scope_id, start)
+            if binding_id is None:
+                continue
+            definition_scope, guarded = self._definition_scope(scope_id)
+            self._add_member_definition(
+                binding_id,
+                reference[1:],
+                self._parse_expression(
+                    rhs_start, rhs_end, scope_id, start
+                ),
+                start,
+                definition_scope,
+                guarded,
+            )
+
+        if self.suffix == ".java":
+            put_pattern = re.compile(
+                r"(?<![\w$.])([A-Za-z_]\w*)\s*\.\s*put\s*\("
+            )
+            for put in put_pattern.finditer(self.lexed.code):
+                opening = self.lexed.code.rfind(
+                    "(", put.start(), put.end()
+                )
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                if closing is None:
+                    continue
+                arguments = split_arguments(
+                    self.lexed.code, opening + 1, closing
+                )
+                if len(arguments) != 2:
+                    continue
+                key = static_lookup_key(self.lexed, *arguments[0])
+                scope_id = self.scope_at(put.start())
+                binding_id = self.graph.visible_binding(
+                    put.group(1), scope_id, put.start()
+                )
+                if key is None or binding_id is None:
+                    continue
+                definition_scope, guarded = self._definition_scope(scope_id)
+                self._add_member_definition(
+                    binding_id,
+                    (key,),
+                    self._parse_expression(
+                        arguments[1][0], arguments[1][1], scope_id, put.start()
+                    ),
+                    put.start(),
+                    definition_scope,
+                    guarded,
+                )
+
+        if self.suffix == ".sh":
+            for reference, start, rhs_start, rhs_end in shell_member_assignments(
+                self.lexed, len(self.lexed.code), self.suffix
+            ):
+                scope_id = self.scope_at(start)
+                binding_id = self.graph.visible_binding(
+                    reference[0], scope_id, start
+                )
+                if binding_id is None:
+                    continue
+                self._add_member_definition(
+                    binding_id,
+                    reference[1:],
+                    self._parse_expression(
+                        rhs_start, rhs_end, scope_id, start
+                    ),
+                    start,
+                    scope_id,
+                    False,
+                )
+
+        for opening, _, rhs_start, rhs_end, leaves in self.destructuring:
+            scope_id = self.scope_at(opening)
+            mutation = opening in self.destructure_mutations
+            definition_scope, guarded = (
+                self._definition_scope(scope_id)
+                if mutation
+                else (scope_id, False)
+            )
+            source = self._parse_expression(
+                rhs_start, rhs_end, scope_id, opening
+            )
+            for name, projection, fallback in leaves:
+                binding_id = self.destructure_bindings.get((opening, name))
+                if binding_id is None:
+                    continue
+                expression: EndpointExpression = EndpointProjected(
+                    source, projection
+                )
+                if fallback is not None:
+                    expression = EndpointDefault(
+                        expression,
+                        self._parse_expression(
+                            fallback[0], fallback[1], scope_id, opening
+                        ),
+                    )
+                self.graph.add_definition(
+                    binding_id,
+                    (),
+                    expression,
+                    opening,
+                    definition_scope,
+                    "mutation" if mutation else "declaration",
+                    guarded,
+                )
+
+        delete_pattern = re.compile(r"\bdelete\s+([^;\n]+)")
+        for deletion in delete_pattern.finditer(self.lexed.code):
+            reference = static_reference_expression(
+                self.lexed, deletion.start(1), deletion.end(1)
+            )
+            if reference is None or len(reference) < 2:
+                continue
+            scope_id = self.scope_at(deletion.start())
+            binding_id = self.graph.visible_binding(
+                reference[0].lstrip("$"), scope_id, deletion.start()
+            )
+            if binding_id is not None:
+                definition_scope, guarded = self._definition_scope(scope_id)
+                self._add_member_definition(
+                    binding_id,
+                    reference[1:],
+                    EndpointUnknown("delete"),
+                    deletion.start(),
+                    definition_scope,
+                    guarded,
+                )
+
+    def resolve_expression(
+        self,
+        start: int,
+        end: int,
+        before: int,
+        projection: EndpointReference = (),
+    ) -> EndpointValue:
+        scope_id = self.scope_at(before)
+        expression = self._parse_expression(
+            start, end, scope_id, before
+        )
+        return self.graph.evaluate(
+            EndpointExpressionState(
+                expression, projection, before, scope_id
+            )
+        )
+
+    def config_method_may_mutate(
+        self, span: tuple[int, int], before: int
+    ) -> bool:
+        """Return whether a request config can use POST, PUT, or PATCH.
+
+        A proven config without a method defaults to GET. Static methods use
+        the shared mutating-method contract, while unresolved dynamic configs
+        remain in scope so analysis fails safely.
+        """
+
+        value = self.resolve_expression(
+            span[0], span[1], before, ("method",)
+        )
+        if value.exact is not None:
+            return value.exact.upper() in MUTATING_HTTP_METHODS
+        method_spans = config_object_member_spans(
+            self.lexed, span, before, self.suffix, ("method",)
+        )
+        if method_spans:
+            method_source = self.lexed.code[slice(*method_spans[-1])].strip()
+            if method_source in {"null", "undefined"}:
+                return False
+            method = static_method_value(
+                self.lexed,
+                method_spans[-1],
+                before,
+                self.suffix,
+            )
+            return method is None or method in MUTATING_HTTP_METHODS
+        if resolved_config_object_span(
+            self.lexed, span, before, self.suffix
+        ) is not None:
+            return False
+        return self.lexed.code[slice(*span)].strip() not in {
+            "null", "undefined"
+        }
+
+    def request_is_required(self, call: Call) -> bool:
+        args = split_arguments(
+            self.lexed.code, call.open_paren + 1, call.end - 1
+        )
+        callee = re.sub(
+            r"\s+", "", self.lexed.code[call.start:call.open_paren]
+        ).lower()
+        if callee == "fetch":
+            # Fetch defaults to GET.  Only known mutating methods, or an
+            # unresolved dynamic method that may be mutating, are sends.
+            if len(args) < 2:
+                return False
+            if not self.config_method_may_mutate(args[1], call.start):
+                return False
+        receiver = call_receiver(self.lexed, call)
+        config_span: tuple[int, int] | None = None
+        if callee in {"axios", "axios.request"} or (
+            callee == "request" and receiver == "axios"
+        ):
+            config_span = args[0] if args else None
+        elif callee == "request" and args:
+            if resolved_config_object_span(
+                self.lexed, args[0], call.start, self.suffix
+            ) is not None:
+                config_span = args[0]
+            elif len(args) > 1 and resolved_config_object_span(
+                self.lexed, args[1], call.start, self.suffix
+            ) is not None:
+                config_span = args[1]
+        if config_span is not None and not self.config_method_may_mutate(
+            config_span, call.start
+        ):
+            return False
+        if callee == "curl_setopt" and len(args) >= 3:
+            option = self.lexed.code[slice(*args[1])].strip()
+            if option == "CURLOPT_URL":
+                handle = self.lexed.code[slice(*args[0])].strip()
+                method = php_curl_handle_method(
+                    self.lexed, handle, call.start, self.suffix
+                )
+                if method is not None and method not in MUTATING_HTTP_METHODS:
+                    return False
+        original_spans = _request_url_spans(self.lexed, call, self.suffix)
+        resolved = []
+        for span in original_spans:
+            unwrapped = unwrap_url_constructor(self.lexed, span)
+            value = self.resolve_expression(
+                unwrapped[0], unwrapped[1], call.start
+            )
+            resolved.append(value)
+            # new URL(path, base) resolves the path relative to the base per
+            # RFC 3986 — a base without a trailing slash drops its last
+            # segment — so use urljoin rather than naive concatenation.
+            constructor_base = url_constructor_base(self.lexed, span, self.suffix)
+            if (
+                constructor_base is not None
+                and value.exact is not None
+                and required_endpoint(urljoin(constructor_base, value.exact))
+            ):
+                return True
+        if any(value.kind == REQUIRED for value in resolved):
+            return True
+        # A client base URL makes the request path relative, so combine the
+        # base with the resolved path before classifying:
+        # axios.create({baseURL: '.../messages'}).post('/number_pool').
+        base = client_base_url(self.lexed, call, self.suffix)
+        if base is not None and any(
+            value.exact is not None
+            and required_endpoint(join_base_and_path(base, value.exact))
+            for value in resolved
+        ):
+            return True
+        # Guzzle, Faraday, and HttpClient also allow the base to be declared
+        # in a nearby client configuration form that is not a root assignment
+        # the binding index can recover. Keep this fallback narrow: only the
+        # three base-client languages, only a relative required suffix, and
+        # only a prior static URL whose path is the messages collection.
+        if self.suffix in {".php", ".rb", ".cs"} and any(
+            value.exact is not None
+            and re.search(r"(?:^|/)(?:number_pool|alphanumeric_sender_id)/?$", value.exact)
+            for value in resolved
+        ):
+            prior_bases = [
+                token.contents
+                for token in self.lexed.strings
+                if token.end <= call.start
+                and re.search(r"/messages/?$", urlsplit(token.contents).path)
+            ]
+            if prior_bases and any(
+                value.exact is not None
+                and required_endpoint(join_base_and_path(prior_bases[-1], value.exact))
+                for value in resolved
+            ):
+                return True
+        if not args:
+            return False
+        return bool(
+            config_span is not None
+            and self.resolve_expression(
+                config_span[0], config_span[1], call.start, ("url",)
+            ).kind
+            == REQUIRED
+        )
+
+    def shell_curl_is_required(self, call: Call) -> bool:
+        method = shell_curl_http_method(self.lexed, call)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return False
+        scope_id = self.scope_at(call.start)
+        allowed_references = shell_curl_url_references(self.lexed, call)
+        for argument in shell_curl_url_arguments(self.lexed, call):
+            if required_endpoint(argument.strip("'\"")):
+                return True
+            references = shell_static_references(argument)
+            if references and any(
+                reference not in allowed_references
+                for reference in references
+            ):
+                continue
+            expression = self._shell_text_expression(
+                argument, scope_id, call.start
+            )
+            if self.graph.evaluate(
+                EndpointExpressionState(
+                    expression, (), call.start, scope_id
+                )
+            ).kind == REQUIRED:
+                return True
+        return False
+
+
+ABSENT, MAYBE, PRESENT = "absent", "maybe", "present"
+NO_WRITE, WRITE_ABSENT, WRITE_MAYBE, WRITE_PRESENT = range(4)
+
+
+@dataclass(frozen=True)
+class Presence:
+    state: str
+    evidence: bool = False
+
+
+ABSENT_VALUE = Presence(ABSENT)
+MAYBE_VALUE = Presence(MAYBE)
+PRESENT_VALUE = Presence(PRESENT, True)
+
+
+def join_presence(values: Iterable[Presence]) -> Presence:
+    values = tuple(values)
+    states = {value.state for value in values}
+    return Presence(
+        next(iter(states)) if len(states) == 1 else MAYBE,
+        any(value.evidence for value in values),
+    ) if values else MAYBE_VALUE
+
+
+def apply_field_effect(value: Presence, effect: int) -> Presence:
+    if effect == NO_WRITE:
+        return value
+    if effect == WRITE_PRESENT:
+        return PRESENT_VALUE
+    if effect == WRITE_ABSENT:
+        return Presence(ABSENT, True)
+    return Presence(MAYBE, True)
+
+
+def overlay_effect(value: Presence) -> int:
+    if value.state == PRESENT:
+        return WRITE_PRESENT
+    if value.state == MAYBE:
+        return WRITE_MAYBE
+    return WRITE_ABSENT if value.evidence else NO_WRITE
+
+
+@dataclass(frozen=True)
+class ObjectTargets:
+    must: frozenset[tuple[int, int]] = frozenset()
+    may: frozenset[tuple[int, int]] = frozenset()
+    unknown: bool = False
+
+    @property
+    def all(self) -> frozenset[tuple[int, int]]:
+        return self.must | self.may
+
+
+def join_targets(values: Iterable[ObjectTargets]) -> ObjectTargets:
+    values = tuple(values)
+    if not values:
+        return ObjectTargets(unknown=True)
+    possible = frozenset().union(*(value.all for value in values))
+    must = set(values[0].must)
+    for value in values[1:]:
+        must.intersection_update(value.must)
+    if any(value.unknown for value in values):
+        must.clear()
+    required = frozenset(must)
+    return ObjectTargets(required, possible - required, any(v.unknown for v in values))
+
+
+@dataclass(frozen=True)
+class ControlArm:
+    group: int
+    branch: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class RootFieldEvent:
+    binding: int
+    start: int
+    rhs: tuple[int, int]
+    scope: int
+    execution: int
+    kind: str
+    path: tuple[tuple[int, int], ...]
+    aliases: tuple[int, ...] | None
+    alias_unknown: bool = False
+
+    @property
+    def object_id(self) -> tuple[int, int]:
+        return self.binding, self.start
+
+
+@dataclass(frozen=True)
+class FieldEvent:
+    binding: int
+    start: int
+    scope: int
+    execution: int
+    path: tuple[tuple[int, int], ...]
+    effect: int
+    overlay: tuple[int, int] | None = None
+
+
+class ControlIndex:
+    """Finite branch index; callable boundaries remain in the binding graph."""
+
+    C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
+
+    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+        self.lexed, self.suffix = lexed, suffix
+        self.arms: list[ControlArm] = []
+        self.exhaustive: set[int] = set()
+        if suffix in self.C_SUFFIXES:
+            self._curly()
+            # Expression-level guards are not a JavaScript peculiarity: PHP,
+            # Ruby and Python all write `cond && payload[...] = x`, `cond and
+            # payload.update(...)` and the ternary forms, and a field written
+            # that way is CONDITIONAL. Indexing them only for JS/TS meant the
+            # same guarded write read as unconditional in every other language -
+            # a silent pass on a profile that may never be set.
+            if suffix in JS_TS_SUFFIXES or suffix == ".php":
+                self._expression_guards()
+        elif suffix in {".py", ".rb", ".sh"}:
+            self._lines()
+            if suffix in {".py", ".rb"}:
+                self._expression_guards()
+
+    def _unbraced_body_end(self, start: int) -> int | None:
+        """End of a single-statement `if (cond) stmt;` body after the ')'.
+
+        The lexer masks string interiors, so scanning the masked code for a
+        top-level ';' or line break is safe. Returns None if no statement
+        follows (e.g. a stray brace).
+        """
+        code = self.lexed.code
+        index = start
+        while index < len(code) and code[index].isspace():
+            index += 1
+        if index >= len(code) or code[index] in "{};":
+            return None
+        depth = 0
+        while index < len(code):
+            character = code[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif depth == 0 and character == ";":
+                return index + 1
+            elif depth == 0 and character == "\n":
+                return index
+            index += 1
+        return None
+
+    def _expression_guards(self) -> None:
+        """Index short-circuit and ternary expression arms in JS/TS.
+
+        A field write after `&&`/`||`, in either side of `?:`, or through a
+        logical assignment (`&&=`/`||=`) is conditional even though no block
+        exists. Scope only the containing statement so adjacent unconditional
+        writes retain an empty control path.
+        """
+        code = self.lexed.code
+        # A WRAPPED guard is still one statement. Breaking on every raw newline
+        # put `usePool &&` and `(payload.messaging_profile_id = p)` into
+        # different segments, so neither held both the operator and the write
+        # and the conditional write read as unconditional. Only a newline that
+        # neither follows nor precedes a logical/ternary operator ends a
+        # statement; nothing else is joined, so unrelated lines cannot merge
+        # into a spurious arm.
+        # Ruby, PHP and Python spell the same operators as WORDS as well.
+        word_ops = self.suffix in {".php", ".rb", ".py"}
+        logical_re = (
+            r"&&=?|\|\|=?|(?<![\w])(?:and|or)(?![\w])" if word_ops
+            else r"&&=?|\|\|=?"
+        )
+        dangling = re.compile(
+            r"(?:&&|\|\||\?|(?<![\w])(?:and|or))\s*$" if word_ops
+            else r"(?:&&|\|\||\?)\s*$"
+        )
+        continuing = re.compile(
+            r"[ \t]*(?:&&|\|\||\?|:|(?<![\w])(?:and|or)(?![\w]))" if word_ops
+            else r"[ \t]*(?:&&|\|\||\?|:)"
+        )
+        statement_start = 0
+        for match in re.finditer(r"[;\n]|$", code):
+            statement_end = match.start()
+            segment = code[statement_start:statement_end]
+            if match.group(0) == "\n" and (
+                dangling.search(segment)
+                or continuing.match(code, match.end())
+            ):
+                continue
+            # Search the ORIGINAL text, not the masked code: a Python/PHP/Ruby
+            # payload spells the key as a STRING ("messaging_profile_id"), and
+            # string interiors are blanked in lexed.code - so the guard was only
+            # ever found in JS, where object keys are usually bare identifiers.
+            # Offsets are preserved by the lexer, so the spans stay valid.
+            profile = PROFILE_IDENTIFIER_RE.search(
+                self.lexed.original[statement_start:statement_end]
+            )
+            if profile is not None:
+                absolute_profile = statement_start + profile.start()
+                logical = list(re.finditer(logical_re, segment))
+                for operator in logical:
+                    operator_end = statement_start + operator.end()
+                    if operator_end <= absolute_profile:
+                        self.arms.append(
+                            ControlArm(statement_start, 0, operator_end, statement_end)
+                        )
+                question = segment.find("?")
+                colon = segment.find(":", question + 1) if question >= 0 else -1
+                if question >= 0 and colon >= 0 and absolute_profile > statement_start + question:
+                    self.arms.append(
+                        ControlArm(
+                            statement_start,
+                            0 if absolute_profile < statement_start + colon else 1,
+                            statement_start + question + 1,
+                            statement_end,
+                        )
+                    )
+            statement_start = match.end()
+
+    def _body_arm(self, group: int, branch: int, after: int) -> int | None:
+        """Index one control body — a braced block OR an unbraced single
+        statement — starting at/after `after`. Appends a ControlArm and
+        returns the position after the body, or None if there is no body.
+
+        Every C-family control construct routes through here so that braced
+        and unbraced bodies are treated identically: a field write inside any
+        of them is conditional. Handling only braced bodies let unbraced if /
+        else / for / while writes look unconditional and pass a send that can
+        run without the profile.
+        """
+        code = self.lexed.code
+        cursor = after
+        while cursor < len(code) and code[cursor].isspace():
+            cursor += 1
+        if self.suffix == ".php" and cursor < len(code) and code[cursor] == ":":
+            # PHP alternative syntax (`if (…): … endif;`). The body runs to its
+            # end-keyword, not to the first ';', so _php_alt spans it. Treating
+            # the ':' as a one-statement body would guard only the first
+            # statement and leave a later profile write looking unconditional.
+            return None
+        if cursor < len(code) and code[cursor] == "{":
+            closing = matching_delimiter(code, cursor, "{", "}")
+            if closing is None:
+                return None
+            self.arms.append(ControlArm(group, branch, cursor, closing + 1))
+            return closing + 1
+        body_end = self._unbraced_body_end(after)
+        if body_end is None:
+            return None
+        self.arms.append(ControlArm(group, branch, after, body_end))
+        return body_end
+
+    def _curly(self) -> None:
+        code = self.lexed.code
+        # PHP spells a chained branch as one word, `elseif`, so `\bif` never
+        # matches inside it: neither the elseif body nor the `else` that closes
+        # the chain was indexed and a profile written there looked
+        # unconditional. Treat it exactly like the C-family `else if` - its own
+        # group, closed by its own `else`.
+        opener = r"\b(?:else)?if\s*\(" if self.suffix == ".php" else r"\bif\s*\("
+        # An `else if` used to open a group of its own, which was then marked
+        # exhaustive by its trailing `else` INDEPENDENTLY of the outer `if` -
+        # so `if (a) {} else if (b) {mp} else {mp}` looked like it always set
+        # the profile even though the `a` path sets nothing. The whole
+        # if/else-if/else chain is one group with one branch per arm, and only
+        # a final bare `else` makes it exhaustive (as Ruby/shell/PHP-alt
+        # chains already do).
+        chained = (
+            r"\s*(?:else\s*if|elseif|else)\b"
+            if self.suffix == ".php"
+            else r"\s*(?:else\s*if|else)\b"
+        )
+        handled: set[int] = set()
+        for match in re.finditer(opener, code):
+            if match.start() in handled:
+                continue
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            if close is None:
+                continue
+            group = match.start()
+            branch = 0
+            after = self._body_arm(group, branch, close + 1)
+            if after is None:
+                continue
+            while True:
+                tail = re.match(chained, code[after:])
+                if tail is None:
+                    break
+                head = after + tail.end()
+                if tail.group(0).strip() == "else":
+                    branch += 1
+                    if self._body_arm(group, branch, head) is not None:
+                        self.exhaustive.add(group)
+                    break
+                token = re.search(r"(?:\belseif|\bif)\s*$", code[after:head])
+                paren = head
+                while paren < len(code) and code[paren].isspace():
+                    paren += 1
+                if token is None or paren >= len(code) or code[paren] != "(":
+                    break
+                closing = matching_delimiter(code, paren, "(", ")")
+                if closing is None:
+                    break
+                handled.add(after + token.start())
+                branch += 1
+                nxt = self._body_arm(group, branch, closing + 1)
+                if nxt is None:
+                    break
+                after = nxt
+        if self.suffix == ".go":
+            # Go conditions and range clauses conventionally omit the
+            # parentheses required by the C-family forms above.
+            for match in re.finditer(r"\bif\b(?!\s*\()[^{}\n]*\{", code):
+                opening = code.rfind("{", match.start(), match.end())
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is None:
+                    continue
+                group = match.start()
+                self.arms.append(ControlArm(group, 0, opening, closing + 1))
+                tail = re.match(r"\s*else\s*", code[closing + 1:])
+                if tail is None:
+                    continue
+                cursor = closing + 1 + tail.end()
+                else_open = code.find("{", cursor)
+                if else_open >= 0 and not code[cursor:else_open].strip():
+                    else_close = matching_delimiter(code, else_open, "{", "}")
+                    if else_close is not None:
+                        self.arms.append(
+                            ControlArm(group, 1, else_open, else_close + 1)
+                        )
+                        self.exhaustive.add(group)
+            for match in re.finditer(r"\bfor\b(?!\s*\()[^{}\n]*\{", code):
+                opening = code.rfind("{", match.start(), match.end())
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is not None:
+                    self.arms.append(
+                        ControlArm(match.start(), 0, opening, closing + 1)
+                    )
+        # for / while / foreach / catch bodies, braced or unbraced. A loop may
+        # execute zero times, so a profile write in its body is conditional —
+        # `while (cond) payload.messaging_profile_id = p; send()` can send
+        # without the profile. A do-while `} while (cond);` has no following
+        # body (the next token is `;`), so _body_arm yields nothing for it,
+        # which is correct: a do body always runs at least once.
+        for match in re.finditer(r"\b(?:for|foreach|while|catch)\s*\(", code):
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            if close is None:
+                continue
+            self._body_arm(match.start(), 0, close + 1)
+        # `try { … }` takes no condition, so the parenthesised sweep above (which
+        # already covers `catch (…)`) never saw it. A try body is NOT
+        # unconditional: when a sibling catch swallows the error, execution
+        # continues past the statement with the write skipped. Treated as an arm,
+        # a send INSIDE the body shares it and stays unguarded, while a send
+        # after the statement is correctly guarded. Same rule as Python's `try`.
+        for match in re.finditer(r"\btry\s*\{", code):
+            opening = code.find("{", match.start())
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is None:
+                continue
+            # ONLY a try whose handler SWALLOWS is a guard. `try { } finally { }`
+            # with no handler propagates, and so does `catch (e) { throw e; }`:
+            # a later send is never reached and the write is not conditional
+            # relative to it - treating either as an arm reported compliant
+            # code as missing the profile.
+            if not self._swallowing_catch(closing + 1):
+                continue
+            self.arms.append(
+                ControlArm(match.start(), 0, opening, closing + 1)
+            )
+        # Go writes `switch mode {`, `switch x := f(); x {` and the bare
+        # `switch {` with NO parentheses, so the paren-anchored scan below never
+        # saw them: every case arm read as unconditional code, and a profile
+        # set in a single arm certified the whole send. Indexed here with the
+        # same per-arm modelling, so an exhaustive switch (one with `default:`)
+        # still counts as covering every path.
+        if self.suffix == ".go":
+            # The body brace is found by a BALANCED SCAN, not a lookahead. Two
+            # successive lookahead patterns were tried and both failed, because
+            # a Go switch header is not lexically simple: it may contain
+            # parentheses (`switch v := i.(type) {`), a semicolon and an init
+            # statement (`switch x := f(); x {`), a newline when it wraps, and
+            # a COMPOSITE LITERAL whose own brace (`switch cfg{A: 1}.mode {`)
+            # is not the body. Each failure indexed no arms at all, so a profile
+            # set in one arm read as unconditional - a silent pass every time.
+            # Scanning for the first brace that opens a BLOCK handles all four
+            # without another round of pattern guessing.
+            for match in re.finditer(r"(?<![\w.])switch(?![\w])", code):
+                opening = _go_block_brace(code, match.end())
+                if opening < 0:
+                    continue
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is None:
+                    continue
+                split = self._switch_arms(opening, closing)
+                if split is None:
+                    self.arms.append(
+                        ControlArm(match.start(), 0, opening, closing + 1)
+                    )
+                    continue
+                spans, has_default = split
+                for branch, (arm_start, arm_end) in enumerate(spans):
+                    self.arms.append(
+                        ControlArm(match.start(), branch, arm_start, arm_end)
+                    )
+                if has_default:
+                    self.exhaustive.add(match.start())
+
+        # switch bodies are always braced.
+        for match in re.finditer(r"\bswitch\s*\(", code):
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            opening = code.find("{", close + 1) if close is not None else -1
+            if opening < 0 or code[close + 1:opening].strip():
+                continue
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is None:
+                continue
+            # One arm for the whole body could never be exhaustive, so a switch
+            # in which EVERY arm (including `default:`) sets the profile was
+            # still reported as missing it. Index one arm per case label and
+            # mark the group exhaustive when a `default:` covers the rest.
+            split = self._switch_arms(opening, closing)
+            if split is None:
+                self.arms.append(ControlArm(match.start(), 0, opening, closing + 1))
+                continue
+            spans, has_default = split
+            for branch, (arm_start, arm_end) in enumerate(spans):
+                self.arms.append(
+                    ControlArm(match.start(), branch, arm_start, arm_end)
+                )
+            if has_default:
+                self.exhaustive.add(match.start())
+        if self.suffix == ".php":
+            self._php_alt()
+
+    def _swallowing_catch(self, cursor: int) -> bool:
+        """True when a `catch` clause at `cursor` can SWALLOW the error.
+
+        Only a swallowing handler makes the try body conditional. A handler
+        that re-raises (`catch (e) { log(e); throw e; }` — the standard
+        log-and-rethrow idiom) never lets execution continue past the
+        statement, so a write in the try body is unconditional relative to a
+        later send. Every handler must re-raise for the body to lose its arm;
+        a handler we cannot parse counts as swallowing, which keeps the
+        cautious FLAG.
+        """
+        code = self.lexed.code
+        while True:
+            head = re.match(r"\s*catch\b", code[cursor:cursor + 40])
+            if head is None:
+                return False
+            index = cursor + head.end()
+            while index < len(code) and code[index].isspace():
+                index += 1
+            if index < len(code) and code[index] == "(":
+                shut = matching_delimiter(code, index, "(", ")")
+                if shut is None:
+                    return True
+                index = shut + 1
+                while index < len(code) and code[index].isspace():
+                    index += 1
+            if index >= len(code) or code[index] != "{":
+                return True
+            shut = matching_delimiter(code, index, "{", "}")
+            if shut is None:
+                return True
+            if not self._braced_tail_throws(code[index + 1:shut]):
+                return True
+            cursor = shut + 1
+
+    @staticmethod
+    def _braced_tail_throws(body: str) -> bool:
+        """True when the LAST statement of a braced handler body re-raises.
+
+        Deliberately conservative: only a trailing top-level `throw` counts, so
+        a nested or conditional `if (fatal) { throw e; }` still reads as
+        swallowing and the body keeps its arm.
+        """
+        text = body.rstrip().rstrip(";").rstrip()
+        depth = 0
+        start = 0
+        for index in range(len(text) - 1, -1, -1):
+            character = text[index]
+            if character in ")]}":
+                depth += 1
+            elif character in "([{":
+                depth -= 1
+                if depth < 0:
+                    start = index + 1
+                    break
+            elif depth == 0 and character == ";":
+                start = index + 1
+                break
+        return re.match(r"\s*(?:throw|rethrow)\b", text[start:]) is not None
+
+    @staticmethod
+    def _label_colon(text: str, start: int) -> int | None:
+        """Offset of the ':' ending a `case …:` label, or None.
+
+        Skips bracketed spans, the `::` scope operator (`Status::SENT`) and the
+        ':' of a ternary so a computed case expression still finds its label.
+        """
+        depth = 0
+        pending = 0
+        index = start
+        while index < len(text):
+            character = text[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+            elif character in ";\n" and depth == 0 and pending == 0:
+                return None
+            elif depth == 0 and character == "?":
+                pending += 1
+            elif depth == 0 and character == ":":
+                if text[index + 1:index + 2] == ":":
+                    index += 2
+                    continue
+                if pending:
+                    pending -= 1
+                else:
+                    return index
+            index += 1
+        return None
+
+    def _switch_arms(
+        self, opening: int, closing: int
+    ) -> tuple[list[tuple[int, int]], bool] | None:
+        """Per-case arm spans for a switch body, plus whether it has a default.
+
+        Returns None when the shape cannot be modelled safely - no labels, an
+        unparsable label, or an IMPLICIT FALL-THROUGH (a non-empty case body
+        with no break/return before the next label). In those cases the caller
+        keeps the single whole-body arm, which over-guards rather than
+        under-guards. Consecutive labels with nothing between them share one
+        arm, which is exactly how `case 'a': case 'b': …` behaves.
+        """
+        code = self.lexed.code
+        body = code[opening + 1:closing]
+        depths: list[int] = []
+        depth = 0
+        for character in body:
+            depths.append(depth)
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+        labels: list[tuple[int, int, bool]] = []
+        for match in re.finditer(r"\b(case|default)\b", body):
+            if depths[match.start()] != 0:
+                continue
+            if match.group(1) == "default":
+                tail = re.match(r"\s*:", body[match.end():])
+                if tail is None:
+                    continue
+                colon = match.end() + tail.end() - 1
+            else:
+                found = self._label_colon(body, match.end())
+                if found is None:
+                    return None
+                colon = found
+            labels.append(
+                (
+                    opening + 1 + match.start(),
+                    opening + 2 + colon,
+                    match.group(1) == "default",
+                )
+            )
+        if not labels:
+            return None
+        terminator = re.compile(r"\b(?:break|return|continue|throw|goto|exit|die)\b")
+        spans: list[tuple[int, int]] = []
+        arm_start: int | None = None
+        for position, (label_start, body_start, _) in enumerate(labels):
+            if arm_start is None:
+                arm_start = label_start
+            body_end = (
+                labels[position + 1][0]
+                if position + 1 < len(labels)
+                else closing
+            )
+            segment = code[body_start:body_end]
+            if not segment.strip():
+                # Consecutive labels share one arm (`case 'a': case 'b': …`) in
+                # the C family, where an empty body falls through. Go does NOT
+                # fall through, so an empty `case "a":` is a real arm that runs
+                # and sets nothing - merging it into the following `default:`
+                # let that default certify a path which writes no profile.
+                if self.suffix == ".go":
+                    spans.append((arm_start, body_end))
+                    arm_start = None
+                continue
+            # Go breaks IMPLICITLY - falling through needs an explicit
+            # `fallthrough` keyword - so a Go arm without `break` is the normal
+            # case, not an unmodellable fall-through. Requiring a terminator
+            # there made every Go switch fall back to one whole-body arm, so an
+            # exhaustive switch whose every arm (including `default:`) sets the
+            # profile was still reported as missing it.
+            if self.suffix == ".go":
+                if re.search(r"\bfallthrough\b", segment):
+                    return None
+            elif position + 1 < len(labels) and terminator.search(segment) is None:
+                return None
+            spans.append((arm_start, body_end))
+            arm_start = None
+        if arm_start is not None:
+            spans.append((arm_start, closing))
+        return spans, any(is_default for _, _, is_default in labels)
+
+    def _php_alt(self) -> None:
+        """Index PHP alternative-syntax bodies (`if (…): … endif;`).
+
+        The colon-delimited forms have no braces, so _body_arm cannot span
+        them; without this a profile write between the ':' and the closing
+        `endif` / `else` / `elseif` looks unconditional. A stack pairs each
+        opener with its terminator so the if/elseif/else chain shares one group
+        (a trailing `else` marks it exhaustive) and the loop/switch forms get a
+        single conditional arm.
+        """
+        code = self.lexed.code
+        openers = {"if", "elseif", "else", "for", "foreach", "while", "switch"}
+        terminators = {
+            "endif": "if",
+            "endforeach": "foreach",
+            "endfor": "for",
+            "endwhile": "while",
+            "endswitch": "switch",
+        }
+        token = re.compile(
+            r"\b(if|elseif|else|for|foreach|while|switch)\b"
+            r"|\b(endif|endforeach|endfor|endwhile|endswitch)\b"
+        )
+        stack: list[list[int | str]] = []
+        for match in token.finditer(code):
+            keyword = match.group(1)
+            if keyword is not None:
+                if keyword == "else":
+                    head_end = match.end()
+                else:
+                    paren = match.end()
+                    while paren < len(code) and code[paren].isspace():
+                        paren += 1
+                    if paren >= len(code) or code[paren] != "(":
+                        continue
+                    close = matching_delimiter(code, paren, "(", ")")
+                    if close is None:
+                        continue
+                    head_end = close + 1
+                probe = head_end
+                while probe < len(code) and code[probe].isspace():
+                    probe += 1
+                if probe >= len(code) or code[probe] != ":":
+                    # Brace syntax or a non-alternative use — leave it to the
+                    # C-family handler.
+                    continue
+                body_start = probe + 1
+                if keyword in {"elseif", "else"}:
+                    if not stack or stack[-1][0] != "if":
+                        continue
+                    entry = stack[-1]
+                    self.arms.append(
+                        ControlArm(entry[1], entry[2], entry[3], match.start())
+                    )
+                    entry[2] += 1
+                    entry[3] = body_start
+                    if keyword == "else":
+                        self.exhaustive.add(entry[1])
+                elif keyword in openers:
+                    kind = "if" if keyword == "if" else keyword
+                    stack.append([kind, match.start(), 0, body_start])
+            else:
+                want = terminators[match.group(2)]
+                if stack and stack[-1][0] == want:
+                    entry = stack.pop()
+                    self.arms.append(
+                        ControlArm(entry[1], entry[2], entry[3], match.start())
+                    )
+
+    def _py_header_colon(self, start: int, end: int) -> int | None:
+        """Offset of the ':' that ends a Python compound-statement header.
+
+        Scans the masked line (strings/comments already blanked) for the first
+        top-level ':' — skipping brackets (slices, dicts, call args) and the
+        walrus ':=' — so a compact `if cond: stmt` header is found even when its
+        condition contains colons.
+        """
+        code = self.lexed.code
+        depth = 0
+        index = start
+        while index < end:
+            character = code[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+            elif character == ":" and depth == 0:
+                if index + 1 < len(code) and code[index + 1] == "=":
+                    index += 2
+                    continue
+                return index
+            index += 1
+        return None
+
+    def _py_logical_row(
+        self, lines: list[tuple[int, int, int, str]], index: int
+    ) -> int:
+        """Index of the last physical row of the logical line starting at `index`.
+
+        A compound header may WRAP: `if (use_pool\n        and enabled):` keeps
+        its ':' on a continuation row, so scanning only the first physical line
+        found no colon at all and the guard was never indexed - a profile
+        written in its body read as unconditional.
+        """
+        code = self.lexed.code
+        depth = 0
+        row = index
+        while True:
+            for position in range(lines[row][0], lines[row][1]):
+                character = code[position]
+                if character in "([{":
+                    depth += 1
+                elif character in ")]}":
+                    depth -= 1
+            if depth <= 0 or row + 1 >= len(lines):
+                return row
+            row += 1
+
+    def _swallowing_except(
+        self, lines: list[tuple[int, int, int, str]], index: int, indent: int
+    ) -> bool:
+        """True when an `except` handler of the `try` at `index` can SWALLOW.
+
+        Python mirror of `_swallowing_catch`: a handler whose last statement is
+        `raise` propagates, so execution never continues past the statement
+        with the write skipped. Every handler must re-raise for the try body to
+        lose its arm; anything unparseable counts as swallowing.
+        """
+        row = index + 1
+        while row < len(lines):
+            _, _, row_indent, text = lines[row]
+            if not text or row_indent > indent:
+                row += 1
+                continue
+            if row_indent < indent:
+                return False
+            if re.match(r"(?:else|finally)\b", text):
+                row += 1
+                continue
+            if re.match(r"except\b", text) is None:
+                return False
+            if not self._py_handler_reraises(lines, row, indent):
+                return True
+            row += 1
+        return False
+
+    def _py_handler_reraises(
+        self, lines: list[tuple[int, int, int, str]], row: int, indent: int
+    ) -> bool:
+        """True when the `except` handler at `row` ends in a bare-level `raise`.
+
+        Deliberately conservative: a `raise` nested deeper than the handler's
+        own body indent is conditional, so it reads as swallowing and the try
+        body keeps its arm.
+        """
+        code = self.lexed.code
+        last = self._py_logical_row(lines, row)
+        header_end = lines[last][1]
+        colon = self._py_header_colon(lines[row][0], header_end)
+        if colon is None:
+            return False
+        inline = code[colon + 1:header_end]
+        if inline.strip():
+            return self._tail_statement_raises(inline)
+        body = []
+        for entry in lines[last + 1:]:
+            if not entry[3]:
+                continue
+            if entry[2] <= indent:
+                break
+            body.append(entry)
+        if not body or body[-1][2] != body[0][2]:
+            return False
+        return self._tail_statement_raises(body[-1][3])
+
+    @staticmethod
+    def _tail_statement_raises(text: str) -> bool:
+        """True when the last `;`-separated statement of `text` is a `raise`."""
+        statements = [part for part in text.split(";") if part.strip()]
+        return bool(statements) and re.match(r"\s*raise\b", statements[-1]) is not None
+
+    def _python(self, lines: list[tuple[int, int, int, str]]) -> None:
+        """Index Python control arms, block and compact one-line forms alike.
+
+        A guard writes a profile only on some path — an `if`/`elif`/`else`
+        branch, a loop body that may not run, an `except` handler, or one
+        `case` arm — whether the body sits on its own indented lines or inline
+        after the header colon (`if cond: payload[...] = p`, or a `;`-separated
+        suite). Block `if`/`else` chains and `match`/`case` groups are tracked
+        so a fully-covering `else` / wildcard `case _` stays exhaustive and a
+        genuinely unconditional write is never guarded.
+        """
+        code = self.lexed.code
+        # A `try` body is NOT unconditional: when a sibling handler swallows the
+        # error, execution continues past the statement with the write skipped.
+        # It is an arm like any other — a send INSIDE the same body shares the
+        # arm and stays unguarded, while a send after the statement is guarded.
+        conditional = {"if", "elif", "else", "for", "while", "except", "case", "try"}
+        if_pending: dict[int, int] = {}
+        case_pending: dict[int, int] = {}
+        for index, (start, line_end, indent, text) in enumerate(lines):
+            header = re.match(
+                r"(if|elif|else|for|while|try|except|finally|with|match|case)\b",
+                text,
+            )
+            if header is None:
+                continue
+            word = header.group(1)
+            if word == "match":
+                # `match` only dispatches; its `case` arms carry the guard.
+                # Start a fresh case chain for any deeper indent.
+                for level in [key for key in case_pending if key > indent]:
+                    del case_pending[level]
+                continue
+            if word not in conditional:
+                # with / finally bodies always execute — not guards.
+                continue
+            if word == "try":
+                # ONLY a try whose handler SWALLOWS is a guard. `try: / finally:`
+                # with no handler propagates, and so does an `except:` whose
+                # body ends in `raise`: a later send is never reached and the
+                # write is not conditional relative to it - treating either as
+                # an arm reported compliant code as missing the profile.
+                if not self._swallowing_except(lines, index, indent):
+                    continue
+            last = self._py_logical_row(lines, index)
+            header_end = lines[last][1]
+            colon = self._py_header_colon(start, header_end)
+            if colon is None:
+                continue
+            if code[colon + 1:header_end].strip():
+                end = header_end  # compact inline body — guard only this line
+            else:
+                end = next(
+                    (row[0] for row in lines[last + 1:] if row[3] and row[2] <= indent),
+                    len(code),
+                )
+            orphan = False
+            if word in {"elif", "else"}:
+                orphan = indent not in if_pending
+                group = if_pending.get(indent, start)
+                if_pending[indent] = group
+            elif word == "case":
+                group = case_pending.get(indent, start)
+                case_pending[indent] = group
+            else:
+                group = start
+                if word in {"if", "for", "while"}:
+                    if_pending[indent] = group
+            self.arms.append(
+                ControlArm(
+                    group,
+                    sum(arm.group == group for arm in self.arms),
+                    start,
+                    end,
+                )
+            )
+            if word == "else" and not orphan:
+                # An `else` with NO recorded opener at this indent is not the
+                # tail of an if/for/while chain - it is `try/except/else`, whose
+                # body runs only when no exception was raised. Marking it
+                # exhaustive made a one-branch group that is always taken, so a
+                # profile written there read as unconditional.
+                self.exhaustive.add(group)
+            elif word == "case":
+                pattern = code[start + indent + len(word):colon].strip()
+                if re.fullmatch(r"_|[a-z]\w*", pattern):
+                    self.exhaustive.add(group)
+
+    def _lines(self) -> None:
+        lines: list[tuple[int, int, int, str]] = []
+        cursor = 0
+        for line in self.lexed.code.splitlines(keepends=True):
+            stripped = line.lstrip(" \t")
+            lines.append((cursor, cursor + len(line), len(line) - len(stripped), stripped.strip()))
+            cursor += len(line)
+        if self.suffix == ".py":
+            self._python(lines)
+            return
+        stack: list[tuple[str, int, int, int]] = []
+        for start, end, indent, text in lines:
+            if self.suffix == ".rb":
+                if re.match(r"(?:if|unless|case|for|while|until|begin)\b", text) or re.match(
+                    r".+\.(?:each|each_pair|each_with_index|times|map|select)\b.*\bdo(?:\s*\|[^|]*\|)?\s*$",
+                    text,
+                ):
+                    stack.append(("end", start, start, 0))
+                elif re.match(r"(?:elsif|when|rescue)\b", text) and stack:
+                    # A MIDDLE branch closes the previous one and opens the
+                    # next, but does NOT make the group exhaustive - only a
+                    # final `else` does. Without this, an `elsif`/`when` body
+                    # folded into branch 0 and a profile written only there
+                    # read as unconditional.
+                    token, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, start))
+                    stack.append((token, group, start, branch + 1))
+                elif text == "else" and stack:
+                    token, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, start))
+                    self.exhaustive.add(group)
+                    stack.append((token, group, start, branch + 1))
+                elif re.match(r"end\b", text) and stack:
+                    _, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, end))
+                elif re.search(
+                    r"\S\s+\b(?:if|unless|while|until)\b\s+\S", text
+                ) and not re.search(r"\b(?:then|do)\b\s*(?:\|[^|]*\|)?\s*$", text):
+                    # Trailing modifier: `stmt if cond` / `stmt unless cond`
+                    # runs the statement only conditionally. It is not a block
+                    # opener (those start with the keyword) so it has no `end`.
+                    self.arms.append(ControlArm(start, 0, start, end))
+            else:
+                one_line_if = re.match(r"if\b.*;\s*then\b.*\bfi\b", text)
+                if one_line_if:
+                    # Self-contained `if …; then …; fi` — the body is guarded
+                    # but there is no separate `fi` line to close it.
+                    self.arms.append(ControlArm(start, 0, start, end))
+                else:
+                    opener = re.match(r"(if|for|while|until|case)\b", text)
+                    if opener:
+                        close = "fi" if opener.group(1) == "if" else "esac" if opener.group(1) == "case" else "done"
+                        stack.append((close, start, start, 0))
+                    elif (
+                        re.match(r"elif\b", text)
+                        and stack
+                        and stack[-1][0] == "fi"
+                    ):
+                        # Same as Ruby's elsif: closes the previous branch,
+                        # opens the next, does not make the group exhaustive.
+                        token, group, branch_start, branch = stack.pop()
+                        self.arms.append(
+                            ControlArm(group, branch, branch_start, start)
+                        )
+                        stack.append((token, group, start, branch + 1))
+                    elif text == "else" and stack and stack[-1][0] == "fi":
+                        token, group, branch_start, branch = stack.pop()
+                        self.arms.append(ControlArm(group, branch, branch_start, start))
+                        self.exhaustive.add(group)
+                        stack.append((token, group, start, branch + 1))
+                    elif stack and re.match(rf"{stack[-1][0]}\b", text):
+                        _, group, branch_start, branch = stack.pop()
+                        self.arms.append(ControlArm(group, branch, branch_start, end))
+                guard = re.search(r"&&|\|\|", text)
+                if guard is not None and not re.match(
+                    r"(?:if|elif|else|fi|for|while|until|case|esac|done|then|do)\b",
+                    text,
+                ):
+                    # `cond && assign` / `cond || assign` runs the right side
+                    # only conditionally; guard from the operator onward so a
+                    # left-hand assignment that always runs stays unguarded.
+                    self.arms.append(
+                        ControlArm(start, 0, start + indent + guard.end(), end)
+                    )
+
+    def path(self, offset: int) -> tuple[tuple[int, int], ...]:
+        arms = [arm for arm in self.arms if arm.start <= offset < arm.end]
+        arms.sort(key=lambda arm: (-(arm.end - arm.start), arm.start))
+        return tuple((arm.group, arm.branch) for arm in arms)
+
+    def environments(self, paths: Iterable[tuple[tuple[int, int], ...]], call_path: tuple[tuple[int, int], ...]) -> list[dict[int, int | None]]:
+        fixed = dict(call_path)
+        groups: dict[int, set[int]] = {}
+        for path in paths:
+            for group, branch in path:
+                if group not in fixed:
+                    groups.setdefault(group, set()).add(branch)
+        environments: list[dict[int, int | None]] = [fixed]
+        for group, branches in groups.items():
+            if group in self.exhaustive:
+                # An exhaustive if/else covers all paths, but a branch that
+                # writes nothing never appears in the write paths above. Pull
+                # in every branch of the group so the path through a
+                # profile-less branch is considered — otherwise
+                # `if (skip) {...} else payload.messaging_profile_id = p;` was
+                # read as always setting the profile.
+                branches = branches | {
+                    arm.branch for arm in self.arms if arm.group == group
+                }
+            choices: list[int | None] = sorted(branches)
+            if group not in self.exhaustive:
+                choices.append(None)
+            expanded: list[dict[int, int | None]] = []
+            for environment in environments:
+                for choice in choices:
+                    candidate = dict(environment)
+                    candidate[group] = choice
+                    expanded.append(candidate)
+            environments = expanded
+            if len(environments) > 64:
+                return []
+        return environments
+
+    @staticmethod
+    def active(path: tuple[tuple[int, int], ...], environment: dict[int, int | None]) -> bool:
+        return all(environment.get(group) == branch for group, branch in path)
+
+
+class PayloadStateResolver:
+    """Indexed abstract interpreter for payload field/object state."""
+
+    JS_SUFFIXES = JS_TS_SUFFIXES
+
+    def __init__(
+        self,
+        lexed: LexedSource,
+        suffix: str,
+        fields: Iterable[str],
+        *,
+        require_value: bool,
+        source: SourceEndpointResolver | None = None,
+    ) -> None:
+        self.lexed, self.suffix = lexed, suffix
+        self.fields, self.require_value = frozenset(fields), require_value
+        self.source = source or SourceEndpointResolver(lexed, suffix)
+        self.control = ControlIndex(lexed, suffix)
+        self.roots: dict[int, list[RootFieldEvent]] = {}
+        self.root_offsets: dict[int, list[int]] = {}
+        self.objects: dict[tuple[int, int], RootFieldEvent] = {}
+        self.events: list[FieldEvent] = []
+        self.event_offsets: list[int] = []
+        self._targets_memo: dict[tuple[int, int, int], ObjectTargets] = {}
+        self._presence_memo: dict[tuple[tuple[int, int], int, int], Presence] = {}
+        self._index_roots()
+        self._index_field_events()
+
+    def _binding(self, start: int, end: int, scope: int, before: int) -> int | None:
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is not None and len(reference) == 1:
+            name = reference[0].lstrip("$")
+        else:
+            text = re.sub(r"^(?:\.\.\.|\*\*|[&*])\s*", "", self.lexed.code[start:end].strip())
+            match = re.fullmatch(r"\$?([A-Za-z_]\w*)", text)
+            if match is None:
+                return None
+            name = match.group(1)
+        return self.source.graph.visible_binding(name, scope, before)
+
+    def _index_roots(self) -> None:
+        for assignment in self.source.root_assignments:
+            binding = self.source.assignment_bindings[assignment.start()]
+            scope = self.source.scope_at(assignment.start())
+            end = assignment_end(self.lexed, assignment.end(), self.suffix)
+            owner = self.source.graph.bindings[binding]
+            direct_alias = self._binding(
+                assignment.end(), end, scope, assignment.start()
+            )
+            conditional = self._conditional(assignment.end(), end)
+            aliases: tuple[int, ...] | None = (
+                (direct_alias,) if direct_alias is not None else None
+            )
+            alias_unknown = False
+            if conditional is not None:
+                choices = tuple(
+                    self._binding(*span, scope, assignment.start())
+                    for span in conditional
+                )
+                aliases = tuple(
+                    dict.fromkeys(choice for choice in choices if choice is not None)
+                )
+                alias_unknown = any(choice is None for choice in choices)
+            event = RootFieldEvent(
+                binding,
+                assignment.start(),
+                (assignment.end(), end),
+                scope,
+                self.source.graph.execution_scope(scope),
+                "declaration" if owner.declaration_start == assignment.start() else "mutation",
+                self.control.path(assignment.start()),
+                aliases,
+                alias_unknown,
+            )
+            self.roots.setdefault(binding, []).append(event)
+            self.root_offsets.setdefault(binding, []).append(event.start)
+            if event.aliases is None:
+                self.objects[event.object_id] = event
+
+    def _add_event(self, binding: int, start: int, effect: int, overlay: tuple[int, int] | None = None) -> None:
+        scope = self.source.scope_at(start)
+        self.events.append(FieldEvent(
+            binding,
+            start,
+            scope,
+            self.source.graph.execution_scope(scope),
+            self.control.path(start),
+            effect,
+            overlay,
+        ))
+
+    def _value_effect(
+        self, start: int, end: int, seen: frozenset[int] = frozenset()
+    ) -> int:
+        if not self.require_value:
+            return WRITE_PRESENT
+        conditional = self._conditional(start, end)
+        if conditional is not None:
+            effects = {
+                self._value_effect(span[0], span[1], seen) for span in conditional
+            }
+            return effects.pop() if len(effects) == 1 else WRITE_MAYBE
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        code = self.lexed.code[start:end].strip()
+        if re.fullmatch(r"(?:null|nil|none|undefined|Optional\s*\.\s*empty\s*\(\s*\))", code, re.I):
+            return WRITE_ABSENT
+        # A messaging_profile_id must be a non-empty identifier. A statically
+        # falsy or empty literal — false/true, 0, [], {}, and empty collection
+        # constructors — is present in shape but unusable, so the Messages API
+        # receives an invalid profile. Treat those as absent (shape vs value).
+        if re.fullmatch(
+            r"(?:false|true"
+            r"|[+-]?0(?:\.0+)?"
+            r"|\[\s*\]|\{\s*\}|\(\s*\)"
+            r"|(?:dict|list|tuple|set|array|Array|Map|Set|Object|String)\s*\(\s*\)"
+            r"|new\s+(?:Array|Map|Set|Object)\s*\(\s*\))",
+            code,
+            re.I,
+        ):
+            return WRITE_ABSENT
+        tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
+        if len(tokens) == 1:
+            residual = (self.lexed.code[start:tokens[0].start] + self.lexed.code[tokens[0].end:end]).strip().lower()
+            if residual in {"", "f", "r", "u", "b", "fr", "rf"}:
+                return (
+                    WRITE_PRESENT
+                    if tokens[0].contents.strip()
+                    else WRITE_ABSENT
+                )
+        # A value with an empty fallback is not guaranteed usable. Treat both
+        # nullish and logical-OR fallbacks consistently; a concrete non-empty
+        # fallback is handled by the conditional resolver above.
+        if re.search(r"(?:\?\?|\|\||\boptional\b|\bmaybe\b)", code, re.I):
+            return WRITE_MAYBE
+        if self.suffix == ".py":
+            env_getter = re.search(
+                r"(?:os\.environ\.get|os\.getenv)\s*\(",
+                self.lexed.code[start:end],
+            )
+            if env_getter is not None:
+                opening = start + env_getter.end() - 1
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                arguments = (
+                    split_arguments(self.lexed.code, opening + 1, closing)
+                    if closing is not None and closing <= end
+                    else []
+                )
+                if len(arguments) < 2:
+                    return WRITE_MAYBE
+        if tokens and all(not token.contents.strip() for token in tokens):
+            # Empty literal concatenations/coercions (`'' + ''`,
+            # `String('   ')`, `.concat('')`, `.join('')`) are statically
+            # unusable even though their source text is non-empty.
+            residual = self.lexed.code[start:end]
+            if not re.search(r"[A-Za-z_$]\w*(?!\s*\()", residual):
+                return WRITE_ABSENT
+        alias = self._alias_absence(start, code, seen)
+        if alias is not None:
+            return alias
+        return WRITE_PRESENT if code else WRITE_ABSENT
+
+    def _assignment_entries(self) -> list[tuple[str, int, int, int]]:
+        cached = getattr(self, "_assignment_entries_cache", None)
+        if cached is None:
+            cached = assignment_index(self.lexed, self.suffix)
+            self._assignment_entries_cache = cached
+        return cached
+
+    def _alias_absence(
+        self, start: int, code: str, seen: frozenset[int]
+    ) -> int | None:
+        """Resolve a bare-identifier value to its nearest static literal.
+
+        A direct empty/falsy literal is already treated as absent above, but a
+        value assigned through a local constant — ``const mp = ''; {..: mp}`` —
+        would otherwise pass as present because the identifier text is non-empty.
+        Resolve the nearest binding-matched assignment and recurse, so every
+        empty/falsy form and any alias chain is caught. This ONLY returns a
+        proven absence: a present/maybe value keeps the existing behaviour, so
+        the resolution can flag more, never fewer (no new false positives on a
+        genuinely populated alias).
+        """
+        match = re.fullmatch(r"\$?([A-Za-z_]\w*)", code)
+        if match is None:
+            return None
+        name = match.group(1)
+        # DECLARED but never assigned - `let mp;` / `var mp;`. Such a name has
+        # no assignment entry at all, so it also has no binding, and the lookup
+        # below returns None before any absence can be proven. The serialized
+        # payload is byte-identical to the explicitly-empty `let mp = ""` case
+        # that IS flagged, so treat a bare declaration as proven absence.
+        # Checked BEFORE the binding lookup for exactly that reason.
+        if not any(
+            entry_name.lstrip("$") == name
+            for entry_name, _, _, _ in self._assignment_entries()
+        ) and re.search(
+            rf"(?:^|[;{{}}\n])[ \t]*(?:let|var|my|our)[ \t]+\$?{re.escape(name)}[ \t]*(?=[;\n])",
+            self.lexed.code[:start],
+        ):
+            return WRITE_ABSENT
+        binding = self.source.graph.visible_binding(
+            name, self.source.scope_at(start), start
+        )
+        if binding is None or binding in seen:
+            return None
+        assignments: list[tuple[int, int, int]] = []
+        for entry_name, entry_start, rhs_start, rhs_end in self._assignment_entries():
+            if entry_name.lstrip("$") != name:
+                continue
+            entry_binding = self.source.graph.visible_binding(
+                name, self.source.scope_at(entry_start), entry_start
+            )
+            if entry_binding == binding:
+                assignments.append((entry_start, rhs_start, rhs_end))
+        # Only a SINGLE static assignment is a constant alias. A reassigned or
+        # conditionally-assigned binding may hold a different value at the use
+        # site, so leave it to the existing present/maybe handling — stay
+        # conservative and never manufacture a false absence.
+        if len(assignments) != 1:
+            return None
+        entry_start, rhs_start, rhs_end = assignments[0]
+        if entry_start >= start:
+            return None
+        resolved = self._value_effect(rhs_start, rhs_end, seen | {binding})
+        return WRITE_ABSENT if resolved == WRITE_ABSENT else None
+
+    def _index_field_events(self) -> None:
+        seen: set[tuple[int, int, int, tuple[int, int] | None]] = set()
+
+        def add(binding: int | None, start: int, effect: int, overlay: tuple[int, int] | None = None) -> None:
+            if binding is None or (binding, start, effect, overlay) in seen:
+                return
+            seen.add((binding, start, effect, overlay))
+            self._add_event(binding, start, effect, overlay)
+
+        for reference, start, rhs_start, rhs_end in direct_member_assignments(self.lexed, len(self.lexed.code), self.suffix):
+            if len(reference) != 2 or reference[1] not in self.fields:
+                continue
+            scope = self.source.scope_at(start)
+            add(self.source.graph.visible_binding(reference[0].lstrip("$"), scope, start), start, self._value_effect(rhs_start, rhs_end))
+        if self.suffix == ".sh":
+            for reference, start, rhs_start, rhs_end in shell_member_assignments(self.lexed, len(self.lexed.code), self.suffix):
+                if len(reference) == 2 and reference[1] in self.fields:
+                    scope = self.source.scope_at(start)
+                    add(self.source.graph.visible_binding(reference[0], scope, start), start, self._value_effect(rhs_start, rhs_end))
+
+        names = "|".join(map(re.escape, sorted(self.fields)))
+        root_spans = [event.rhs for events in self.roots.values() for event in events]
+        setter = re.compile(rf"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:set)?(?:{names})\s*\(")
+        for match in setter.finditer(self.lexed.code):
+            if any(start <= match.start() < end for start, end in root_spans):
+                continue
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            scope = self.source.scope_at(match.start())
+            if closing is not None:
+                add(self.source.graph.visible_binding(match.group(1), scope, match.start()), match.start(), self._value_effect(opening + 1, closing))
+
+        # `.Add(key, value)` (C# Dictionary), `.TryAdd(...)`, `.set(...)` (JS
+        # Map) and `.putIfAbsent(...)` are the same two-argument key/value write
+        # as Java's `.put(...)`. Modelling only `put` meant a C# payload built
+        # with Dictionary.Add was seen as never receiving the profile, so a
+        # COMPLIANT send was reported as missing it.
+        put = re.compile(
+            r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*"
+            r"(?:put|putIfAbsent|Add|TryAdd|set)\s*\("
+        )
+        for match in put.finditer(self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if len(arguments) == 2 and static_lookup_key(self.lexed, *arguments[0]) in self.fields:
+                scope = self.source.scope_at(match.start())
+                add(self.source.graph.visible_binding(match.group(1), scope, match.start()), match.start(), self._value_effect(*arguments[1]))
+
+        # Snapshot overlays and in-place merge/update adapters.
+        merge = re.compile(r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:update|merge!|putAll)\s*\(")
+        for match in merge.finditer(self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            if closing is not None:
+                scope = self.source.scope_at(match.start())
+                binding = self.source.graph.visible_binding(match.group(1), scope, match.start())
+                for span in split_arguments(self.lexed.code, opening + 1, closing):
+                    add(binding, match.start() + span[0] - opening, NO_WRITE, span)
+        for match in re.finditer(r"\bObject\s*\.\s*assign\s*\(", self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if len(arguments) < 2:
+                continue
+            scope = self.source.scope_at(match.start())
+            binding = self._binding(*arguments[0], scope, match.start())
+            for span in arguments[1:]:
+                add(binding, span[0], NO_WRITE, span)
+
+        deletion_patterns = (
+            re.compile(r"\b(?:delete|del)\s+([^;\n]+)"),
+            re.compile(r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:delete|remove|Remove)\s*\(([^)]*)\)"),
+            re.compile(r"\bdelete\s*\(\s*([A-Za-z_]\w*)\s*,([^)]*)\)"),
+            re.compile(r"\bunset\s*\(\s*([^)]*)\)"),
+        )
+        for index, pattern in enumerate(deletion_patterns):
+            for match in pattern.finditer(self.lexed.code):
+                reference = static_reference_expression(self.lexed, match.start(1), match.end(1)) if index in {0, 3} else None
+                if index in {1, 2} and static_lookup_key(self.lexed, *match.span(2)) in self.fields:
+                    reference = (match.group(1), next(iter(self.fields)))
+                if reference is None or len(reference) != 2 or reference[1] not in self.fields:
+                    continue
+                scope = self.source.scope_at(match.start())
+                add(self.source.graph.visible_binding(reference[0].lstrip("$"), scope, match.start()), match.start(), WRITE_ABSENT)
+        self.events.sort(key=lambda event: event.start)
+        self.event_offsets = [event.start for event in self.events]
+
+    def _conditional(self, start: int, end: int) -> tuple[tuple[int, int], tuple[int, int]] | None:
+        round_depth = square_depth = curly_depth = nested = 0
+        question: int | None = None
+        for index in range(start, end):
+            character = self.lexed.code[index]
+            if character == "(": round_depth += 1
+            elif character == ")" and round_depth: round_depth -= 1
+            elif character == "[": square_depth += 1
+            elif character == "]" and square_depth: square_depth -= 1
+            elif character == "{": curly_depth += 1
+            elif character == "}" and curly_depth: curly_depth -= 1
+            elif not (round_depth or square_depth or curly_depth):
+                if character == "?" and not self.lexed.code.startswith(("?.", "??"), index):
+                    if question is None: question = index
+                    else: nested += 1
+                elif character == ":" and question is not None:
+                    if nested: nested -= 1
+                    else: return (question + 1, index), (index + 1, end)
+        # Python's `a if cond else b`. The `if`/`else` must be at the TOP LEVEL
+        # of the span: a plain `build(a if flag else b)` was split by a naive
+        # fullmatch into the bogus alias branches "build(a" and "b)", and the
+        # payload it really assigns became unresolvable - compliant code was
+        # reported as missing the profile.
+        depth = 0
+        word_if: int | None = None
+        for token in re.finditer(
+            r"[()\[\]{}]|\bif\b|\belse\b", self.lexed.code[start:end]
+        ):
+            text = token.group(0)
+            if text in "([{":
+                depth += 1
+            elif text in ")]}":
+                depth -= 1
+            elif depth:
+                continue
+            elif text == "if":
+                if word_if is None and token.start() > 0:
+                    word_if = token.start()
+            elif word_if is not None:
+                return (
+                    (start, start + word_if),
+                    (start + token.end(), end),
+                )
+        return None
+
+    def _root_reaches(self, event: RootFieldEvent, use_scope: int) -> bool:
+        if event.kind == "declaration":
+            return self.source.graph.bindings[event.binding].scope_id in self.source.graph.ancestors(use_scope)
+        return event.execution == self.source.graph.execution_scope(use_scope)
+
+    def targets(self, binding: int, before: int, use_scope: int, visiting: frozenset[tuple[int, int, int]] = frozenset()) -> ObjectTargets:
+        key = (binding, before, use_scope)
+        if key in self._targets_memo:
+            return self._targets_memo[key]
+        if key in visiting:
+            return ObjectTargets(unknown=True)
+        stop = bisect.bisect_left(self.root_offsets.get(binding, ()), before)
+        events = [event for event in self.roots.get(binding, ())[:stop] if self._root_reaches(event, use_scope)]
+        call_path = self.control.path(before)
+        environments = self.control.environments((event.path for event in events), call_path)
+        if not environments:
+            return ObjectTargets(unknown=True)
+        results: list[ObjectTargets] = []
+        for environment in environments:
+            current = ObjectTargets(unknown=True)
+            for event in events:
+                if not self.control.active(event.path, environment):
+                    continue
+                current = (
+                    ObjectTargets(frozenset((event.object_id,)))
+                    if event.aliases is None
+                    else join_targets(
+                        [
+                            self.targets(
+                                alias,
+                                event.start,
+                                event.scope,
+                                visiting | {key},
+                            )
+                            for alias in event.aliases
+                        ]
+                        + (
+                            [ObjectTargets(unknown=True)]
+                            if event.alias_unknown
+                            else []
+                        )
+                    )
+                )
+            results.append(current)
+        value = join_targets(results)
+        self._targets_memo[key] = value
+        return value
+
+    def _effect_from_presence(self, value: Presence) -> int:
+        return overlay_effect(value)
+
+    def _object_presence(self, object_id: tuple[int, int], before: int, use_scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]] = frozenset()) -> Presence:
+        key = (object_id, before, use_scope)
+        if key in self._presence_memo:
+            return self._presence_memo[key]
+        if key in visiting or object_id not in self.objects:
+            return MAYBE_VALUE
+        root = self.objects[object_id]
+        initial = self._span_presence(*root.rhs, root.start, root.scope, visiting | {key})
+        stop = bisect.bisect_left(self.event_offsets, before)
+        # A field write in an ENCLOSING function reaches a send written inside
+        # a callback: the object is captured by the closure and the write has
+        # already run at the point the send is written. Requiring an exact
+        # execution-scope match dropped every such write, so
+        # `payload.messaging_profile_id = mp; items.forEach(i => fetch(...))`
+        # was reported as missing the profile it plainly sets. The reverse
+        # direction stays blocked - a write INSIDE a callback still cannot
+        # prove anything about a send outside it, because the callback may
+        # never run.
+        enclosing = self.source.graph.ancestors(use_scope)
+        events = [event for event in self.events[:stop] if event.execution in enclosing]
+        environments = self.control.environments((event.path for event in events), self.control.path(before))
+        if not environments:
+            return Presence(MAYBE, initial.evidence or bool(events))
+        outcomes: list[Presence] = []
+        for environment in environments:
+            value = initial
+            for event in events:
+                if not self.control.active(event.path, environment):
+                    continue
+                targets = self.targets(event.binding, event.start, event.scope)
+                definite = object_id in targets.must
+                possible = definite or object_id in targets.may or targets.unknown
+                if not possible:
+                    continue
+                effect = event.effect
+                if event.overlay is not None:
+                    effect = self._effect_from_presence(self._span_presence(*event.overlay, event.start, event.scope, visiting | {key}))
+                changed = apply_field_effect(value, effect)
+                value = changed if definite else join_presence((value, changed))
+            outcomes.append(value)
+        result = join_presence(outcomes)
+        self._presence_memo[key] = result
+        return result
+
+    def presence_for_binding(self, binding: int, before: int, use_scope: int) -> Presence:
+        targets = self.targets(binding, before, use_scope)
+        values = [self._object_presence(object_id, before, use_scope) for object_id in targets.all]
+        if targets.unknown:
+            values.append(MAYBE_VALUE)
+        return join_presence(values)
+
+    def presence_for_name(self, name: str, before: int) -> Presence:
+        scope = self.source.scope_at(before)
+        binding = self.source.graph.visible_binding(name.lstrip("$"), scope, before)
+        return self.presence_for_binding(binding, before, scope) if binding is not None else MAYBE_VALUE
+
+    def _serialized(self, value: str) -> Presence | None:
+        candidates = [value]
+        try:
+            decoded = json.loads(f'"{value}"')
+            if decoded != value: candidates.append(decoded)
+        except (TypeError, ValueError):
+            pass
+        for candidate in candidates:
+            try: payload = json.loads(candidate)
+            except (TypeError, ValueError): continue
+            if not isinstance(payload, dict):
+                return ABSENT_VALUE
+            selected = next((payload[name] for name in reversed(tuple(payload)) if name in self.fields), ...)
+            if selected is ...:
+                return ABSENT_VALUE
+            if not self.require_value:
+                return PRESENT_VALUE
+            return Presence(
+                PRESENT
+                if selected not in (None, "", [], {}, False)
+                else ABSENT,
+                True,
+            )
+        return None
+
+    def text_presence(self, value: str) -> Presence:
+        return self._serialized(value) or MAYBE_VALUE
+
+    def _members(self, kind: str, opening: int, closing: int, before: int, scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]]) -> Presence:
+        members = split_arguments(self.lexed.code, opening + 1, closing)
+        value = ABSENT_VALUE
+        if kind == "pairs":
+            for key_span, value_span in zip(members[::2], members[1::2]):
+                key = static_object_key(self.lexed, *key_span)
+                if key in self.fields: value = apply_field_effect(value, self._value_effect(*value_span))
+                elif key is None: value = join_presence((value, MAYBE_VALUE))
+            return value
+        for member_start, member_end in members:
+            text = self.lexed.code[member_start:member_end].strip()
+            if not text: continue
+            # Match on raw source offsets: `text` is stripped, so any offset
+            # derived from it is short by the member's leading whitespace and
+            # `{ a, ...base }` resolved to `.base` instead of `base`.
+            spread = SPREAD_MEMBER_RE.match(self.lexed.code, member_start, member_end)
+            if spread:
+                value = apply_field_effect(value, overlay_effect(self._span_presence(spread.end(), member_end, before, scope, visiting)))
+                continue
+            colon = top_level_colon(self.lexed.code, member_start, member_end)
+            separator = (colon, colon + 1) if colon is not None else top_level_assignment_separator(self.lexed.code, member_start, member_end)
+            if separator is None:
+                key = static_object_key(self.lexed, member_start, member_end)
+                # A separator-less member is either a string key or a JS/TS
+                # shorthand. Shorthand means the VARIABLE's value, so the value
+                # still has to be analysed - hard-coding WRITE_PRESENT
+                # certified `const messaging_profile_id = ''; {..., messaging_profile_id}`.
+                # For a string-literal key the span is its own non-empty
+                # literal, so _value_effect keeps the previous verdict.
+                if key in self.fields: value = apply_field_effect(value, self._value_effect(member_start, member_end))
+                elif key is None and text.startswith("["): value = join_presence((value, MAYBE_VALUE))
+                continue
+            separator_start, value_start = separator
+            key = static_object_key(self.lexed, member_start, separator_start)
+            if key in self.fields: value = apply_field_effect(value, self._value_effect(value_start, member_end))
+            elif key is None: value = join_presence((value, MAYBE_VALUE))
+        return value
+
+    def _builder(self, start: int, end: int) -> Presence | None:
+        names = "|".join(map(re.escape, sorted(self.fields)))
+        matches = list(
+            re.compile(
+                rf"(?:\.|->)\s*(?:set)?(?:{names})\s*\("
+            ).finditer(self.lexed.code, start, end)
+        )
+        matches = [
+            match
+            for match in matches
+            if structural_depth(self.lexed.code, start, match.start())
+            == (0, 0, 0)
+        ]
+        if not matches: return None
+        opening = self.lexed.code.rfind("(", matches[-1].start(), matches[-1].end())
+        closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+        return Presence(MAYBE, True) if closing is None or closing > end else apply_field_effect(ABSENT_VALUE, self._value_effect(opening + 1, closing))
+
+    def _arguments(self, start: int, end: int) -> Presence | None:
+        value, found = ABSENT_VALUE, False
+        for member_start, member_end in split_arguments(self.lexed.code, start, end):
+            colon = top_level_colon(self.lexed.code, member_start, member_end)
+            separator = (colon, colon + 1) if colon is not None else top_level_assignment_separator(self.lexed.code, member_start, member_end)
+            if separator is None: continue
+            key = static_object_key(self.lexed, member_start, separator[0])
+            if key in self.fields:
+                value, found = apply_field_effect(value, self._value_effect(separator[1], member_end)), True
+        return value if found else None
+
+    def _span_presence(self, start: int, end: int, before: int, scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]] = frozenset()) -> Presence:
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end: return ABSENT_VALUE
+        conditional = self._conditional(start, end)
+        if conditional is not None:
+            return join_presence(self._span_presence(*span, before, scope, visiting) for span in conditional)
+        wrapper = re.match(r"\s*(?:JSON\s*\.\s*stringify|json\s*\.\s*dumps)\s*\(", self.lexed.code[start:end])
+        if wrapper:
+            opening = self.lexed.code.find("(", start, start + wrapper.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if arguments: return self._span_presence(*arguments[0], before, scope, visiting)
+        # Ruby's serializer is a suffix, not a call wrapper: `payload.to_json`
+        # is the idiomatic Net::HTTP/Faraday body. Only the inline-literal form
+        # `{..}.to_json` resolved, so a compliant send through a variable was
+        # reported as missing the profile.
+        to_json = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*to_json\s*(?:\(\s*\))?\s*",
+            self.lexed.code[start:end],
+        )
+        if to_json is not None:
+            return self._span_presence(
+                start + to_json.start(1), start + to_json.end(1), before, scope, visiting
+            )
+        assign = re.match(r"\s*Object\s*\.\s*assign\s*\(", self.lexed.code[start:end])
+        if assign:
+            opening = self.lexed.code.find("(", start, start + assign.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            value = ABSENT_VALUE
+            for span in split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []:
+                value = apply_field_effect(value, overlay_effect(self._span_presence(*span, before, scope, visiting)))
+            return value
+        copy_call = re.fullmatch(
+            r"\s*(?:new\s+)?(?:dict|HashMap|Dictionary)"
+            r"(?:\s*<[^>]*>)?\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if copy_call is not None:
+            copy_start = start + copy_call.start(1)
+            return self._span_presence(
+                copy_start,
+                start + copy_call.end(1),
+                before,
+                scope,
+                visiting,
+            )
+        copy_method = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*"
+            r"(?:copy|dup|clone)\s*(?:\(\s*\))?\s*",
+            self.lexed.code[start:end],
+        )
+        if copy_method is not None:
+            name_start = start + copy_method.start(1)
+            binding = self._binding(
+                name_start, start + copy_method.end(1), scope, before
+            )
+            if binding is not None:
+                return self.presence_for_binding(binding, before, scope)
+        clone_call = re.fullmatch(
+            r"\s*maps\s*\.\s*Clone\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if clone_call is not None:
+            clone_start = start + clone_call.start(1)
+            return self._span_presence(
+                clone_start,
+                start + clone_call.end(1),
+                before,
+                scope,
+                visiting,
+            )
+        merge_copy = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*merge\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if merge_copy is not None:
+            receiver_start = start + merge_copy.start(1)
+            value = self._span_presence(
+                receiver_start,
+                start + merge_copy.end(1),
+                before,
+                scope,
+                visiting,
+            )
+            argument_start = start + merge_copy.start(2)
+            for span in split_arguments(
+                self.lexed.code,
+                argument_start,
+                start + merge_copy.end(2),
+            ):
+                value = apply_field_effect(
+                    value,
+                    overlay_effect(
+                        self._span_presence(*span, before, scope, visiting)
+                    ),
+                )
+            return value
+        container = root_literal_container(self.lexed, start, end, self.suffix)
+        if container is not None: return self._members(*container, before, scope, visiting)
+        builder = self._builder(start, end)
+        if builder is not None: return builder
+        arguments = self._arguments(start, end)
+        if arguments is not None: return arguments
+        binding = self._binding(start, end, scope, before)
+        if binding is not None: return self.presence_for_binding(binding, before, scope)
+        tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
+        if len(tokens) == 1:
+            serialized = self._serialized(tokens[0].contents)
+            if serialized is not None: return serialized
+        if (
+            self.require_value
+            and self.suffix == ".sh"
+            and shell_jq_assignment_has_profile(self.lexed, start, end)
+        ):
+            return PRESENT_VALUE
+        old = region_has_profile(self.lexed, start, end, serialized_assignment=True, allow_js_shorthand=self.suffix in self.JS_SUFFIXES) if self.require_value else region_has_message_body(self.lexed, start, end, self.suffix)
+        return PRESENT_VALUE if old else MAYBE_VALUE
+
+    def span_presence(self, start: int, end: int, before: int) -> Presence:
+        return self._span_presence(start, end, before, self.source.scope_at(before))
+
+
+def shell_static_key(source: str) -> str | None:
+    key = source.strip()
+    if len(key) >= 2 and key[0] == key[-1] and key[0] in {"'", '"'}:
+        key = key[1:-1]
+    return key if re.fullmatch(r"(?:[A-Za-z_]\w*|\d+)", key) else None
+
+
+def shell_static_references(
+    source: str,
+) -> list[EndpointReference]:
+    references: list[EndpointReference] = []
+    for match in SHELL_STATIC_REFERENCE_RE.finditer(source):
+        root = match.group(1) or match.group(3)
+        key = shell_static_key(match.group(2)) if match.group(2) else None
+        if match.group(2) and key is None:
+            continue
+        references.append((root, key) if key is not None else (root,))
+    return references
+
+
+def shell_member_assignments(
+    lexed: LexedSource, before: int, suffix: str
+) -> list[tuple[EndpointReference, int, int, int]]:
+    pattern = re.compile(
+        r"(?<![\w$])([A-Za-z_]\w*)\[\s*([^\]]+)\s*\]\s*=(?!=)"
+    )
+    assignments: list[tuple[EndpointReference, int, int, int]] = []
+    for match in pattern.finditer(lexed.without_comments, 0, before):
+        key = shell_static_key(match.group(2))
+        if key is None:
+            continue
+        assignments.append(
+            (
+                (match.group(1), key),
+                match.start(),
+                match.end(),
+                assignment_end(lexed, match.end(), suffix),
+            )
+        )
+    return assignments
+
+
+def shell_separator(lexed: LexedSource, offset: int) -> bool:
+    character = lexed.code[offset]
+    if character not in {"\n", ";", "&", "|"}:
+        return False
+    backslashes = 0
+    cursor = offset - 1
+    while cursor >= 0 and lexed.original[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 0
+
+
+def shell_command_span(lexed: LexedSource, offset: int) -> tuple[int, int]:
+    """Bound one shell command without merging adjacent curl payloads."""
+
+    start = 0
+    for index in range(offset - 1, -1, -1):
+        if shell_separator(lexed, index):
+            start = index + 1
+            break
+    end = len(lexed.original)
+    for index in range(offset, len(lexed.code)):
+        if shell_separator(lexed, index):
+            end = index
+            break
+    return start, end
+
+
+def shell_curl_is_command(
+    lexed: LexedSource, command_start: int, curl_start: int
+) -> bool:
+    """Exclude prose/arguments containing the word curl without executing it."""
+
+    prefix = lexed.original[command_start:curl_start].strip()
+    if not prefix or prefix.endswith("$("):
+        return True
+    try:
+        tokens = shlex.split(prefix, comments=True, posix=True)
+    except ValueError:
+        return False
+    allowed = {
+        "!", "command", "do", "elif", "env", "if", "then", "until", "while"
+    }
+    return all(
+        token in allowed or SHELL_ASSIGNMENT_TOKEN_RE.fullmatch(token)
+        for token in tokens
+    )
+
+
+def shell_curl_calls(lexed: LexedSource) -> list[Call]:
+    calls: list[Call] = []
+    seen: set[tuple[int, int]] = set()
+    for match in SHELL_CURL_RE.finditer(lexed.code):
+        start, end = shell_command_span(lexed, match.start(1))
+        if not shell_curl_is_command(lexed, start, match.start(1)):
+            continue
+        if (start, end) not in seen:
+            seen.add((start, end))
+            calls.append(Call(start, start, end, parenthesized=False))
+    return calls
+
+
+def shell_curl_url_arguments(lexed: LexedSource, call: Call) -> list[str]:
+    """Return curl URL arguments while excluding option values and payloads."""
+
+    source = lexed.original[call.start:call.end]
+    try:
+        tokens = shlex.split(source, comments=True, posix=True)
+    except ValueError:
+        return []
+    curl_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if re.search(r"(?:^|[/$(])curl$", token)
+        ),
+        None,
+    )
+    if curl_index is None:
+        return []
+
+    candidates: list[str] = []
+    index = curl_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        option, separator, attached = token.partition("=")
+        if separator and option in SHELL_CURL_VALUE_OPTIONS:
+            if option in SHELL_CURL_URL_OPTIONS:
+                candidates.append(attached)
+            index += 1
+            continue
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            if index + 1 < len(tokens) and token in SHELL_CURL_URL_OPTIONS:
+                candidates.append(tokens[index + 1])
+            index += 2
+            continue
+        if any(
+            token.startswith(short) and len(token) > len(short)
+            for short in ("-A", "-d", "-H", "-o", "-u", "-w", "-X")
+        ):
+            index += 1
+            continue
+        if not token.startswith("-"):
+            candidates.append(token)
+        index += 1
+    return candidates
+
+
+def shell_curl_url_references(
+    lexed: LexedSource, call: Call
+) -> set[EndpointReference]:
+    expanded: set[EndpointReference] = set()
+    for match in SHELL_STATIC_REFERENCE_RE.finditer(
+        lexed.original, call.start, call.end
+    ):
+        token = next(
+            (
+                candidate
+                for candidate in lexed.strings
+                if candidate.start <= match.start() < candidate.end
+            ),
+            None,
+        )
+        if token is not None and lexed.original[token.start] == "'":
+            continue
+        root = match.group(1) or match.group(3)
+        key = shell_static_key(match.group(2)) if match.group(2) else None
+        expanded.add((root, key) if key is not None else (root,))
+    return {
+        reference
+        for candidate in shell_curl_url_arguments(lexed, call)
+        for reference in shell_static_references(candidate)
+        if reference in expanded
+    }
+
+
+def iter_source_files(project_root: Path):
+    for directory, child_dirs, filenames in os.walk(project_root):
+        child_dirs[:] = sorted(name for name in child_dirs if name not in EXCLUDED_DIRS)
+        for filename in sorted(filenames):
+            # Generated bundles are build OUTPUT, not source. The scanner and
+            # both shell validators already exclude *.bundle.js / *.chunk.js /
+            # *.min.css alongside *.min.js; skipping only *.min.js here meant a
+            # stale webpack bundle carrying an old number-pool POST kept failing
+            # `lint-telnyx-correctness.sh --product messaging` long after the
+            # source was fixed, with no file the user could correct.
+            if filename in EXCLUDED_FILES or filename.endswith(
+                (".min.js", ".min.css", ".bundle.js", ".chunk.js")
+            ):
+                continue
+            path = Path(directory, filename)
+            suffix = path.suffix.lower()
+            if suffix in INCLUDED_SUFFIXES:
+                yield path
+            elif not suffix and shebang_suffix(path) is not None:
+                yield path
+
+
+
+
+# --- member-clearance net (proof-based; see member_net_contexts) ---
+
+ASSIGNMENT_TARGET_RE = re.compile(
+    r"(?<![\w$.>])(\$?[A-Za-z_]\w*)(?!\w)(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+)
+
+
+MEMBER_ACCESS_AFTER_RE = re.compile(r"\s*(?:\?\.|\.)\s*([A-Za-z_]\w*)")
+
+
+SUBSCRIPT_AFTER_RE = re.compile(r"\s*\[([^\[\]\n]*)\]")
+
+
+CALL_AFTER_RE = re.compile(r"\s*\(")
+
+
+IDENTIFIER_TOKEN_RE = re.compile(r"\$?[A-Za-z_]\w*")
+
+
+RESERVED_TARGETS = frozenset(
+    {"export", "default", "module", "exports", "return", "yield", "await",
+     "typeof", "delete", "void", "new", "in", "of", "import", "case"}
+)
+
+
+def quoted_key_before(lexed: LexedSource, position: int) -> str | None:
+    """Read back a masked quoted key ending immediately before `position`."""
+
+    for token in reversed(lexed.strings):
+        if token.end > position:
+            continue
+        if lexed.code[token.end : position].strip():
+            return None
+        key = token.contents
+        return key if re.fullmatch(r"[A-Za-z_]\w*", key) else None
+    return None
+
+
+def literal_subscript_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    """Key of `obj[...]` when the subscript is a literal; None when dynamic."""
+
+    region = lexed.code[start:end]
+    numeric = re.fullmatch(r"\s*(\d+)\s*", region)
+    if numeric is not None:
+        # Normalize so sloppy-mode `[01]` compares equal to position 1.
+        return str(int(numeric.group(1)))
+    symbol = re.fullmatch(r"\s*:\s*([A-Za-z_]\w*)\s*", region)
+    if symbol is not None:
+        return symbol.group(1)
+    if region.strip():
+        return None
+    tokens = [t for t in lexed.strings if start <= t.start and t.end <= end]
+    if len(tokens) != 1:
+        return None
+    key = tokens[0].contents
+    return key if re.fullmatch(r"[A-Za-z_]\w*", key) else None
+
+
+def stored_member_key(lexed: LexedSource, token_start: int) -> str | None:
+    """Mapping key a literal is stored under: `pool:`, `'pool':`, `=>` forms."""
+
+    code = lexed.code
+    end = token_start
+    while end > 0 and code[end - 1].isspace():
+        end -= 1
+    # End-anchored searches only need a small window, not the whole prefix.
+    window_start = max(0, end - 160)
+    window = code[window_start:end]
+    if window.endswith("=>"):
+        symbol = re.search(r":([A-Za-z_]\w*)\s*$", window[:-2])
+        if symbol is not None:
+            return symbol.group(1)
+        return quoted_key_before(lexed, end - 2)
+    if window.endswith(":"):
+        # Not a key when the colon belongs to a ternary (`cond ? x : "..."`).
+        if re.search(r"\?[^:{,\n]*:$", window):
+            return None
+        identifier = re.search(r"(?<![\w$]):?([A-Za-z_]\w*)\s*:$", window)
+        if identifier is not None:
+            return identifier.group(1)
+        return quoted_key_before(lexed, end - 1)
+    return None
+
+
+def container_is_file_private(
+    lexed: LexedSource, assign_start: int, name: str, suffix: str, operator: str
+) -> bool:
+    """Whether the container provably cannot be referenced from another file.
+
+    Clearing is only sound when every use is visible to this analysis, and
+    this analysis reads one file. JS/TS module locals qualify unless exported.
+    Go's `:=` declares a function local; anything else is package-visible
+    across files. Python, Ruby and PHP top-level names are importable or
+    global, so only indented (function-scoped) definitions qualify; Ruby
+    constants (uppercase) never do.
+    """
+
+    line_start, _ = line_bounds(lexed.original, assign_start)
+    line_prefix = lexed.code[line_start:assign_start]
+    if suffix in JS_TS_SUFFIXES:
+        return re.search(r"\bexport\b", line_prefix) is None
+    if suffix == ".go":
+        return operator == ":="
+    if suffix in {".py", ".rb", ".php"}:
+        if suffix == ".rb" and name[:1].isupper():
+            return False
+        # Indented (whitespace-only prefix) AND enclosed by a `def`, not a
+        # `class` body — class attributes are reachable from other files.
+        if line_prefix == "" or line_prefix.strip() != "":
+            return False
+        indent = len(line_prefix)
+        position = line_bounds(lexed.original, assign_start)[0]
+        while position > 0:
+            position = lexed.original.rfind("\n", 0, position - 1) + 1
+            line_end = lexed.original.find("\n", position)
+            line = lexed.original[position : line_end if line_end >= 0 else None]
+            stripped = line.strip()
+            if not stripped or len(line) - len(line.lstrip()) >= indent:
+                if position == 0:
+                    break
+                continue
+            if suffix == ".php":
+                return "function" in stripped
+            return bool(re.match(r"(?:async\s+)?def\s", stripped))
+        return False
+    if suffix in {".cs", ".java"}:
+        return (
+            re.search(r"\b(?:public|protected|internal)\b", line_prefix)
+            is None
+        )
+    return False
+
+
+def assignment_index(
+    lexed: LexedSource, suffix: str
+) -> list[tuple[str, int, int, int]]:
+    """Every assignment as (name, start, rhs_start, rhs_end), computed once.
+
+    Per-token rescans of the file are what made an earlier attempt at this
+    analysis quadratic; everything below reads this index instead.
+    """
+
+    entries = []
+    for assignment in ASSIGNMENT_TARGET_RE.finditer(lexed.code):
+        rhs_start = assignment.end()
+        entries.append(
+            (
+                assignment.group(1),
+                assignment.start(),
+                rhs_start,
+                assignment_end(lexed, rhs_start, suffix),
+            )
+        )
+    return entries
+
+
+def container_for_token(
+    lexed: LexedSource,
+    token: StringToken,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    walkers: dict[int, list],
+) -> tuple[str, list[str], tuple[int, int], str] | None:
+    """(name, required key chain, definition span, operator) for `token`."""
+
+    for name, start, rhs_start, rhs_end in reversed(assignments):
+        if start >= token.start:
+            continue
+        if not (rhs_start <= token.start < rhs_end):
+            continue
+        # Incremental stack walker per RHS: path tokens arrive in ascending
+        # order, so each RHS is walked once in total, not once per token —
+        # a per-token walk made large single-container literals quadratic.
+        walker = walkers.get(rhs_start)
+        if walker is None:
+            walker = [rhs_start, []]
+            walkers[rhs_start] = walker
+        position, stack = walker
+        while position < token.start:
+            character = lexed.code[position]
+            if character in "([{":
+                stack.append([character, position, 0])
+            elif character in ")]}" and stack:
+                stack.pop()
+            elif character == "," and stack:
+                stack[-1][2] += 1
+            position += 1
+        walker[0] = position
+        if not stack:
+            return None
+        # Resolve the FULL key chain, outermost to innermost. Comparing only
+        # the innermost key let a reference to an ancestor member count as
+        # proof while handing out the object that contains the required path.
+        chain: list[str] = []
+        for level, (opener, opener_at, commas) in enumerate(stack):
+            boundary = (
+                stack[level + 1][1]
+                if level + 1 < len(stack)
+                else token.start
+            )
+            if opener == "{":
+                key = stored_member_key(lexed, boundary)
+            elif opener == "[":
+                # PHP spells associative arrays with `[` — a `=>` key wins
+                # over position.
+                key = stored_member_key(lexed, boundary)
+                if key is None:
+                    key = str(commas)
+            else:
+                # A call such as Map.of(...) — not a literal this rule models.
+                return None
+            if key is None:
+                return None
+            chain.append(key)
+        operator = lexed.code[max(0, rhs_start - 2) : rhs_start].strip()
+        return name, chain, (start, rhs_end), operator
+    return None
+
+
+def access_chain_after(
+    lexed: LexedSource, position: int
+) -> tuple[list[str], bool, bool]:
+    """Static keys accessed after an occurrence: (keys, resolvable, is_call)."""
+
+    keys: list[str] = []
+    code = lexed.code
+    while True:
+        member = MEMBER_ACCESS_AFTER_RE.match(code, position)
+        if member is not None:
+            keys.append(member.group(1))
+            position = member.end()
+            continue
+        subscript = SUBSCRIPT_AFTER_RE.match(code, position)
+        if subscript is not None:
+            key = literal_subscript_key(
+                lexed, subscript.start(1), subscript.end(1)
+            )
+            if key is None:
+                return keys, False, False
+            keys.append(key)
+            position = subscript.end()
+            continue
+        break
+    return keys, True, CALL_AFTER_RE.match(code, position) is not None
+
+
+def identifier_occurrences(lexed: LexedSource) -> dict[str, list[int]]:
+    """Map identifier -> end offsets of its standalone occurrences in code.
+
+    One pass per file; per-token lookups replace whole-file rescans (the
+    quadratic trap an earlier attempt fell into).
+    """
+
+    positions: dict[str, list[int]] = {}
+    dotted: dict[str, list[int]] = {}
+    for match in IDENTIFIER_TOKEN_RE.finditer(lexed.code):
+        before = lexed.code[match.start() - 1] if match.start() else " "
+        if before == ".":
+            # Reached through a property path (`globalThis.x`, `Config.x`,
+            # `...x` spread) — a use this rule cannot align, NOT an ignorable
+            # one. Skipping these silently is how a container escaped once.
+            dotted.setdefault(match.group(0), []).append(match.start())
+            continue
+        if before == "$" or before.isalnum() or before == "_":
+            continue
+        positions.setdefault(match.group(0), []).append(match.start())
+    return positions, dotted
+
+
+def masked_identifier_names(lexed: LexedSource) -> dict[str, list[int]]:
+    """Identifiers inside strings or comments (unreadable uses), by position."""
+
+    names: dict[str, list[int]] = {}
+    for match in IDENTIFIER_TOKEN_RE.finditer(lexed.original):
+        if lexed.code[match.start()] != lexed.original[match.start()]:
+            names.setdefault(match.group(0), []).append(match.start())
+    return names
+
+
+def member_accesses_prove_unused(
+    lexed: LexedSource,
+    offset: int,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    occurrences: dict[str, list[int]],
+    masked_names: set[str],
+    dotted_names: set[str],
+    walkers: dict[int, list],
+    reference_cache: dict[str, tuple[bool, bool, list[list[str]]]],
+) -> bool:
+    token = next(
+        (t for t in lexed.strings if t.start <= offset < t.end), None
+    )
+    if token is None:
+        return False
+    resolved = container_for_token(lexed, token, suffix, assignments, walkers)
+    if resolved is None:
+        return False
+    name, required_chain, definition, operator = resolved
+    if not container_is_file_private(
+        lexed, definition[0], name, suffix, operator
+    ):
+        return False
+
+    summary = reference_cache.get(name)
+    if summary is None:
+        names = {name}
+        skip_spans = [definition]
+        for alias, start, rhs_start, rhs_end in assignments:
+            alias_of = lexed.code[rhs_start:rhs_end].strip()
+            if (
+                alias_of == name
+                and alias != name
+                and alias.lstrip("$") not in RESERVED_TARGETS
+            ):
+                names.add(alias)
+                skip_spans.append((start, rhs_end))
+        # Unreadable uses — via a property path, or mentioned inside a string
+        # or comment (template literals, exports lists) — forbid proof.
+        readable = not any(
+            n in dotted_names or n in masked_names for n in names
+        )
+        chains: list[list[str]] = []
+        proved = False
+        if readable:
+            for n in sorted(names):
+                for start in occurrences.get(n, ()):
+                    if any(s <= start < e for s, e in skip_spans):
+                        continue
+                    keys, resolvable, is_call = access_chain_after(
+                        lexed, start + len(n)
+                    )
+                    if not resolvable or not keys or is_call:
+                        readable = False
+                        break
+                    chains.append(keys)
+                    proved = True
+                if not readable:
+                    break
+        summary = (readable, proved, chains)
+        reference_cache[name] = summary
+
+    readable, proved, chains = summary
+    if not readable or not proved:
+        return False
+    for chain in chains:
+        # A reference conflicts when it agrees with the required chain for
+        # its whole shared prefix: it reaches the required member or an
+        # ancestor holding it. Only a divergent chain is proof of non-use.
+        shared = min(len(chain), len(required_chain))
+        if chain[:shared] == required_chain[:shared]:
+            return False
+    return True
+
+
+
+DESTRUCTURE_LHS_RE = re.compile(r"[}\]]\s*$")
+
+
+
+def safe_literal_span(
+    lexed: LexedSource,
+    rhs_from: int,
+    rhs_to: int,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+) -> bool:
+    """Whether an assignment RHS is provably free of required paths.
+
+    Accepts a single string literal, or a bare variable whose own latest
+    assignment is such a literal (one indirection, no recursion)."""
+
+    tokens = [
+        t for t in lexed.strings
+        if rhs_from <= t.start and t.end <= rhs_to
+    ]
+    remainder = lexed.code[rhs_from:rhs_to].strip()
+    if len(tokens) == 1 and not remainder:
+        return not MEMBER_NET_PATH_RE.search(tokens[0].contents)
+    if tokens:
+        return False
+    variable = re.fullmatch(r"\$?[A-Za-z_]\w*", remainder.rstrip(";").strip())
+    if variable is None:
+        return False
+    latest = None
+    for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+        if a_name == variable.group(0) and a_rhs_start < rhs_from:
+            latest = (a_rhs_start, a_rhs_end)
+    if latest is None:
+        return False
+    inner = [
+        t for t in lexed.strings
+        if latest[0] <= t.start and t.end <= latest[1]
+    ]
+    if len(inner) != 1 or lexed.code[latest[0]:latest[1]].strip():
+        return False
+    return not MEMBER_NET_PATH_RE.search(inner[0].contents)
+
+
+def build_binding_index(
+    lexed: LexedSource,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+) -> dict:
+    """Once-per-file maps the per-container summary builder reads: binding
+    positions per name (pattern keys excluded) and bare-name RHS aliases."""
+
+    own: dict[str, list[int]] = {}
+    bare_rhs: dict[str, list[tuple[str, int, int]]] = {}
+    for alias, start, rhs_start, rhs_end in assignments:
+        before = start
+        while before > 0 and lexed.code[before - 1] in " \t":
+            before -= 1
+        if (
+            before > 0
+            and lexed.code[before - 1] in "{,("
+            and ":" in lexed.code[start:rhs_start]
+        ):
+            continue
+        own.setdefault(alias, []).append(start)
+        alias_of = lexed.code[rhs_start:rhs_end].strip()
+        if re.fullmatch(r"\$?[A-Za-z_]\w*;?", alias_of):
+            bare_rhs.setdefault(alias_of.rstrip(";"), []).append(
+                (alias, start, rhs_end)
+            )
+    return {"own": own, "bare_rhs": bare_rhs}
+
+def build_container_summary(
+    lexed: LexedSource,
+    name: str,
+    definition: tuple[int, int],
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    binding_index: dict,
+    occurrences: dict[str, list[int]],
+    masked_names: set[str],
+    dotted_names: set[str],
+    evaluated_spans: list[tuple[int, int]],
+    flagged_spans: list[tuple[int, int]],
+) -> dict:
+    """Chain-independent reference summary for one container, built once.
+
+    Per-token work then reduces to prefix checks against an index keyed by
+    each reference chain's first element — the per-token full rescans of an
+    earlier version were quadratic on large containers."""
+
+    names = {name}
+    skip_spans = [definition]
+    own_assignments = binding_index["own"]
+    for alias, start, rhs_end in binding_index["bare_rhs"].get(name, ()):
+        if alias != name and alias.lstrip("$") not in RESERVED_TARGETS:
+            names.add(alias)
+            skip_spans.append((start, rhs_end))
+
+    summary = {
+        "ok": True,
+        "had_skipped": False,
+        "proved_any": False,
+        "by_first": {},
+        "destructured": [],
+        "kills": [],
+    }
+
+    def flagged_has(word: str) -> bool:
+        ref = re.compile(rf"(?<![\w$.]){re.escape(word)}(?!\w)")
+        return any(ref.search(lexed.code, fs, fe) for fs, fe in flagged_spans)
+
+    def evaluated_has(word: str) -> bool:
+        ref = re.compile(rf"(?<![\w$.]){re.escape(word)}(?!\w)")
+        return any(
+            ref.search(lexed.code, es, ee) for es, ee in evaluated_spans
+        )
+
+    unreadable = [n for n in names if n in dotted_names or n in masked_names]
+    for n in unreadable:
+        spots = list(masked_names.get(n, ())) + list(dotted_names.get(n, ()))
+        for spot in spots:
+            if any(ds <= spot < de for ds, de in skip_spans):
+                continue
+            covering = None
+            for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+                if a_rhs_start <= spot < a_rhs_end:
+                    covering = a_name
+                    break
+            if covering is None or not flagged_has(covering):
+                summary["ok"] = False
+                return summary
+        summary["had_skipped"] = True
+
+    for n in sorted(names):
+        for start in occurrences.get(n, ()):
+            if any(ds <= start < de for ds, de in skip_spans):
+                continue
+            nearest = None
+            for a_start in own_assignments.get(n, ()):
+                if a_start <= start:
+                    nearest = a_start if nearest is None else max(
+                        nearest, a_start
+                    )
+            if nearest is not None and all(
+                nearest != ds for ds, _de in skip_spans
+            ):
+                summary["had_skipped"] = True
+                continue
+            end = start + len(n)
+            keys, resolvable, is_call = access_chain_after(lexed, end)
+            in_evaluated = any(
+                es <= start < ee for es, ee in evaluated_spans
+            )
+            if not resolvable:
+                if in_evaluated:
+                    # Dynamic keys inside evaluated calls are the resolver's
+                    # corpus-pinned domain.
+                    summary["had_skipped"] = True
+                    continue
+                # A dynamic key handed to code the resolver never judged can
+                # reach the required member — no proof.
+                summary["ok"] = False
+                return summary
+            if not keys:
+                prefix_end = start
+                while prefix_end > 0 and lexed.code[prefix_end - 1] in " \t":
+                    prefix_end -= 1
+                if lexed.code[max(0, prefix_end - 1):prefix_end] == "=":
+                    lhs_close = prefix_end - 1
+                    while lhs_close > 0 and lexed.code[lhs_close - 1] in " \t":
+                        lhs_close -= 1
+                    if lexed.code[lhs_close - 1:lhs_close] in "}]":
+                        opener = {"}": "{", "]": "["}[
+                            lexed.code[lhs_close - 1]
+                        ]
+                        depth = 0
+                        lhs_open = -1
+                        for pos in range(lhs_close - 1, -1, -1):
+                            ch = lexed.code[pos]
+                            if ch in ")]}":
+                                depth += 1
+                            elif ch in "([{":
+                                depth -= 1
+                                if depth == 0 and ch == opener:
+                                    lhs_open = pos
+                                    break
+                        if lhs_open >= 0:
+                            pattern = lexed.code[lhs_open:lhs_close]
+                            source_pattern = lexed.original[
+                                lhs_open:lhs_close
+                            ]
+                            if "..." in pattern or "**" in pattern:
+                                # Rest elements can bind the required
+                                # member invisibly.
+                                summary["ok"] = False
+                                return summary
+                            if opener == "[":
+                                # Array patterns bind by position — the
+                                # resolver's corpus tracks them end to end.
+                                summary["had_skipped"] = True
+                                continue
+                            if "[" in pattern[1:]:
+                                # Computed property names in an object
+                                # pattern can bind the required member
+                                # invisibly.
+                                summary["ok"] = False
+                                return summary
+                            words = set(
+                                re.findall(
+                                    r"[A-Za-z_]\w*", source_pattern
+                                )
+                            )
+                            covered = any(
+                                flagged_has(w) for w in words
+                            )
+                            summary["destructured"].append(
+                                (frozenset(words), covered)
+                            )
+                            summary["proved_any"] = True
+                            continue
+                depth = 0
+                callee = None
+                for pos in range(start - 1, -1, -1):
+                    ch = lexed.code[pos]
+                    if ch in ")]}":
+                        depth += 1
+                    elif ch in "([{":
+                        if depth == 0:
+                            if ch == "(":
+                                callee = re.search(
+                                    r"([A-Za-z_$][\w$]*)\s*$",
+                                    lexed.code[max(0, pos - 60):pos],
+                                )
+                            break
+                        depth -= 1
+                if callee is not None and callee.group(1) in {
+                    "axios", "fetch", "request", "post",
+                }:
+                    summary["had_skipped"] = True
+                    continue
+                summary["ok"] = False
+                return summary
+            if is_call:
+                summary["ok"] = False
+                return summary
+            entry = {
+                "start": start,
+                "keys": keys,
+                "in_evaluated": in_evaluated,
+                "flag_covered": any(
+                    fs <= start < fe for fs, fe in flagged_spans
+                ),
+                "alias_covered": False,
+                "alias_evaluated": False,
+                "kill": None,
+            }
+            enclosing_alias = None
+            for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+                if a_rhs_start <= start < a_rhs_end:
+                    enclosing_alias = a_name
+                    break
+            if enclosing_alias is not None:
+                entry["alias_covered"] = flagged_has(enclosing_alias)
+                entry["alias_evaluated"] = evaluated_has(enclosing_alias)
+            m = re.match(
+                r"(?:\s*(?:\?\.|\.)\s*[A-Za-z_]\w*|"
+                r"\s*\[[^\[\]\n]*\])*",
+                lexed.code[end:],
+            )
+            chain_end = end + (m.end() if m else 0)
+            write = re.match(r"\s*=(?!=)", lexed.code[chain_end:])
+            if write is not None:
+                rhs_from = chain_end + write.end()
+                rhs_to = assignment_end(lexed, rhs_from, suffix)
+                open_braces: list[int] = []
+                for position in range(definition[1], start):
+                    character = lexed.code[position]
+                    if character in "([{":
+                        open_braces.append(position)
+                    elif character in ")]}" and open_braces:
+                        open_braces.pop()
+                # A bare statement block always executes, so a kill inside it
+                # dominates; a block belonging to if/else/loop/switch/catch is
+                # conditional and proves nothing about the send's path.
+                conditional = False
+                for brace_at in open_braces:
+                    if lexed.code[brace_at] != "{":
+                        conditional = True
+                        break
+                    before = brace_at
+                    while before > 0 and lexed.code[before - 1].isspace():
+                        before -= 1
+                    if lexed.code[before - 1 : before] == ")":
+                        conditional = True
+                        break
+                    word = re.search(
+                        r"([A-Za-z_]\w*)\s*$", lexed.code[:before]
+                    )
+                    if word is not None and word.group(1) in {
+                        "else", "do", "case", "default", "finally",
+                    }:
+                        conditional = True
+                        break
+                if not conditional and safe_literal_span(
+                    lexed, rhs_from, rhs_to, suffix, assignments
+                ):
+                    entry["kill"] = chain_end
+            summary["by_first"].setdefault(keys[0], []).append(entry)
+    return summary
+
+
+def member_net_proves_unused(
+    lexed: LexedSource,
+    resolved: tuple,
+    suffix: str,
+    summary: dict,
+) -> bool:
+    name, required_chain, definition, operator = resolved
+    if not summary["ok"]:
+        return False
+    private = container_is_file_private(
+        lexed, definition[0], name, suffix, operator
+    )
+    required_key = required_chain[-1] if required_chain else None
+    for words, covered in summary["destructured"]:
+        if required_key in words and not covered:
+            return False
+    had_skipped = summary["had_skipped"] or bool(summary["destructured"])
+    proved = summary["proved_any"]
+    kill_at = None
+    conflicts = []
+    for entry in summary["by_first"].get(required_chain[0], []):
+        keys = entry["keys"]
+        shared = min(len(keys), len(required_chain))
+        if keys[:shared] != required_chain[:shared]:
+            proved = True
+            continue
+        if entry["in_evaluated"] and entry["start"] >= definition[1]:
+            had_skipped = True
+            continue
+        if (
+            entry["kill"] is not None
+            and len(keys) == len(required_chain)
+        ):
+            kill_at = entry["kill"]
+            proved = True
+            continue
+        if entry["flag_covered"] or entry["alias_covered"]:
+            had_skipped = True
+            continue
+        conflicts.append(entry["start"])
+    for first, entries in summary["by_first"].items():
+        if first == required_chain[0]:
+            continue
+        for entry in entries:
+            if entry["in_evaluated"] and entry["start"] >= definition[1]:
+                had_skipped = True
+            elif entry["alias_evaluated"]:
+                had_skipped = True
+            else:
+                proved = True
+    if conflicts:
+        if kill_at is None:
+            return False
+        if any(c < kill_at for c in conflicts):
+            return False
+    if proved:
+        return private
+    return True if had_skipped else private
+
+MEMBER_NET_PATH_RE = re.compile(
+    # A leading slash, or a relative path at the very start of a string
+    # literal (base-URL clients pass "messages/number_pool").
+    r"(?:/|(?<=['\"`]))(?:v2/)?messages/"
+    r"(?:number_pool|alphanumeric_sender_id)\b"
+)
+
+
+def member_net_contexts(
+    lexed: LexedSource,
+    suffix: str,
+    evaluated_spans: list[tuple[int, int]],
+    flagged_spans: list[tuple[int, int]],
+) -> list[Call]:
+    """Literal-driven safety net over the call-centric analysis.
+
+    The resolver only judges recognized calls, so a required path that never
+    flows into one (helper parameters, exports, spreads, dynamic keys,
+    cross-file definitions) would otherwise vanish. Every required-path
+    literal held in a CONTAINER MEMBER outside the evaluated call spans is
+    flagged at its definition unless member-access analysis PROVES the member
+    is unused in this file, or the resolver already flagged a call that
+    references the container (reporting the definition too would be noise).
+    """
+
+    contexts: list[Call] = []
+    assignments = None
+    occurrences: dict[str, list[int]] = {}
+    dotted: set[str] = set()
+    masked: set[str] = set()
+    walkers: dict[int, list] = {}
+    cache: dict[str, tuple[bool, bool, list[list[str]]]] = {}
+    for match in MEMBER_NET_PATH_RE.finditer(lexed.without_comments):
+        if any(s <= match.start() < e for s, e in evaluated_spans):
+            continue
+        if assignments is None:
+            assignments = assignment_index(lexed, suffix)
+            binding_index = build_binding_index(lexed, suffix, assignments)
+            occurrences, dotted = identifier_occurrences(lexed)
+            masked = masked_identifier_names(lexed)
+        token = next(
+            (t for t in lexed.strings if t.start <= match.start() < t.end),
+            None,
+        )
+        if token is None:
+            continue
+        tail = token.contents.rstrip("/")
+        if not (
+            required_endpoint(token.contents)
+            or tail.endswith("messages/number_pool")
+            or tail.endswith("messages/alphanumeric_sender_id")
+            # A URL builder splits the path, so the literal may be only a
+            # fragment ("%snumber_pool"). Accept the distinctive segment, but
+            # ONLY for a URL-shaped token - prose that merely mentions the path
+            # contains whitespace and must not be treated as an endpoint.
+            or (
+                not re.search(r"\s", tail)
+                and re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
+            )
+        ):
+            # The literal merely MENTIONS a required path (prose, docs);
+            # it is not itself an endpoint value.
+            continue
+        resolved = container_for_token(
+            lexed, token, suffix, assignments, walkers
+        )
+        if resolved is None:
+            # Plain variables and direct arguments are the resolver's tested
+            # domain; the net only covers container members, which the
+            # call-centric analysis never evaluates.
+            continue
+        name = resolved[0]
+        summary = cache.get(name)
+        if summary is None:
+            summary = build_container_summary(
+                lexed, name, resolved[2], suffix, assignments,
+                binding_index, occurrences, masked, dotted,
+                evaluated_spans, flagged_spans,
+            )
+            cache[name] = summary
+        if member_net_proves_unused(lexed, resolved, suffix, summary):
+            continue
+        if suffix == ".sh":
+            start, end = shell_command_span(lexed, match.start())
+        else:
+            start, end = resolved[2]
+        contexts.append(Call(start, start, end, parenthesized=False))
+    return contexts
+
+
+# A send is only exempt from the profile requirement when it is provably NOT a
+# mutating request. These are the spellings that prove it.
+def required_path_tokens(lexed: LexedSource) -> list[StringToken]:
+    """Return every string literal that IS a required endpoint value.
+
+    Prose that merely mentions the path is excluded: an endpoint literal has no
+    whitespace and either resolves as a required endpoint or ends with the
+    required path segment.
+    """
+    found: list[StringToken] = []
+    for match in MEMBER_NET_PATH_RE.finditer(lexed.without_comments):
+        token = next(
+            (t for t in lexed.strings if t.start <= match.start() < t.end), None
+        )
+        if token is None or any(t.start == token.start for t in found):
+            continue
+        tail = token.contents.rstrip("/")
+        if re.search(r"\s", tail):
+            continue
+        if (
+            required_endpoint(token.contents)
+            or tail.endswith("messages/number_pool")
+            or tail.endswith("messages/alphanumeric_sender_id")
+            or re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
+        ):
+            found.append(token)
+    return found
+
+
+def _tokens_in_span(
+    lexed: LexedSource, span: tuple[int, int]
+) -> set[tuple[int, int]]:
+    return {
+        (t.start, t.end)
+        for t in lexed.strings
+        if span[0] <= t.start and t.end <= span[1]
+    }
+
+
+def consumed_endpoint_tokens(
+    lexed: LexedSource, call: Call, suffix: str
+) -> set[tuple[int, int]]:
+    """Return the endpoint literals this call's URL resolution actually USED.
+
+    PROVENANCE, not proximity. A literal counts as accounted-for only when the
+    analyzer consumed it while resolving THIS call's endpoint - directly as the
+    URL expression, or indirectly through the binding the URL expression names.
+    Two sends in one file therefore consume their own literals independently,
+    and a recognised send can never account for a different, unrecognised one.
+    """
+    consumed: set[tuple[int, int]] = set()
+    if suffix == ".sh":
+        # Shell curl resolves URLs from word-split tokens rather than spans, so
+        # the call's own text plus any variable it dereferences is the region.
+        consumed |= _tokens_in_span(lexed, (call.start, call.end))
+        for name in set(re.findall(r"\$\{?([A-Za-z_]\w*)", lexed.original[call.start:call.end])):
+            for form in (f"${name}", name):
+                for match in assignment_matches(lexed.code, form, call.end):
+                    rhs = match.end()
+                    consumed |= _tokens_in_span(
+                        lexed, (rhs, assignment_end(lexed, rhs, suffix))
+                    )
+        return consumed
+
+    # An ANALYSED call consumes the endpoint literals of its own statement even
+    # when it is ultimately dismissed (a GET, or a request object that is never
+    # executed). The analyzer examined those literals and reached a verdict, so
+    # they are accounted for - "analysed and rejected" is not "never analysed",
+    # and only the latter is unresolved.
+    # Consumption is therefore per ENCLOSING STATEMENT, not per call span: a
+    # builder chain puts the URL literal outside the span of the call that was
+    # analysed (HttpRequest.newBuilder().uri(URI.create(URL)).POST(...)), so a
+    # span-only check re-reported a send the analyser had already resolved.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        chain_newline_boundary(lexed.code, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    ) + 1
+    statement_end = call.end
+    for terminator in (";", "\n"):
+        found = lexed.code.find(terminator, call.end)
+        if found > 0:
+            # Forward mirror of `chain_newline_boundary`: a wrapped chain's
+            # remaining links belong to the same statement, so a newline the
+            # chain continues across is not the end of it.
+            while (
+                terminator == "\n"
+                and found > 0
+                and newline_continues_chain(lexed.code, found)
+            ):
+                nxt = lexed.code.find("\n", found + 1)
+                if nxt < 0:
+                    found = len(lexed.code)
+                    break
+                found = nxt
+            statement_end = max(statement_end, found)
+            break
+    consumed |= _tokens_in_span(lexed, (statement_start, statement_end))
+
+    for span in request_url_spans(lexed, call, suffix):
+        consumed |= _tokens_in_span(lexed, span)
+        # Follow the alias chain the resolver itself walked. The endpoint is
+        # often held one or more hops away - `url = routes.get("pool")` where
+        # `routes` is a Map.of/dict/array literal - so stopping at the first hop
+        # left the real literal looking unconsumed and reported it as
+        # unresolved. Bounded to keep this linear and cycle-free.
+        pending = [lexed.code[span[0]:span[1]].strip()]
+        seen: set[str] = set()
+        for _ in range(4):
+            names: list[str] = []
+            for text in pending:
+                for name in re.findall(r"\$?[A-Za-z_]\w*", text):
+                    if name not in seen:
+                        seen.add(name)
+                        names.append(name)
+            if not names:
+                break
+            pending = []
+            for name in names:
+                for form in {name, name.lstrip("$")}:
+                    for match in assignment_matches(lexed.code, form, call.end):
+                        rhs = match.end()
+                        end = assignment_end(lexed, rhs, suffix)
+                        consumed |= _tokens_in_span(lexed, (rhs, end))
+                        pending.append(lexed.code[rhs:end])
+    return consumed
+
+
+def unresolved_endpoint_tokens(
+    lexed: LexedSource,
+    suffix: str,
+    analysed_calls: list[Call],
+) -> list[StringToken]:
+    """Return required endpoints that NO analysed send accounted for.
+
+    These are reported as "could not verify" - a distinct outcome from "missing
+    profile". The analyzer recognised a required endpoint in the source but was
+    unable to attribute it to a send it understands, so it must not certify the
+    file either way.
+    """
+    consumed: set[tuple[int, int]] = set()
+    unexplained_calls = 0
+    for call in analysed_calls:
+        tokens = consumed_endpoint_tokens(lexed, call, suffix)
+        if tokens:
+            consumed |= tokens
+        else:
+            # The analyzer resolved this call's endpoint through a path this
+            # consumption model does not mirror - a destructuring default, an
+            # interprocedural alias, a computed member. It still ACCOUNTED for
+            # one endpoint, so it explains one otherwise-unconsumed literal.
+            # Budgeting them this way keeps two independent sends independent:
+            # a file with two endpoint literals and one resolved call still
+            # reports the second.
+            unexplained_calls += 1
+    candidates = [
+        token
+        for token in required_path_tokens(lexed)
+        if (token.start, token.end) not in consumed
+        and _looks_like_a_send_target(lexed, token, suffix)
+    ]
+    return candidates[unexplained_calls:] if unexplained_calls else candidates
+
+
+# A required path can appear WITHOUT being a request target: as a curl -d body,
+# in a header value, or in prose (`echo curl "$url"`). Those are not sends and
+# reporting them blocks valid code, so an unconsumed literal is only actionable
+# when it is used somewhere that looks like a request.
+_SEND_SITE_RE = re.compile(
+    # NOT preceded by a word character - the same guard the read-verb regex
+    # below already carries. Without it `isOpen ` matches the `open`
+    # alternative and `recall ` matches `call `, so an ordinary declaration
+    # looks like a send. `do` is restricted to `do(` (Go's `client.Do(req)`)
+    # because bare `do ` matches the English word in a trailing comment.
+    r"(?<![A-Za-z0-9_])"
+    r"(?:(?:post|put|patch|send|transmit|request|fetch|execute|dispatch|submit"
+    r"|invoke|call|open|urlopen|curl)\s*(?:\(|\s)"
+    r"|do\s*\()",
+    re.I,
+)
+_ENDPOINT_KEY_RE = re.compile(
+    r"(?:url|uri|endpoint|href|target|address)\s*[:=]\s*$", re.I
+)
+
+
+# A literal sitting under a NON-URL key is payload, headers or metadata - not an
+# endpoint - even when the enclosing line is a real send to a DIFFERENT endpoint.
+_NON_URL_KEY_RE = re.compile(
+    r"(?:data|body|json|header|headers|metadata|meta|audit|params|query|form"
+    r"|note|comment|description|payload|options|context|extra|tags)"
+    r"\s*[:=]\s*$",
+    re.I,
+)
+
+
+_ANY_KEY_RE = re.compile(
+    r"""(?:['"`]?)(\w+)(?:['"`]?)\s*(?::|=>)\s*$"""
+)
+
+
+def _under_non_url_key(prefix: str) -> bool:
+    """Return whether the literal sits under a key that is not an endpoint.
+
+    Inverted deliberately: if the literal has ANY immediately-preceding object
+    key, that key must be URL-like. A decoy under `audit:`, a route table under
+    `pool:`, or a payload under `data:` are all non-endpoints, and enumerating
+    only the bad names would leave every unlisted key looking like a send.
+    A POSITIONAL literal (no key) keeps its normal treatment.
+    """
+    stripped = prefix.rstrip()[-80:]
+    if _ENDPOINT_KEY_RE.search(stripped):
+        return False
+    return _ANY_KEY_RE.search(stripped) is not None
+
+
+# The verb of the call that ENCLOSES the literal, split off its receiver. The
+# line-anchored `echo|printf|print|console.log` test only sees a display command
+# that starts the line, so `console.error(...)`, `logger.info(...)`,
+# `fmt.Printf(...)`, `var_dump(...)` and a mid-line `echo` all read as sends.
+_DISPLAY_VERB_RE = re.compile(
+    r"^(?:echo|puts|write_?line|[sf]?print(?:f|ln|_r)?|printStackTrace"
+    r"|var_dump|var_export|dump|inspect"
+    r"|log|logf|logln|debug|info|warn|warnf|warning|error|errorf|fatal|fatalf"
+    r"|trace|critical|exception)$",
+    re.I,
+)
+# A string INSPECTION is not a transport. `url.endswith(URL)` reaches the
+# fluent-client catch-all otherwise, because the literal is an argument of a
+# call like any other.
+_INSPECTION_VERB_RE = re.compile(
+    r"^(?:ends?_?with|starts?_?with|includes|contains|str_?contains"
+    r"|index_?of|last_?index_?of|strpos|strcmp"
+    r"|match|matches|search|test|replace|replace_?all|split"
+    r"|equals|equals_?ignore_?case|compare|compare_?to"
+    r"|substr|substring|slice|trim)$",
+    re.I,
+)
+# `if (url === URL)` is a comparison, not a call - but the catch-all only asks
+# whether a `(` precedes the literal and a `,` or `)` follows it.
+_NOT_A_CALL_VERB_RE = re.compile(
+    r"^(?:if|elif|elsif|while|switch|for|foreach|when|unless|until|case"
+    r"|catch|except|with|return|and|or|not|in|is)$",
+    re.I,
+)
+# A display STATEMENT has no parentheses to enclose the literal: `<?php echo
+# "$url"`, `then echo "$url"`.
+_DISPLAY_STATEMENT_RE = re.compile(
+    # The tail must not cross a call or a command separator: `echo start; curl
+    # -X POST "$URL"` is a SEND, and letting `echo` reach across the `;` would
+    # excuse it.
+    r"(?:^|[;&|`>{}\s])(?:echo|print|print_r|var_dump|var_export|puts|printf)"
+    r"\s+[^()\n;&|]*$",
+    re.I,
+)
+
+_CALLEE_SPLIT_RE = re.compile(r"\s*(?:->|::|\?\.|\.)\s*")
+_CALLEE_TAIL_RE = re.compile(
+    r"[A-Za-z_$][\w$]*(?:\s*(?:->|::|\?\.|\.)\s*[A-Za-z_$][\w$]*)*$"
+)
+
+
+def _enclosing_call_verb(lexed: LexedSource, position: int) -> str:
+    """Return the verb of the innermost unclosed CALL enclosing `position`.
+
+    Scans the blanked source backwards so brackets inside strings and comments
+    cannot unbalance the walk. Returns "" when the innermost enclosure is an
+    object/array literal rather than a call, or when there is no enclosure.
+    """
+    window_start = max(0, position - 600)
+    prefix = lexed.code[window_start:position]
+    depth = 0
+    for index in range(len(prefix) - 1, -1, -1):
+        char = prefix[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth:
+                depth -= 1
+                continue
+            if char != "(":
+                return ""
+            head = lexed.original[window_start:window_start + index].rstrip()
+            match = _CALLEE_TAIL_RE.search(head)
+            if match is None:
+                return ""
+            return _CALLEE_SPLIT_RE.split(match.group(0))[-1]
+    return ""
+
+
+def _is_display_or_inspection(lexed: LexedSource, position: int, prefix: str) -> bool:
+    """Return whether the literal is shown, compared or inspected, not sent."""
+    verb = _enclosing_call_verb(lexed, position)
+    if verb and (
+        _DISPLAY_VERB_RE.match(verb)
+        or _INSPECTION_VERB_RE.match(verb)
+        or _NOT_A_CALL_VERB_RE.match(verb)
+    ):
+        return True
+    return _DISPLAY_STATEMENT_RE.search(prefix) is not None
+
+
+def _is_standalone_binding(lexed: LexedSource, token: StringToken) -> bool:
+    """Return whether the literal is a statement-level `NAME = "..."` binding.
+
+    A binding stands alone when nothing on its line opens a call, an object or
+    an array around it - `export const POOL_URL = "..."`, `POOL_URL="..."`,
+    `const NumberPoolURL = "..."`. A MEMBER (`{endpoint: "..."}`, `url="..."`
+    inside a call) always sits within an opener, on its line or an earlier one,
+    and a member separator is `:`/`=>`, never a bare `=`.
+    """
+    line_start = lexed.code.rfind("\n", 0, token.start) + 1
+    declaration = lexed.code[line_start:token.start]
+    if any(bracket in declaration for bracket in "([{,"):
+        return False
+    return re.search(r"(?<![=!<>])=\s*$", declaration) is not None
+
+
+def _looks_like_a_send_target(
+    lexed: LexedSource, token: StringToken, suffix: str
+) -> bool:
+    """Return whether an unconsumed endpoint literal is plausibly a request."""
+    # A ROUTE TABLE is data, not a send. `Map.of("pool", URL)`, `{pool: URL}`,
+    # `["...URL"]` assigned to a name are declarations; the send happens where
+    # the table is READ, and that site is judged on its own. Reporting the
+    # declaration duplicates the real send and contradicts the documented scope
+    # boundary for computed/interprocedural lookups.
+    line_start_decl = lexed.code.rfind("\n", 0, token.start) + 1
+    declaration = lexed.original[line_start_decl:token.start]
+    if re.search(
+        r"(?:=|:=)\s*(?:new\s+\w+[^=]*)?(?:Map\s*\.\s*of|List\s*\.\s*of"
+        r"|Arrays\s*\.\s*asList|array|dict|\{|\[|\()",
+        declaration,
+    ) and not _SEND_SITE_RE.search(declaration):
+        return False
+
+    prefix = lexed.original[max(0, token.start - 120):token.start]
+    if _under_non_url_key(prefix):
+        return False
+    key = _ENDPOINT_KEY_RE.search(prefix.rstrip()[-60:])
+    if key is not None:
+        name = re.search(r"([A-Za-z_]\w*)\s*[:=]\s*$", prefix.rstrip())
+        if name is None:
+            return True
+        # An endpoint-named MEMBER (`endpoint: "..."`) sits inside the call that
+        # would send it. An endpoint-named VARIABLE does not - it must still be
+        # used somewhere that looks like a request, or it is just a constant
+        # that happens to be printed or documented.
+        references = [
+            match
+            for match in re.finditer(
+                rf"(?<![\w$])\$?\{{?{re.escape(name.group(1))}(?![\w])",
+                lexed.original,
+            )
+            if match.start() > token.end
+        ]
+        if not references:
+            # NO use of the binding in this file. A MEMBER is still a send: the
+            # call that would send it is the one it sits inside. A standalone
+            # BINDING is not - an endpoint constants module exports the URL and
+            # the request lives in another file, where it is judged on its own.
+            # Reporting the declaration instead blocks the most common correct
+            # layout in a migrated project.
+            return not _is_standalone_binding(lexed, token)
+        for match in references:
+            start = lexed.original.rfind("\n", 0, match.start()) + 1
+            stop = lexed.original.find("\n", match.end())
+            line = lexed.original[start:stop if stop > 0 else len(lexed.original)]
+            if re.match(
+                r"\s*(?:echo|printf|print|console\s*\.\s*log|#|//)\b", line
+            ) or _is_display_or_inspection(
+                lexed, match.start(), lexed.original[start:match.start()]
+            ):
+                continue
+            if _under_non_url_key(lexed.original[:match.start()]):
+                # `fetch(other, {metadata: endpoint})` - the variable reaches a
+                # send, but not as its URL.
+                continue
+            if _SEND_SITE_RE.search(line):
+                return True
+        return False
+    # Otherwise require a request-like call on the same logical line, and NOT a
+    # display command, which is how prose mentions reach the source.
+    line_start = lexed.code.rfind("\n", 0, token.start) + 1
+    line_end = lexed.code.find("\n", token.end)
+    line = lexed.original[line_start:line_end if line_end > 0 else len(lexed.original)]
+    if re.match(r"\s*(?:echo|printf|print|console\s*\.\s*log|#|//)\b", line):
+        return False
+    # The line-anchored test above only catches a display command that STARTS
+    # the line. `console.error(..., URL)`, `logger.info(..., URL)`,
+    # `fmt.Printf(..., URL)`, `var_dump(URL)`, a mid-line `echo`, a string
+    # inspection (`url.endsWith(URL)`) and a comparison (`if (url === URL)`)
+    # all reach the fluent-client catch-all below otherwise.
+    if _is_display_or_inspection(
+        lexed, token.start, lexed.original[line_start:token.start]
+    ):
+        return False
+    # A TEST ASSERTION is not a send. `expect(x).toBe(URL)`, `assertEqual(...)`,
+    # `x.should.equal(URL)` all mention the endpoint to compare against it.
+    if re.search(
+        r"(?<![\w])(?:expect|assert\w*|should|toBe|toEqual|toHaveBeenCalledWith"
+        r"|assertEqual|assertIn|is_expected)\s*[.(]",
+        line,
+        re.I,
+    ):
+        return False
+    # A READ verb is not a send. Without this, `requests.get(url)` - which the
+    # analyzer deliberately does not treat as a required send - was reported as
+    # unverifiable purely because no send consumed its endpoint.
+    if re.search(
+        # NOT preceded by a word character - otherwise the `get` inside
+        # `target(` matches and a fluent send is silently excused. `.get(` is
+        # fine because `.` is not a word character. Async suffixes included for
+        # C# (`GetAsync(`).
+        r"(?<![A-Za-z0-9_])"
+        r"(?:get|head|options|read|download|list|find|query)(?:Async)?\s*\(",
+        line,
+        re.I,
+    ) and not _SEND_SITE_RE.search(line):
+        return False
+    if _SEND_SITE_RE.search(line) is not None:
+        return True
+    # A fluent client can spell its verbs anything (`zoom.target(url).fire()`),
+    # so relying on a known-verb list makes the gate brittle in the dangerous
+    # direction. Any CALL that takes the endpoint as an argument counts, with
+    # display/logging commands excluded above.
+    tail = lexed.original[token.end:token.end + 4]
+    return bool(re.match(r"\s*[,)]", tail)) and "(" in line[: line.find(
+        token.contents[:20]
+    ) if token.contents[:20] in line else len(line)]
+
+
+
+def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
+    source = path.read_text(encoding="utf-8", errors="replace")
+    suffix = canonical_suffix(path)
+    lexed = lex_source(source, suffix)
+    sdk_calls = calls_matching(lexed, SDK_CALL_RE)
+    fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
+    shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
+    required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
+    source_resolver = SourceEndpointResolver(lexed, suffix)
+    profile_resolver = PayloadStateResolver(
+        lexed,
+        suffix,
+        PROFILE_NAMES,
+        require_value=True,
+        source=source_resolver,
+    )
+
+    seen_rest_contexts: set[tuple[int, int]] = set()
+    endpoint_calls = shell_curls if suffix == ".sh" else fetch_calls
+    if endpoint_calls:
+        for context in endpoint_calls:
+            is_required = (
+                source_resolver.shell_curl_is_required(context)
+                if suffix == ".sh"
+                else source_resolver.request_is_required(context)
+            )
+            if is_required:
+                seen_rest_contexts.add((context.start, context.end))
+                required_calls.append((context, False))
+
+    # Literal-driven safety net: required container-member paths the
+    # call-centric resolver never evaluated stay reported unless provably
+    # unused (see member_net_contexts). A miss is worse than an extra report.
+    evaluated_spans = [(c.start, c.end) for c in endpoint_calls]
+    flagged_spans = [
+        (c.start, c.end) for c, sdk in required_calls if not sdk
+    ]
+    for context in member_net_contexts(
+        lexed, suffix, evaluated_spans, flagged_spans
+    ):
+        key = (context.start, context.end)
+        if key not in seen_rest_contexts:
+            seen_rest_contexts.add(key)
+            required_calls.append((context, False))
+
+    required_calls.sort(key=lambda item: (item[0].start, item[0].end))
+    missing = [
+        call_detail(path, lexed, call)
+        for call, sdk_call in required_calls
+        if not call_has_profile(
+            lexed,
+            call,
+            suffix,
+            path,
+            project_root,
+            sdk_call=sdk_call,
+            resolver=profile_resolver,
+        )
+    ]
+
+    # Fail-safe backstop: a required endpoint the analysis never accounted for
+    # is reported for manual verification rather than passed silently.
+    # BLOCKING, provenance-based. A required endpoint that NO analysed send
+    # consumed is reported as "could not verify" - a distinct outcome from
+    # "missing profile". Attribution is by CONSUMPTION, so each send accounts
+    # only for the literals it actually resolved: multiple sends in one file are
+    # independent, and a recognised send never suppresses an unrecognised one.
+    analysed = list(endpoint_calls) + [call for call, _ in required_calls]
+    unresolved = unresolved_endpoint_tokens(lexed, suffix, analysed)
+    for token in unresolved:
+        bounds = line_bounds(source, token.start)
+        missing.append(
+            finding_row(
+                path,
+                line_number(source, token.start),
+                f"{source[bounds[0]:bounds[1]].strip()}"
+                "  [could not verify this send - the endpoint was found but no "
+                "recognized request consumed it; verify messaging_profile_id manually]",
+            )
+        )
+    # An unresolved endpoint is a CANDIDATE send, so it counts toward the total.
+    # Reporting it while excluding it from the count produced total=0 with
+    # missing=1, breaking the missing <= total contract every caller assumes.
+    return len(required_calls) + len(unresolved), missing
+
+
+def at_object_member_start(
+    code: str, start: int, end: int, offset: int
+) -> bool:
+    """Return true when offset starts a direct object-literal member."""
+
+    root_depth = payload_root_depth(code, start, end)
+    if root_depth[2] == 0 or structural_depth(code, start, offset) != root_depth:
+        return False
+    cursor = offset - 1
+    while cursor >= start and code[cursor].isspace():
+        cursor -= 1
+    return cursor >= start and code[cursor] in {"{", ","}
+
+
+def region_has_message_body(
+    lexed: LexedSource, start: int, end: int, suffix: str
+) -> bool:
+    """Recognize a real top-level message body field in one payload region."""
+
+    body_identifier = re.compile(r"(?<![\w$])body(?!\w)")
+    for match in body_identifier.finditer(lexed.code, start, end):
+        if not at_payload_root(lexed.code, start, end, match.start()):
+            continue
+        after = lexed.code[match.end() : end]
+        if re.match(r"\s*(?::|=(?!=))", after):
+            return True
+        if (
+            suffix in JS_TS_SUFFIXES
+            and at_object_member_start(
+                lexed.code, start, end, match.start()
+            )
+            and re.match(r"\s*(?=[,}])", after)
+        ):
+            return True
+
+    for token in lexed.strings:
+        if token.contents != "body" or token.start < start or token.end > end:
+            continue
+        after = lexed.without_comments[token.end : end]
+        if (
+            at_payload_root(lexed.code, start, end, token.start)
+            and re.match(r"\s*(?::|=>|=(?!=))", after)
+        ):
+            return True
+        if suffix not in JS_TS_SUFFIXES:
+            continue
+        prefix = lexed.code[start : token.start]
+        computed = re.search(r"\[\s*$", prefix)
+        if computed is None or not re.match(r"\s*\]\s*:", after):
+            continue
+        opening = start + computed.start()
+        if at_object_member_start(lexed.code, start, end, opening):
+            return True
+    return False
+
+
+def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
+    """Return real top-level body fields from selected messaging calls."""
+
+    source = path.read_text(encoding="utf-8", errors="replace")
+    suffix = canonical_suffix(path)
+    lexed = lex_source(source, suffix)
+    source_resolver = SourceEndpointResolver(lexed, suffix)
+    resolver = PayloadStateResolver(
+        lexed,
+        suffix,
+        ("body", "Body"),
+        require_value=False,
+        source=source_resolver,
+    )
+    matches: list[str] = []
+    for call in calls_matching(lexed, pattern):
+        states = [
+            resolver.span_presence(start, end, call.start)
+            for start, end in payload_spans(
+                lexed, call, suffix, "body"
+            )
+        ]
+        if any(
+            state.state == PRESENT
+            or (state.state == MAYBE and state.evidence)
+            for state in states
+        ):
+            matches.append(call_detail(path, lexed, call))
+    return matches
+
+
+def main(argv: list[str]) -> int:
+    source_modes = {
+        "--twilio-body-fields": TWILIO_MESSAGE_CREATE_RE,
+        "--message-body-fields": MESSAGE_BODY_CALL_RE,
+    }
+    if len(argv) == 3 and argv[1] in source_modes:
+        project_root = Path(argv[2]).resolve()
+        if not project_root.is_dir():
+            print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
+            return 2
+        findings = [
+            finding
+            for path in iter_source_files(project_root)
+            for finding in message_body_fields(path, source_modes[argv[1]])
+        ]
+        print("\n".join(findings))
+        return 0
+    if len(argv) != 2:
+        print(
+            f"Usage: {Path(argv[0]).name} "
+            "[--twilio-body-fields|--message-body-fields] <project-root>",
+            file=sys.stderr,
+        )
+        return 2
+    project_root = Path(argv[1]).resolve()
+    if not project_root.is_dir():
+        print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
+        return 2
+
+    total = 0
+    missing: list[str] = []
+    for path in iter_source_files(project_root):
+        try:
+            file_total, file_missing = analyze_file(path, project_root)
+        except Exception as error:  # noqa: BLE001 - one file must not abort the scan
+            # A pathological file previously took the WHOLE run down, so every
+            # other file went unanalysed and the project was reported clean.
+            # Fail safe instead: keep scanning and surface the file for manual
+            # review rather than silently dropping it.
+            total += 1
+            missing.append(
+                finding_row(
+                    path,
+                    1,
+                    f"  [could not analyze this file "
+                    f"({type(error).__name__}) - verify messaging_profile_id manually]",
+                )
+            )
+            continue
+        total += file_total
+        missing.extend(file_missing)
+
+    print(total)
+    print("\n".join(missing))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -682,8 +682,27 @@ SDK_CALL_RE = re.compile(
     rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
     r"\s*(?:\?\.)?\s*\("
 )
+CSHARP_HTTP_CONTENT_METHODS = ("PostAsync", "PutAsync", "PatchAsync")
+CSHARP_JSON_MUTATING_METHOD_NAMES = (
+    "PostAsJsonAsync",
+    "PutAsJsonAsync",
+    "PatchAsJsonAsync",
+)
+CSHARP_HTTP_CONTENT_METHOD_PATTERN = "|".join(CSHARP_HTTP_CONTENT_METHODS)
+CSHARP_JSON_MUTATING_METHOD_PATTERN = "|".join(
+    CSHARP_JSON_MUTATING_METHOD_NAMES
+)
+CSHARP_JSON_MUTATING_METHODS = frozenset(
+    name.lower() for name in CSHARP_JSON_MUTATING_METHOD_NAMES
+)
+CSHARP_ONLY_FETCH_METHODS = frozenset(
+    {"PutAsync", "PatchAsync", *CSHARP_JSON_MUTATING_METHOD_NAMES}
+)
 FETCH_CALL_RE = re.compile(
-    r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
+    rf"(?<![\w$])(?:fetch|request|post_form|postAsync|"
+    rf"(?:{CSHARP_HTTP_CONTENT_METHOD_PATTERN})|"
+    rf"(?:{CSHARP_JSON_MUTATING_METHOD_PATTERN})(?:\s*<[^()]{{0,512}}>)?|"
+    r"post|Post|POST|"
     # curl_init($url) is the documented one-liner that sets CURLOPT_URL
     # directly. Listing only the setopt spellings made that whole shape
     # invisible: no endpoint resolved, so the send was never counted and the
@@ -1922,7 +1941,14 @@ def rest_payload_spans(
             if projected is not None:
                 return [projected]
 
-    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    callee = normalized_call_callee(lexed, call)
+    callee_lower = callee.lower()
+    if suffix == ".cs" and callee_lower in CSHARP_JSON_MUTATING_METHODS:
+        named_value = named_argument_spans(lexed, arguments, "value")
+        if named_value:
+            return named_value[-1:]
+        offset = csharp_json_extension_argument_offset(lexed, call)
+        return arguments[offset + 1 : offset + 2]
     if suffix == ".php" and callee == "file_get_contents":
         region = php_stream_context_region(lexed, call, suffix)
         if region is None:
@@ -3045,6 +3071,44 @@ def call_receiver(lexed: LexedSource, call: Call) -> str | None:
     return match.group(1).lstrip("$") if match is not None else None
 
 
+def normalized_call_callee(lexed: LexedSource, call: Call) -> str:
+    """Return a call name without whitespace or C# generic type arguments."""
+
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    return re.sub(r"<[^()]{0,512}>$", "", callee)
+
+
+def csharp_json_extension_argument_offset(
+    lexed: LexedSource, call: Call
+) -> int:
+    """Return the URL offset for instance versus static extension calls.
+
+    ``client.PostAsJsonAsync(url, value)`` starts at URL argument zero, while
+    ``HttpClientJsonExtensions.PostAsJsonAsync(client, url, value)`` and a
+    ``using static`` call start at argument one.  A type alias for the official
+    extension class is the same static form.  Expression receivers such as
+    ``GetClient().PostAsJsonAsync(...)`` remain instance calls even though they
+    do not have a simple identifier receiver.
+    """
+
+    receiver = call_receiver(lexed, call)
+    explicit_receiver = bool(
+        re.search(r"(?:\?|!)?\s*\.\s*$", lexed.code[:call.start])
+    )
+    if receiver is None:
+        return 0 if explicit_receiver else 1
+    if receiver == "HttpClientJsonExtensions":
+        return 1
+    if re.search(
+        rf"(?m)^\s*(?:global\s+)?using\s+{re.escape(receiver)}\s*=\s*"
+        r"(?:global\s*::\s*)?System\s*\.\s*Net\s*\.\s*Http\s*\.\s*Json"
+        r"\s*\.\s*HttpClientJsonExtensions\s*;",
+        lexed.original,
+    ):
+        return 1
+    return 0
+
+
 # Factory methods that build an HTTP client which then sends. A `.post()` on
 # such a factory (requests.Session().post, httpx.Client().post,
 # axios.create(...).post) is a real send; a `.post()` on a mock/assertion
@@ -4114,7 +4178,10 @@ def request_write_payload_spans(
 
 
 URL_CONSTRUCTOR_RE = re.compile(
-    r"^\s*(?:new\s+)?(?:URI|URL)(?:\s*\.\s*(?:create|parse|join))?\s*\("
+    # Java/Ruby use URI/URL; .NET's official overload uses System.Uri.  The
+    # case-sensitive type spelling matters because strings are already masked
+    # and this runs on arbitrary expressions, not on a C# AST.
+    r"^\s*(?:new\s+)?(?:URI|URL|Uri)(?:\s*\.\s*(?:create|parse|join))?\s*\("
 )
 
 
@@ -4424,9 +4491,7 @@ def _request_url_spans(
     args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
     if not args:
         return []
-    callee = re.sub(
-        r"\s+", "", lexed.code[call.start:call.open_paren]
-    )
+    callee = normalized_call_callee(lexed, call)
     callee_lower = callee.lower()
     receiver = call_receiver(lexed, call)
     explicit_receiver = bool(
@@ -4484,6 +4549,11 @@ def _request_url_spans(
         for name in URL_MEMBER_NAMES
         for span in named_argument_spans(lexed, args, name)
     ]
+    if suffix == ".cs" and callee_lower in CSHARP_JSON_MUTATING_METHODS:
+        if named_url:
+            return named_url[-1:]
+        offset = csharp_json_extension_argument_offset(lexed, call)
+        return args[offset : offset + 1]
     if callee_lower in {"post", "postasync"} and named_url:
         return named_url[-1:]
     if suffix == ".php" and callee == "file_get_contents" and args:
@@ -11413,6 +11483,16 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     lexed = lex_source(source, suffix)
     sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
+    if suffix != ".cs":
+        # These PascalCase names are official .NET HttpClient methods. Keeping
+        # their discovery C#-only avoids turning an unrelated Java/JavaScript
+        # method with the same name into a recognised transport call.
+        fetch_calls = [
+            call
+            for call in fetch_calls
+            if normalized_call_callee(lexed, call)
+            not in CSHARP_ONLY_FETCH_METHODS
+        ]
     shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
     required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
     source_resolver = SourceEndpointResolver(

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -56,6 +56,7 @@ SUFFIX_LANGUAGE_ALIASES = {
     ".pyw": ".py",
     ".rake": ".rb",
     ".cshtml": ".cs",
+    ".razor": ".cs",
     ".scala": ".java",
     # Kotlin shares Java's grammar for everything this linter models - the
     # OkHttp/java.net.http builder chains, the braced control-flow arms, the
@@ -224,6 +225,200 @@ def _balanced_parenthesis_ranges(
     return ranges
 
 
+def _balanced_delimiter_end(source: str, opening: int) -> int | None:
+    """Return the index after a quote-aware (), [], or {} expression."""
+
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    opening_character = source[opening] if opening < len(source) else ""
+    if opening_character not in pairs:
+        return None
+    stack = [pairs[opening_character]]
+    quote = ""
+    escaped = False
+    for index in range(opening + 1, len(source)):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif character in pairs:
+            stack.append(pairs[character])
+        elif character == stack[-1]:
+            stack.pop()
+            if not stack:
+                return index + 1
+    return None
+
+
+def _razor_implicit_expression_ranges(source: str) -> list[tuple[int, int]]:
+    """Return executable C# spans introduced by Razor's implicit ``@`` form.
+
+    Razor permits member, invocation, indexer, null-conditional, and ``await``
+    expressions without the explicit ``@(...)`` wrapper.  Parse those access
+    chains instead of preserving a handful of examples; markup and email-like
+    text remain excluded by requiring a non-word boundary before ``@``.
+    """
+
+    ranges: list[tuple[int, int]] = []
+    start_pattern = re.compile(
+        r"(?<![\w@])@(?!@)(?P<expression>await\s+|[A-Za-z_][\w]*)",
+        re.IGNORECASE,
+    )
+    for match in start_pattern.finditer(source):
+        start = match.start("expression")
+        cursor = match.end("expression")
+        if source[start:cursor].lower().startswith("await"):
+            identifier = re.match(r"[A-Za-z_][\w]*", source[cursor:])
+            if not identifier:
+                continue
+            cursor += identifier.end()
+
+        # Directives and control blocks are handled by the dedicated ranges
+        # below.  Treating their keyword as an expression adds no coverage and
+        # can retain adjacent markup as though it were C#.
+        first_identifier = re.match(r"[A-Za-z_][\w]*", source[start:])
+        if first_identifier and first_identifier.group(0).lower() in {
+            "addtaghelper", "attribute", "case", "catch", "class", "code",
+            "default", "do", "else", "finally", "for", "foreach", "functions",
+            "helper", "if", "implements", "inherits", "inject", "lock", "model",
+            "namespace", "page", "removetaghelper", "section", "switch",
+            "taghelperprefix", "try", "using", "while",
+        }:
+            continue
+
+        while cursor < len(source):
+            chain = re.match(r"(?:\?\.|\.)[A-Za-z_][\w]*", source[cursor:])
+            if chain:
+                cursor += chain.end()
+                continue
+            if source[cursor] in "([{":
+                end = _balanced_delimiter_end(source, cursor)
+                if end is None:
+                    break
+                cursor = end
+                continue
+            if source[cursor] in "!?":
+                cursor += 1
+                continue
+            break
+        ranges.append((start, cursor))
+    return ranges
+
+
+def _razor_continuation_block_ranges(
+    source: str, initial_ranges: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Return ``else``/``catch``/``finally`` blocks chained to Razor C#."""
+
+    continuations: list[tuple[int, int]] = []
+    pending = list(initial_ranges)
+    while pending:
+        _, closing = pending.pop()
+        tail = source[closing + 1 :]
+        match = re.match(
+            r"\s*@?(?:else(?:\s+if\b[^{}]*)?|catch\b[^{}]*|finally\b)\s*\{",
+            tail,
+            flags=re.IGNORECASE,
+        )
+        if not match:
+            continue
+        opening = closing + 1 + match.end() - 1
+        balanced = _balanced_brace_ranges(source, [opening])
+        if balanced:
+            continuations.extend(balanced)
+            pending.extend(balanced)
+    return continuations
+
+
+def _vue_directive_expression_ranges(source: str) -> list[tuple[int, int]]:
+    """Return value and dynamic-argument expressions for every Vue directive."""
+
+    directive = (
+        r"(?<!\S)(?:v-[\w-]+(?::(?:[\w:-]+|\[[^\]\r\n]+\]))?"
+        r"|[@:#.](?:[\w:-]+|\[[^\]\r\n]+\]))"
+        r"(?:\.[\w-]+)*"
+    )
+    ranges: list[tuple[int, int]] = []
+
+    # Restrict directive discovery to opening tags.  A documentation snippet
+    # rendered as text (``<pre>v-if="..."</pre>``) is not executable Vue and
+    # must not become a false positive merely because it resembles an
+    # attribute.  Scan tag endings quote-aware so ``>`` inside an expression
+    # does not truncate the attribute list.
+    tag_ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        if opening + 1 >= len(source) or not re.match(
+            r"[A-Za-z]", source[opening + 1]
+        ):
+            cursor = opening + 1
+            continue
+        quote = ""
+        for index in range(opening + 1, len(source)):
+            character = source[index]
+            if quote:
+                if character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+            elif character == ">":
+                tag_ranges.append((opening, index + 1))
+                cursor = index + 1
+                break
+        else:
+            break
+
+    for tag_start, tag_end in tag_ranges:
+        tag = source[tag_start:tag_end]
+        outside_attribute_value: list[bool] = []
+        quote = ""
+        for character in tag:
+            outside_attribute_value.append(not quote)
+            if quote:
+                if character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+
+        value_pattern = re.compile(
+            directive
+            + r"\s*=\s*(?:(?P<quote>['\"])(?P<quoted>.*?)(?P=quote)"
+            + r"|(?P<unquoted>[^\s>]+))",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        for candidate in re.finditer(directive, tag, flags=re.IGNORECASE):
+            if not outside_attribute_value[candidate.start()]:
+                continue
+            match = value_pattern.match(tag, candidate.start())
+            if not match:
+                continue
+            group = "quoted" if match.group("quoted") is not None else "unquoted"
+            start, end = match.span(group)
+            ranges.append((tag_start + start, tag_start + end))
+
+        # A dynamic directive argument is JavaScript independently of its
+        # value: ``:[selectEndpoint()]="payload"`` executes both expressions.
+        for match in re.finditer(
+            r"(?<!\S)(?:v-[\w-]+:|[@:#])\[(?P<argument>[^\]\r\n]+)\]",
+            tag,
+            flags=re.IGNORECASE,
+        ):
+            if not outside_attribute_value[match.start()]:
+                continue
+            start, end = match.span("argument")
+            ranges.append((tag_start + start, tag_start + end))
+    return ranges
+
+
 def _javascript_template_expression_ranges(
     source: str, start: int, end: int
 ) -> list[tuple[int, int]]:
@@ -283,15 +478,7 @@ def executable_source(path: Path, source: str) -> str:
             if frontmatter:
                 ranges.append(frontmatter.span(1))
         if suffix == ".vue":
-            ranges.extend(
-                match.span("expression")
-                for match in re.finditer(
-                    r"(?:v-on:[\w:-]+|@[\w:-]+)(?:\.[\w-]+)*\s*=\s*"
-                    r"(?P<quote>['\"])(?P<expression>.*?)(?P=quote)",
-                    template_source,
-                    re.DOTALL,
-                )
-            )
+            ranges.extend(_vue_directive_expression_ranges(template_source))
             # Vue interpolations may contain nested object literals. A
             # non-greedy regex leaves such calls unterminated; balance the
             # entire double-brace region and retain its inner expression.
@@ -320,37 +507,66 @@ def executable_source(path: Path, source: str) -> str:
                 for match in re.finditer(r"\{", expression_source)
             ]
             ranges.extend(_balanced_brace_ranges(expression_source, openings))
-    elif suffix == ".cshtml":
+    elif suffix in {".cshtml", ".razor"}:
         # Razor is a mixed HTML/C# template. Retain explicit expressions,
         # statement/code blocks, and single-line directives while blanking page
         # markup so text such as `<p>VoiceResponse()</p>` is not treated as C#.
+        razor_source = re.sub(
+            r"@\*.*?\*@",
+            lambda match: "".join(
+                char if char in "\r\n" else " " for char in match.group(0)
+            ),
+            source,
+            flags=re.DOTALL,
+        )
         brace_openings = [
             match.end() - 1
             for match in re.finditer(
                 r"(?<!@)@(?:\s*|(?:code|functions)\s*)\{",
-                source,
+                razor_source,
                 flags=re.IGNORECASE,
             )
         ]
-        brace_openings.extend(
+        control_openings = [
             match.end() - 1
             for match in re.finditer(
-                r"(?<!@)@(?:if|for|foreach|while|switch|try|catch|finally|using|lock)\b[^{}]*\{",
-                source,
+                r"(?<!@)@(?:if|for|foreach|while|do|switch|try|catch|finally|using|lock)\b[^{}]*\{",
+                razor_source,
                 flags=re.IGNORECASE,
             )
+        ]
+        ordinary_brace_ranges = _balanced_brace_ranges(
+            razor_source, brace_openings
         )
-        ranges.extend(_balanced_brace_ranges(source, brace_openings))
+        control_ranges = _balanced_brace_ranges(razor_source, control_openings)
+        ranges.extend(ordinary_brace_ranges)
+        ranges.extend(control_ranges)
+        ranges.extend(_razor_continuation_block_ranges(razor_source, control_ranges))
+
+        # The condition after a Razor do/while body is executable C# too.
+        for opening in control_openings:
+            prefix = razor_source[max(0, opening - 16) : opening]
+            if not re.search(r"@do\s*$", prefix, re.IGNORECASE):
+                continue
+            body = _balanced_brace_ranges(razor_source, [opening])
+            if not body:
+                continue
+            tail = razor_source[body[0][1] + 1 :]
+            while_match = re.match(r"\s*while\s*\(", tail, re.IGNORECASE)
+            if while_match:
+                paren = body[0][1] + 1 + while_match.end() - 1
+                ranges.extend(_balanced_parenthesis_ranges(razor_source, [paren]))
         paren_openings = [
             match.end() - 1
-            for match in re.finditer(r"(?<!@)@\s*\(", source)
+            for match in re.finditer(r"(?<!@)@\s*\(", razor_source)
         ]
-        ranges.extend(_balanced_parenthesis_ranges(source, paren_openings))
+        ranges.extend(_balanced_parenthesis_ranges(razor_source, paren_openings))
+        ranges.extend(_razor_implicit_expression_ranges(razor_source))
         ranges.extend(
             match.span()
             for match in re.finditer(
                 r"(?m)^\s*@(?:using|inject|model|inherits|implements|namespace|addTagHelper|removeTagHelper|tagHelperPrefix)\b[^\r\n]*",
-                source,
+                razor_source,
             )
         )
     elif suffix == ".phtml":
@@ -358,9 +574,13 @@ def executable_source(path: Path, source: str) -> str:
         # Feeding its markup to the PHP lexer lets an apostrophe in page text
         # open a string that masks a later request inside <?php ... ?>.
         ranges.extend(
-            match.span(1)
+            match.span("code")
             for match in re.finditer(
-                r"<\?(?:php\b|=)(.*?)(?:\?>|\Z)",
+                # Plain ``<?`` is executable when short_open_tag is enabled.
+                # Keep XML declarations out: with short tags disabled they are
+                # markup, and with short tags enabled they make the PHP file
+                # invalid rather than forming a customer request.
+                r"<\?(?:php\b|=|(?!(?:xml)\b))(?P<code>.*?)(?:\?>|\Z)",
                 source,
                 flags=re.IGNORECASE | re.DOTALL,
             )

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -11,6 +11,7 @@ their nearest real assignment in the same file.
 from __future__ import annotations
 
 import bisect
+import html
 import json
 import os
 import posixpath
@@ -150,7 +151,7 @@ def canonical_suffix(path: Path) -> str:
         if re.search(
             r"<script\b[^>]*\blang\s*=\s*(?:(['\"])(?:ts|typescript)\1|(?:ts|typescript)(?=\s|>))",
             source,
-            re.I,
+            re.I | re.ASCII,
         ):
             return ".ts"
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
@@ -1268,6 +1269,298 @@ def _mask_jsx_markup(source: str, suffix: str) -> str:
     return "".join(output)
 
 
+_JAVASCRIPT_MIME_ESSENCES = {
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "text/ecmascript",
+    "text/javascript",
+    "text/javascript1.0",
+    "text/javascript1.1",
+    "text/javascript1.2",
+    "text/javascript1.3",
+    "text/javascript1.4",
+    "text/javascript1.5",
+    "text/jscript",
+    "text/livescript",
+    "text/x-ecmascript",
+    "text/x-javascript",
+}
+
+
+def _html_attributes(attributes: str) -> list[tuple[str, str]]:
+    """Parse static HTML attributes without matching inside quoted values."""
+
+    parsed: list[tuple[str, str]] = []
+    index = 0
+    while index < len(attributes):
+        while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+            index += 1
+        if index >= len(attributes) or attributes[index] in {">", "/"}:
+            break
+        name_start = index
+        while (
+            index < len(attributes)
+            and attributes[index] not in "\t\n\f\r "
+            and attributes[index] not in {'=', '>', '/'}
+        ):
+            index += 1
+        name = attributes[name_start:index].lower()
+        if not name:
+            index += 1
+            continue
+        while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+            index += 1
+        value = ""
+        if index < len(attributes) and attributes[index] == "=":
+            index += 1
+            while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+                index += 1
+            if index < len(attributes) and attributes[index] in {'"', "'"}:
+                quote = attributes[index]
+                index += 1
+                value_start = index
+                closing = attributes.find(quote, index)
+                if closing < 0:
+                    value = attributes[value_start:]
+                    index = len(attributes)
+                else:
+                    value = attributes[value_start:closing]
+                    index = closing + 1
+            else:
+                value_start = index
+                while (
+                    index < len(attributes)
+                    and attributes[index] not in "\t\n\f\r "
+                    and attributes[index] != ">"
+                ):
+                    index += 1
+                value = attributes[value_start:index]
+        parsed.append((name, html.unescape(value)))
+    return parsed
+
+
+def _script_attributes_execute_javascript(attributes: str) -> bool:
+    """Return whether a browser treats a static script tag as JavaScript."""
+
+    attribute_values: dict[str, str] = {}
+    for name, value in _html_attributes(attributes):
+        # HTML keeps the first duplicate attribute and ignores later ones.
+        attribute_values.setdefault(name, value)
+
+    if "type" in attribute_values:
+        value = attribute_values["type"].strip("\t\n\f\r ")
+        # A server-generated type cannot be classified statically. Retaining
+        # its body prevents a dynamic JavaScript block from silently escaping.
+        if "<%" in value:
+            return True
+        if not value:
+            return True
+        lowered = value.lower()
+        if lowered == "module":
+            return True
+        # HTML's JavaScript MIME *essence match* is an exact comparison against
+        # these legacy strings, not MIME parsing.  In particular the standard
+        # says `text/javascript; charset=utf-8` is a data block and is not run.
+        return lowered in _JAVASCRIPT_MIME_ESSENCES
+
+    language = attribute_values.get("language", "").strip("\t\n\f\r ")
+    if not language or "<%" in language:
+        return True
+    essence = language.lower()
+    if "/" not in essence:
+        essence = f"text/{essence}"
+    return essence in _JAVASCRIPT_MIME_ESSENCES
+
+
+_HTML_TAG_RE = re.compile(r"<(?P<closing>/)?(?P<name>[^\t\n\f\r />]+)")
+_HTML_INERT_RAW_TEXT_ELEMENTS = {
+    "iframe",
+    "noembed",
+    "noframes",
+    "noscript",
+    "plaintext",
+    "style",
+    "template",
+    "textarea",
+    "title",
+    "xmp",
+}
+
+
+def _html_tag_end(source: str, start: int) -> int | None:
+    """Return the first tag-closing angle bracket outside quoted attributes."""
+
+    quote = ""
+    index = start
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if character == quote:
+                quote = ""
+        elif character in {'"', "'"}:
+            quote = character
+        elif character == ">":
+            return index
+        index += 1
+    return None
+
+
+def _html_raw_text_end(
+    source: str, start: int, name: str
+) -> tuple[int, int] | None:
+    """Return the start/end of a raw-text element's next matching end tag."""
+
+    closer = re.compile(
+        rf"</{re.escape(name)}(?=[\t\n\f\r />])", re.I | re.ASCII
+    ).search(source, start)
+    if closer is None:
+        return None
+    end = _html_tag_end(source, closer.end())
+    return closer.start(), len(source) if end is None else end + 1
+
+
+def _html_template_end(source: str, start: int) -> int | None:
+    """Return the end of a template element, including nested templates."""
+
+    depth = 1
+    cursor = start
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            return None
+        tag = _HTML_TAG_RE.match(source, opening)
+        if tag is None:
+            cursor = opening + 1
+            continue
+        tag_end = _html_tag_end(source, tag.end())
+        if tag_end is None:
+            return None
+        name = tag.group("name").lower()
+        if tag.group("closing"):
+            if name == "template":
+                depth -= 1
+                if depth == 0:
+                    return tag_end + 1
+            cursor = tag_end + 1
+            continue
+        if name == "plaintext":
+            cursor = len(source)
+            continue
+        if name == "template":
+            depth += 1
+            cursor = tag_end + 1
+            continue
+        if name == "script" or name in (_HTML_INERT_RAW_TEXT_ELEMENTS - {"template"}):
+            closer = _html_raw_text_end(source, tag_end + 1, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return None
+
+
+def _script_element_body_ranges(source: str) -> list[tuple[int, int]]:
+    """Return executable JavaScript bodies from quote-aware HTML script tags."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        opener = _HTML_TAG_RE.match(source, opening)
+        if opener is None:
+            cursor = opening + 1
+            continue
+        boundary = opener.end()
+        tag_end = _html_tag_end(source, boundary)
+        if tag_end is None:
+            break
+        name = opener.group("name").lower()
+        if opener.group("closing"):
+            cursor = tag_end + 1
+            continue
+
+        body_start = tag_end + 1
+        if name == "script":
+            closer = _html_raw_text_end(source, body_start, name)
+            body_end = len(source) if closer is None else closer[0]
+            if _script_attributes_execute_javascript(source[boundary:tag_end]):
+                ranges.append((body_start, body_end))
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        if name == "template":
+            closing_end = _html_template_end(source, body_start)
+            cursor = len(source) if closing_end is None else closing_end
+            continue
+        if name in _HTML_INERT_RAW_TEXT_ELEMENTS:
+            closer = _html_raw_text_end(source, body_start, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return ranges
+
+
+def _html_comment_end(source: str, opening: int) -> int:
+    """Return the offset after an HTML comment, or EOF when unterminated."""
+
+    content_start = opening + 4
+    abrupt = (
+        content_start + 1
+        if source.startswith(">", content_start)
+        else content_start + 2
+        if source.startswith("->", content_start)
+        else -1
+    )
+    normal = source.find("-->", content_start)
+    bang = source.find("--!>", content_start)
+    closers = [position for position in (abrupt, normal, bang) if position >= 0]
+    closing = min(closers) if closers else -1
+    if closing < 0:
+        return len(source)
+    if closing == abrupt:
+        return abrupt
+    if closing == bang:
+        return bang + 4
+    return normal + 3
+
+
+def _without_html_comments(source: str) -> str:
+    """Blank HTML comments in markup state while preserving source offsets."""
+
+    output = list(source)
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        if source.startswith("<!--", opening):
+            end = _html_comment_end(source, opening)
+            _blank(output, opening, end)
+            cursor = end
+            continue
+        tag = _HTML_TAG_RE.match(source, opening)
+        if tag is None:
+            cursor = opening + 1
+            continue
+        tag_end = _html_tag_end(source, tag.end())
+        if tag_end is None:
+            break
+        name = tag.group("name").lower()
+        if tag.group("closing"):
+            cursor = tag_end + 1
+            continue
+        if name == "plaintext":
+            break
+        if name == "script" or name in (_HTML_INERT_RAW_TEXT_ELEMENTS - {"template"}):
+            closer = _html_raw_text_end(source, tag_end + 1, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return "".join(output)
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
@@ -1275,32 +1568,28 @@ def executable_source(path: Path, source: str) -> str:
     if suffix in JSX_CAPABLE_SUFFIXES:
         return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
-        # Comments may contain complete, syntactically valid examples. Preserve
-        # their offsets/newlines but remove their contents before discovering
-        # script blocks, handlers, interpolations, or balanced expressions.
-        template_source = re.sub(
-            r"<!--.*?-->",
-            lambda match: "".join(
-                char if char in "\r\n" else " " for char in match.group(0)
-            ),
-            source,
-            flags=re.DOTALL,
-        )
-        ranges.extend(
-            match.span(1)
-            for match in re.finditer(
-                r"<script\b[^>]*>(.*?)</script\b[^>]*>", template_source,
-                flags=re.IGNORECASE | re.DOTALL,
-            )
-        )
+        frontmatter = None
+        markup_source = source
         if suffix == ".astro":
+            # Astro frontmatter is JavaScript/TypeScript, not HTML markup. A
+            # string such as `"<!--"` must therefore not open an HTML comment
+            # that erases the remaining executable frontmatter.
             frontmatter = re.match(
                 r"\A\s*---\s*\r?\n(.*?)\r?\n---(?:\s*\r?\n|\Z)",
-                template_source,
+                source,
                 re.DOTALL,
             )
             if frontmatter:
-                ranges.append(frontmatter.span(1))
+                markup = list(source)
+                _blank(markup, *frontmatter.span(1))
+                markup_source = "".join(markup)
+        # Comments may contain complete, syntactically valid examples. Preserve
+        # their offsets/newlines but remove their contents before discovering
+        # script blocks, handlers, interpolations, or balanced expressions.
+        template_source = _without_html_comments(markup_source)
+        ranges.extend(_script_element_body_ranges(template_source))
+        if frontmatter:
+            ranges.append(frontmatter.span(1))
         if suffix == ".vue":
             ranges.extend(_vue_directive_expression_ranges(template_source))
             # Vue interpolations may contain nested object literals. A
@@ -1418,11 +1707,7 @@ def executable_source(path: Path, source: str) -> str:
             # blocks execute in the generated browser page. Both can contain
             # migration-sensitive JavaScript and must remain visible.
             ranges.extend(
-                match.span(1)
-                for match in re.finditer(
-                    r"<script\b[^>]*>(.*?)</script\b[^>]*>", source,
-                    flags=re.IGNORECASE | re.DOTALL,
-                )
+                _script_element_body_ranges(_without_html_comments(source))
             )
         for match in re.finditer(
             r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL
@@ -1539,8 +1824,11 @@ FETCH_CALL_RE = re.compile(
     r"axios\s*\.\s*post|axios)\s*\("
 )
 TWILIO_MESSAGE_CREATE_RE = re.compile(
+    r"(?:"
     r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
     r"create\s*(?:\?\.)?\s*\("
+    r"|(?<![\w$])MessageResource\s*\.\s*Create\s*\("
+    r")"
 )
 MESSAGE_BODY_CALL_RE = re.compile(
     r"(?:"
@@ -1550,6 +1838,7 @@ MESSAGE_BODY_CALL_RE = re.compile(
     r"Send\s*\("
     r"|(?:\?\.|\.|->)\s*messages\s*\(\s*\)\s*"
     r"(?:\?\.|\.|->)\s*send\s*\("
+    r"|(?<![\w$])MessageResource\s*\.\s*Create\s*\("
     r")"
 )
 SIMPLE_VARIABLE_RE = re.compile(r"(?:\.\.\.|\*\*|[&*])?\s*(\$?[A-Za-z_]\w*)\s*$")
@@ -1815,13 +2104,89 @@ def _line_comment_end(source: str, start: int, suffix: str) -> int:
 _HEREDOC_OPENER_RE = re.compile(
     r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)(?!\w)"
 )
+_RUBY_HEREDOC_OPENER_RE = re.compile(
+    r"<<(?P<indent>[-~]?)(?:"
+    r"'(?P<single>[^'\r\n]*)'|"
+    r'"(?P<double>[^"\r\n]*)"|'
+    r"`(?P<command>[^`\r\n]*)`|"
+    r"(?P<tag>(?!\d)\w+)"
+    r")"
+)
 # Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
 # singleton-class syntax `class <<self` also puts a bare word straight after
 # `<<` at end of line, so it parsed as a heredoc opening a body that never
 # closed - blanking the rest of the file and silently passing every send below
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
-_NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+def _ruby_heredoc_tag(match: "re.Match[str]") -> str:
+    """Return the delimiter spelling from a Ruby heredoc opener match."""
+
+    for name in ("single", "double", "command", "tag"):
+        value = match.group(name)
+        if value is not None:
+            return value
+    return ""
+
+
+def _ruby_heredoc_quote(match: "re.Match[str]") -> str:
+    """Return the quote mode used by one Ruby heredoc opener."""
+
+    if match.group("single") is not None:
+        return "'"
+    if match.group("double") is not None:
+        return '"'
+    if match.group("command") is not None:
+        return "`"
+    return ""
+
+
+def _ruby_heredoc_has_shift_left_context(source: str, index: int) -> bool:
+    """Return whether Ruby lexes this compact ``<<TAG`` as left shift."""
+
+    cursor = index - 1
+    adjacent = cursor >= 0 and source[cursor] not in " \t\r\n"
+    while cursor >= 0 and source[cursor] in " \t":
+        cursor -= 1
+    if cursor < 0 or source[cursor] in "\r\n":
+        return False
+    # Ruby's lexical ambiguity treats command/local/constant receivers followed
+    # by whitespace and <<TAG as heredocs, but literals, completed expressions,
+    # and instance/global variables remain shift operands.  These are the
+    # contexts Ripper emits as on_op rather than on_heredoc_beg.
+    if source[cursor].isdigit() or source[cursor] in "'\"`)]}/":
+        return True
+    if not (source[cursor].isalnum() or source[cursor] == "_"):
+        return False
+    end = cursor + 1
+    while cursor >= 0 and (source[cursor].isalnum() or source[cursor] == "_"):
+        cursor -= 1
+    word = source[cursor + 1:end]
+    return (
+        adjacent
+        or word
+        in {
+            "nil",
+            "true",
+            "false",
+            "self",
+            "__FILE__",
+            "__LINE__",
+            "__ENCODING__",
+        }
+        or (cursor >= 0 and source[cursor] in {"@", "$", ":"})
+    )
+
+
+def _ruby_heredoc_has_class_left_context(source: str, index: int) -> bool:
+    """Return whether the token before ``<<`` is Ruby's ``class`` keyword."""
+
+    cursor = index - 1
+    while cursor >= 0 and source[cursor] in " \t":
+        cursor -= 1
+    end = cursor + 1
+    while cursor >= 0 and (source[cursor].isalnum() or source[cursor] == "_"):
+        cursor -= 1
+    return source[cursor + 1:end] == "class"
 
 
 def _heredoc_opener_at(
@@ -1833,7 +2198,18 @@ def _heredoc_opener_at(
     applying the rejection there would disable heredoc masking on any opener
     line that merely ENDS with the word `class` (`echo class <<EOT`).
     """
-    match = _HEREDOC_OPENER_RE.match(source, index)
+    opener_pattern = _HEREDOC_OPENER_RE
+    if suffix == ".rb":
+        match = _RUBY_HEREDOC_OPENER_RE.match(source, index)
+        if match is None:
+            return None
+        if (
+            _ruby_heredoc_has_class_left_context(source, index)
+            or _ruby_heredoc_has_shift_left_context(source, index)
+        ):
+            return None
+        return match
+    match = opener_pattern.match(source, index)
     if match is None:
         return None
     # In shell, three opening angle brackets introduce an inline here-string,
@@ -1850,10 +2226,68 @@ def _heredoc_opener_at(
         line_end = len(source)
     if suffix != ".sh" and source[match.end():line_end].strip():
         return None
-    if suffix == ".rb":
-        if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
-            return None
     return match
+
+
+def _ruby_heredoc_openers_at(
+    source: str, index: int
+) -> list["re.Match[str]"]:
+    """Return ordered Ruby heredoc openers declared by one expression.
+
+    Ruby consumes multiple heredoc bodies after the declaration line, in the
+    same order as their openers. The ordinary single-opener validator requires
+    an opener to end its line, so this also accepts comma-separated openers on
+    the declaration line without lending one opener's mode to another body.
+    """
+
+    first = _heredoc_opener_at(source, index, ".rb")
+    if first is None:
+        return []
+    line_end = source.find("\n", first.end())
+    if line_end < 0:
+        line_end = len(source)
+
+    openers = [first]
+    cursor = first.end()
+    quote = ""
+    escaped = False
+    while cursor < line_end:
+        character = source[cursor]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            cursor += 1
+            continue
+        if character == "#":
+            break
+        if character in {"'", '"', "`"}:
+            quote = character
+            cursor += 1
+            continue
+        if character == "/":
+            regexp = _ruby_slash_regex(source, cursor, allow_newlines=False)
+            if regexp is not None and regexp[0] <= line_end:
+                cursor = regexp[0]
+                continue
+        if character == "%":
+            percent = _ruby_percent_literal(source, cursor)
+            if percent is not None and percent[0] <= line_end:
+                cursor = percent[0]
+                continue
+        if source.startswith("<<", cursor):
+            candidate = _heredoc_opener_at(source, cursor, ".rb")
+            if candidate is not None:
+                openers.append(candidate)
+                cursor = candidate.end()
+                continue
+            cursor += 2
+            continue
+        cursor += 1
+    return openers
 
 
 def _heredoc_langs(suffix: str) -> bool:
@@ -2283,7 +2717,244 @@ def _ruby_command_regex_has_valid_tail(source: str, regexp_end: int) -> bool:
     return re.match(r"(?:[+-]\s*)?(?:[$@A-Za-z_\d]|[('\"\[{])", tail) is None
 
 
-def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
+def _ruby_bound_shift_offsets(source: str, code: str) -> frozenset[int]:
+    """Return ambiguous ``<<TAG`` offsets whose receiver is a local binding.
+
+    Ruby lexes ``puts <<DOC`` as a heredoc, but lexes ``value <<BITS`` as an
+    operator once ``value`` has been introduced as a local in the same lexical
+    method/top-level scope.  A first masking pass gives us comment/string-safe
+    code and method boundaries; this binding pass then prevents the second pass
+    from swallowing the rest of the file as a nonexistent heredoc body.
+    """
+
+    spans = sorted(_ruby_function_spans(code))
+    span_starts = [start for start, _ in spans]
+    parents: list[int] = []
+    stack: list[int] = []
+    for span_index, (start, end) in enumerate(spans):
+        while stack and spans[stack[-1]][1] <= start:
+            stack.pop()
+        parents.append(stack[-1] if stack else -1)
+        stack.append(span_index)
+
+    def owner(offset: int) -> tuple[int, int] | None:
+        # Intervals are nested or disjoint. Start with the latest possible
+        # owner and follow its precomputed parent chain instead of scanning all
+        # method spans for every binding/candidate (quadratic on large files).
+        span_index = bisect.bisect_right(span_starts, offset) - 1
+        while span_index >= 0:
+            start, end = spans[span_index]
+            if start <= offset < end:
+                return start, end
+            span_index = parents[span_index]
+        return None
+
+    def parameter_names(parameters: str) -> set[str]:
+        """Return declaration names, excluding identifiers in defaults."""
+
+        names: set[str] = set()
+        start = 0
+        depth = 0
+        for index, character in enumerate(parameters + ","):
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth = max(0, depth - 1)
+            elif character in {",", ";"} and depth == 0:
+                piece = parameters[start:index].strip()
+                start = index + 1
+                while (
+                    len(piece) >= 2
+                    and piece[0] == "("
+                    and matching_delimiter(piece, 0, "(", ")")
+                    == len(piece) - 1
+                ):
+                    piece = piece[1:-1].strip()
+                if "," in piece:
+                    names.update(parameter_names(piece))
+                    continue
+                declared = re.match(
+                    r"(?:\*\*?|&)?\s*(?P<name>[a-z_]\w*)\b", piece
+                )
+                if declared is not None:
+                    names.add(declared.group("name"))
+        return names
+
+    def do_block_end(opening_end: int) -> int:
+        """Match a Ruby ``do`` with its structurally corresponding ``end``."""
+
+        depth = 1
+        boundaries = list(re.finditer(r"[;\r\n]", code[opening_end:]))
+        start = opening_end
+        pieces: list[tuple[int, int]] = []
+        for boundary in boundaries:
+            end = opening_end + boundary.start()
+            pieces.append((start, end))
+            start = opening_end + boundary.end()
+        pieces.append((start, len(code)))
+        for statement_start, statement_end in pieces:
+            stripped = code[statement_start:statement_end].strip()
+            if not stripped:
+                continue
+            if re.match(r"end\b", stripped):
+                depth -= 1
+                if depth == 0:
+                    return statement_end
+                continue
+            if (
+                re.match(
+                    r"(?:def|class|module|if|unless|case|begin|for|while|until)\b",
+                    stripped,
+                )
+                or re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped)
+            ):
+                depth += 1
+        return len(code)
+
+    # Identify block parameter lists before ordinary assignments: a default
+    # such as `|item = fallback|` binds only `item` inside the block and must
+    # not invent either name as an outer local.
+    pipe_spans = [
+        (match.start(), match.end(), parameter_names(match.group("params")))
+        for match in re.finditer(r"\|(?P<params>[^|\r\n]*)\|", code)
+    ]
+    block_bindings: list[tuple[int, int, set[str], tuple[int, int] | None]] = []
+    for pipe_start, pipe_end, names in pipe_spans:
+        if not names:
+            continue
+        prefix_start = max(0, pipe_start - 120)
+        prefix = code[prefix_start:pipe_start]
+        brace = prefix.rfind("{")
+        if brace >= 0:
+            opening = prefix_start + brace
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is not None:
+                block_bindings.append((pipe_end, closing, names, owner(pipe_start)))
+                continue
+        do_match = re.search(r"\bdo\s*$", prefix)
+        if do_match is not None:
+            opening_end = prefix_start + do_match.end()
+            closing = do_block_end(opening_end)
+            block_bindings.append((pipe_end, closing, names, owner(pipe_start)))
+
+    bindings: dict[tuple[tuple[int, int] | None, str], list[int]] = {}
+
+    def bind(name: str, offset: int) -> None:
+        if not re.fullmatch(r"[a-z_]\w*", name):
+            return
+        bindings.setdefault((owner(offset), name), []).append(offset)
+
+    # Simple and compound assignments establish a Ruby local from that point
+    # onward.  Strings/comments/heredoc bodies are blank in ``code``, so text
+    # that merely resembles an assignment cannot leak a binding into code.
+    assignment = re.compile(
+        r"(?<![\w@$.])([a-z_]\w*)\s*"
+        r"(?:\|\|=|&&=|<<=|>>=|\*\*=|[+\-*/%&|^]=|=(?!=|>))"
+    )
+    for match in assignment.finditer(code):
+        if any(start <= match.start() < end for start, end, _ in pipe_spans):
+            continue
+        if any(
+            start <= match.start() < end and match.group(1) in names
+            for start, end, names, _ in block_bindings
+        ):
+            continue
+        bind(match.group(1), match.start(1))
+
+    # Multiple assignment binds every bare local on its left side, not just
+    # the identifier adjacent to ``=``.
+    for match in re.finditer(
+        r"(?:^|[;\r\n])\s*"
+        r"(?P<lhs>[a-z_]\w*(?:\s*,\s*[a-z_]\w*)+)\s*=(?!=|>)",
+        code,
+        re.M,
+    ):
+        for name in re.findall(r"[a-z_]\w*", match.group("lhs")):
+            if any(
+                start <= match.start("lhs") < end
+                for start, end, _ in pipe_spans
+            ):
+                continue
+            if any(
+                start <= match.start("lhs") < end and name in names
+                for start, end, names, _ in block_bindings
+            ):
+                continue
+            bind(name, match.start("lhs"))
+
+    # Method parameters are local for the whole method body.  Their binding
+    # position is the method opener so a shift in an endless method expression
+    # is covered too.
+    for start, end in spans:
+        method = re.match(
+            r"\s*(?:(?:private|protected|public)\s+)?def\s+"
+            r"(?:self\s*\.\s*)?(?:\[\]=?|[A-Za-z_]\w*[!?=]?)",
+            code[start:end],
+        )
+        if method is None:
+            continue
+        params_start = start + method.end()
+        while params_start < end and code[params_start] in " \t":
+            params_start += 1
+        if params_start < end and code[params_start] == "(":
+            params_end = matching_delimiter(code, params_start, "(", ")")
+            if params_end is None:
+                continue
+            parameters = code[params_start + 1:params_end]
+        else:
+            ends = [
+                position
+                for position in (
+                    code.find("\n", params_start, end),
+                    code.find(";", params_start, end),
+                )
+                if position >= 0
+            ]
+            params_end = min(ends) if ends else end
+            parameters = code[params_start:params_end]
+        for name in parameter_names(parameters):
+            bind(name, start)
+
+    for positions in bindings.values():
+        positions.sort()
+
+    shifts: set[int] = set()
+    for candidate in re.finditer(r"<<", code):
+        index = candidate.start()
+        opener = _RUBY_HEREDOC_OPENER_RE.match(source, index)
+        if opener is None:
+            continue
+        cursor = index - 1
+        if cursor < 0 or code[cursor] not in " \t":
+            continue
+        while cursor >= 0 and code[cursor] in " \t":
+            cursor -= 1
+        word_end = cursor + 1
+        while cursor >= 0 and (code[cursor].isalnum() or code[cursor] == "_"):
+            cursor -= 1
+        name = code[cursor + 1:word_end]
+        if re.fullmatch(r"[a-z_]\w*", name) is None:
+            continue
+        scope = owner(index)
+        positions = bindings.get((scope, name), [])
+        insertion = bisect.bisect_left(positions, index)
+        if insertion and positions[insertion - 1] < index:
+            shifts.add(index)
+            continue
+        if any(
+            start <= index < end and block_owner == scope and name in names
+            for start, end, names, block_owner in block_bindings
+        ):
+            shifts.add(index)
+    return frozenset(shifts)
+
+
+def _lex_source_once(
+    source: str,
+    suffix: str,
+    dialect: str = "",
+    ruby_shift_offsets: frozenset[int] = frozenset(),
+) -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
     code = list(source)
@@ -2472,17 +3143,31 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         # Heredoc bodies are DATA, not code. They were lexed as code, so an
         # apostrophe inside one ("Don't edit by hand") paired with a later quote
         # and masked the send that followed.
-        heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
-        if heredoc is not None:
-            body_start = source.find("\n", heredoc.end())
+        openers: list["re.Match[str]"] = []
+        if suffix == ".rb":
+            if index not in ruby_shift_offsets:
+                openers = _ruby_heredoc_openers_at(source, index)
+        elif _heredoc_langs(suffix):
+            heredoc = _heredoc_opener_at(source, index, suffix)
+            if heredoc is not None:
+                openers = [heredoc]
+        if openers:
+            body_start = source.find("\n", openers[0].end())
             if body_start < 0:
-                index = heredoc.end()
+                index = openers[-1].end()
                 continue
             body_start += 1
-            openers = [heredoc]
             for opener in openers:
-                tag = opener.group("tag")
-                terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
+                if suffix == ".rb":
+                    tag = _ruby_heredoc_tag(opener)
+                    indentation = opener.group("indent")
+                    line_prefix = r"^[ \t]*" if indentation in {"-", "~"} else "^"
+                    terminator_pattern = (
+                        rf"{line_prefix}{re.escape(tag)}(?=\r?$)"
+                    )
+                else:
+                    tag = opener.group("tag")
+                    terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
                 terminator = re.compile(terminator_pattern, re.M).search(
                     source, body_start
                 )
@@ -2491,7 +3176,7 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 )
                 _blank(code, body_start, body_end)
                 _blank(without_comments, body_start, body_end)
-                if suffix == ".rb" and opener.group("q") != "'":
+                if suffix == ".rb" and _ruby_heredoc_quote(opener) != "'":
                     for expression_start, expression_end in _ruby_interpolation_ranges(
                         source, body_start, body_end
                     ):
@@ -2775,6 +3460,24 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
             last_js_opaque_end = index
 
     return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
+
+
+def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
+    """Mask comments/strings, resolving Ruby's binding-sensitive ``<<``."""
+
+    if suffix != ".rb":
+        return _lex_source_once(source, suffix, dialect)
+
+    ruby_shift_offsets: frozenset[int] = frozenset()
+    while True:
+        lexed = _lex_source_once(
+            source, suffix, dialect, ruby_shift_offsets
+        )
+        discovered = _ruby_bound_shift_offsets(source, lexed.code)
+        combined = ruby_shift_offsets | discovered
+        if combined == ruby_shift_offsets:
+            return lexed
+        ruby_shift_offsets = combined
 
 
 def matching_delimiter(code: str, opening: int, left: str, right: str) -> int | None:
@@ -4089,6 +4792,10 @@ def payload_spans(
             # the argument list this region covers.
             spans.append(arguments[-1])
         return spans
+    if suffix == ".cs" and mode == "body":
+        # Twilio's MessageResource.Create uses independent named arguments;
+        # `body:` is commonly the third argument, not an object in argument 0.
+        return [(start, end)]
     return arguments[:1]
 
 
@@ -4876,6 +5583,13 @@ def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
                 r"(?:if|unless|case|begin|for|while|until)\b", stripped
             ):
                 stack.append(("control", None))
+    # A provisional heredoc pass can mask the `end` belonging to a method whose
+    # body contains a binding-sensitive shift. Retain such open named scopes to
+    # EOF so the repair pass can still associate parameters and assignments
+    # with the correct method rather than dropping the scope entirely.
+    for kind, opener_start in stack:
+        if kind in {"def", "class", "module"} and opener_start is not None:
+            spans.append((opener_start, len(code)))
     return spans
 
 
@@ -13827,6 +14541,92 @@ def call_belongs_to_kept_product(
     )
 
 
+def csharp_twilio_message_calls(
+    lexed: LexedSource, source: SourceEndpointResolver | None = None
+) -> list[Call]:
+    return csharp_twilio_resource_calls(
+        lexed, "Twilio.Rest.Api.V2010.Account.MessageResource", ("Create",), source
+    )
+
+
+def csharp_twilio_resource_calls(
+    lexed: LexedSource, target: str, methods: tuple[str, ...],
+    source: SourceEndpointResolver | None = None,
+) -> list[Call]:
+    """Resolve the SDK resource's C# using/alias forms before checking its body.
+
+    Generic class names are not sufficient ownership evidence. Keep imports
+    scoped to their namespace and let local types shadow namespace imports.
+    """
+    code = lexed.code
+    namespaces = _csharp_namespace_spans(code)
+    types = _csharp_type_spans(code)
+    source = source or SourceEndpointResolver(lexed, ".cs")
+
+    def namespace_at(offset: int) -> tuple[int, int, str] | None:
+        return max((span for span in namespaces if span[0] < offset < span[1]),
+                   key=lambda span: span[0], default=None)
+
+    imports = []
+    for match in re.finditer(
+        r"\b(?:global\s+)?using\s+(?:(?P<static>static)\s+)?"
+        r"(?:(?P<alias>\w+)\s*=\s*)?(?:global\s*::\s*)?"
+        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;", code
+    ):
+        imports.append((match, re.sub(r"\s+", "", match.group("target")),
+                        namespace_at(match.start())))
+    candidates = calls_matching(lexed, re.compile(
+        r"(?<![\w$.])(?:global\s*::\s*)?(?:\w+\s*\.\s*)*(?:"
+        + "|".join(re.escape(method) for method in methods) + r")\s*\("
+    ))
+    result = []
+    for call in candidates:
+        head = re.sub(r"\s+", "", code[call.start:call.open_paren])
+        receiver = head.rsplit(".", 1)[0] if "." in head else ""
+        if receiver.startswith("global::"):
+            if receiver.removeprefix("global::") == target:
+                result.append(call)
+            continue
+        visible = [(match, name) for match, name, scope in imports
+                   if scope is None or scope[0] < call.start < scope[1]]
+        aliases = {match.group("alias"): name for match, name in visible
+                   if match.group("alias")}
+        first, dot, rest = receiver.partition(".")
+        binding_id = source.graph.visible_binding(
+            first, source.scope_at(call.start), call.start
+        ) if first else None
+        if binding_id is not None:
+            declaration = source.graph.bindings[binding_id].declaration_start
+            if (scope_contains(code, declaration, call.start)
+                    and not any(match.start() <= declaration < match.end()
+                                for match, _, _ in imports)):
+                # Local variables, parameters and fields beat a using alias.
+                # Reuse the normal scope index so an unrelated method/block
+                # cannot hide the SDK receiver here.
+                continue
+        expanded = aliases.get(first, first) + (dot + rest if dot else "")
+        if expanded == target:
+            result.append(call)
+            continue
+        # A same-namespace or enclosing type declaration takes precedence over
+        # imported namespace members, even when declared after the use.
+        local = any(name == first and (
+            opening < call.start < closing
+            or namespace_at(opening) == namespace_at(call.start)
+        ) for opening, closing, name in types)
+        if local or first in aliases:
+            continue
+        if receiver == target.rsplit(".", 1)[-1] and any(
+            not match.group("alias") and not match.group("static")
+            and name == target.rsplit(".", 1)[0] for match, name in visible
+        ):
+            result.append(call)
+        elif not receiver and any(match.group("static") and name == target
+                                  for match, name in visible):
+            result.append(call)
+    return result
+
+
 def message_body_fields(
     path: Path, pattern: re.Pattern[str], kept_products: set[str] | None = None
 ) -> list[str]:
@@ -13845,7 +14645,15 @@ def message_body_fields(
         source=source_resolver,
     )
     matches: list[str] = []
-    for call in calls_matching(lexed, pattern):
+    # Ownership applies only to the ambiguous C# resource class, not to the
+    # existing generic Messages.Send / messages.create body-check families.
+    calls = [call for call in calls_matching(lexed, pattern)
+             if not re.search(r"\bMessageResource\s*\.\s*Create\s*$",
+                              lexed.code[call.start:call.open_paren])]
+    if suffix == ".cs":
+        calls.extend(csharp_twilio_message_calls(lexed, source_resolver))
+    calls = list({call.open_paren: call for call in calls}.values())
+    for call in calls:
         if call_belongs_to_kept_product(
             lexed, call, kept_products or set(), pattern
         ):

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -6473,6 +6473,12 @@ class SourceEndpointResolver:
         self.suffix = suffix
         self.external_values = external_values or {}
         self.external_names = external_names or set()
+        self.csharp_namespace_spans = (
+            _csharp_namespace_spans(lexed.original) if suffix == ".cs" else []
+        )
+        self.csharp_type_spans = (
+            _csharp_type_spans(lexed.original) if suffix == ".cs" else []
+        )
         self.unverified_external_calls: set[int] = set()
         self.graph = EndpointGraph(len(lexed.code))
         self.c_headers = c_function_headers(lexed, suffix)
@@ -8107,7 +8113,14 @@ class SourceEndpointResolver:
         if access is not None:
             return access
 
-        reference = static_reference_expression(self.lexed, start, end)
+        reference_start = start
+        if self.suffix == ".cs":
+            global_prefix = re.match(
+                r"\s*global\s*::\s*", self.lexed.original[start:end]
+            )
+            if global_prefix is not None:
+                reference_start += global_prefix.end()
+        reference = static_reference_expression(self.lexed, reference_start, end)
         if reference is not None:
             name = reference[0].lstrip("$")
             binding_id = self.graph.visible_binding(
@@ -8432,11 +8445,45 @@ class SourceEndpointResolver:
         # per-file binding graph. Keeping module provenance explicit avoids
         # conflating same-named locals and makes the cross-file boundary the
         # only special case; all endpoint classification remains shared.
-        expression_text = self.lexed.code[start:end].strip()
-        if not projection and re.fullmatch(r"[A-Za-z_$]\w*", expression_text):
-            external = self.external_values.get(expression_text.lstrip("$"))
-            if external is not None:
-                return endpoint_literal_value(external)
+        reference_start = start
+        if self.suffix == ".cs":
+            global_prefix = re.match(
+                r"\s*global\s*::\s*", self.lexed.original[start:end]
+            )
+            if global_prefix is not None:
+                reference_start += global_prefix.end()
+        reference = static_reference_expression(self.lexed, reference_start, end)
+        if not projection and reference is not None:
+            reference_key = ".".join(
+                part.lstrip("$") for part in reference
+            )
+            scope_id = self.scope_at(before)
+            if self.suffix == ".cs" and self.graph.visible_binding(
+                reference[0].lstrip("$"), scope_id, before
+            ) is not None:
+                expression = self._parse_expression(
+                    start, end, scope_id, before
+                )
+                return self.graph.evaluate(
+                    EndpointExpressionState(
+                        expression, projection, before, scope_id
+                    )
+                )
+            candidates = (
+                _csharp_reference_candidates(
+                    before,
+                    reference_key,
+                    self.csharp_namespace_spans,
+                    self.csharp_type_spans,
+                    global_only=global_prefix is not None,
+                )
+                if self.suffix == ".cs"
+                else (reference_key,)
+            )
+            for candidate in candidates:
+                external = self.external_values.get(candidate)
+                if external is not None:
+                    return endpoint_literal_value(external)
         scope_id = self.scope_at(before)
         expression = self._parse_expression(
             start, end, scope_id, before
@@ -11804,7 +11851,9 @@ def _looks_like_a_send_target(
         r"|\b(?:public|private|protected|internal)[ \t]+const"
         r"|\b(?:public|private|protected|internal)?[ \t]*static[ \t]+readonly)"
         r"[ \t]+[A-Za-z_$][\w$<>,.?\[\]]*[ \t]+"
-        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*$",
+        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*"
+        r"(?:new[ \t]*(?:(?:System[ \t]*\.[ \t]*)?Uri[ \t]*)?"
+        r"\([ \t]*)?@?[ \t]*$",
         declaration,
         re.I,
     ) and _SEND_SITE_RE.search(declaration) is None:
@@ -12072,8 +12121,233 @@ def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
     return assignment.group("value") if assignment is not None else None
 
 
+def _python_from_imports(visible: str) -> list[tuple[str, str, str]]:
+    """Return ``(module, exported, local)`` for logical Python imports.
+
+    Python permits a parenthesized member list to span physical lines, and a
+    backslash can continue the unparenthesized form. Parse the bounded logical
+    statement once and share it between exact local-module resolution and the
+    fail-closed external-provenance index so those two contracts cannot drift.
+    """
+
+    imports: list[tuple[str, str, str]] = []
+    header = re.compile(
+        r"(?m)(?:^|;)[ \t]*from[ \t]+"
+        r"(?P<module>\.*(?:[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)?)"
+        r"[ \t]+import[ \t]*"
+    )
+    for match in header.finditer(visible):
+        module = match.group("module")
+        if not module:
+            continue
+        start = match.end()
+        while start < len(visible) and visible[start] in " \t":
+            start += 1
+        if start < len(visible) and visible[start] == "(":
+            closing = matching_delimiter(visible, start, "(", ")")
+            if closing is None:
+                continue
+            members = visible[start + 1 : closing]
+        else:
+            end = start
+            while end < len(visible):
+                line_break = re.search(r"\r\n|\r|\n", visible[end:])
+                if line_break is None:
+                    end = len(visible)
+                    break
+                line_end = end + line_break.start()
+                semicolon = visible.find(";", end, line_end)
+                if semicolon >= 0:
+                    end = semicolon
+                    break
+                if visible[start:line_end].rstrip().endswith("\\"):
+                    end += line_break.end()
+                    continue
+                end = line_end
+                break
+            members = re.sub(r"\\(?:\r\n|\r|\n)", " ", visible[start:end])
+        for member in members.split(","):
+            parsed = re.fullmatch(
+                r"\s*(?P<export>[A-Za-z_]\w*)"
+                r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
+                member,
+            )
+            if parsed is not None:
+                imports.append(
+                    (
+                        module,
+                        parsed.group("export"),
+                        parsed.group("local") or parsed.group("export"),
+                    )
+                )
+    return imports
+
+
+def _csharp_namespace_spans(source: str) -> list[tuple[int, int, str]]:
+    """Return namespace scopes with their fully qualified names."""
+
+    code = lex_source(source, ".cs").code
+    raw: list[tuple[int, int, str]] = []
+    for match in re.finditer(
+        r"\bnamespace\s+(?P<name>[A-Za-z_]\w*"
+        r"(?:\s*\.\s*[A-Za-z_]\w*)*)\s*(?P<kind>;|\{)",
+        code,
+    ):
+        name = re.sub(r"\s+", "", match.group("name"))
+        if match.group("kind") == ";":
+            raw.append((match.end(), len(code), name))
+            continue
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is not None:
+            raw.append((opening, closing, name))
+
+    qualified: list[tuple[int, int, str]] = []
+    for start, end, name in sorted(raw, key=lambda item: (item[0], -item[1])):
+        parents = [
+            span for span in qualified if span[0] < start and end < span[1]
+        ]
+        parent = max(parents, key=lambda span: span[0], default=None)
+        full_name = f"{parent[2]}.{name}" if parent is not None else name
+        qualified.append((start, end, full_name))
+    return qualified
+
+
+def _csharp_static_scalars(source: str) -> dict[str, str]:
+    """Return fully qualified, statically addressable C# scalar members."""
+
+    lexed = lex_source(source, ".cs")
+    code = lexed.code
+    type_spans = _csharp_type_spans(source)
+
+    values: dict[str, str] = {}
+    namespace_spans = _csharp_namespace_spans(source)
+    for token in lexed.strings:
+        enclosing = sorted(
+            (span for span in type_spans if span[0] < token.start < span[1]),
+            key=lambda span: span[0],
+        )
+        if not enclosing:
+            continue
+        innermost = enclosing[-1]
+        # Type fields are at curly depth zero. A static readonly Uri keeps the
+        # string inside its constructor parentheses, so round depth is allowed.
+        if structural_depth(code, innermost[0] + 1, token.start)[2] != 0:
+            continue
+        declaration_start = max(
+            code.rfind(";", innermost[0] + 1, token.start),
+            code.rfind("{", innermost[0] + 1, token.start),
+            code.rfind("}", innermost[0] + 1, token.start),
+        ) + 1
+        prefix = code[declaration_start:token.start]
+        field = re.search(
+            r"(?P<head>.*?)\b(?P<name>[A-Za-z_]\w*)\s*=\s*"
+            r"(?:new\s*(?:(?:System\s*\.\s*)?Uri\s*)?\(\s*)?@?$",
+            prefix,
+            re.DOTALL,
+        )
+        if field is None:
+            continue
+        modifiers = field.group("head")
+        if not (
+            re.search(r"\bconst\b", modifiers)
+            or (
+                re.search(r"\bstatic\b", modifiers)
+                and re.search(r"\breadonly\b", modifiers)
+            )
+        ):
+            continue
+        type_path = ".".join(span[2] for span in enclosing)
+        namespaces = [
+            span for span in namespace_spans if span[0] < token.start < span[1]
+        ]
+        namespace = max(namespaces, key=lambda span: span[0], default=None)
+        prefix = f"{namespace[2]}." if namespace is not None else ""
+        values[f"{prefix}{type_path}.{field.group('name')}"] = token.contents
+    return values
+
+
+def _csharp_type_spans(source: str) -> list[tuple[int, int, str]]:
+    """Return nested C# type scopes as ``(open, close, local_name)``."""
+
+    code = lex_source(source, ".cs").code
+    type_spans: list[tuple[int, int, str]] = []
+    for match in re.finditer(
+        r"\b(?:class|struct|record(?:\s+class|\s+struct)?)\s+"
+        r"(?P<name>[A-Za-z_]\w*)[^;{}]*\{",
+        code,
+    ):
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is not None:
+            type_spans.append((opening, closing, match.group("name")))
+    return type_spans
+
+
+def _csharp_project_static_index(project_root: Path) -> dict[str, str]:
+    """Build one exact C# static-member index for an analyzer invocation."""
+
+    resolved: dict[str, str] = {}
+    for candidate in project_root.rglob("*.cs"):
+        try:
+            relative = candidate.relative_to(project_root)
+        except ValueError:
+            continue
+        if any(part in EXCLUDED_DIRS for part in relative.parts[:-1]):
+            continue
+        candidate_source = _read_source_text(candidate)
+        resolved.update(_csharp_static_scalars(candidate_source))
+    return resolved
+
+
+def _csharp_reference_candidates(
+    position: int,
+    reference: str,
+    namespace_spans: list[tuple[int, int, str]],
+    type_spans: list[tuple[int, int, str]],
+    *,
+    global_only: bool = False,
+) -> tuple[str, ...]:
+    """Return C# member spellings from nearest lexical scope to global."""
+
+    if global_only:
+        return (reference,)
+    candidates: list[str] = []
+    namespaces = [
+        span
+        for span in namespace_spans
+        if span[0] < position < span[1]
+    ]
+    namespace = max(namespaces, key=lambda span: span[0], default=None)
+    namespace_name = namespace[2] if namespace is not None else ""
+    enclosing_types = sorted(
+        (
+            span
+            for span in type_spans
+            if span[0] < position < span[1]
+        ),
+        key=lambda span: span[0],
+    )
+    for count in range(len(enclosing_types), 0, -1):
+        prefix = ".".join(span[2] for span in enclosing_types[:count])
+        candidates.append(
+            ".".join(part for part in (namespace_name, prefix, reference) if part)
+        )
+    namespace_parts = namespace_name.split(".") if namespace_name else []
+    for count in range(len(namespace_parts), 0, -1):
+        candidates.append(
+            f"{'.'.join(namespace_parts[:count])}.{reference}"
+        )
+    candidates.append(reference)
+    return tuple(dict.fromkeys(candidates))
+
+
 def external_static_values(
-    path: Path, project_root: Path, source: str, suffix: str
+    path: Path,
+    project_root: Path,
+    source: str,
+    suffix: str,
+    csharp_project_values: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Resolve relative named imports to statically exported scalar strings.
 
@@ -12147,28 +12421,26 @@ def external_static_values(
                         )
                     )
     elif suffix == ".py":
-        for match in re.finditer(
-            r"(?m)^\s*from\s+(?P<module>\.*[A-Za-z_][\w.]*)\s+import\s+"
-            r"(?P<members>[^\r\n]+)",
-            visible,
+        for module, exported, local in _python_from_imports(
+            lex_source(source, ".py").code
         ):
-            for member in match.group("members").split(","):
-                parsed = re.fullmatch(
-                    r"\s*(?P<export>[A-Za-z_]\w*)"
-                    r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
-                    member,
+            dots = len(module) - len(module.lstrip("."))
+            module_tail = module[dots:].replace(".", "/")
+            relative = "../" * max(0, dots - 1) + module_tail
+            imports.append(
+                (
+                    "./" + relative if dots else module,
+                    exported,
+                    local,
                 )
-                if parsed is not None:
-                    dots = len(match.group("module")) - len(match.group("module").lstrip("."))
-                    module_tail = match.group("module")[dots:].replace(".", "/")
-                    relative = "../" * max(0, dots - 1) + module_tail
-                    imports.append(
-                        (
-                            "./" + relative if dots else match.group("module"),
-                            parsed.group("export"),
-                            parsed.group("local") or parsed.group("export"),
-                        )
-                    )
+            )
+    elif suffix == ".cs":
+        project_values = (
+            csharp_project_values
+            if csharp_project_values is not None
+            else _csharp_project_static_index(project_root)
+        )
+        return project_values
 
     resolved: dict[str, str] = {}
     for module, exported, local in imports:
@@ -12310,14 +12582,12 @@ def external_reference_names(
                 if parsed is not None:
                     names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
     elif suffix == ".py":
-        for match in re.finditer(r"(?m)^\s*from\s+[\w.]+\s+import\s+([^\r\n]+)", visible):
-            for member in match.group(1).split(","):
-                parsed = re.fullmatch(
-                    r"\s*([A-Za-z_]\w*)(?:\s+as\s+([A-Za-z_]\w*))?\s*",
-                    member,
-                )
-                if parsed is not None:
-                    names.add(parsed.group(2) or parsed.group(1))
+        names.update(
+            local
+            for _, _, local in _python_from_imports(
+                lex_source(source, ".py").code
+            )
+        )
         for match in re.finditer(
             r"(?m)^\s*import\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)"
             r"(?:\s+as\s+([A-Za-z_]\w*))?",
@@ -12353,7 +12623,11 @@ def external_reference_names(
     return names
 
 
-def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
+def analyze_file(
+    path: Path,
+    project_root: Path,
+    csharp_project_values: dict[str, str] | None = None,
+) -> tuple[int, list[str]]:
     # newline="" is required: Path.read_text() performs universal-newline
     # translation, destroying bare-CR and CRLF source boundaries before the
     # lexer and grep-line protocol can agree on them.
@@ -12382,7 +12656,13 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source_resolver = SourceEndpointResolver(
         lexed,
         suffix,
-        external_static_values(path, project_root, source, suffix),
+        external_static_values(
+            path,
+            project_root,
+            source,
+            suffix,
+            csharp_project_values,
+        ),
         external_reference_names(source, suffix, project_root),
     )
     profile_resolver = PayloadStateResolver(
@@ -12651,9 +12931,12 @@ def main(argv: list[str]) -> int:
 
     total = 0
     missing: list[str] = []
+    csharp_project_values = _csharp_project_static_index(project_root)
     for path in iter_source_files(project_root):
         try:
-            file_total, file_missing = analyze_file(path, project_root)
+            file_total, file_missing = analyze_file(
+                path, project_root, csharp_project_values
+            )
         except Exception as error:  # noqa: BLE001 - one file must not abort the scan
             # A pathological file previously took the WHOLE run down, so every
             # other file went unanalysed and the project was reported clean.

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1007,6 +1007,162 @@ def _heredoc_langs(suffix: str) -> bool:
     return suffix in {".sh", ".php", ".rb"}
 
 
+_JS_REGEX_PREFIX_WORDS = {
+    "await",
+    "break",
+    "case",
+    "continue",
+    "debugger",
+    "delete",
+    "do",
+    "else",
+    "in",
+    "instanceof",
+    "new",
+    "of",
+    "return",
+    "throw",
+    "typeof",
+    "void",
+    "yield",
+}
+_JS_CONTROL_PAREN_WORDS = {"catch", "for", "if", "switch", "while", "with"}
+
+
+def _previous_code_index(code: list[str], before: int) -> int | None:
+    for index in range(before - 1, -1, -1):
+        if not code[index].isspace():
+            return index
+    return None
+
+
+def _word_before(code: list[str], before: int) -> str:
+    end = before
+    start = end
+    while start > 0 and (code[start - 1].isalnum() or code[start - 1] in "_$"):
+        start -= 1
+    return "".join(code[start:end])
+
+
+def _javascript_control_paren(code: list[str], closing: int) -> bool:
+    """Whether `closing` ends a control header after which a statement starts."""
+
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == ")":
+            depth += 1
+        elif code[index] == "(":
+            depth -= 1
+            if depth == 0:
+                previous = _previous_code_index(code, index)
+                return (
+                    previous is not None
+                    and _word_before(code, previous + 1).lower()
+                    in _JS_CONTROL_PAREN_WORDS
+                )
+    return False
+
+
+def _javascript_block_brace(code: list[str], closing: int) -> bool:
+    """Conservatively identify a closing statement/class/function block."""
+
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == "}":
+            depth += 1
+        elif code[index] == "{":
+            depth -= 1
+            if depth != 0:
+                continue
+            previous = _previous_code_index(code, index)
+            if previous is None:
+                return True
+            if code[previous] == ")":
+                return True
+            if code[previous] == ">" and previous > 0 and code[previous - 1] == "=":
+                return True
+            return _word_before(code, previous + 1).lower() in {
+                "class",
+                "do",
+                "else",
+                "finally",
+                "function",
+                "try",
+            }
+    return False
+
+
+def _javascript_regex_can_start(
+    source: str, code: list[str], index: int, last_opaque_end: int
+) -> bool:
+    """Approximate ECMAScript's regexp lexical goal from the preceding token.
+
+    JavaScript uses the same slash for division and regexp literals. The
+    distinction is grammatical: a regexp can begin where an expression is
+    expected, but not after an operand. `code` already has earlier comments and
+    literals blanked, while `last_opaque_end` prevents a preceding string,
+    template, or regexp operand from disappearing from that decision.
+    """
+
+    previous = _previous_code_index(code, index)
+    if last_opaque_end and (previous is None or previous < last_opaque_end):
+        if all(character.isspace() for character in code[last_opaque_end:index]):
+            return False
+    if previous is None:
+        return True
+
+    character = code[previous]
+    if (
+        character == "<"
+        and previous == index - 1
+        and index + 1 < len(source)
+        and (source[index + 1].isalpha() or source[index + 1] in "_$>")
+    ):
+        # JSX closing tags (`</Panel>` and `</>`) are markup delimiters, not a
+        # regexp in the expression position that `<` would otherwise permit.
+        return False
+    if character in "([,;:=!?&|^~<>*%":
+        return True
+    if character in "+-":
+        return previous == 0 or code[previous - 1] != character
+    if character == ")":
+        return _javascript_control_paren(code, previous)
+    if character == "}":
+        return _javascript_block_brace(code, previous)
+    if character.isalnum() or character in "_$":
+        return _word_before(code, previous + 1).lower() in _JS_REGEX_PREFIX_WORDS
+    return False
+
+
+def _javascript_regex_end(source: str, start: int) -> int | None:
+    """Return the end of a valid-looking JS regexp literal, including flags."""
+
+    if source.startswith(("//", "/*"), start):
+        return None
+    index = start + 1
+    in_class = False
+    while index < len(source):
+        character = source[index]
+        if character in {"\r", "\n", "\u2028", "\u2029"}:
+            return None
+        if character == "\\":
+            index += 2
+            continue
+        if character == "[":
+            in_class = True
+        elif character == "]" and in_class:
+            in_class = False
+        elif character == "/" and not in_class:
+            index += 1
+            while index < len(source) and (
+                source[index].isalpha() or source[index] in "_$"
+            ):
+                index += 1
+            return index
+        index += 1
+    return None
+
+
 def lex_source(source: str, suffix: str) -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
@@ -1017,8 +1173,24 @@ def lex_source(source: str, suffix: str) -> LexedSource:
     c_block_comments = c_line_comments
     hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
     index = 0
+    last_js_opaque_end = 0
 
     while index < len(source):
+        if (
+            suffix in JS_TS_SUFFIXES
+            and source[index] == "/"
+            and _javascript_regex_can_start(
+                source, code, index, last_js_opaque_end
+            )
+        ):
+            regex_end = _javascript_regex_end(source, index)
+            if regex_end is not None:
+                _blank(code, index, regex_end)
+                _blank(without_comments, index, regex_end)
+                last_js_opaque_end = regex_end
+                index = regex_end
+                continue
+
         if c_block_comments and source.startswith("/*", index):
             end = source.find("*/", index + 2)
             end = len(source) if end < 0 else end + 2
@@ -1170,6 +1342,8 @@ def lex_source(source: str, suffix: str) -> LexedSource:
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
+        if suffix in JS_TS_SUFFIXES:
+            last_js_opaque_end = index
 
     return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -74,6 +74,8 @@ SUFFIX_LANGUAGE_ALIASES = {
     ".svelte": ".js",
     ".astro": ".js",
     ".erb": ".rb",
+    ".ejs": ".js",
+    ".jsp": ".java",
 }
 INCLUDED_SUFFIXES = {
     ".cs",
@@ -120,8 +122,281 @@ def canonical_suffix(path: Path) -> str:
     """Return the language suffix a file should be analysed as."""
     suffix = path.suffix.lower()
     if not suffix:
+        if path.name.lower() == "rakefile":
+            return ".rb"
         return shebang_suffix(path) or ""
+    # Component files can opt into TypeScript inside their script block. Keep
+    # that grammar mode: treating `as const` as JavaScript can make endpoint
+    # resolution fail while provenance still consumes the literal, silently
+    # certifying a required-profile send.
+    # Astro frontmatter is TypeScript-capable by default; JavaScript remains a
+    # valid subset, so using the TS grammar avoids consuming an endpoint literal
+    # while failing to resolve a legal `as const` alias.
+    if suffix == ".astro":
+        return ".ts"
+    if suffix in {".vue", ".svelte"}:
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            source = ""
+        if re.search(
+            r"<script\b[^>]*\blang\s*=\s*(?:(['\"])(?:ts|typescript)\1|(?:ts|typescript)(?=\s|>))",
+            source,
+            re.I,
+        ):
+            return ".ts"
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
+
+
+def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
+    """Preserve offsets/newlines while retaining only executable ranges."""
+    keep = bytearray(len(source))
+    for start, end in ranges:
+        keep[start:end] = b"\x01" * (end - start)
+    return "".join(
+        char if char in "\r\n" or keep[index] else " "
+        for index, char in enumerate(source)
+    )
+
+
+def _balanced_brace_ranges(source: str, openings: list[int]) -> list[tuple[int, int]]:
+    """Return quote-aware inner spans for balanced template expressions."""
+
+    ranges: list[tuple[int, int]] = []
+    for opening in openings:
+        depth = 0
+        quote = ""
+        escaped = False
+        for index in range(opening, len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+                continue
+            if character in {"'", '"', "`"}:
+                quote = character
+            elif character == "{":
+                depth += 1
+            elif character == "}":
+                depth -= 1
+                if depth == 0:
+                    ranges.append((opening + 1, index))
+                    break
+    return ranges
+
+
+def _balanced_parenthesis_ranges(
+    source: str, openings: list[int]
+) -> list[tuple[int, int]]:
+    """Return quote-aware inner spans for balanced parenthesized expressions."""
+
+    ranges: list[tuple[int, int]] = []
+    for opening in openings:
+        depth = 0
+        quote = ""
+        escaped = False
+        for index in range(opening, len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+                continue
+            if character in {"'", '"', "`"}:
+                quote = character
+            elif character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+                if depth == 0:
+                    ranges.append((opening + 1, index))
+                    break
+    return ranges
+
+
+def _javascript_template_expression_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable `${...}` spans inside one JavaScript template literal."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("${", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        probe = marker - 1
+        while probe >= start and source[probe] == "\\":
+            backslashes += 1
+            probe -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        balanced = _balanced_brace_ranges(source, [marker + 1])
+        if not balanced or balanced[0][1] > end:
+            break
+        ranges.append(balanced[0])
+        cursor = balanced[0][1] + 1
+    return ranges
+
+
+def executable_source(path: Path, source: str) -> str:
+    """Extract executable host-language regions from mixed template files."""
+    suffix = path.suffix.lower()
+    ranges: list[tuple[int, int]] = []
+    if suffix in {".vue", ".svelte", ".astro"}:
+        # Comments may contain complete, syntactically valid examples. Preserve
+        # their offsets/newlines but remove their contents before discovering
+        # script blocks, handlers, interpolations, or balanced expressions.
+        template_source = re.sub(
+            r"<!--.*?-->",
+            lambda match: "".join(
+                char if char in "\r\n" else " " for char in match.group(0)
+            ),
+            source,
+            flags=re.DOTALL,
+        )
+        ranges.extend(
+            match.span(1)
+            for match in re.finditer(
+                r"<script\b[^>]*>(.*?)</script\s*>", template_source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+        )
+        if suffix == ".astro":
+            frontmatter = re.match(
+                r"\A\s*---\s*\r?\n(.*?)\r?\n---(?:\s*\r?\n|\Z)",
+                template_source,
+                re.DOTALL,
+            )
+            if frontmatter:
+                ranges.append(frontmatter.span(1))
+        if suffix == ".vue":
+            ranges.extend(
+                match.span("expression")
+                for match in re.finditer(
+                    r"(?:v-on:[\w:-]+|@[\w:-]+)(?:\.[\w-]+)*\s*=\s*"
+                    r"(?P<quote>['\"])(?P<expression>.*?)(?P=quote)",
+                    template_source,
+                    re.DOTALL,
+                )
+            )
+            # Vue interpolations may contain nested object literals. A
+            # non-greedy regex leaves such calls unterminated; balance the
+            # entire double-brace region and retain its inner expression.
+            for opening in (
+                match.start() for match in re.finditer(r"\{\{", template_source)
+            ):
+                balanced = _balanced_brace_ranges(template_source, [opening])
+                if balanced:
+                    _, closing = balanced[0]
+                    ranges.append((opening + 2, closing - 1))
+        else:
+            # Svelte event handlers / expressions and Astro template
+            # expressions are executable JavaScript outside <script> too.
+            # Preserve their complete balanced spans, including nested payload
+            # objects, rather than stopping at the first closing brace.
+            expression_source = re.sub(
+                r"<style\b[^>]*>.*?</style\s*>",
+                lambda match: "".join(
+                    char if char in "\r\n" else " " for char in match.group(0)
+                ),
+                template_source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            openings = [
+                match.start()
+                for match in re.finditer(r"\{", expression_source)
+            ]
+            ranges.extend(_balanced_brace_ranges(expression_source, openings))
+    elif suffix == ".cshtml":
+        # Razor is a mixed HTML/C# template. Retain explicit expressions,
+        # statement/code blocks, and single-line directives while blanking page
+        # markup so text such as `<p>VoiceResponse()</p>` is not treated as C#.
+        brace_openings = [
+            match.end() - 1
+            for match in re.finditer(
+                r"(?<!@)@(?:\s*|(?:code|functions)\s*)\{",
+                source,
+                flags=re.IGNORECASE,
+            )
+        ]
+        brace_openings.extend(
+            match.end() - 1
+            for match in re.finditer(
+                r"(?<!@)@(?:if|for|foreach|while|switch|try|catch|finally|using|lock)\b[^{}]*\{",
+                source,
+                flags=re.IGNORECASE,
+            )
+        )
+        ranges.extend(_balanced_brace_ranges(source, brace_openings))
+        paren_openings = [
+            match.end() - 1
+            for match in re.finditer(r"(?<!@)@\s*\(", source)
+        ]
+        ranges.extend(_balanced_parenthesis_ranges(source, paren_openings))
+        ranges.extend(
+            match.span()
+            for match in re.finditer(
+                r"(?m)^\s*@(?:using|inject|model|inherits|implements|namespace|addTagHelper|removeTagHelper|tagHelperPrefix)\b[^\r\n]*",
+                source,
+            )
+        )
+    elif suffix == ".phtml":
+        # PHTML is a mixed HTML/PHP template, not a plain PHP source file.
+        # Feeding its markup to the PHP lexer lets an apostrophe in page text
+        # open a string that masks a later request inside <?php ... ?>.
+        ranges.extend(
+            match.span(1)
+            for match in re.finditer(
+                r"<\?(?:php\b|=)(.*?)(?:\?>|\Z)",
+                source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+        )
+    elif suffix in {".ejs", ".erb", ".jsp"}:
+        if suffix == ".ejs":
+            # EJS scriptlets execute on the server, while ordinary <script>
+            # blocks execute in the generated browser page. Both can contain
+            # migration-sensitive JavaScript and must remain visible.
+            ranges.extend(
+                match.span(1)
+                for match in re.finditer(
+                    r"<script\b[^>]*>(.*?)</script\s*>", source,
+                    flags=re.IGNORECASE | re.DOTALL,
+                )
+            )
+        for match in re.finditer(
+            r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL
+        ):
+            # ERB/EJS <%# ... %> and JSP <%-- ... --%> are template
+            # comments, not executable scriptlets.
+            if source.startswith(("<%#", "<%--"), match.start()):
+                continue
+            ranges.append(match.span(1))
+    else:
+        return source
+    return _blank_outside_ranges(source, ranges)
+
+
+def backend_executable_source(path: Path, source: str) -> str:
+    """Return executable regions that can declare server-side handlers."""
+    if path.suffix.lower() != ".ejs":
+        return executable_source(path, source)
+    ranges: list[tuple[int, int]] = []
+    for match in re.finditer(r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL):
+        if source.startswith("<%#", match.start()):
+            continue
+        ranges.append(match.span(1))
+    return _blank_outside_ranges(source, ranges)
 # Kept in step with the EXCLUDE_DIRS list in scan-twilio-usage.sh. Generated
 # output belongs here as much as node_modules: a stale compiled bundle under
 # .next carrying a pre-fix number-pool send would fail Phase 4 after the
@@ -612,6 +887,30 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         _blank(code, string_start, index)
+        if delimiter == "`" and suffix in JS_TS_SUFFIXES:
+            # JavaScript template literal text is inert, but every `${...}`
+            # interpolation is executable JavaScript. Recursively lex those
+            # spans and restore their code/comments at the original offsets.
+            # Nested string tokens are recorded before the enclosing template
+            # token so lookups inside an interpolation select the narrow token.
+            for expression_start, expression_end in _javascript_template_expression_ranges(
+                source, contents_start, contents_end
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
@@ -3517,13 +3816,20 @@ def client_base_url(lexed: LexedSource, call: Call, suffix: str) -> str | None:
             return base
 
     if receiver is None:
-        region = _paren_group_span_before_accessor(lexed, call)
-        return _base_url_in_region(lexed, region) if region is not None else None
+        # `axios.post(...)` has no client instance receiver. Use the dotted
+        # callee prefix so `axios.defaults.baseURL = ...` participates in the
+        # same member-assignment resolution as an axios instance.
+        prefix = re.split(r"->|::|\.", callee)[0] if "." in callee else ""
+        if prefix and re.fullmatch(r"[a-z_]\w*", prefix):
+            receiver = prefix
+        else:
+            region = _paren_group_span_before_accessor(lexed, call)
+            return _base_url_in_region(lexed, region) if region is not None else None
 
-    # C# commonly configures HttpClient in a separate member assignment:
-    # `client.BaseAddress = new Uri("..."); client.PostAsync(path, ...)`.
+    # C# and Axios both support assigning a base URL after construction.
     member_base_pattern = re.compile(
-        rf"\b{re.escape(receiver)}\s*\.\s*BaseAddress\s*="
+        rf"\b{re.escape(receiver)}\s*\.\s*"
+        rf"(?:BaseAddress|(?:defaults\s*\.\s*)?base[Uu][Rr][LlIi]?)\s*="
     )
     member_base = list(
         member_base_pattern.finditer(lexed.code, 0, call.start)
@@ -8787,7 +9093,7 @@ def iter_source_files(project_root: Path):
                 continue
             path = Path(directory, filename)
             suffix = path.suffix.lower()
-            if suffix in INCLUDED_SUFFIXES:
+            if suffix in INCLUDED_SUFFIXES or filename.lower() == "rakefile":
                 yield path
             elif not suffix and shebang_suffix(path) is not None:
                 yield path
@@ -9630,12 +9936,13 @@ def required_path_tokens(lexed: LexedSource) -> list[StringToken]:
         tail = token.contents.rstrip("/")
         if re.search(r"\s", tail):
             continue
-        if (
-            required_endpoint(token.contents)
-            or tail.endswith("messages/number_pool")
-            or tail.endswith("messages/alphanumeric_sender_id")
-            or re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
-        ):
+        template_endpoint = re.fullmatch(
+            r"(?:\$\{[^{}\s]+\}|#\{[^{}\s]+\}|\{[^{}\s]+\})"
+            r"(?:/v2)?/messages/(?:number_pool|alphanumeric_sender_id)/?"
+            r"(?:[?#][^\s]*)?",
+            tail,
+        )
+        if required_endpoint(token.contents) or template_endpoint:
             found.append(token)
     return found
 
@@ -9752,27 +10059,19 @@ def unresolved_endpoint_tokens(
     file either way.
     """
     consumed: set[tuple[int, int]] = set()
-    unexplained_calls = 0
     for call in analysed_calls:
         tokens = consumed_endpoint_tokens(lexed, call, suffix)
         if tokens:
             consumed |= tokens
-        else:
-            # The analyzer resolved this call's endpoint through a path this
-            # consumption model does not mirror - a destructuring default, an
-            # interprocedural alias, a computed member. It still ACCOUNTED for
-            # one endpoint, so it explains one otherwise-unconsumed literal.
-            # Budgeting them this way keeps two independent sends independent:
-            # a file with two endpoint literals and one resolved call still
-            # reports the second.
-            unexplained_calls += 1
     candidates = [
         token
         for token in required_path_tokens(lexed)
         if (token.start, token.end) not in consumed
         and _looks_like_a_send_target(lexed, token, suffix)
     ]
-    return candidates[unexplained_calls:] if unexplained_calls else candidates
+    # Never use one call as a positional "budget" for an unrelated literal.
+    # Only provenance from that exact call may consume a candidate endpoint.
+    return candidates
 
 
 # A required path can appear WITHOUT being a request target: as a curl -d body,
@@ -9855,6 +10154,14 @@ _NOT_A_CALL_VERB_RE = re.compile(
     r"|catch|except|with|return|and|or|not|in|is)$",
     re.I,
 )
+_READ_VERB_RE = re.compile(
+    r"^(?:get|head|options|read|download|list|find|query)(?:Async)?$", re.I
+)
+_ASSERTION_VERB_RE = re.compile(
+    r"^(?:expect|assert\w*|should|toBe|toEqual|toHaveBeenCalledWith"
+    r"|assertEqual|assertIn|is_expected)$",
+    re.I,
+)
 # A display STATEMENT has no parentheses to enclose the literal: `<?php echo
 # "$url"`, `then echo "$url"`.
 _DISPLAY_STATEMENT_RE = re.compile(
@@ -9870,6 +10177,30 @@ _CALLEE_SPLIT_RE = re.compile(r"\s*(?:->|::|\?\.|\.)\s*")
 _CALLEE_TAIL_RE = re.compile(
     r"[A-Za-z_$][\w$]*(?:\s*(?:->|::|\?\.|\.)\s*[A-Za-z_$][\w$]*)*$"
 )
+
+
+def _enclosing_call_verbs(lexed: LexedSource, position: int) -> list[str]:
+    """Return innermost-to-outermost unclosed call verbs at `position`."""
+
+    window_start = max(0, position - 600)
+    prefix = lexed.code[window_start:position]
+    depth = 0
+    verbs: list[str] = []
+    for index in range(len(prefix) - 1, -1, -1):
+        char = prefix[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth:
+                depth -= 1
+                continue
+            if char != "(":
+                continue
+            head = lexed.original[window_start:window_start + index].rstrip()
+            match = _CALLEE_TAIL_RE.search(head)
+            if match is not None:
+                verbs.append(_CALLEE_SPLIT_RE.split(match.group(0))[-1])
+    return verbs
 
 
 def _enclosing_call_verb(lexed: LexedSource, position: int) -> str:
@@ -9991,6 +10322,28 @@ def _looks_like_a_send_target(
             if _SEND_SITE_RE.search(line):
                 return True
         return False
+    # Use the lexical call enclosure before falling back to a physical line.
+    # A custom request call commonly wraps its URL onto the next line; limiting
+    # this check to the URL's line silently certified such unknown clients.
+    # The nearest call can be a helper nested inside an OUTER assertion, e.g.
+    # `assertTrue(required_endpoint(URL))`. Consider every enclosing call before
+    # treating the innermost unknown helper as a send.
+    if any(
+        _ASSERTION_VERB_RE.match(verb)
+        for verb in _enclosing_call_verbs(lexed, token.start)
+    ):
+        return False
+    enclosing_verb = _enclosing_call_verb(lexed, token.start)
+    if enclosing_verb:
+        if (
+            _DISPLAY_VERB_RE.match(enclosing_verb)
+            or _INSPECTION_VERB_RE.match(enclosing_verb)
+            or _NOT_A_CALL_VERB_RE.match(enclosing_verb)
+            or _READ_VERB_RE.match(enclosing_verb)
+            or _ASSERTION_VERB_RE.match(enclosing_verb)
+        ):
+            return False
+        return True
     # Otherwise require a request-like call on the same logical line, and NOT a
     # display command, which is how prose mentions reach the source.
     line_start = lexed.code.rfind("\n", 0, token.start) + 1
@@ -10045,6 +10398,7 @@ def _looks_like_a_send_target(
 
 def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = path.read_text(encoding="utf-8", errors="replace")
+    source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
     sdk_calls = calls_matching(lexed, SDK_CALL_RE)
@@ -10185,10 +10539,50 @@ def region_has_message_body(
     return False
 
 
-def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
+def call_belongs_to_kept_product(
+    lexed: LexedSource,
+    call: Call,
+    kept_products: set[str],
+    pattern: re.Pattern[str],
+) -> bool:
+    """Recognize product-qualified calls that intentionally remain on Twilio."""
+
+    call_head = lexed.code[call.start:call.open_paren]
+    # A retained Twilio Messaging client uses messages.create({body: ...}).
+    # Do not waive Telnyx-only messages.send({body: ...}) calls in the same
+    # hybrid file.
+    if pattern is MESSAGE_BODY_CALL_RE and "messaging" in kept_products and re.search(
+        r"\bcreate\s*$", call_head, re.IGNORECASE
+    ):
+        return True
+
+    if "conversations" not in kept_products and "conversation" not in kept_products:
+        return False
+
+    # Bind the waiver to the immediate receiver of `.messages`, not to any
+    # conversation-looking identifier earlier on the line. Preserve newlines
+    # inside a fluent `client.conversations(id)\n  .messages.create(...)` chain.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        lexed.code.rfind("{", 0, call.start),
+        lexed.code.rfind("}", 0, call.start),
+    ) + 1
+    receiver = lexed.code[statement_start:call.start].strip()
+    return bool(
+        re.search(r"(?:^|[^\w$])(?:conversation|channel)\s*$", receiver, re.I)
+        or re.search(
+            r"\.\s*conversations?\s*\([^;{}]*\)\s*$", receiver, re.I
+        )
+    )
+
+
+def message_body_fields(
+    path: Path, pattern: re.Pattern[str], kept_products: set[str] | None = None
+) -> list[str]:
     """Return real top-level body fields from selected messaging calls."""
 
     source = path.read_text(encoding="utf-8", errors="replace")
+    source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
     source_resolver = SourceEndpointResolver(lexed, suffix)
@@ -10201,6 +10595,10 @@ def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
     )
     matches: list[str] = []
     for call in calls_matching(lexed, pattern):
+        if call_belongs_to_kept_product(
+            lexed, call, kept_products or set(), pattern
+        ):
+            continue
         states = [
             resolver.span_presence(start, end, call.start)
             for start, end in payload_spans(
@@ -10221,22 +10619,43 @@ def main(argv: list[str]) -> int:
         "--twilio-body-fields": TWILIO_MESSAGE_CREATE_RE,
         "--message-body-fields": MESSAGE_BODY_CALL_RE,
     }
-    if len(argv) == 3 and argv[1] in source_modes:
-        project_root = Path(argv[2]).resolve()
+    if len(argv) in {3, 5} and argv[1] in source_modes:
+        kept_products: set[str] = set()
+        if len(argv) == 5:
+            if argv[2] != "--kept-products":
+                print("Error: expected --kept-products", file=sys.stderr)
+                return 2
+            kept_products = {
+                product.strip().lower()
+                for product in argv[3].split(",")
+                if product.strip()
+            }
+        project_root = Path(argv[-1]).resolve()
         if not project_root.is_dir():
             print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
             return 2
-        findings = [
-            finding
-            for path in iter_source_files(project_root)
-            for finding in message_body_fields(path, source_modes[argv[1]])
-        ]
+        findings: list[str] = []
+        for path in iter_source_files(project_root):
+            try:
+                findings.extend(
+                    message_body_fields(path, source_modes[argv[1]], kept_products)
+                )
+            except Exception as error:  # noqa: BLE001 - fail safe per file
+                findings.append(
+                    finding_row(
+                        path,
+                        1,
+                        f"  [could not analyze this file "
+                        f"({type(error).__name__}) - verify body fields manually]",
+                    )
+                )
         print("\n".join(findings))
         return 0
     if len(argv) != 2:
         print(
             f"Usage: {Path(argv[0]).name} "
-            "[--twilio-body-fields|--message-body-fields] <project-root>",
+            "[--twilio-body-fields|--message-body-fields] "
+            "[--kept-products <csv>] <project-root>",
             file=sys.stderr,
         )
         return 2

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -10898,16 +10898,95 @@ def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
 
     lexed = lex_source(source, suffix)
     visible = lexed.without_comments
-    escaped = re.escape(name)
     if suffix in JS_TS_SUFFIXES:
-        assignment = re.search(
+        def literal(
+            pattern: str, separator: str = r"\s*=\s*"
+        ) -> str | None:
+            match = re.search(
+                pattern
+                + separator
+                + r"(?P<quote>['\"`])(?P<value>.*?)(?P=quote)",
+                visible,
+                re.S,
+            )
+            if match is None:
+                return None
+            value = match.group("value")
+            if match.group("quote") == "`" and "${" in value:
+                return None
+            return value
+
+        def local_literal(local: str) -> str | None:
+            escaped_local = re.escape(local)
+            return literal(
+                rf"\b(?:const|let|var)\s+{escaped_local}"
+            )
+
+        if name == "default":
+            direct = literal(r"\bexport\s+default", r"\s+")
+            if direct is None:
+                direct = literal(
+                    r"(?:\b(?:module\s*\.\s*)?exports\s*\.\s*default|"
+                    r"\bmodule\s*\.\s*exports)"
+                )
+            if direct is not None:
+                return direct
+            alias = re.search(
+                r"(?:\bexport\s+default\s+"
+                r"|\bmodule\s*\.\s*exports\s*=\s*"
+                r"|\b(?:module\s*\.\s*)?exports\s*\.\s*default\s*=\s*)"
+                r"(?P<local>[A-Za-z_$]\w*)\b"
+                r"|\bexport\s*\{\s*(?P<braced>[A-Za-z_$]\w*)"
+                r"\s+as\s+default\s*\}",
+                visible,
+            )
+            if alias is not None:
+                return local_literal(alias.group("local") or alias.group("braced"))
+            for export_list in re.finditer(
+                r"\bexport\s*\{(?P<members>[^{}]*)\}", visible
+            ):
+                for member in export_list.group("members").split(","):
+                    parsed = re.fullmatch(
+                        r"\s*(?P<local>[A-Za-z_$]\w*)\s+as\s+default\s*",
+                        member,
+                    )
+                    if parsed is not None:
+                        return local_literal(parsed.group("local"))
+            return None
+        if name == "<module>":
+            direct = literal(r"\bmodule\s*\.\s*exports")
+            if direct is not None:
+                return direct
+            alias = re.search(
+                r"\bmodule\s*\.\s*exports\s*=\s*"
+                r"(?P<local>[A-Za-z_$]\w*)\b",
+                visible,
+            )
+            return local_literal(alias.group("local")) if alias is not None else None
+
+        escaped = re.escape(name)
+        direct = literal(
             rf"(?:\bexport\s+(?:const|let|var)\s+{escaped}"
             rf"|\b(?:module\s*\.\s*)?exports\s*\.\s*{escaped})"
-            r"\s*=\s*(['\"])(?P<value>.*?)\1",
-            visible,
-            re.S,
         )
+        if direct is not None:
+            return direct
+        for export_list in re.finditer(
+            r"\bexport\s*\{(?P<members>[^{}]*)\}", visible
+        ):
+            for member in export_list.group("members").split(","):
+                parsed = re.fullmatch(
+                    rf"\s*(?P<local>[A-Za-z_$]\w*)"
+                    rf"(?:\s+as\s+{escaped})?\s*",
+                    member,
+                )
+                if parsed is not None and (
+                    " as " in member or parsed.group("local") == name
+                ):
+                    return local_literal(parsed.group("local"))
+        return None
     elif suffix == ".py":
+        escaped = re.escape(name)
         assignment = re.search(
             rf"(?m)^[ \t]*{escaped}\s*=\s*(['\"])(?P<value>.*?)\1",
             visible,
@@ -10931,7 +11010,17 @@ def external_static_values(
     imports: list[tuple[str, str, str]] = []
     if suffix in JS_TS_SUFFIXES:
         for match in re.finditer(
-            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
+            r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
+            r"from\s*(['\"])(?P<module>\.[^'\"]*)\2",
+            visible,
+        ):
+            imports.append(
+                (match.group("module"), "default", match.group("local"))
+            )
+        for match in re.finditer(
+            r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+            r"\{(?P<members>[^{}]*)\}\s*from\s*"
             r"(['\"])(?P<module>\.[^'\"]*)\2",
             visible,
         ):
@@ -10949,6 +11038,19 @@ def external_static_values(
                             parsed.group("local") or parsed.group("export"),
                         )
                     )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+(?P<local>[A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)"
+            r"(?P<default>\s*\.\s*default)?",
+            visible,
+        ):
+            imports.append(
+                (
+                    match.group("module"),
+                    "default" if match.group("default") else "<module>",
+                    match.group("local"),
+                )
+            )
         for match in re.finditer(
             r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
             r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)",
@@ -11022,8 +11124,18 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
     visible = lex_source(source, suffix).without_comments
     names: set[str] = set()
     if suffix in JS_TS_SUFFIXES:
+        names.update(
+            match.group("local")
+            for match in re.finditer(
+                r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
+                r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
+                r"from\s*(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
         for match in re.finditer(
-            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+            r"\{(?P<members>[^{}]*)\}\s*from\s*"
             r"(['\"])\.[^'\"]*\2",
             visible,
         ):
@@ -11037,7 +11149,8 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
         names.update(
             match.group(1)
             for match in re.finditer(
-                r"\bimport\s+\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
+                r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+                r"\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
                 r"(['\"])\.[^'\"]*\2",
                 visible,
             )

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -2872,21 +2872,59 @@ def ruby_request_body_spans(
     arrives in a later statement as `req.body = ...`, so the constructor's own
     arguments never reveal it.
     """
-    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    # Ruby permits several statements on one line.  Starting at the physical
+    # line boundary makes `uri = ...; req = Post.new(uri)` bind the request to
+    # `uri`, and reading the body through the next newline absorbs every later
+    # compact statement.  Use logical statement boundaries in both directions.
+    line_start = max(
+        lexed.code.rfind("\n", 0, call.start),
+        lexed.code.rfind(";", 0, call.start),
+    ) + 1
     binding = re.search(
-        r"([A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+        r"(?<![\w@$.])((?:@@|@|\$)?[A-Za-z_]\w*)\s*=",
+        lexed.code[line_start:call.start],
     )
     if binding is None:
         return []
     name = re.escape(binding.group(1))
-    match = re.search(
-        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*", lexed.code[call.end:]
+    local_binding = not binding.group(1).startswith(("@", "$"))
+    ruby_spans = _ruby_function_spans(lexed.code)
+
+    # A later body assignment is relevant only if it reaches the execution of
+    # THIS request in the SAME Ruby method.  Without both bounds, a helper's
+    # body assignment could satisfy a top-level send, or an assignment after
+    # `http.request(req)` could retroactively make the already-issued request
+    # look compliant.
+    execution_pattern = re.compile(
+        rf"\.\s*request\s*(?:\(\s*{name}\b|[ \t]+{name}\b)"
     )
-    if match is None:
+    execution_offset = None
+    for execution in execution_pattern.finditer(lexed.code, call.end):
+        if not local_binding or _same_ruby_function_scope(
+            lexed.code, call.start, execution.start(), ruby_spans
+        ):
+            execution_offset = execution.start()
+            break
+    if execution_offset is None:
         return []
-    start = call.end + match.end()
-    end = lexed.code.find("\n", start)
-    span = (start, end if end > 0 else len(lexed.code))
+
+    body_pattern = re.compile(
+        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*"
+    )
+    assignments = [
+        match
+        for match in body_pattern.finditer(
+            lexed.code, call.end, execution_offset
+        )
+        if not local_binding
+        or _same_ruby_function_scope(
+            lexed.code, call.start, match.start(), ruby_spans
+        )
+    ]
+    if not assignments:
+        return []
+    start = assignments[-1].end()
+    span = (start, assignment_end(lexed, start, suffix))
     return [resolve_wrapped_payload(lexed, span, span[0], suffix)]
 
 
@@ -4270,35 +4308,166 @@ _EXECUTION_LINK_RE = {
 _INLINE_EXECUTION_RE = re.compile(
     # The constructor may be namespaced inside the execution call, as in
     # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
-    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
+    r"(?:urlopen|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
     r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
 )
 
 
 def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
-    """Return conservative Ruby `def ... end` spans from masked source."""
+    """Return Ruby local-scope spans for methods, classes, and modules."""
 
     stack: list[tuple[str, int | None]] = []
     spans: list[tuple[int, int]] = []
-    cursor = 0
-    for line in code.splitlines(keepends=True):
-        stripped = line.strip()
+    # Newlines and semicolons are equivalent Ruby statement separators.  The
+    # old line-only stack leaked executions from `def f; ...; end` into top
+    # level and ignored endless methods (`def f = expr`) altogether.
+    boundaries = list(re.finditer(r"[;\r\n]", code))
+    pieces: list[tuple[int, int, int]] = []
+    start = 0
+    for boundary in boundaries:
+        pieces.append((start, boundary.start(), boundary.end()))
+        start = boundary.end()
+    pieces.append((start, len(code), len(code)))
+
+    for statement_start, statement_end, terminated_end in pieces:
+        statement = code[statement_start:statement_end]
+        stripped = statement.strip()
+        if not stripped:
+            continue
+        content_start = statement_start + len(statement) - len(statement.lstrip())
         if re.match(r"end\b", stripped) and stack:
-            kind, start = stack.pop()
-            if kind == "def" and start is not None:
-                spans.append((start, cursor + len(line)))
+            kind, opener_start = stack.pop()
+            if kind in {"def", "class", "module"} and opener_start is not None:
+                spans.append((opener_start, terminated_end))
         else:
-            opener = re.match(r"(def|class|module)\b", stripped)
+            opener = re.match(
+                r"(?:(?:private|protected|public)\s+)?(?P<def>def)\b"
+                r"|(?P<container>class|module)\b",
+                stripped,
+            )
             if opener is not None:
-                stack.append((opener.group(1), cursor))
+                kind = "def" if opener.group("def") else opener.group("container")
+                if kind == "def":
+                    separator = top_level_assignment_separator(
+                        stripped, opener.end(), len(stripped)
+                    )
+                    # A setter's name owns its adjacent `=` (`writer=`, `[]=`).
+                    # It is an ordinary `def ... end` unless a SECOND top-level
+                    # `=` follows its parameter list, as in an endless setter.
+                    setter = False
+                    if separator is not None:
+                        left, right = separator
+                        setter = left > 0 and not stripped[left - 1].isspace()
+                        if setter:
+                            later = top_level_assignment_separator(
+                                stripped, right, len(stripped)
+                            )
+                            if later is not None:
+                                separator = later
+                                setter = False
+                    if separator is not None and not setter:
+                        spans.append((content_start, statement_end))
+                        continue
+                stack.append((kind, content_start))
             elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
                 stack.append(("block", None))
             elif re.match(
                 r"(?:if|unless|case|begin|for|while|until)\b", stripped
             ):
                 stack.append(("control", None))
-        cursor += len(line)
     return spans
+
+
+def _enclosing_named_call(
+    code: str, position: int, name: str
+) -> tuple[int, int] | None:
+    """Return `(open, close)` for the innermost named call around position."""
+
+    candidate: tuple[int, int] | None = None
+    pattern = re.compile(rf"\b{re.escape(name)}\s*\(")
+    for match in pattern.finditer(code, 0, position):
+        opening = code.rfind("(", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "(", ")")
+        if closing is not None and opening < position < closing:
+            candidate = (opening, closing)
+    return candidate
+
+
+def _inline_okhttp_is_executed(lexed: LexedSource, call: Call) -> bool:
+    """An inline OkHttp request is live only after execute()/enqueue()."""
+
+    enclosing = _enclosing_named_call(lexed.code, call.start, "newCall")
+    if enclosing is None:
+        return False
+    tail = lexed.code[enclosing[1] + 1 : enclosing[1] + 80]
+    if re.match(
+        r"\s*(?:\?|!!)?\s*\.\s*(?:execute|enqueue)\s*\(", tail
+    ) is not None:
+        return True
+
+    # The Call itself may be stored before execution:
+    #   Call pending = client.newCall(new Request.Builder()...build());
+    #   pending.execute();
+    statement_start = max(
+        lexed.code.rfind(";", 0, enclosing[0]),
+        lexed.code.rfind("\n", 0, enclosing[0]),
+        lexed.code.rfind("{", 0, enclosing[0]),
+    ) + 1
+    prefix = lexed.code[statement_start:enclosing[0]]
+    assignment = re.search(
+        r"(?:(?:final|public|private|protected|static)\s+)*"
+        r"(?:[\w.<>,?\[\]]+\s+)?(?P<alias>[A-Za-z_]\w*)\s*=\s*"
+        r"[^;\n]*\bnewCall\s*$",
+        prefix,
+    )
+    if assignment is None:
+        return False
+    alias = assignment.group("alias")
+    after = enclosing[1] + 1
+    execution = re.search(
+        rf"(?<![\w$]){re.escape(alias)}\s*(?:\?|!!)?\s*\.\s*"
+        rf"(?:execute|enqueue)\s*\(",
+        lexed.code[after:],
+    )
+    if execution is None:
+        return False
+    execution_offset = after + execution.start()
+    return re.search(
+        rf"(?<![\w$]){re.escape(alias)}\s*=(?!=)",
+        lexed.code[after:execution_offset],
+    ) is None
+
+
+def _stored_okhttp_execution_offsets(
+    tail: str, request_name: str
+) -> list[tuple[int, int]]:
+    """`(execution, capture)` offsets for stored OkHttp Call aliases."""
+
+    offsets: list[tuple[int, int]] = []
+    assignment_re = re.compile(
+        rf"(?:^|[;\n{{}}])\s*(?:(?:final|public|private|protected|static)\s+)*"
+        rf"(?:[\w.<>,?\[\]]+\s+)?"
+        rf"(?P<alias>[A-Za-z_]\w*)\s*=\s*[^;\n]*?"
+        rf"\bnewCall\s*\(\s*{re.escape(request_name)}\s*\)"
+    )
+    for assignment in assignment_re.finditer(tail):
+        alias = assignment.group("alias")
+        after = assignment.end()
+        execution = re.search(
+            rf"(?<![\w$]){re.escape(alias)}\s*(?:\?|!!)?\s*\.\s*"
+            rf"(?:execute|enqueue)\s*\(",
+            tail[after:],
+        )
+        if execution is None:
+            continue
+        execution_offset = after + execution.start()
+        rebound = re.search(
+            rf"(?<![\w$]){re.escape(alias)}\s*=(?!=)",
+            tail[after:execution_offset],
+        )
+        if rebound is None:
+            offsets.append((execution_offset, assignment.start()))
+    return offsets
 
 
 def _same_ruby_function_scope(
@@ -4328,7 +4497,13 @@ def request_object_is_executed(
     if pattern is None:
         return True
 
-    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)).
+    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)). OkHttp's
+    # newCall(...) only creates a Call; network I/O begins at execute/enqueue.
+    if canonical == ".java" and _BUILDER_LINK_KIND.get(
+        (id(lexed), call.start)
+    ) == "url":
+        if _inline_okhttp_is_executed(lexed, call):
+            return True
     prefix = lexed.code[max(0, call.start - 160):call.start]
     if _INLINE_EXECUTION_RE.search(prefix):
         return True
@@ -4347,7 +4522,7 @@ def request_object_is_executed(
         # An UNBOUND chain can still be executed inline:
         #   client.send(HttpRequest.newBuilder()...build(), handler)
         return re.search(
-            r"(?:send|sendAsync|newCall|execute|enqueue|urlopen|Do)\s*\(", head
+            r"(?:send|sendAsync|execute|enqueue|urlopen|Do)\s*\(", head
         ) is not None
     # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
     # never the one executed, so every candidate must be tried.
@@ -4372,8 +4547,18 @@ def request_object_is_executed(
         rebound_pattern = re.compile(
             rf"{binding_boundary}{re.escape(name)}\s*=(?!=)"
         )
-        for execution in re.finditer(execution_pattern, tail):
-            execution_offset = call.end + execution.start()
+        execution_events = [
+            (execution.start(), execution.start())
+            for execution in re.finditer(execution_pattern, tail)
+        ]
+        if canonical == ".java":
+            execution_events.extend(
+                _stored_okhttp_execution_offsets(tail, name)
+            )
+        for relative_execution_offset, capture_offset in sorted(
+            set(execution_events)
+        ):
+            execution_offset = call.end + relative_execution_offset
             # Ruby locals belong to one method/top-level scope. Instance,
             # class and global variables retain their identity across methods.
             local_ruby_binding = suffix == ".rb" and not name.startswith(
@@ -4387,7 +4572,9 @@ def request_object_is_executed(
             # every exact-binding assignment before THIS execution; for Ruby
             # locals, assignments in unrelated methods do not rebind it.
             rebound = False
-            for candidate in rebound_pattern.finditer(tail, 0, execution.start()):
+            for candidate in rebound_pattern.finditer(
+                tail, 0, capture_offset
+            ):
                 candidate_offset = call.end + candidate.start()
                 if local_ruby_binding and not _same_ruby_function_scope(
                     lexed.code, call.start, candidate_offset, ruby_spans

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -906,6 +906,68 @@ def _shell_command_substitution_ranges(
     return ranges
 
 
+def _php_closing_tag(source: str, start: int) -> int | None:
+    """Return the next PHP closing tag outside strings/comments/heredocs."""
+
+    index = start
+    quote = ""
+    escaped = False
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if source.startswith("/*", index):
+            closing = source.find("*/", index + 2)
+            index = len(source) if closing < 0 else closing + 2
+            continue
+        heredoc = _heredoc_opener_at(source, index, ".php")
+        if heredoc is not None and source.startswith("<<<", index):
+            body_start = source.find("\n", heredoc.end())
+            if body_start < 0:
+                return None
+            terminator = re.compile(
+                rf"^[ \t]*{re.escape(heredoc.group('tag'))}\b[^\r\n]*",
+                re.MULTILINE,
+            ).search(source, body_start + 1)
+            index = len(source) if terminator is None else terminator.end()
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if source.startswith("?>", index):
+            return index
+        index += 1
+    return None
+
+
+def _php_executable_ranges(source: str) -> list[tuple[int, int]]:
+    """Return PHP code regions with lexical, rather than textual, closers."""
+
+    opener = re.compile(
+        r"<\?(?:php\b|=|(?!(?:xml)\b))",
+        re.IGNORECASE,
+    )
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while match := opener.search(source, cursor):
+        start = match.end()
+        closing = _php_closing_tag(source, start)
+        end = len(source) if closing is None else closing
+        ranges.append((start, end))
+        if closing is None:
+            break
+        cursor = closing + 2
+    return ranges
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
@@ -1037,18 +1099,10 @@ def executable_source(path: Path, source: str) -> str:
         # regions whenever tags are present. Tagless `.php` remains supported
         # because many analyzer fixtures and generated snippets contain raw PHP
         # statements without an opening tag; tagless `.phtml` remains markup.
-        php_ranges = [
-            match.span("code")
-            for match in re.finditer(
-                # Plain ``<?`` is executable when short_open_tag is enabled.
-                # Keep XML declarations out: with short tags disabled they are
-                # markup, and with short tags enabled they make the PHP file
-                # invalid rather than forming a customer request.
-                r"<\?(?:php\b|=|(?!(?:xml)\b))(?P<code>.*?)(?:\?>|\Z)",
-                source,
-                flags=re.IGNORECASE | re.DOTALL,
-            )
-        ]
+        # Plain ``<?`` is executable when short_open_tag is enabled. Keep XML
+        # declarations out, and find closing tags lexically: a textual `?>`
+        # inside a PHP string, block comment, heredoc, or nowdoc is data.
+        php_ranges = _php_executable_ranges(source)
         if (
             suffix == ".php"
             and not php_ranges
@@ -1134,11 +1188,15 @@ PROFILE_IDENTIFIER_RE = re.compile(
     rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
 )
 PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
-SDK_METHOD_PATTERN = (
-    r"sendNumberPool|send_number_pool|SendNumberPool|"
-    r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
-    r"SendWithAlphanumericSender"
+SDK_METHOD_NAMES = (
+    "sendNumberPool",
+    "send_number_pool",
+    "SendNumberPool",
+    "sendWithAlphanumericSender",
+    "send_with_alphanumeric_sender",
+    "SendWithAlphanumericSender",
 )
+SDK_METHOD_PATTERN = "|".join(map(re.escape, SDK_METHOD_NAMES))
 SDK_CALL_RE = re.compile(
     rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
     r"\s*(?:\?\.)?\s*\("
@@ -1601,7 +1659,7 @@ def _javascript_regex_can_start(
         # JSX closing tags (`</Panel>` and `</>`) are markup delimiters, not a
         # regexp in the expression position that `<` would otherwise permit.
         return False
-    if character in "([,;:=!?&|^~<>*%":
+    if character in "([{,;:=!?&|^~<>*%":
         return True
     if character in "+-":
         return previous == 0 or code[previous - 1] != character
@@ -2158,6 +2216,70 @@ def sdk_alias_calls(lexed: LexedSource) -> list[Call]:
             if callable_arg == alias and key not in seen:
                 seen.add(key)
                 calls.append(call)
+    return calls
+
+
+def sdk_computed_calls(lexed: LexedSource, suffix: str) -> list[Call]:
+    """Find JS/TS SDK calls with a statically named bracket member.
+
+    The lexer deliberately blanks string literals, so the direct SDK regex
+    cannot see ``messages['sendNumberPool'](...)``. Recover only exact static
+    method-name tokens that are bracket members on a real receiver. Dynamic
+    lookups and object/array literals remain unresolved rather than being
+    misclassified as SDK sends.
+    """
+
+    if suffix not in JS_TS_SUFFIXES:
+        return []
+
+    code = lexed.code
+    calls: list[Call] = []
+    for token in lexed.strings:
+        if token.contents not in SDK_METHOD_NAMES:
+            continue
+
+        opening_bracket = token.start - 1
+        while opening_bracket >= 0 and code[opening_bracket].isspace():
+            opening_bracket -= 1
+        if opening_bracket < 0 or code[opening_bracket] != "[":
+            continue
+
+        receiver_end = opening_bracket - 1
+        while receiver_end >= 0 and code[receiver_end].isspace():
+            receiver_end -= 1
+        if (
+            receiver_end >= 1
+            and code[receiver_end] == "."
+            and code[receiver_end - 1] == "?"
+        ):
+            receiver_end -= 2
+            while receiver_end >= 0 and code[receiver_end].isspace():
+                receiver_end -= 1
+        if receiver_end < 0 or not (
+            code[receiver_end].isalnum()
+            or code[receiver_end] in {"_", "$", "]", ")"}
+        ):
+            continue
+
+        closing_bracket = token.end
+        while closing_bracket < len(code) and code[closing_bracket].isspace():
+            closing_bracket += 1
+        if closing_bracket >= len(code) or code[closing_bracket] != "]":
+            continue
+
+        opening = closing_bracket + 1
+        while opening < len(code) and code[opening].isspace():
+            opening += 1
+        if code.startswith("?.", opening):
+            opening += 2
+            while opening < len(code) and code[opening].isspace():
+                opening += 1
+        if opening >= len(code) or code[opening] != "(":
+            continue
+
+        closing = matching_delimiter(code, opening, "(", ")")
+        if closing is not None:
+            calls.append(Call(opening_bracket, opening, closing + 1))
     return calls
 
 
@@ -12239,7 +12361,11 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix, source_dialect(path))
-    sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
+    sdk_calls = (
+        calls_matching(lexed, SDK_CALL_RE)
+        + sdk_alias_calls(lexed)
+        + sdk_computed_calls(lexed, suffix)
+    )
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     if suffix != ".cs":
         # These PascalCase names are official .NET HttpClient methods. Keeping

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -136,7 +136,10 @@ def canonical_suffix(path: Path) -> str:
         return ".ts"
     if suffix in {".vue", ".svelte"}:
         try:
-            source = path.read_text(encoding="utf-8", errors="replace")
+            with path.open(
+                "r", encoding="utf-8", errors="replace", newline=""
+            ) as source_file:
+                source = source_file.read()
         except OSError:
             source = ""
         if re.search(
@@ -154,7 +157,7 @@ def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
     for start, end in ranges:
         keep[start:end] = b"\x01" * (end - start)
     return "".join(
-        char if char in "\r\n" or keep[index] else " "
+        char if char in "\r\n\u2028\u2029" or keep[index] else " "
         for index, char in enumerate(source)
     )
 
@@ -440,12 +443,14 @@ PROFILE_IDENTIFIER_RE = re.compile(
     rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
 )
 PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
-SDK_CALL_RE = re.compile(
-    r"(?:\?\.|\.|->)\s*(?:"
+SDK_METHOD_PATTERN = (
     r"sendNumberPool|send_number_pool|SendNumberPool|"
     r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
     r"SendWithAlphanumericSender"
-    r")\s*(?:\?\.)?\s*\("
+)
+SDK_CALL_RE = re.compile(
+    rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
+    r"\s*(?:\?\.)?\s*\("
 )
 FETCH_CALL_RE = re.compile(
     r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
@@ -710,8 +715,24 @@ class EndpointFrame:
 
 def _blank(buffer: list[str], start: int, end: int) -> None:
     for index in range(start, end):
-        if buffer[index] != "\n":
+        # Preserve every source line terminator. JavaScript recognizes U+2028
+        # and U+2029 in addition to CR/LF, and all C-style languages accept a
+        # bare CR as a physical line boundary. Replacing one with a space can
+        # merge the comment with executable code on the following line.
+        if buffer[index] not in {"\r", "\n", "\u2028", "\u2029"}:
             buffer[index] = " "
+
+
+def _line_comment_end(source: str, start: int, suffix: str) -> int:
+    """Return the first language-valid line terminator after ``start``."""
+
+    terminators = {"\r", "\n"}
+    if suffix in JS_TS_SUFFIXES:
+        terminators.update({"\u2028", "\u2029"})
+    for index in range(start, len(source)):
+        if source[index] in terminators:
+            return index
+    return len(source)
 
 
 # Heredoc openers: shell/ruby `<<TAG`, `<<-TAG`, `<<~TAG`, `<<'TAG'`; PHP
@@ -777,8 +798,7 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         if c_line_comments and source.startswith("//", index):
-            end = source.find("\n", index + 2)
-            end = len(source) if end < 0 else end
+            end = _line_comment_end(source, index + 2, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)
             index = end
@@ -786,11 +806,10 @@ def lex_source(source: str, suffix: str) -> LexedSource:
 
         if hash_comments and source[index] == "#":
             if suffix == ".sh" and index == 0 and source.startswith("#!", index):
-                end = source.find("\n", index + 2)
-                index = len(source) if end < 0 else end
+                end = _line_comment_end(source, index + 2, suffix)
+                index = end
                 continue
-            end = source.find("\n", index + 1)
-            end = len(source) if end < 0 else end
+            end = _line_comment_end(source, index + 1, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)
             index = end
@@ -866,7 +885,14 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             if honours_escapes and source[index] == "\\":
                 index = min(len(source), index + 2)
                 continue
-            if source[index] == "\n" and line_bounded:
+            if (
+                line_bounded
+                and source[index] in {"\r", "\n", "\u2028", "\u2029"}
+                and (
+                    source[index] in {"\r", "\n"}
+                    or suffix in JS_TS_SUFFIXES
+                )
+            ):
                 # A single/double-quoted JS/TS or Python literal cannot contain a
                 # raw newline, so hitting one means the quote never opened a
                 # string at all (an apostrophe in JSX text, prose, or a comment).
@@ -940,6 +966,118 @@ def calls_matching(lexed: LexedSource, pattern: re.Pattern[str]) -> list[Call]:
             closing = lexed.code.find("\n", opening)
             closing = len(lexed.code) - 1 if closing < 0 else closing
         calls.append(Call(match.start(), opening, closing + 1))
+    return calls
+
+
+def sdk_alias_calls(lexed: LexedSource) -> list[Call]:
+    """Find calls through local aliases of required-profile SDK methods.
+
+    Method values/delegates are ordinary customer code in Python, JS/TS, Go,
+    Java/Kotlin and C#. The direct-call regex cannot see them once the member
+    name is assigned. Track both assignment/bind forms and JS destructuring,
+    and require the defining assignment to remain the nearest one before each
+    call so a later reassignment does not create a false SDK finding.
+    """
+
+    code = lexed.code
+    definitions: list[tuple[str, int]] = []
+    member = re.compile(
+        rf"(?:\?\.|\.|->|::)\s*(?:{SDK_METHOD_PATTERN})(?!\w)"
+    )
+    for match in member.finditer(code):
+        # A direct invocation is already covered by SDK_CALL_RE.
+        after = code[match.end():]
+        if re.match(r"\s*(?:\?\.)?\s*\(", after):
+            continue
+        line_start = max(code.rfind("\n", 0, match.start()), code.rfind(";", 0, match.start())) + 1
+        prefix = code[line_start:match.start()]
+        assignment = re.search(
+            r"(?P<alias>\$?[A-Za-z_][A-Za-z0-9_]*)\s*(?:=|:=)\s*.*$",
+            prefix,
+        )
+        if assignment is not None:
+            definitions.append((assignment.group("alias").lstrip("$"), match.end()))
+
+    # JavaScript/TypeScript/CommonJS destructuring aliases.
+    for match in re.finditer(r"\{(?P<members>[^{}]*)\}\s*=", code):
+        for item in split_arguments(code, match.start("members"), match.end("members")):
+            text = code[slice(*item)].strip()
+            parsed = re.fullmatch(
+                rf"(?P<method>{SDK_METHOD_PATTERN})(?:\s*:\s*(?P<alias>[A-Za-z_$]\w*))?",
+                text,
+            )
+            if parsed is not None:
+                definitions.append(
+                    ((parsed.group("alias") or parsed.group("method")).lstrip("$"), match.end())
+                )
+
+    # Ruby's bound Method and PHP callable-array/Closure forms store the SDK
+    # method name as a symbol or string, so it is intentionally absent from the
+    # masked code view used above. without_comments retains those values while
+    # still excluding prose and comments.
+    visible = lexed.without_comments
+    for match in re.finditer(
+        rf"(?m)^\s*(?P<alias>[A-Za-z_]\w*)\s*=\s*[^\r\n;]*"
+        rf"\.\s*method\s*\(\s*:\s*(?:{SDK_METHOD_PATTERN})\s*\)",
+        visible,
+    ):
+        definitions.append((match.group("alias"), match.end()))
+    for match in re.finditer(
+        rf"(?m)^\s*\$(?P<alias>[A-Za-z_]\w*)\s*=\s*"
+        rf"(?:Closure\s*::\s*fromCallable\s*\(\s*)?\["
+        rf"[^\]\r\n]*,\s*['\"](?:{SDK_METHOD_PATTERN})['\"]\s*\]",
+        visible,
+    ):
+        definitions.append((match.group("alias"), match.end()))
+
+    calls: list[Call] = []
+    seen: set[tuple[int, int]] = set()
+    for alias, definition_end in definitions:
+        invocation_patterns = (
+            re.compile(rf"(?<![\w$.>])\$?{re.escape(alias)}\s*\("),
+            re.compile(
+                rf"(?<![\w$])\$?{re.escape(alias)}\s*(?:\.|->)\s*"
+                r"(?:call|apply|accept|invoke|Invoke)\s*\("
+            ),
+        )
+        invocations = sorted(
+            (
+                match
+                for pattern in invocation_patterns
+                for match in pattern.finditer(code, definition_end)
+            ),
+            key=lambda match: match.start(),
+        )
+        for match in invocations:
+            # A later assignment/shadowing invalidates the original method
+            # value. Nearest-definition semantics match the rest of the linter.
+            between = code[definition_end:match.start()]
+            if re.search(
+                rf"(?<![\w$])\$?{re.escape(alias)}\s*(?:=|:=)(?!=)",
+                between,
+            ):
+                continue
+            opening = code.find("(", match.start(), match.end())
+            closing = matching_delimiter(code, opening, "(", ")")
+            if closing is None:
+                continue
+            key = (match.start(), closing + 1)
+            if key not in seen:
+                seen.add(key)
+                calls.append(Call(match.start(), opening, closing + 1))
+
+        # PHP also invokes callable arrays via call_user_func(_array).
+        for call in calls_matching(
+            lexed, re.compile(r"(?<!\w)call_user_func(?:_array)?\s*\(")
+        ):
+            args = split_arguments(code, call.open_paren + 1, call.end - 1)
+            if not args:
+                continue
+            callable_arg = code[slice(*args[0])].strip().lstrip("$")
+            key = (call.start, call.end)
+            if callable_arg == alias and key not in seen:
+                seen.add(key)
+                calls.append(call)
     return calls
 
 
@@ -2073,7 +2211,12 @@ def finding_row(path: Path, line: int, detail: str) -> str:
     in one run leaves a consumer unable to group, dedupe or open by file.
     """
 
-    return f"{path}:{line}:{detail}"
+    # The analyzer-to-shell protocol is LF-delimited. POSIX permits CR and LF
+    # in filenames, so emitting a raw path can turn one finding into several
+    # records and inflate both counts and details.files. Escape only the record
+    # delimiters; keep the rest of the path byte-for-byte displayable.
+    display_path = str(path).replace("\r", "\\r").replace("\n", "\\n")
+    return f"{display_path}:{line}:{detail}"
 
 
 def call_detail(path: Path, lexed: LexedSource, call: Call) -> str:
@@ -5060,9 +5203,18 @@ class SourceEndpointResolver:
     JAVASCRIPT_SUFFIXES = JS_TS_SUFFIXES
     C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
 
-    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+    def __init__(
+        self,
+        lexed: LexedSource,
+        suffix: str,
+        external_values: dict[str, str] | None = None,
+        external_names: set[str] | None = None,
+    ) -> None:
         self.lexed = lexed
         self.suffix = suffix
+        self.external_values = external_values or {}
+        self.external_names = external_names or set()
+        self.unverified_external_calls: set[int] = set()
         self.graph = EndpointGraph(len(lexed.code))
         self.c_headers = c_function_headers(lexed, suffix)
         self.class_fields = class_field_regions(lexed, suffix)
@@ -7017,6 +7169,15 @@ class SourceEndpointResolver:
         before: int,
         projection: EndpointReference = (),
     ) -> EndpointValue:
+        # Resolve statically imported scalar endpoints before entering the
+        # per-file binding graph. Keeping module provenance explicit avoids
+        # conflating same-named locals and makes the cross-file boundary the
+        # only special case; all endpoint classification remains shared.
+        expression_text = self.lexed.code[start:end].strip()
+        if not projection and re.fullmatch(r"[A-Za-z_$]\w*", expression_text):
+            external = self.external_values.get(expression_text.lstrip("$"))
+            if external is not None:
+                return endpoint_literal_value(external)
         scope_id = self.scope_at(before)
         expression = self._parse_expression(
             start, end, scope_id, before
@@ -7026,6 +7187,33 @@ class SourceEndpointResolver:
                 expression, projection, before, scope_id
             )
         )
+
+    def _is_external_expression(self, start: int, end: int) -> bool:
+        """Return whether an unresolved URL expression crosses a module boundary."""
+
+        # Shell references commonly live inside double-quoted URL arguments,
+        # which the code view masks as string data. This check is already
+        # bounded to the selected URL/call span, so the original view is the
+        # correct place to recover the imported reference spelling.
+        text = self.lexed.original[start:end].strip()
+        references = re.findall(r"\$?[A-Za-z_][A-Za-z0-9_$]*", text)
+        normalized = [reference.lstrip("$") for reference in references]
+        if any(reference in self.external_names for reference in normalized):
+            return True
+        if "<uppercase>" in self.external_names and any(
+            re.fullmatch(r"[A-Z][A-Z0-9_]*", reference)
+            for reference in normalized
+        ):
+            return True
+        if "<qualified>" in self.external_names and re.search(
+            r"(?:\.|::|->)\s*[A-Za-z_]", text
+        ):
+            return True
+        if "<shell>" in self.external_names and re.search(
+            r"\$(?:\{)?[A-Za-z_]", text
+        ):
+            return True
+        return False
 
     def config_method_may_mutate(
         self, span: tuple[int, int], before: int
@@ -7158,6 +7346,19 @@ class SourceEndpointResolver:
                 for value in resolved
             ):
                 return True
+        # A mutating request whose URL crosses a module boundary must not be
+        # certified merely because this file has no literal. Resolve exact
+        # local exports where possible; otherwise fail closed only for a URL
+        # expression proven to originate from an import/require/source form.
+        # The caller emits a distinct manual-verification finding, rather than
+        # pretending the unknown endpoint is definitely a number-pool route.
+        if any(
+            value.kind in {UNKNOWN, MISSING}
+            and self._is_external_expression(*span)
+            for span, value in zip(original_spans, resolved)
+        ):
+            self.unverified_external_calls.add(call.start)
+            return True
         if not args:
             return False
         return bool(
@@ -7191,6 +7392,20 @@ class SourceEndpointResolver:
                     expression, (), call.start, scope_id
                 )
             ).kind == REQUIRED:
+                return True
+            if (
+                self.graph.evaluate(
+                    EndpointExpressionState(
+                        expression, (), call.start, scope_id
+                    )
+                ).kind
+                in {UNKNOWN, MISSING}
+                and self._is_external_expression(
+                    call.start,
+                    call.end,
+                )
+            ):
+                self.unverified_external_calls.add(call.start)
                 return True
         return False
 
@@ -8329,6 +8544,19 @@ class PayloadStateResolver:
             r"|new\s+(?:Array|Map|Set|Object)\s*\(\s*\))",
             code,
             re.I,
+        ):
+            return WRITE_ABSENT
+        # The public API contract is a UUID string. Reject every statically
+        # numeric literal (not just zero) across the advertised languages;
+        # dynamic expressions remain MAYBE/PRESENT because their runtime type
+        # cannot be proven here.
+        if re.fullmatch(
+            r"[+-]?(?:(?:0[xX][0-9a-fA-F](?:_?[0-9a-fA-F])*)"
+            r"|(?:0[bB][01](?:_?[01])*)|(?:0[oO][0-7](?:_?[0-7])*)"
+            r"|(?:(?:\d(?:_?\d)*)(?:\.(?:\d(?:_?\d)*)?)?"
+            r"|\.(?:\d(?:_?\d)*))(?:[eE][+-]?\d(?:_?\d)*)?)"
+            r"(?:[nNlLfFdDmM])?",
+            code,
         ):
             return WRITE_ABSENT
         tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
@@ -10270,6 +10498,21 @@ def _looks_like_a_send_target(
     # boundary for computed/interprocedural lookups.
     line_start_decl = lexed.code.rfind("\n", 0, token.start) + 1
     declaration = lexed.original[line_start_decl:token.start]
+    # A class/package constant is a declaration, not a send. Braces from the
+    # surrounding class made _is_standalone_binding reject Java/C# fields, so a
+    # compliant cross-file consumer was still accompanied by an unverifiable
+    # finding on the constant definition itself. The imported use site is now
+    # judged (or failed closed) independently.
+    if re.search(
+        r"(?:\bstatic[ \t]+final"
+        r"|\b(?:public|private|protected|internal)[ \t]+const"
+        r"|\b(?:public|private|protected|internal)?[ \t]*static[ \t]+readonly)"
+        r"[ \t]+[A-Za-z_$][\w$<>,.?\[\]]*[ \t]+"
+        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*$",
+        declaration,
+        re.I,
+    ) and _SEND_SITE_RE.search(declaration) is None:
+        return False
     if re.search(
         r"(?:=|:=)\s*(?:new\s+\w+[^=]*)?(?:Map\s*\.\s*of|List\s*\.\s*of"
         r"|Arrays\s*\.\s*asList|array|dict|\{|\[|\()",
@@ -10396,16 +10639,271 @@ def _looks_like_a_send_target(
 
 
 
+def _read_source_text(path: Path) -> str:
+    """Read source without universal-newline translation."""
+
+    with path.open(
+        "r", encoding="utf-8", errors="replace", newline=""
+    ) as source_file:
+        return source_file.read()
+
+
+def _relative_module_candidates(
+    source_path: Path, module: str, suffix: str, project_root: Path
+) -> list[Path]:
+    """Return bounded local-module candidates for JS/TS and Python imports."""
+
+    if module.startswith("."):
+        base = source_path.parent / module
+    elif suffix == ".py":
+        # Python commonly imports a sibling/top-level project module without a
+        # leading dot. Resolve only beneath the scanned project root; package
+        # dependencies are intentionally outside this static contract.
+        base = project_root / module.replace(".", "/")
+    else:
+        return []
+    candidates = [base]
+    if base.suffix:
+        return candidates
+    if suffix in JS_TS_SUFFIXES:
+        candidates.extend(base.with_suffix(ext) for ext in sorted(JS_TS_SUFFIXES))
+        candidates.extend((base / "index").with_suffix(ext) for ext in sorted(JS_TS_SUFFIXES))
+    elif suffix == ".py":
+        candidates.extend((base.with_suffix(".py"), base / "__init__.py"))
+    return candidates
+
+
+def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
+    """Resolve one exported/top-level name when its value is a string literal."""
+
+    lexed = lex_source(source, suffix)
+    visible = lexed.without_comments
+    escaped = re.escape(name)
+    if suffix in JS_TS_SUFFIXES:
+        assignment = re.search(
+            rf"(?:\bexport\s+(?:const|let|var)\s+{escaped}"
+            rf"|\b(?:module\s*\.\s*)?exports\s*\.\s*{escaped})"
+            r"\s*=\s*(['\"])(?P<value>.*?)\1",
+            visible,
+            re.S,
+        )
+    elif suffix == ".py":
+        assignment = re.search(
+            rf"(?m)^[ \t]*{escaped}\s*=\s*(['\"])(?P<value>.*?)\1",
+            visible,
+        )
+    else:
+        assignment = None
+    return assignment.group("value") if assignment is not None else None
+
+
+def external_static_values(
+    path: Path, project_root: Path, source: str, suffix: str
+) -> dict[str, str]:
+    """Resolve relative named imports to statically exported scalar strings.
+
+    This deliberately follows only explicit relative modules and literal
+    exports. Dynamic/package imports stay unknown instead of being guessed.
+    """
+
+    lexed = lex_source(source, suffix)
+    visible = lexed.without_comments
+    imports: list[tuple[str, str, str]] = []
+    if suffix in JS_TS_SUFFIXES:
+        for match in re.finditer(
+            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"(['\"])(?P<module>\.[^'\"]*)\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_$]\w*)"
+                    r"(?:\s+as\s+(?P<local>[A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    imports.append(
+                        (
+                            match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_$]\w*)"
+                    r"(?:\s*:\s*(?P<local>[A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    imports.append(
+                        (
+                            match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+    elif suffix == ".py":
+        for match in re.finditer(
+            r"(?m)^\s*from\s+(?P<module>\.*[A-Za-z_][\w.]*)\s+import\s+"
+            r"(?P<members>[^\r\n]+)",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_]\w*)"
+                    r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    dots = len(match.group("module")) - len(match.group("module").lstrip("."))
+                    module_tail = match.group("module")[dots:].replace(".", "/")
+                    relative = "../" * max(0, dots - 1) + module_tail
+                    imports.append(
+                        (
+                            "./" + relative if dots else match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+
+    resolved: dict[str, str] = {}
+    for module, exported, local in imports:
+        for candidate in _relative_module_candidates(
+            path, module, suffix, project_root
+        ):
+            if not candidate.is_file():
+                continue
+            target_suffix = canonical_suffix(candidate)
+            value = _exported_scalar(
+                _read_source_text(candidate), target_suffix, exported
+            )
+            if value is not None:
+                resolved[local] = value
+            break
+    return resolved
+
+
+def external_reference_names(source: str, suffix: str) -> set[str]:
+    """Return local names whose values originate outside the current file.
+
+    Exact static exports are resolved separately. This index covers the wider
+    language-level import boundary so an unresolved mutating request fails
+    closed instead of silently passing. Sentinels are intentionally narrow:
+    uppercase constants after require/include, qualified package/class members,
+    and shell variables only when a source command is present.
+    """
+
+    visible = lex_source(source, suffix).without_comments
+    names: set[str] = set()
+    if suffix in JS_TS_SUFFIXES:
+        for match in re.finditer(
+            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"(['\"])\.[^'\"]*\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_$]\w*)(?:\s+as\s+([A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"\bimport\s+\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
+                r"(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+                r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_$]\w*)(?:\s*:\s*([A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
+    elif suffix == ".py":
+        for match in re.finditer(r"(?m)^\s*from\s+[\w.]+\s+import\s+([^\r\n]+)", visible):
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_]\w*)(?:\s+as\s+([A-Za-z_]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add(parsed.group(2) or parsed.group(1))
+        for match in re.finditer(
+            r"(?m)^\s*import\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)"
+            r"(?:\s+as\s+([A-Za-z_]\w*))?",
+            visible,
+        ):
+            names.add(match.group(2) or match.group(1).split(".")[0])
+    elif suffix == ".rb" and re.search(r"(?m)^\s*require(?:_relative)?\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".php" and re.search(r"\b(?:require|require_once|include|include_once)\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".go" and re.search(r"(?m)^\s*import\b", visible):
+        names.add("<qualified>")
+        for match in re.finditer(
+            r"(?m)^\s*(?:import\s+)?(?:(\w+)\s+)?['\"]([^'\"]+)['\"]",
+            visible,
+        ):
+            names.add(match.group(1) or match.group(2).rsplit("/", 1)[-1])
+    elif suffix == ".java" and re.search(r"(?m)^\s*import\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"(?m)^\s*import\s+(?:static\s+)?(?:[\w$]+\.)*([A-Za-z_$]\w*)\s*;",
+                visible,
+            )
+        )
+    elif suffix == ".cs" and re.search(r"(?m)^\s*using\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".sh" and re.search(
+        r"(?m)^\s*(?:source\s+|\.\s+)[^\r\n]+", visible
+    ):
+        names.add("<shell>")
+    return names
+
+
 def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
-    source = path.read_text(encoding="utf-8", errors="replace")
+    # newline="" is required: Path.read_text() performs universal-newline
+    # translation, destroying bare-CR and CRLF source boundaries before the
+    # lexer and grep-line protocol can agree on them.
+    source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
-    sdk_calls = calls_matching(lexed, SDK_CALL_RE)
+    sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
     required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
-    source_resolver = SourceEndpointResolver(lexed, suffix)
+    source_resolver = SourceEndpointResolver(
+        lexed,
+        suffix,
+        external_static_values(path, project_root, source, suffix),
+        external_reference_names(source, suffix),
+    )
     profile_resolver = PayloadStateResolver(
         lexed,
         suffix,
@@ -10443,10 +10941,9 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
             required_calls.append((context, False))
 
     required_calls.sort(key=lambda item: (item[0].start, item[0].end))
-    missing = [
-        call_detail(path, lexed, call)
-        for call, sdk_call in required_calls
-        if not call_has_profile(
+    missing: list[str] = []
+    for call, sdk_call in required_calls:
+        if call_has_profile(
             lexed,
             call,
             suffix,
@@ -10454,8 +10951,15 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
             project_root,
             sdk_call=sdk_call,
             resolver=profile_resolver,
-        )
-    ]
+        ):
+            continue
+        detail = call_detail(path, lexed, call)
+        if call.start in source_resolver.unverified_external_calls:
+            detail += (
+                "  [could not resolve the imported endpoint for this mutating "
+                "request; verify messaging_profile_id manually]"
+            )
+        missing.append(detail)
 
     # Fail-safe backstop: a required endpoint the analysis never accounted for
     # is reported for manual verification rather than passed silently.
@@ -10581,7 +11085,7 @@ def message_body_fields(
 ) -> list[str]:
     """Return real top-level body fields from selected messaging calls."""
 
-    source = path.read_text(encoding="utf-8", errors="replace")
+    source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -38,6 +38,10 @@ JS_TS_SUFFIXES = {
     ".tsx",
 }
 TYPESCRIPT_SUFFIXES = {".ts", ".tsx", ".mts", ".cts"}
+# Babel, SWC, esbuild, and React Native commonly accept JSX in ordinary
+# JavaScript module files. TypeScript reserves JSX for `.tsx`, so applying JSX
+# masking to `.ts`/`.mts`/`.cts` would risk hiding valid type assertions.
+JSX_CAPABLE_SUFFIXES = {".cjs", ".js", ".jsx", ".mjs", ".tsx"}
 # Keys a request-style config object may carry its URL under. Shared so the
 # named-argument path and the config-object path cannot recognise different
 # spellings, which is how `uri` came to work as a named argument but not as
@@ -582,12 +586,98 @@ def _ruby_interpolation_ranges(
         if backslashes % 2:
             cursor = marker + 2
             continue
-        balanced = _balanced_brace_ranges(source, [marker + 1])
-        if not balanced or balanced[0][1] > end:
+        closing = _ruby_interpolation_closing(source, marker + 1, end)
+        if closing is None:
             break
-        ranges.append(balanced[0])
-        cursor = balanced[0][1] + 1
+        ranges.append((marker + 2, closing))
+        cursor = closing + 1
     return ranges
+
+
+def _ruby_interpolation_closing(
+    source: str, opening: int, end: int
+) -> int | None:
+    """Return a Ruby-aware closing brace for one interpolation expression.
+
+    Generic brace matching is insufficient here: Ruby regexp and percent
+    literals may legally contain ``}``, and comments may contain arbitrary
+    braces. Treat those regions as opaque while balancing executable braces so
+    a data character cannot truncate the restored expression.
+    """
+
+    depth = 0
+    index = opening
+    code = list(source)
+    last_opaque_end = 0
+    while index < end:
+        character = source[index]
+        if character == "#":
+            line_end = source.find("\n", index + 1, end)
+            index = end if line_end < 0 else line_end + 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            literal_start = index
+            index += 1
+            while index < end:
+                if source[index] == "\\":
+                    index = min(end, index + 2)
+                    continue
+                if quote in {'"', "`"} and source.startswith("#{", index):
+                    nested_closing = _ruby_interpolation_closing(
+                        source, index + 1, end
+                    )
+                    if nested_closing is None:
+                        return None
+                    index = nested_closing + 1
+                    continue
+                if source[index] == quote:
+                    index += 1
+                    _blank(code, literal_start, index)
+                    last_opaque_end = index
+                    break
+                index += 1
+            else:
+                return None
+            continue
+        if character == "%":
+            percent_literal = _ruby_percent_literal(source, index)
+            if percent_literal is not None and percent_literal[0] <= end:
+                literal_end = percent_literal[0]
+                _blank(code, index, literal_end)
+                last_opaque_end = literal_end
+                index = literal_end
+                continue
+        if character == "/":
+            regexp_context = _ruby_regex_can_start(
+                source, code, index, last_opaque_end
+            )
+            regexp = (
+                _ruby_slash_regex(
+                    source,
+                    index,
+                    allow_newlines=regexp_context == "command",
+                )
+                if regexp_context
+                else None
+            )
+            if regexp is not None and regexp[0] <= end and (
+                regexp_context != "command"
+                or _ruby_command_regex_has_valid_tail(source, regexp[0])
+            ):
+                regexp_end = regexp[0]
+                _blank(code, index, regexp_end)
+                last_opaque_end = regexp_end
+                index = regexp_end
+                continue
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
 
 
 def _ruby_percent_literal(
@@ -1112,50 +1202,69 @@ def _jsx_element(
 def _mask_jsx_markup(source: str, suffix: str) -> str:
     """Blank definite JSX markup/text while retaining expression containers."""
 
-    # Locate roots in lexed code so `<Panel>` inside an ordinary string or
-    # comment cannot cause subsequent JavaScript to be hidden. The JSX parser
-    # itself uses the raw source after a root is established because inert text
-    # may legally contain quote characters that are not JavaScript strings.
-    lexical = lex_source(source, suffix).code
     output = list(source)
-    cursor = 0
-    while cursor < len(source):
-        start = lexical.find("<", cursor)
-        if start < 0:
-            break
-        previous = start - 1
-        while previous >= 0 and lexical[previous].isspace():
-            previous -= 1
-        previous_word = _word_before(list(lexical), previous + 1).lower()
-        expression_context = (
-            previous < 0
-            or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
-            or (
-                lexical[previous] == ")"
-                and _javascript_control_paren(list(lexical), previous)
+    # Process expression containers with an explicit worklist. The former
+    # recursive call overflowed Python's stack on valid deeply nested JSX.
+    # Each queued span is strictly contained by the JSX element that exposed
+    # it, so the traversal always makes progress without a recursion limit.
+    pending = [(0, len(source))]
+    while pending:
+        span_start, span_end = pending.pop()
+        segment = source[span_start:span_end]
+        # Locate roots in lexed code so `<Panel>` inside an ordinary string or
+        # comment cannot hide subsequent JavaScript. The JSX parser itself uses
+        # raw source after a root is established because inert JSX text may
+        # legally contain quote characters that are not JavaScript strings.
+        lexical = lex_source(segment, suffix).code
+        lexical_chars = list(lexical)
+        cursor = 0
+        while cursor < len(segment):
+            start = lexical.find("<", cursor)
+            if start < 0:
+                break
+            previous = start - 1
+            while previous >= 0 and lexical[previous].isspace():
+                previous -= 1
+            previous_word = _word_before(lexical_chars, previous + 1).lower()
+            expression_context = (
+                previous < 0
+                or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
+                or (
+                    lexical[previous] == ")"
+                    and _javascript_control_paren(lexical_chars, previous)
+                )
+                or (
+                    lexical[previous] == "}"
+                    and _javascript_block_brace(lexical_chars, previous)
+                )
+                or previous_word
+                in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
             )
-            or (
-                lexical[previous] == "}"
-                and _javascript_block_brace(list(lexical), previous)
-            )
-            or previous_word
-            in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
-        )
-        if not expression_context:
-            cursor = start + 1
-            continue
-        element = _jsx_element(source, lexical, start, suffix)
-        if element is None:
-            cursor = start + 1
-            continue
-        end, expressions = element
-        _blank(output, start, end)
-        for expression_start, expression_end in expressions:
-            nested = _mask_jsx_markup(
-                source[expression_start:expression_end], suffix
-            )
-            output[expression_start:expression_end] = list(nested)
-        cursor = end
+            if not expression_context:
+                cursor = start + 1
+                continue
+            element = _jsx_element(segment, lexical, start, suffix)
+            if element is None:
+                cursor = start + 1
+                continue
+            element_end, expressions = element
+            absolute_start = span_start + start
+            absolute_end = span_start + element_end
+            _blank(output, absolute_start, absolute_end)
+            for expression_start, expression_end in expressions:
+                absolute_expression_start = span_start + expression_start
+                absolute_expression_end = span_start + expression_end
+                output[
+                    absolute_expression_start:absolute_expression_end
+                ] = list(
+                    source[
+                        absolute_expression_start:absolute_expression_end
+                    ]
+                )
+                pending.append(
+                    (absolute_expression_start, absolute_expression_end)
+                )
+            cursor = element_end
     return "".join(output)
 
 
@@ -1163,7 +1272,7 @@ def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
     ranges: list[tuple[int, int]] = []
-    if suffix in {".jsx", ".tsx"}:
+    if suffix in JSX_CAPABLE_SUFFIXES:
         return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
         # Comments may contain complete, syntactically valid examples. Preserve
@@ -2381,6 +2490,26 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                     len(source) if terminator is None else terminator.start()
                 )
                 _blank(code, body_start, body_end)
+                _blank(without_comments, body_start, body_end)
+                if suffix == ".rb" and opener.group("q") != "'":
+                    for expression_start, expression_end in _ruby_interpolation_ranges(
+                        source, body_start, body_end
+                    ):
+                        nested = lex_source(
+                            source[expression_start:expression_end], suffix, dialect
+                        )
+                        code[expression_start:expression_end] = list(nested.code)
+                        without_comments[expression_start:expression_end] = list(
+                            nested.without_comments
+                        )
+                        strings.extend(
+                            StringToken(
+                                expression_start + token.start,
+                                expression_start + token.end,
+                                token.contents,
+                            )
+                            for token in nested.strings
+                        )
                 strings.append(
                     StringToken(
                         body_start, body_end, source[body_start:body_end]
@@ -2445,6 +2574,18 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         ) and not (csharp_verbatim or jvm_raw)
         terminated = False
         while index < len(source):
+            if (
+                suffix == ".rb"
+                and delimiter in {'"', "`"}
+                and source.startswith("#{", index)
+            ):
+                interpolation_end = _ruby_interpolation_closing(
+                    source, index + 1, len(source)
+                )
+                if interpolation_end is None:
+                    break
+                index = interpolation_end + 1
+                continue
             if python_f_string or csharp_interpolates or jvm_interpolates:
                 brace_count = csharp_brace_count if csharp_interpolates else 1
                 opener = "${" if jvm_interpolates else "{" * brace_count

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -968,10 +968,203 @@ def _php_executable_ranges(source: str) -> list[tuple[int, int]]:
     return ranges
 
 
+def _jsx_tag_end(
+    source: str, lexical: str, start: int, suffix: str
+) -> int | None:
+    """Return the first JSX tag-closing ``>`` outside quotes/expressions."""
+
+    index = start + 1
+    quote = ""
+    escaped = False
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+        elif character in {"'", '"', "`"}:
+            quote = character
+        elif character == "{":
+            expression = _jsx_brace_range(
+                source, lexical, index, suffix
+            )
+            if expression is None:
+                return None
+            index = expression[1] + 1
+            continue
+        elif character == ">":
+            return index + 1
+        index += 1
+    return None
+
+
+def _jsx_brace_range(
+    source: str, lexical: str, opening: int, suffix: str
+) -> tuple[int, int] | None:
+    """Return one JSX expression range after masking JS lexical data."""
+
+    balanced = _balanced_brace_ranges(lexical, [opening])
+    if balanced:
+        return balanced[0]
+    # JSX text may contain quote characters which the host lexer paired across
+    # an expression. Retry only this exceptional span locally; normal files use
+    # the single cached lexical projection above and remain linear.
+    local = lex_source(source[opening:], suffix).code
+    balanced = _balanced_brace_ranges(local, [0])
+    if balanced:
+        start, end = balanced[0]
+        return opening + start, opening + end
+    return None
+
+
+def _jsx_element(
+    source: str,
+    lexical: str,
+    start: int,
+    suffix: str,
+    depth: int = 0,
+) -> tuple[int, list[tuple[int, int]]] | None:
+    """Parse one balanced JSX element and return its executable expressions."""
+
+    if depth > 128:
+        return None
+    fragment = source.startswith("<>", start)
+    identifier_start = r"(?:[^\W\d]|[$_])"
+    name_match = re.match(
+        rf"<({identifier_start}[\w$:.-]*)(?=[\s/>])", source[start:]
+    )
+    if not fragment and name_match is None:
+        return None
+    name = "" if fragment else name_match.group(1)
+    opening_end = _jsx_tag_end(source, lexical, start, suffix)
+    if opening_end is None:
+        return None
+
+    expressions: list[tuple[int, int]] = []
+    opening = source[start:opening_end]
+    # Attribute expressions execute even though tag names and quoted values do
+    # not. Keep only outermost balanced braces found outside quoted values.
+    cursor = start + 1
+    quote = ""
+    escaped = False
+    while cursor < opening_end:
+        character = source[cursor]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            cursor += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            cursor += 1
+            continue
+        if character == "{":
+            balanced = _jsx_brace_range(source, lexical, cursor, suffix)
+            if balanced is None or balanced[1] >= opening_end:
+                return None
+            expressions.append(balanced)
+            cursor = balanced[1] + 1
+            continue
+        cursor += 1
+
+    if opening.rstrip().endswith("/>"):
+        return opening_end, expressions
+
+    cursor = opening_end
+    while cursor < len(source):
+        if source[cursor] == "{":
+            balanced = _jsx_brace_range(source, lexical, cursor, suffix)
+            if balanced is None:
+                return None
+            expressions.append(balanced)
+            cursor = balanced[1] + 1
+            continue
+        if source[cursor] == "<":
+            if fragment and source.startswith("</>", cursor):
+                return cursor + 3, expressions
+            closing = re.match(
+                rf"</\s*({identifier_start}[\w$:.-]*)\s*>",
+                source[cursor:],
+            )
+            if closing and closing.group(1) == name:
+                return cursor + closing.end(), expressions
+            child = _jsx_element(
+                source, lexical, cursor, suffix, depth + 1
+            )
+            if child is not None:
+                child_end, child_expressions = child
+                expressions.extend(child_expressions)
+                cursor = child_end
+                continue
+            if re.match(rf"<{identifier_start}", source[cursor:]):
+                return None
+        cursor += 1
+    return None
+
+
+def _mask_jsx_markup(source: str, suffix: str) -> str:
+    """Blank definite JSX markup/text while retaining expression containers."""
+
+    # Locate roots in lexed code so `<Panel>` inside an ordinary string or
+    # comment cannot cause subsequent JavaScript to be hidden. The JSX parser
+    # itself uses the raw source after a root is established because inert text
+    # may legally contain quote characters that are not JavaScript strings.
+    lexical = lex_source(source, suffix).code
+    output = list(source)
+    cursor = 0
+    while cursor < len(source):
+        start = lexical.find("<", cursor)
+        if start < 0:
+            break
+        previous = start - 1
+        while previous >= 0 and lexical[previous].isspace():
+            previous -= 1
+        previous_word = _word_before(list(lexical), previous + 1).lower()
+        expression_context = (
+            previous < 0
+            or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
+            or (
+                lexical[previous] == ")"
+                and _javascript_control_paren(list(lexical), previous)
+            )
+            or (
+                lexical[previous] == "}"
+                and _javascript_block_brace(list(lexical), previous)
+            )
+            or previous_word
+            in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
+        )
+        if not expression_context:
+            cursor = start + 1
+            continue
+        element = _jsx_element(source, lexical, start, suffix)
+        if element is None:
+            cursor = start + 1
+            continue
+        end, expressions = element
+        _blank(output, start, end)
+        for expression_start, expression_end in expressions:
+            nested = _mask_jsx_markup(
+                source[expression_start:expression_end], suffix
+            )
+            output[expression_start:expression_end] = list(nested)
+        cursor = end
+    return "".join(output)
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
     ranges: list[tuple[int, int]] = []
+    if suffix in {".jsx", ".tsx"}:
+        return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
         # Comments may contain complete, syntactically valid examples. Preserve
         # their offsets/newlines but remove their contents before discovering
@@ -1790,7 +1983,7 @@ def _javascript_regex_can_start(
     previous = _previous_code_index(code, index)
     if last_opaque_end and (previous is None or previous < last_opaque_end):
         if all(character.isspace() for character in code[last_opaque_end:index]):
-            return False
+            return ""
     if previous is None:
         return True
 
@@ -1862,6 +2055,125 @@ def _javascript_regex_end(source: str, start: int) -> int | None:
     return None
 
 
+_RUBY_REGEXP_PREFIX_WORDS = {
+    "and",
+    "begin",
+    "case",
+    "do",
+    "else",
+    "elsif",
+    "if",
+    "in",
+    "not",
+    "or",
+    "rescue",
+    "return",
+    "then",
+    "unless",
+    "until",
+    "when",
+    "while",
+    "yield",
+}
+
+
+def _ruby_regex_can_start(
+    source: str, code: list[str], index: int, last_opaque_end: int
+) -> str:
+    """Distinguish a Ruby regexp opener from division and ``/=``."""
+
+    if index + 1 < len(code) and code[index + 1] == "=":
+        return ""
+    previous = _previous_code_index(code, index)
+    if last_opaque_end and (previous is None or previous < last_opaque_end):
+        if all(character.isspace() for character in code[last_opaque_end:index]):
+            return False
+    if previous is None:
+        return "exact"
+    character = code[previous]
+    if character in "([{,;:=!?&|^~<>*%":
+        return "exact"
+    if character in "+-":
+        return "exact" if previous == 0 or code[previous - 1] != character else ""
+    if character.isalnum() or character in "_$@":
+        word = _word_before(code, previous + 1).lower()
+        if word in _RUBY_REGEXP_PREFIX_WORDS:
+            return "exact"
+        # Ruby permits a regexp as the unparenthesized argument of a command
+        # call (`warn /pattern/`). Mark the command-shaped form separately so
+        # its closing context can still distinguish chained division.
+        word_start = previous + 1 - len(word)
+        line_start = source.rfind("\n", 0, word_start) + 1
+        prefix = source[line_start:word_start].strip()
+        if not prefix or prefix.endswith((".", "&.")):
+            return "command"
+    return ""
+
+
+def _ruby_slash_regex(
+    source: str, start: int, allow_newlines: bool
+) -> tuple[int, int, int] | None:
+    """Return slash-regexp bounds, respecting escapes, classes and holes."""
+
+    index = start + 1
+    in_class = False
+    while index < len(source):
+        character = source[index]
+        if character in {"\r", "\n"} and not allow_newlines:
+            return None
+        if character == "\\":
+            index += 2
+            continue
+        if source.startswith("#{", index):
+            balanced = _balanced_brace_ranges(source, [index + 1])
+            if not balanced:
+                return None
+            index = balanced[0][1] + 1
+            continue
+        if character == "[":
+            in_class = True
+        elif character == "]" and in_class:
+            in_class = False
+        elif character == "/" and not in_class:
+            contents_end = index
+            index += 1
+            while index < len(source) and source[index].isalpha():
+                index += 1
+            return index, start + 1, contents_end
+        index += 1
+    return None
+
+
+def _ruby_command_regex_has_valid_tail(source: str, regexp_end: int) -> bool:
+    """Reject command-regexp guesses that are actually chained division."""
+
+    line_end = source.find("\n", regexp_end)
+    if line_end < 0:
+        line_end = len(source)
+    tail = source[regexp_end:line_end].strip()
+    if not tail or tail.startswith(("#", ",", ")", "]", "}", ";")):
+        return True
+    if tail.startswith("/"):
+        # Most importantly, do not pair a division slash with the first slash
+        # of a later `https://...` literal when command regexes span lines.
+        return False
+    word = re.match(r"([A-Za-z_]\w*)", tail)
+    if word and word.group(1) in {
+        "and",
+        "do",
+        "if",
+        "or",
+        "rescue",
+        "unless",
+        "until",
+        "while",
+    }:
+        return True
+    # An operand immediately following the second slash identifies `a / b / c`,
+    # not `command /regexp/`.
+    return re.match(r"(?:[+-]\s*)?(?:[$@A-Za-z_\d]|[('\"\[{])", tail) is None
+
+
 def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
@@ -1875,6 +2187,7 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     shell_heredoc_index = 0
     index = 0
     last_js_opaque_end = 0
+    last_ruby_opaque_end = 0
 
     while index < len(source):
         while (
@@ -1907,6 +2220,51 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 _blank(without_comments, index, regex_end)
                 last_js_opaque_end = regex_end
                 index = regex_end
+                continue
+
+        ruby_regex_context = (
+            _ruby_regex_can_start(source, code, index, last_ruby_opaque_end)
+            if suffix == ".rb" and source[index] == "/"
+            else ""
+        )
+        if ruby_regex_context:
+            regexp = _ruby_slash_regex(
+                source,
+                index,
+                allow_newlines=True,
+            )
+            if regexp is not None:
+                regexp_end, contents_start, contents_end = regexp
+                if (
+                    ruby_regex_context == "command"
+                    and not _ruby_command_regex_has_valid_tail(
+                        source, regexp_end
+                    )
+                ):
+                    index += 1
+                    continue
+                _blank(code, index, regexp_end)
+                _blank(without_comments, index, regexp_end)
+                for expression_start, expression_end in _ruby_interpolation_ranges(
+                    source, contents_start, contents_end
+                ):
+                    nested = lex_source(
+                        source[expression_start:expression_end], suffix, dialect
+                    )
+                    code[expression_start:expression_end] = list(nested.code)
+                    without_comments[expression_start:expression_end] = list(
+                        nested.without_comments
+                    )
+                    strings.extend(
+                        StringToken(
+                            expression_start + token.start,
+                            expression_start + token.end,
+                            token.contents,
+                        )
+                        for token in nested.strings
+                    )
+                last_ruby_opaque_end = regexp_end
+                index = regexp_end
                 continue
 
         if c_block_comments and source.startswith("/*", index):
@@ -2270,6 +2628,8 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
+        if suffix == ".rb":
+            last_ruby_opaque_end = index
         if suffix in JS_TS_SUFFIXES:
             last_js_opaque_end = index
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -267,7 +267,7 @@ def executable_source(path: Path, source: str) -> str:
         ranges.extend(
             match.span(1)
             for match in re.finditer(
-                r"<script\b[^>]*>(.*?)</script\s*>", template_source,
+                r"<script\b[^>]*>(.*?)</script\b[^>]*>", template_source,
                 flags=re.IGNORECASE | re.DOTALL,
             )
         )
@@ -370,7 +370,7 @@ def executable_source(path: Path, source: str) -> str:
             ranges.extend(
                 match.span(1)
                 for match in re.finditer(
-                    r"<script\b[^>]*>(.*?)</script\s*>", source,
+                    r"<script\b[^>]*>(.*?)</script\b[^>]*>", source,
                     flags=re.IGNORECASE | re.DOTALL,
                 )
             )

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -336,6 +336,112 @@ def _razor_continuation_block_ranges(
     return continuations
 
 
+def _html_element_ranges(source: str) -> list[tuple[int, int]]:
+    """Return quote-aware complete HTML element and standalone-tag spans."""
+
+    tokens: list[tuple[int, int, str, bool, bool]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        match = re.match(r"<\s*(?P<closing>/)?\s*(?P<name>[A-Za-z][\w:.-]*)", source[opening:])
+        if match is None:
+            cursor = opening + 1
+            continue
+        quote = ""
+        escaped = False
+        end = None
+        for index in range(opening + match.end(), len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+            elif character == ">":
+                end = index + 1
+                break
+        if end is None:
+            break
+        tag_text = source[opening:end]
+        tokens.append(
+            (
+                opening,
+                end,
+                match.group("name").lower(),
+                bool(match.group("closing")),
+                bool(re.search(r"/\s*>$", tag_text)),
+            )
+        )
+        cursor = end
+
+    void_elements = {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    }
+    stack: list[tuple[str, int, int]] = []
+    ranges: list[tuple[int, int]] = []
+    for start, end, name, closing, self_closing in tokens:
+        if closing:
+            for stack_index in range(len(stack) - 1, -1, -1):
+                if stack[stack_index][0] != name:
+                    continue
+                _, element_start, _ = stack[stack_index]
+                del stack[stack_index:]
+                ranges.append((element_start, end))
+                break
+        elif self_closing or name in void_elements:
+            ranges.append((start, end))
+        else:
+            stack.append((name, start, end))
+    return ranges
+
+
+def _mask_razor_markup(
+    source: str, executable_ranges: list[tuple[int, int]]
+) -> str:
+    """Mask nested Razor markup with the innermost syntax region winning.
+
+    Razor control bodies mix raw C# with complete HTML elements. A union of
+    executable ranges retains the markup too, so quotes in prose can become
+    fake C# literals and hide a request. HTML and C# transition spans nest;
+    applying larger spans first and smaller spans last preserves the deepest
+    language boundary (markup -> @code -> nested markup -> @expression).
+    """
+
+    rendered = list(source)
+    markup_ranges = _html_element_ranges(source)
+    markup_ranges.extend(
+        match.span()
+        for match in re.finditer(r"<!--.*?-->", source, flags=re.DOTALL)
+    )
+    markup_ranges.extend(
+        match.span("text")
+        for match in re.finditer(
+            r"(?m)(?:^|(?<=[;{}]))[ \t]*@:(?P<text>[^\r\n]*)", source
+        )
+    )
+    operations = [
+        (end - start, 0, start, end) for start, end in markup_ranges
+    ]
+    operations.extend(
+        (end - start, 1, start, end) for start, end in executable_ranges
+    )
+    for _, keep, start, end in sorted(
+        operations, key=lambda item: (-item[0], item[1])
+    ):
+        if keep:
+            rendered[start:end] = source[start:end]
+        else:
+            _blank(rendered, start, end)
+    return "".join(rendered)
+
+
 def _vue_directive_expression_ranges(source: str) -> list[tuple[int, int]]:
     """Return value and dynamic-argument expressions for every Vue directive."""
 
@@ -444,6 +550,90 @@ def _javascript_template_expression_ranges(
         ranges.append(balanced[0])
         cursor = balanced[0][1] + 1
     return ranges
+
+
+def _ruby_interpolation_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable ``#{...}`` spans within an interpolating literal."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("#{", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        probe = marker - 1
+        while probe >= start and source[probe] == "\\":
+            backslashes += 1
+            probe -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        balanced = _balanced_brace_ranges(source, [marker + 1])
+        if not balanced or balanced[0][1] > end:
+            break
+        ranges.append(balanced[0])
+        cursor = balanced[0][1] + 1
+    return ranges
+
+
+def _ruby_percent_literal(
+    source: str, start: int
+) -> tuple[int, int, int, bool] | None:
+    """Return percent-literal bounds and interpolation behavior at ``start``."""
+
+    if start >= len(source) or source[start] != "%":
+        return None
+    cursor = start + 1
+    kind = "Q"
+    if cursor < len(source) and source[cursor] in "qQwWiIxrs":
+        kind = source[cursor]
+        cursor += 1
+    elif cursor >= len(source) or source[cursor] not in "([{<":
+        # Bare `%` is also modulo/assignment syntax. Its untyped literal form
+        # is unambiguous for paired delimiters; typed forms support every Ruby
+        # delimiter below.
+        return None
+    else:
+        previous = start - 1
+        while previous >= 0 and source[previous].isspace():
+            previous -= 1
+        if previous >= 0 and (
+            source[previous].isalnum() or source[previous] in "_$)]}'\""
+        ):
+            return None
+    if cursor >= len(source):
+        return None
+    opening = source[cursor]
+    if opening.isalnum() or opening.isspace():
+        return None
+    closing = {"(": ")", "[": "]", "{": "}", "<": ">"}.get(
+        opening, opening
+    )
+    paired = closing != opening
+    depth = 1
+    contents_start = cursor + 1
+    cursor = contents_start
+    while cursor < len(source):
+        character = source[cursor]
+        if character == "\\":
+            cursor = min(len(source), cursor + 2)
+            continue
+        if paired and character == opening:
+            depth += 1
+        elif character == closing:
+            depth -= 1
+            if depth == 0:
+                return (
+                    cursor + 1,
+                    contents_start,
+                    cursor,
+                    kind in {"Q", "W", "I", "x", "r"},
+                )
+        cursor += 1
+    return None
 
 
 def executable_source(path: Path, source: str) -> str:
@@ -569,6 +759,7 @@ def executable_source(path: Path, source: str) -> str:
                 razor_source,
             )
         )
+        source = _mask_razor_markup(razor_source, ranges)
     elif suffix in {".php", ".phtml"}:
         # Both extensions may be mixed HTML/PHP templates. Feeding surrounding
         # markup to the PHP lexer lets an apostrophe in page text open a string
@@ -1265,6 +1456,44 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             index = end
             continue
 
+        if suffix == ".rb" and source[index] == "%":
+            percent_literal = _ruby_percent_literal(source, index)
+            if percent_literal is not None:
+                literal_end, contents_start, contents_end, interpolates = (
+                    percent_literal
+                )
+                string_start = index
+                _blank(code, string_start, literal_end)
+                _blank(without_comments, string_start, literal_end)
+                if interpolates:
+                    for expression_start, expression_end in _ruby_interpolation_ranges(
+                        source, contents_start, contents_end
+                    ):
+                        nested = lex_source(
+                            source[expression_start:expression_end], suffix
+                        )
+                        code[expression_start:expression_end] = list(nested.code)
+                        without_comments[expression_start:expression_end] = list(
+                            nested.without_comments
+                        )
+                        strings.extend(
+                            StringToken(
+                                expression_start + token.start,
+                                expression_start + token.end,
+                                token.contents,
+                            )
+                            for token in nested.strings
+                        )
+                strings.append(
+                    StringToken(
+                        string_start,
+                        literal_end,
+                        source[contents_start:contents_end],
+                    )
+                )
+                index = literal_end
+                continue
+
         # Heredoc bodies are DATA, not code. They were lexed as code, so an
         # apostrophe inside one ("Don't edit by hand") paired with a later quote
         # and masked the send that followed.
@@ -1350,6 +1579,29 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             # Nested string tokens are recorded before the enclosing template
             # token so lookups inside an interpolation select the narrow token.
             for expression_start, expression_end in _javascript_template_expression_ranges(
+                source, contents_start, contents_end
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif delimiter in {'"', "`"} and suffix == ".rb":
+            # Ruby double-quoted strings and command literals execute
+            # interpolation expressions.
+            # Preserve the code within each `#{...}` while keeping surrounding
+            # string data masked, just as JavaScript template literals do.
+            for expression_start, expression_end in _ruby_interpolation_ranges(
                 source, contents_start, contents_end
             ):
                 nested = lex_source(

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1522,7 +1522,8 @@ _HEREDOC_OPENER_RE = re.compile(
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
 _SHELL_HEREDOC_REDIRECTION_RE = re.compile(
     r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
-    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"])*\"|(?:\\.|[^ \t\r\n;<>&|])+)",
+    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"\\])*\"|"
+    r"(?:\\.|[^\\ \t\r\n;<>&|])+)",
 )
 
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1230,6 +1230,15 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 end = _line_comment_end(source, index + 2, suffix)
                 index = end
                 continue
+            if suffix == ".php" and source.startswith("#[", index):
+                # PHP 8 attributes begin with `#[`. Treating that opener as a
+                # legacy hash comment masks the rest of the physical line,
+                # including a declaration and request that legally follow the
+                # attribute. The attribute body remains ordinary PHP syntax;
+                # the normal string and block-comment branches below still
+                # mask data nested inside it.
+                index += 2
+                continue
             end = _line_comment_end(source, index + 1, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -152,6 +152,17 @@ def canonical_suffix(path: Path) -> str:
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
 
 
+def source_dialect(path: Path) -> str:
+    """Return a dialect that shares a canonical grammar suffix."""
+
+    suffix = path.suffix.lower()
+    if suffix in {".kt", ".kts"}:
+        return "kotlin"
+    if suffix == ".scala":
+        return "scala"
+    return ""
+
+
 def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
     """Preserve offsets/newlines while retaining only executable ranges."""
     keep = bytearray(len(source))
@@ -634,6 +645,253 @@ def _ruby_percent_literal(
                 )
         cursor += 1
     return None
+
+
+def _python_f_string_prefix(source: str, quote_start: int) -> str:
+    """Return a valid Python f-string prefix immediately before a quote."""
+
+    start = quote_start
+    while start > 0 and source[start - 1].isalpha():
+        start -= 1
+    prefix = source[start:quote_start].lower()
+    if prefix not in {"f", "fr", "rf"}:
+        return ""
+    if start > 0 and (source[start - 1].isalnum() or source[start - 1] == "_"):
+        return ""
+    return prefix
+
+
+def _csharp_string_info(
+    source: str, quote_start: int, quote_run: int
+) -> tuple[bool, bool, int]:
+    """Return ``(verbatim_or_raw, interpolates, brace_count)`` for C#."""
+
+    if quote_run >= 3:
+        cursor = quote_start
+        while cursor > 0 and source[cursor - 1] == "$":
+            cursor -= 1
+        dollars = quote_start - cursor
+        return True, dollars > 0, max(1, dollars)
+    prefix_start = max(0, quote_start - 2)
+    prefix = source[prefix_start:quote_start]
+    if prefix in {"$@", "@$"}:
+        return True, True, 1
+    if quote_start > 0 and source[quote_start - 1] == "@":
+        return True, False, 1
+    if quote_start > 0 and source[quote_start - 1] == "$":
+        return False, True, 1
+    return False, False, 1
+
+
+def _scala_interpolated_string_prefix(source: str, quote_start: int) -> str:
+    """Return a Scala interpolator prefix immediately before a quote."""
+
+    start = quote_start
+    while start > 0 and source[start - 1].isalpha():
+        start -= 1
+    prefix = source[start:quote_start]
+    if prefix not in {"s", "f", "raw"}:
+        return ""
+    if start > 0 and (source[start - 1].isalnum() or source[start - 1] == "_"):
+        return ""
+    return prefix
+
+
+def _interpolation_expression_end(
+    source: str, start: int, end: int, language: str
+) -> int:
+    """Trim alignment/conversion/format syntax from an interpolation hole."""
+
+    stack: list[str] = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    quote = ""
+    escaped = False
+    for index in range(start, end):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif character in pairs:
+            stack.append(pairs[character])
+        elif stack and character == stack[-1]:
+            stack.pop()
+        elif not stack and (
+            (language == "python" and character in "!:")
+            or (language == "csharp" and character in ",:")
+        ):
+            return index
+    return end
+
+
+def _interpolation_ranges(
+    source: str,
+    start: int,
+    end: int,
+    *,
+    language: str,
+    brace_count: int = 1,
+    dollar_marker: bool = False,
+) -> list[tuple[int, int]]:
+    """Return executable expression spans within interpolated strings."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    opener = "${" if dollar_marker else "{" * brace_count
+    while cursor < end:
+        marker = source.find(opener, cursor, end)
+        if marker < 0:
+            break
+        if (
+            dollar_marker
+            and language == "scala"
+            and marker > start
+            and source[marker - 1] == "$"
+        ):
+            # Scala's s/f/raw interpolators spell a literal dollar as `$$`.
+            cursor = marker + 2
+            continue
+        if brace_count == 1 and source.startswith("{{", marker):
+            cursor = marker + 2
+            continue
+        expression_start = marker + len(opener)
+        closing = _interpolation_hole_closing(
+            source, expression_start, end, brace_count
+        )
+        if closing is None:
+            break
+        expression_end = _interpolation_expression_end(
+            source, expression_start, closing, language
+        )
+        if expression_start < expression_end:
+            ranges.append((expression_start, expression_end))
+        if language == "python" and expression_end < closing:
+            # Python format specs can themselves contain replacement fields.
+            ranges.extend(
+                _interpolation_ranges(
+                    source,
+                    expression_end + 1,
+                    closing,
+                    language=language,
+                )
+            )
+        cursor = closing + brace_count
+    return ranges
+
+
+def _interpolation_hole_closing(
+    source: str, start: int, end: int, brace_count: int
+) -> int | None:
+    """Return the closing-brace index for one interpolation expression."""
+
+    closer = "}" * brace_count
+    index = start
+    nested_braces = 0
+    quote = ""
+    escaped = False
+    while index < end:
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if character == "{":
+            nested_braces += 1
+            index += 1
+            continue
+        if character == "}":
+            if nested_braces:
+                nested_braces -= 1
+                index += 1
+                continue
+            if source.startswith(closer, index):
+                return index
+        index += 1
+    return None
+
+
+def _shell_command_substitution_end(
+    source: str, start: int, end: int
+) -> int | None:
+    """Return the closing parenthesis for a shell ``$(...)`` expression."""
+
+    depth = 1
+    index = start
+    quote = ""
+    escaped = False
+    while index < end:
+        character = source[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if character == "\\":
+            escaped = True
+            index += 1
+            continue
+        if quote:
+            if character == quote:
+                quote = ""
+            index += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif source.startswith("$(", index):
+            depth += 1
+            index += 1
+        elif character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
+
+
+def _shell_command_substitution_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable command spans inside a shell double-quoted string."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("$(", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        before = marker - 1
+        while before >= start and source[before] == "\\":
+            backslashes += 1
+            before -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        closing = _shell_command_substitution_end(source, marker + 2, end)
+        if closing is None:
+            break
+        ranges.append((marker + 2, closing))
+        ranges.extend(
+            _shell_command_substitution_ranges(source, marker + 2, closing)
+        )
+        cursor = closing + 1
+    return ranges
 
 
 def executable_source(path: Path, source: str) -> str:
@@ -1373,7 +1631,7 @@ def _javascript_regex_end(source: str, start: int) -> int | None:
     return None
 
 
-def lex_source(source: str, suffix: str) -> LexedSource:
+def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
     code = list(source)
@@ -1522,7 +1780,32 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         delimiter = quote
-        if quote in {"'", '"'} and source.startswith(quote * 3, index):
+        quote_run = 1
+        while index + quote_run < len(source) and source[index + quote_run] == quote:
+            quote_run += 1
+        python_f_string = suffix == ".py" and bool(
+            _python_f_string_prefix(source, index)
+        )
+        jvm_interpolates = quote == '"' and (
+            dialect == "kotlin"
+            or (
+                dialect == "scala"
+                and bool(_scala_interpolated_string_prefix(source, index))
+            )
+        )
+        jvm_raw = jvm_interpolates and quote_run >= 3
+        csharp_verbatim = False
+        csharp_interpolates = False
+        csharp_brace_count = 1
+        if suffix == ".cs" and quote == '"':
+            (
+                csharp_verbatim,
+                csharp_interpolates,
+                csharp_brace_count,
+            ) = _csharp_string_info(source, index, quote_run)
+            if quote_run >= 3:
+                delimiter = quote * quote_run
+        elif quote in {"'", '"'} and quote_run >= 3:
             delimiter = quote * 3
         string_start = index
         index += len(delimiter)
@@ -1530,12 +1813,54 @@ def lex_source(source: str, suffix: str) -> LexedSource:
         # A backtick delimits a Go RAW string, which has no escape sequences, so
         # a literal `\` inside one previously consumed the closing backtick and
         # ran the "string" to end of file.
-        honours_escapes = not (suffix == ".go" and delimiter == "`")
-        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
-            JS_TS_SUFFIXES | {".py"}
+        honours_escapes = not (
+            (suffix == ".go" and delimiter == "`")
+            or csharp_verbatim
+            or jvm_raw
         )
+        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
+            JS_TS_SUFFIXES | {".py", ".cs", ".java"}
+        ) and not (csharp_verbatim or jvm_raw)
         terminated = False
         while index < len(source):
+            if python_f_string or csharp_interpolates or jvm_interpolates:
+                brace_count = csharp_brace_count if csharp_interpolates else 1
+                opener = "${" if jvm_interpolates else "{" * brace_count
+                if source.startswith(opener, index):
+                    if (
+                        dialect == "scala"
+                        and jvm_interpolates
+                        and index > contents_start
+                        and source[index - 1] == "$"
+                    ):
+                        index += 2
+                        continue
+                    if brace_count == 1 and source.startswith("{{", index):
+                        index += 2
+                        continue
+                    hole_end = _interpolation_hole_closing(
+                        source,
+                        index + len(opener),
+                        len(source),
+                        brace_count,
+                    )
+                    if hole_end is not None:
+                        index = hole_end + brace_count
+                        continue
+            if suffix == ".sh" and delimiter == '"' and source.startswith("$(", index):
+                hole_end = _shell_command_substitution_end(
+                    source, index + 2, len(source)
+                )
+                if hole_end is not None:
+                    index = hole_end + 1
+                    continue
+            if (
+                csharp_verbatim
+                and len(delimiter) == 1
+                and source.startswith('""', index)
+            ):
+                index += 2
+                continue
             if source.startswith(delimiter, index):
                 contents_end = index
                 index += len(delimiter)
@@ -1582,7 +1907,7 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 source, contents_start, contents_end
             ):
                 nested = lex_source(
-                    source[expression_start:expression_end], suffix
+                    source[expression_start:expression_end], suffix, dialect
                 )
                 code[expression_start:expression_end] = list(nested.code)
                 without_comments[expression_start:expression_end] = list(
@@ -1605,7 +1930,63 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 source, contents_start, contents_end
             ):
                 nested = lex_source(
-                    source[expression_start:expression_end], suffix
+                    source[expression_start:expression_end], suffix, dialect
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif python_f_string or csharp_interpolates or jvm_interpolates:
+            language = (
+                "python"
+                if python_f_string
+                else "csharp"
+                if csharp_interpolates
+                else dialect
+            )
+            brace_count = csharp_brace_count if csharp_interpolates else 1
+            for expression_start, expression_end in _interpolation_ranges(
+                source,
+                contents_start,
+                contents_end,
+                language=language,
+                brace_count=brace_count,
+                dollar_marker=jvm_interpolates,
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix, dialect
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif suffix == ".sh" and delimiter in {'"', "`"}:
+            ranges = (
+                [(contents_start, contents_end)]
+                if delimiter == "`"
+                else _shell_command_substitution_ranges(
+                    source, contents_start, contents_end
+                )
+            )
+            for expression_start, expression_end in ranges:
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix, dialect
                 )
                 code[expression_start:expression_end] = list(nested.code)
                 without_comments[expression_start:expression_end] = list(
@@ -9938,6 +10319,41 @@ def shell_command_span(lexed: LexedSource, offset: int) -> tuple[int, int]:
     return start, end
 
 
+def shell_embedded_command_span(
+    lexed: LexedSource, offset: int
+) -> tuple[int, int] | None:
+    """Bound the narrowest quoted shell command containing ``offset``."""
+
+    candidates: list[tuple[int, int]] = []
+    for token in lexed.strings:
+        if not (token.start < offset < token.end):
+            continue
+        delimiter = lexed.original[token.start]
+        if delimiter == "`":
+            candidates.append((token.start + 1, token.end - 1))
+        elif delimiter == '"':
+            candidates.extend(
+                span
+                for span in _shell_command_substitution_ranges(
+                    lexed.original, token.start + 1, token.end - 1
+                )
+                if span[0] <= offset < span[1]
+            )
+    if not candidates:
+        return None
+    lower, upper = min(candidates, key=lambda span: span[1] - span[0])
+    start, end = lower, upper
+    for index in range(offset - 1, lower - 1, -1):
+        if shell_separator(lexed, index):
+            start = index + 1
+            break
+    for index in range(offset, upper):
+        if shell_separator(lexed, index):
+            end = index
+            break
+    return start, end
+
+
 def shell_curl_is_command(
     lexed: LexedSource, command_start: int, curl_start: int
 ) -> bool:
@@ -9963,7 +10379,9 @@ def shell_curl_calls(lexed: LexedSource) -> list[Call]:
     calls: list[Call] = []
     seen: set[tuple[int, int]] = set()
     for match in SHELL_CURL_RE.finditer(lexed.code):
-        start, end = shell_command_span(lexed, match.start(1))
+        start, end = shell_embedded_command_span(
+            lexed, match.start(1)
+        ) or shell_command_span(lexed, match.start(1))
         if not shell_curl_is_command(lexed, start, match.start(1)):
             continue
         if (start, end) not in seen:
@@ -11526,7 +11944,7 @@ def external_static_values(
     exports. Dynamic/package imports stay unknown instead of being guessed.
     """
 
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     visible = lexed.without_comments
     imports: list[tuple[str, str, str]] = []
     if suffix in JS_TS_SUFFIXES:
@@ -11805,7 +12223,7 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     if suffix != ".cs":
@@ -12010,7 +12428,7 @@ def message_body_fields(
     source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     source_resolver = SourceEndpointResolver(lexed, suffix)
     resolver = PayloadStateResolver(
         lexed,

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1511,7 +1511,7 @@ def _line_comment_end(source: str, start: int, suffix: str) -> int:
 # as heredoc openers, and since no later line matched the pseudo-tag the "body"
 # ran to EOF and blanked every send below it - a silent pass.
 _HEREDOC_OPENER_RE = re.compile(
-    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)[ \t]*(?=\r?\n|$)"
+    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)(?!\w)"
 )
 # Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
 # singleton-class syntax `class <<self` also puts a bare word straight after
@@ -1520,6 +1520,32 @@ _HEREDOC_OPENER_RE = re.compile(
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+_SHELL_HEREDOC_REDIRECTION_RE = re.compile(
+    r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
+    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"])*\"|(?:\\.|[^ \t\r\n;<>&|])+)",
+)
+
+
+def _shell_heredoc_redirection_tail(tail: str) -> bool:
+    """Accept only shell redirections after a heredoc delimiter.
+
+    A delimiter need not end the physical command: `cat <<EOF >out 2>&1` is
+    valid shell.  The lexer must mask that body, while still rejecting an
+    arbitrary expression containing `<< WORD`.  Consuming a sequence of
+    concrete redirections keeps that boundary explicit.
+    """
+
+    position = 0
+    while position < len(tail):
+        if tail[position:].strip() == "":
+            return True
+        if tail[position:].lstrip().startswith("#"):
+            return True
+        match = _SHELL_HEREDOC_REDIRECTION_RE.match(tail, position)
+        if match is None or match.end() == position:
+            return False
+        position = match.end()
+    return True
 
 
 def _heredoc_opener_at(
@@ -1534,8 +1560,17 @@ def _heredoc_opener_at(
     match = _HEREDOC_OPENER_RE.match(source, index)
     if match is None:
         return None
+    line_start = source.rfind("\n", 0, index) + 1
+    line_end = source.find("\n", match.end())
+    if line_end < 0:
+        line_end = len(source)
+    tail = source[match.end():line_end]
+    if suffix == ".sh":
+        if not _shell_heredoc_redirection_tail(tail):
+            return None
+    elif tail.strip():
+        return None
     if suffix == ".rb":
-        line_start = source.rfind("\n", 0, index) + 1
         if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
             return None
     return match
@@ -1668,7 +1703,23 @@ def _javascript_regex_can_start(
     if character == "}":
         return _javascript_block_brace(code, previous)
     if character.isalnum() or character in "_$":
-        return _word_before(code, previous + 1).lower() in _JS_REGEX_PREFIX_WORDS
+        word = _word_before(code, previous + 1).lower()
+        if word == "default":
+            # `export default /pattern/` expects an expression, but treating
+            # every property named `default` as that keyword would mislex
+            # `config.default / divisor` (ordinary division).  Require the
+            # complete contextual keyword pair.
+            word_start = previous + 1 - len(word)
+            before_word = _previous_code_index(code, word_start)
+            if before_word is None:
+                return False
+            export_word = _word_before(code, before_word + 1).lower()
+            export_start = before_word + 1 - len(export_word)
+            before_export = _previous_code_index(code, export_start)
+            return export_word == "export" and (
+                before_export is None or code[before_export] != "."
+            )
+        return word in _JS_REGEX_PREFIX_WORDS
     return False
 
 
@@ -4067,13 +4118,56 @@ _EXECUTION_LINK_RE = {
     ),
     ".py": r"urlopen\s*\(\s*{name}\b",
     ".go": r"\.\s*Do\s*\(\s*{name}\b",
+    # Net::HTTP::{Post,Put,Patch}.new only constructs a request. Ruby sends it
+    # later through Net::HTTP#request, with either parenthesized or command-call
+    # syntax. Requiring that link prevents fixtures/builders from being
+    # reported as live customer sends.
+    ".rb": r"\.\s*request\s*(?:\(\s*{name}\b|[ \t]+{name}\b)",
 }
 _INLINE_EXECUTION_RE = re.compile(
     # The constructor may be namespaced inside the execution call, as in
     # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
-    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do)\s*\(\s*"
+    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
     r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
 )
+
+
+def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
+    """Return conservative Ruby `def ... end` spans from masked source."""
+
+    stack: list[tuple[str, int | None]] = []
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for line in code.splitlines(keepends=True):
+        stripped = line.strip()
+        if re.match(r"end\b", stripped) and stack:
+            kind, start = stack.pop()
+            if kind == "def" and start is not None:
+                spans.append((start, cursor + len(line)))
+        else:
+            opener = re.match(r"(def|class|module)\b", stripped)
+            if opener is not None:
+                stack.append((opener.group(1), cursor))
+            elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
+                stack.append(("block", None))
+            elif re.match(
+                r"(?:if|unless|case|begin|for|while|until)\b", stripped
+            ):
+                stack.append(("control", None))
+        cursor += len(line)
+    return spans
+
+
+def _same_ruby_function_scope(
+    code: str, left: int, right: int, spans: list[tuple[int, int]]
+) -> bool:
+    """Whether two offsets belong to the same Ruby method (or top level)."""
+
+    def owner(offset: int) -> tuple[int, int] | None:
+        containing = [span for span in spans if span[0] <= offset < span[1]]
+        return min(containing, key=lambda span: span[1] - span[0]) if containing else None
+
+    return owner(left) == owner(right)
 
 
 def request_object_is_executed(
@@ -4114,15 +4208,34 @@ def request_object_is_executed(
         ) is not None
     # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
     # never the one executed, so every candidate must be tried.
+    name_pattern = (
+        r"(?:@@|@|\$)?[A-Za-z_]\w*" if suffix == ".rb" else r"[A-Za-z_]\w*"
+    )
     names = [
         name
-        for name in re.findall(r"[A-Za-z_]\w*", assignment.group(1))
+        for name in re.findall(name_pattern, assignment.group(1))
         if name != "_"
     ]
-    return any(
-        re.search(pattern.format(name=re.escape(name)), lexed.code[statement_start:])
-        for name in names
-    )
+    tail = lexed.code[call.end:]
+    ruby_spans = _ruby_function_spans(lexed.code) if suffix == ".rb" else []
+    for name in names:
+        execution = re.search(pattern.format(name=re.escape(name)), tail)
+        if execution is None:
+            continue
+        execution_offset = call.end + execution.start()
+        if suffix == ".rb" and not _same_ruby_function_scope(
+            lexed.code, call.start, execution_offset, ruby_spans
+        ):
+            continue
+        # A new reaching definition supersedes this request object. A later
+        # execution of the same variable must not retroactively execute the
+        # discarded constructor.
+        rebound = re.search(
+            rf"(?<![\w@$]){re.escape(name)}\s*=(?!=)", tail[:execution.start()]
+        )
+        if rebound is None:
+            return True
+    return False
 
 
 def php_stream_context_region(
@@ -5425,7 +5538,7 @@ def _request_url_spans(
         # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
         return args[1:2]
     if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
-        return args[0:1]
+        return args[0:1] if request_object_is_executed(lexed, call, suffix) else []
     if callee == "curl_init" and len(args) >= 1:
         # `curl_init($url)` sets CURLOPT_URL directly - it is the documented
         # one-liner form and is at least as common as the setopt spelling.
@@ -11588,7 +11701,30 @@ def consumed_endpoint_tokens(
             break
     consumed |= _tokens_in_span(lexed, (statement_start, statement_end))
 
-    for span in request_url_spans(lexed, call, suffix):
+    resolved_spans = request_url_spans(lexed, call, suffix)
+    if not resolved_spans:
+        # Recognised request-object constructors can be deliberately rejected
+        # because they are never executed (or use a read-only verb). Their URL
+        # is still accounted for by this analysed call; otherwise an alias such
+        # as `uri = URI(URL); req = Net::HTTP::Post.new(uri)` is re-reported by
+        # the fail-safe as an unknown send. Keep this list to constructors whose
+        # URL position is part of an explicit client signature.
+        args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+        callee = normalized_call_callee(lexed, call)
+        if args and callee.endswith("new") and "Net::HTTP::" in callee:
+            resolved_spans = args[0:1]
+        elif args and suffix == ".py" and callee.split(".")[-1] == "Request":
+            resolved_spans = args[0:1]
+        elif args and callee == "HttpRequestMessage":
+            resolved_spans = args[1:2]
+        elif args and callee == "RestRequest":
+            resolved_spans = args[0:1]
+        elif suffix in {".java", ".kt", ".kts", ".scala"}:
+            builder_span = builder_uri_span(lexed, call)
+            if builder_span is not None:
+                resolved_spans = [builder_span]
+
+    for span in resolved_spans:
         consumed |= _tokens_in_span(lexed, span)
         # Follow the alias chain the resolver itself walked. The endpoint is
         # often held one or more hops away - `url = routes.get("pool")` where

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -738,6 +738,7 @@ def _interpolation_ranges(
     language: str,
     brace_count: int = 1,
     dollar_marker: bool = False,
+    backslash_escapes_marker: bool = False,
 ) -> list[tuple[int, int]]:
     """Return executable expression spans within interpolated strings."""
 
@@ -748,6 +749,17 @@ def _interpolation_ranges(
         marker = source.find(opener, cursor, end)
         if marker < 0:
             break
+        if dollar_marker and backslash_escapes_marker:
+            backslashes = 0
+            before = marker - 1
+            while before >= start and source[before] == "\\":
+                backslashes += 1
+                before -= 1
+            if backslashes % 2:
+                # Kotlin normal strings spell a literal dollar as `\$`.
+                # An even run escapes only itself, leaving `$` executable.
+                cursor = marker + 2
+                continue
         if (
             dollar_marker
             and language == "scala"
@@ -1960,6 +1972,9 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 language=language,
                 brace_count=brace_count,
                 dollar_marker=jvm_interpolates,
+                backslash_escapes_marker=(
+                    dialect == "kotlin" and not jvm_raw
+                ),
             ):
                 nested = lex_source(
                     source[expression_start:expression_end], suffix, dialect

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -569,11 +569,14 @@ def executable_source(path: Path, source: str) -> str:
                 razor_source,
             )
         )
-    elif suffix == ".phtml":
-        # PHTML is a mixed HTML/PHP template, not a plain PHP source file.
-        # Feeding its markup to the PHP lexer lets an apostrophe in page text
-        # open a string that masks a later request inside <?php ... ?>.
-        ranges.extend(
+    elif suffix in {".php", ".phtml"}:
+        # Both extensions may be mixed HTML/PHP templates. Feeding surrounding
+        # markup to the PHP lexer lets an apostrophe in page text open a string
+        # that masks a later request inside <?php ... ?>. Preserve only PHP
+        # regions whenever tags are present. Tagless `.php` remains supported
+        # because many analyzer fixtures and generated snippets contain raw PHP
+        # statements without an opening tag; tagless `.phtml` remains markup.
+        php_ranges = [
             match.span("code")
             for match in re.finditer(
                 # Plain ``<?`` is executable when short_open_tag is enabled.
@@ -584,7 +587,14 @@ def executable_source(path: Path, source: str) -> str:
                 source,
                 flags=re.IGNORECASE | re.DOTALL,
             )
-        )
+        ]
+        if (
+            suffix == ".php"
+            and not php_ranges
+            and re.search(r"</?[A-Za-z!]", source) is None
+        ):
+            return source
+        ranges.extend(php_ranges)
     elif suffix in {".ejs", ".erb", ".jsp"}:
         if suffix == ".ejs":
             # EJS scriptlets execute on the server, while ordinary <script>

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -928,6 +928,24 @@ def _interpolation_hole_closing(
     return None
 
 
+def _shell_comment_start(source: str, index: int, start: int = 0) -> bool:
+    """A shell hash starts a comment only at an unescaped word boundary."""
+    before = index - 1
+    # A continued physical line does not introduce a new shell word.
+    while before > start and source[before - 1:before + 1] == "\\\n":
+        before -= 2
+    if before < start:
+        return True
+    if not (source[before].isspace() or source[before] in ";|&()<>"):
+        return False
+    backslashes = 0
+    cursor = before - 1
+    while cursor >= start and source[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 0
+
+
 def _shell_command_substitution_end(
     source: str, start: int, end: int
 ) -> int | None:
@@ -952,6 +970,12 @@ def _shell_command_substitution_end(
                 quote = ""
             index += 1
             continue
+        if character == "#" and _shell_comment_start(source, index, start):
+            # Parentheses in a shell comment cannot close (or nest) this
+            # substitution. Commands after its newline still execute.
+            newline = source.find("\n", index, end)
+            index = end if newline < 0 else newline + 1
+            continue
         if character in {"'", '"', "`"}:
             quote = character
         elif source.startswith("$(", index):
@@ -970,29 +994,40 @@ def _shell_command_substitution_end(
 def _shell_command_substitution_ranges(
     source: str, start: int, end: int
 ) -> list[tuple[int, int]]:
-    """Return executable command spans inside a shell double-quoted string."""
+    """Return outer substitutions in expanding shell text.
+
+    Each command is lexed in its own shell context by the caller. Descending
+    here would incorrectly execute substitutions inside that command's single
+    quotes or comments. Quotes in the surrounding string/heredoc are data.
+    """
 
     ranges: list[tuple[int, int]] = []
     cursor = start
     while cursor < end:
-        marker = source.find("$(", cursor, end)
-        if marker < 0:
-            break
-        backslashes = 0
-        before = marker - 1
-        while before >= start and source[before] == "\\":
-            backslashes += 1
-            before -= 1
-        if backslashes % 2:
-            cursor = marker + 2
+        if source[cursor] == "\\":
+            cursor += 2
             continue
-        closing = _shell_command_substitution_end(source, marker + 2, end)
+        if source.startswith("$(", cursor):
+            opening = cursor + 2
+            closing = _shell_command_substitution_end(source, opening, end)
+        elif source[cursor] == "`":
+            opening = cursor + 1
+            closing = opening
+            while closing < end:
+                if source[closing] == "\\":
+                    closing += 2
+                elif source[closing] == "`":
+                    break
+                else:
+                    closing += 1
+            if closing >= end:
+                closing = None
+        else:
+            cursor += 1
+            continue
         if closing is None:
             break
-        ranges.append((marker + 2, closing))
-        ranges.extend(
-            _shell_command_substitution_ranges(source, marker + 2, closing)
-        )
+        ranges.append((opening, closing))
         cursor = closing + 1
     return ranges
 
@@ -1804,6 +1839,8 @@ CSHARP_JSON_MUTATING_METHODS = frozenset(
 CSHARP_ONLY_FETCH_METHODS = frozenset(
     {"PutAsync", "PatchAsync", *CSHARP_JSON_MUTATING_METHOD_NAMES}
 )
+# Both net/http constructors share method/URL/body order after optional context.
+GO_REQUEST_METHOD_INDEX = {"NewRequest": 0, "NewRequestWithContext": 1}
 FETCH_CALL_RE = re.compile(
     rf"(?<![\w$])(?:fetch|request|post_form|postAsync|"
     rf"(?:{CSHARP_HTTP_CONTENT_METHOD_PATTERN})|"
@@ -1819,7 +1856,7 @@ FETCH_CALL_RE = re.compile(
     # migrated Ruby uses. Modelling only Net::HTTP.post made the whole shape
     # invisible: zero sends detected, so the fail-safe could not fire either.
     r"Net::HTTP::(?:Post|Put|Patch)\s*\.\s*new|"
-    r"NewRequest|curl_setopt_array|curl_setopt|curl_init|"
+    r"NewRequest(?:WithContext)?|curl_setopt_array|curl_setopt|curl_init|"
     r"HttpRequestMessage|RestRequest|Request|open|file_get_contents|"
     r"axios\s*\.\s*post|axios)\s*\("
 )
@@ -2294,7 +2331,7 @@ def _heredoc_langs(suffix: str) -> bool:
     return suffix in {".php", ".rb"}
 
 
-def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
+def _shell_heredoc_ranges(source: str) -> list[tuple[int, int, bool]]:
     """Return shell heredoc body ranges in one command-aware linear pass.
 
     The scan follows quotes, arithmetic contexts and backslash continuations,
@@ -2304,8 +2341,11 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
     arithmetic shifts and here-strings.
     """
 
-    ranges: list[tuple[int, int]] = []
-    pending: list[tuple[str, bool]] = []
+    ranges: list[tuple[int, int, bool]] = []
+    pending: list[tuple[str, bool, bool]] = []
+    opener_re = re.compile(
+        r'''<<(?P<tabs>-)?[ \t]*(?P<word>(?:\\.|'[^'\n]*'|"[^"\n]*"|[^\s\\'"<>;&|])+)'''
+    )
     quote = ""
     escaped = False
     parenthesis_depth = 0
@@ -2360,9 +2400,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
             quote = character
             index += 1
             continue
-        if character == "#" and (
-            index == command_start or source[index - 1].isspace()
-        ):
+        if character == "#" and _shell_comment_start(source, index, command_start):
             comment_start = index
             newline = source.find("\n", index + 1)
             index = len(source) if newline < 0 else newline
@@ -2370,11 +2408,17 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
         if source.startswith("<<<", index):
             index += 3
             continue
-        opener = _HEREDOC_OPENER_RE.match(source, index)
+        opener = opener_re.match(source, index)
         if opener is not None and (
             index == 0 or source[index - 1] != "<"
         ):
-            pending.append((opener.group("tag"), "<<-" in opener.group(0)))
+            word = opener.group("word")
+            try:
+                tag = shlex.split(word, posix=True)[0]
+            except (ValueError, IndexError):
+                index = opener.end()
+                continue
+            pending.append((tag, bool(opener.group("tabs")), not any(c in word for c in "'\"\\")))
             index = opener.end()
             continue
         if character != "\n":
@@ -2393,7 +2437,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
             continue
 
         body_start = index + 1
-        for tag, strips_tabs in pending:
+        for tag, strips_tabs, expands in pending:
             cursor = body_start
             terminator_start: int | None = None
             terminator_end: int | None = None
@@ -2411,7 +2455,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
                 cursor = line_end + 1
             body_end = len(source) if terminator_start is None else terminator_start
             if body_start < body_end:
-                ranges.append((body_start, body_end))
+                ranges.append((body_start, body_end, expands))
             if terminator_end is None:
                 body_start = len(source)
                 break
@@ -2976,9 +3020,16 @@ def _lex_source_once(
         ):
             shell_heredoc_index += 1
         if shell_heredoc_index < len(shell_heredoc_ranges):
-            body_start, body_end = shell_heredoc_ranges[shell_heredoc_index]
+            body_start, body_end, expands = shell_heredoc_ranges[shell_heredoc_index]
             if body_start <= index < body_end:
                 _blank(code, body_start, body_end)
+                if expands:
+                    for start, end in _shell_command_substitution_ranges(source, body_start, body_end):
+                        nested = lex_source(source[start:end], suffix, dialect)
+                        code[start:end] = list(nested.code)
+                        without_comments[start:end] = list(nested.without_comments)
+                        strings.extend(StringToken(start + token.start, start + token.end, token.contents)
+                                       for token in nested.strings)
                 strings.append(
                     StringToken(
                         body_start, body_end, source[body_start:body_end]
@@ -3062,7 +3113,9 @@ def _lex_source_once(
             index = end
             continue
 
-        if hash_comments and source[index] == "#":
+        if hash_comments and source[index] == "#" and (
+            suffix != ".sh" or _shell_comment_start(source, index)
+        ):
             if suffix == ".sh" and index == 0 and source.startswith("#!", index):
                 end = _line_comment_end(source, index + 2, suffix)
                 index = end
@@ -4251,6 +4304,18 @@ def rest_payload_spans(
         return assigned_named_payload_spans(
             lexed, arguments[0], call.start, suffix
         )
+    if suffix in JS_TS_SUFFIXES and callee == "request":
+        if node_core_request(lexed, call, suffix):
+            return request_write_payload_spans(lexed, call, suffix)
+        # URL/options overloads carry no positional body. In particular the
+        # optional callback must never be inspected as a request payload.
+        config = next((span for span in arguments[:2]
+                       if resolved_config_object_span(lexed, span, call.start, suffix)
+                       is not None), None)
+        if config is not None:
+            configured = named_payload_spans(lexed.code, [config], allow_js_shorthand=True)
+            configured = configured or assigned_named_payload_spans(lexed, config, call.start, suffix)
+            return configured or request_write_payload_spans(lexed, call, suffix)
     named = named_payload_spans(
         lexed.code,
         arguments,
@@ -4263,11 +4328,11 @@ def rest_payload_spans(
         if method is None or method.upper() in MUTATING_HTTP_METHODS:
             return arguments[2:3]
 
-    if callee == "NewRequest" and len(arguments) >= 3:
+    if callee in GO_REQUEST_METHOD_INDEX and len(arguments) >= GO_REQUEST_METHOD_INDEX[callee] + 3:
         # http.NewRequest(method, url, body): the body is the third argument,
         # normally wrapped (bytes.NewBuffer(json.Marshal output)).
         return [
-            resolve_wrapped_payload(lexed, arguments[2], call.start, suffix)
+            resolve_wrapped_payload(lexed, arguments[GO_REQUEST_METHOD_INDEX[callee] + 2], call.start, suffix)
         ]
     if callee.split(".")[-1] == "post_form":
         # Net::HTTP.post_form(uri, k => v, ...): every pair after the URI is
@@ -4832,6 +4897,11 @@ def call_has_profile(
             if resolver.text_presence(value).state == PRESENT:
                 return True
         return False
+    if not sdk_call and suffix in JS_TS_SUFFIXES and normalized_call_callee(lexed, call) == "request":
+        written = request_write_events(lexed, call, suffix)
+        spans = rest_payload_spans(lexed, call, suffix)
+        if node_core_request(lexed, call, suffix) or spans == [event.span for event in written if event.span]:
+            return request_writes_have_profile(lexed, call, suffix, resolver, written)
     return any(
         resolver.span_presence(start, end, call.start).state == PRESENT
         for start, end in payload_spans(
@@ -6020,21 +6090,26 @@ def _top_level_ternary(
         elif char in ")]}":
             depth -= 1
         elif char == "?" and depth == 0:
-            if code[index + 1:index + 2] in (".", "?"):
+            if code[index + 1:index + 2] in (".", "?") or code[index - 1:index] == "?":
                 continue
             question = index
             break
     if question < 0:
         return None
-    depth = 0
+    depth = nested = 0
     for index in range(question + 1, end):
         char = code[index]
         if char in "([{":
             depth += 1
         elif char in ")]}":
             depth -= 1
+        elif char == "?" and depth == 0 and code[index + 1:index + 2] not in (".", "?") and code[index - 1:index] != "?":
+            nested += 1
         elif char == ":" and depth == 0:
-            return (question + 1, index), (index + 1, end)
+            if nested:
+                nested -= 1
+            else:
+                return (question + 1, index), (index + 1, end)
     return None
 
 
@@ -6615,28 +6690,550 @@ ASSIGNED_HANDLE_RE = re.compile(
 )
 
 
-def request_write_payload_spans(
-    lexed: LexedSource, call: Call
-) -> list[tuple[int, int]]:
-    """Return <handle>.write(...) payload spans after a request(...) call."""
+def node_core_request(lexed: LexedSource, call: Call, suffix: str) -> bool:
+    """Resolve core http(s) module ownership without treating library body as core."""
+    source = SourceEndpointResolver(lexed, suffix)
+    receiver = re.search(r"([A-Za-z_$][\w$]*)\s*\.\s*$", lexed.code[:call.start])
+    name = receiver[1] if receiver else "request"
+
+    def owned(name: str, before: int, seen: frozenset[str]) -> bool:
+        if name in seen:
+            return False
+        binding = source.graph.visible_binding(name, source.scope_at(before), before)
+        assignments = [a for a in source.root_assignments if a.start() < before and a[1] == name
+                       and source.graph.visible_binding(name, source.scope_at(a.start()), a.start()) == binding]
+        if assignments:
+            assignment = assignments[-1]
+            end = assignment_end(lexed, assignment.end(), suffix)
+            rhs = lexed.without_comments[assignment.end():end].strip().rstrip(";").strip()
+            if re.fullmatch(r"require\s*\(\s*['\"](?:node:)?https?['\"]\s*\)(?:\s*\.\s*request)?", rhs):
+                return True
+            alias = re.fullmatch(r"([A-Za-z_$][\w$]*)(?:\s*\.\s*request)?", rhs)
+            return bool(alias and owned(alias[1], assignment.start(), seen | {name}))
+        prefix = lexed.without_comments[:before]
+        module = r"['\"](?:node:)?https?['\"]"
+        if receiver:
+            patterns = [r"\bimport\s+(?:\*\s+as\s+)?" + re.escape(name) + r"\s+from\s*" + module]
+        else:
+            patterns = [r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*" + module,
+                        r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*require\s*\(\s*" + module]
+        for pattern in patterns:
+            for origin in re.finditer(pattern, prefix):
+                # Require executable syntax, and the same binding at its origin:
+                # neither import-looking strings nor shadowed parameters own it.
+                if not re.match(r"(?:import|const|let|var)\b", lexed.code[origin.start():]):
+                    continue
+                if not receiver and not any(re.fullmatch(r"request(?:\s*(?:as|:)\s*request)?", member.strip())
+                                            for member in origin["members"].split(",")):
+                    continue
+                if source.graph.visible_binding(name, source.scope_at(origin.start()), origin.end()) == binding:
+                    return True
+        return False
+
+    return owned(name, call.start, frozenset())
+
+
+@dataclass(frozen=True)
+class RequestWriteEvent:
+    offset: int
+    method: str
+    span: tuple[int, int] | None = None
+    binding: int | tuple[int | None, str] | None = None
+    source_binding: int | tuple[int | None, str] | None = None
+
+
+@dataclass(frozen=True)
+class RequestClosure:
+    start: int
+    parameters: tuple[tuple[int, int], ...]
+    body: int
+    end: int
+    arguments: tuple[tuple[int, int], ...] | None
+    invocation_end: int | None
+
+
+def request_closures(resolver: SourceEndpointResolver) -> list[RequestClosure]:
+    """Balanced closure boundaries, including deferred parameter initializers.
+
+    Only direct synchronous invocations are folded. A callback, stored closure,
+    async function or generator does not establish a write before a later end.
+    """
+    cached = getattr(resolver, "_request_closures", None)
+    if cached is not None:
+        return cached
+    code = resolver.lexed.code
+    pairs: dict[int, int] = {}
+    stack: list[int] = []
+    for index, char in enumerate(code):
+        if char in "([{":
+            stack.append(index)
+        elif char in ")]}" and stack:
+            opening = stack.pop()
+            pairs[opening] = index
+            pairs[index] = opening
+    closures = []
+    for token in re.finditer(r"\bfunction\b|=>", code):
+        start = token.start()
+        if token[0] == "function":
+            header = re.match(r"function\s*\*?\s*(?:[A-Za-z_$][\w$]*\s*)?\(", code[start:])
+            if header is None:
+                continue
+            opening = start + header.end() - 1
+            closing = pairs.get(opening)
+            if closing is None:
+                continue
+            body = closing + 1
+        else:
+            closing = token.start() - 1
+            while closing >= 0 and code[closing].isspace():
+                closing -= 1
+            if code[closing:closing + 1] == ")":
+                opening = pairs.get(closing)
+                if opening is None:
+                    continue
+                start = opening
+            else:
+                parameter = re.search(r"[A-Za-z_$][\w$]*$", code[:closing + 1])
+                if parameter is None:
+                    continue
+                start = parameter.start()
+                opening = start - 1
+            body = token.end()
+        parameters = tuple(span for span in split_arguments(code, opening + 1, closing)
+                           if code[slice(*span)].strip())
+        async_prefix = re.search(r"\basync\s*$", code[:start])
+        if async_prefix:
+            start = async_prefix.start()
+        while body < len(code) and code[body].isspace():
+            body += 1
+        if code[body:body + 1] == "{":
+            if body not in pairs:
+                continue
+            end = pairs[body] + 1
+        else:
+            end = body
+            while end < len(code) and code[end] not in ",;\n)]}":
+                end = pairs[end] + 1 if code[end] in "([{" and end in pairs else end + 1
+        wrapped_start, wrapped_end = start, end
+        while True:
+            before = wrapped_start - 1
+            while before >= 0 and code[before].isspace():
+                before -= 1
+            after = wrapped_end
+            while after < len(code) and code[after].isspace():
+                after += 1
+            if before < 0 or code[before] != "(" or pairs.get(before) != after:
+                break
+            # Parentheses owned by an outer call are not grouping parentheses.
+            if re.search(r"[\w$)\]]\s*$", code[:before]):
+                break
+            wrapped_start, wrapped_end = before, after + 1
+        invocation = re.match(r"\s*(?:\.\s*call\s*)?\(", code[wrapped_end:])
+        # A declaration followed by a parenthesized statement is not an IIFE.
+        if (re.match(r"function\s+[A-Za-z_$][\w$]*\s*\(", code[start:])
+                and wrapped_start == start
+                and not re.search(r"[=(:,\[!&|?]\s*$|\breturn\s*$", code[:start])):
+            invocation = None
+        arguments = None
+        invocation_end = None
+        if invocation and not async_prefix and not re.match(r"function\s*\*", code[start:]):
+            argument_open = wrapped_end + invocation.end() - 1
+            argument_end = pairs.get(argument_open)
+            if argument_end is not None:
+                invocation_end = argument_end + 1
+                arguments = tuple(span for span in split_arguments(code, argument_open + 1, argument_end)
+                                  if code[slice(*span)].strip())
+                if "." in invocation[0]:
+                    arguments = arguments[1:]
+        closures.append(RequestClosure(start, parameters, body, end, arguments, invocation_end))
+    resolver._request_closures = closures
+    return closures
+
+
+def request_argument_is_undefined(resolver: SourceEndpointResolver, span: tuple[int, int]) -> bool:
+    """Recognize undefined values without running code or guessing call results."""
+    start, end = span
+    code = resolver.lexed.code
+    while start < end and code[start].isspace():
+        start += 1
+    while end > start and code[end - 1].isspace():
+        end -= 1
+    while code[start:start + 1] == "(" and matching_delimiter(code, start, "(", ")") == end - 1:
+        start, end = start + 1, end - 1
+        while start < end and code[start].isspace():
+            start += 1
+        while end > start and code[end - 1].isspace():
+            end -= 1
+    value = code[start:end]
+    if value == "undefined":
+        return resolver.graph.visible_binding("undefined", resolver.scope_at(start), start) is None
+    # The operand may have effects; event ordering evaluates it before defaults.
+    void = re.match(r"void\b\s*", value)
+    if void:
+        cursor = start + void.end()
+        # A unary void expression is undefined; a binary/conditional
+        # expression containing void need not be. Consume one primary and
+        # balanced postfix operations, not a prefix of an arbitrary expression.
+        primary = re.match(r"[A-Za-z_$][\w$]*|\d+(?:\.\d+)?", code[cursor:end])
+        if primary:
+            cursor += primary.end()
+        elif code[cursor:cursor + 1] != "(":
+            return False
+        while cursor < end:
+            if code[cursor] in "([":
+                closing = matching_delimiter(code, cursor, code[cursor], {"(": ")", "[": "]"}[code[cursor]])
+                if closing is None or closing >= end:
+                    return False
+                cursor = closing + 1
+            elif code[cursor].isspace():
+                cursor += 1
+            elif code[cursor] == ".":
+                member = re.match(r"\.\s*[A-Za-z_$][\w$]*", code[cursor:end])
+                if member is None:
+                    return False
+                cursor += member.end()
+            else:
+                return False
+        return True
+    for closure in request_closures(resolver):
+        if (closure.start < start or code[start:closure.start].strip("( \t\r\n")
+                or closure.invocation_end != end or closure.parameters):
+            continue
+        body = code[closure.body:closure.end]
+        returned = re.fullmatch(r"\{\s*return\s*(undefined|void\s+0)?\s*;?\s*\}", body)
+        if returned:
+            return returned[1] != "undefined" or resolver.graph.visible_binding(
+                "undefined", resolver.scope_at(closure.body), closure.body
+            ) is None
+    return False
+
+
+def request_event_order(resolver: SourceEndpointResolver, offset: int) -> tuple[int, ...]:
+    """Arguments execute before parameters/body, despite their source positions."""
+    key: list[int] = []
+    for closure in sorted(request_closures(resolver), key=lambda item: item.start):
+        if closure.invocation_end is not None and closure.start <= offset < closure.invocation_end:
+            key.extend((closure.start, int(offset < closure.end)))
+    return (*key, offset)
+
+
+def request_argument_has_unknown_call(resolver: SourceEndpointResolver, span: tuple[int, int]) -> bool:
+    """Do not lend ownership across calls whose side effects are unmodelled.
+
+    Direct closures have explicit events. A named no-argument empty function
+    is also harmless, but arbitrary helpers need interprocedural analysis and
+    conservatively invalidate ownership even when void fixes their result.
+    """
+    code = resolver.lexed.code
+    closures = request_closures(resolver)
+    for called in re.finditer(r"(?<![\w$])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)\s*\(", code[slice(*span)]):
+        offset = span[0] + called.start()
+        if called[1] == "void" or any(closure.start <= offset < closure.body for closure in closures):
+            continue
+        candidates = [closure for closure in closures
+                      if not closure.parameters
+                      and re.fullmatch(r"\{\s*\}", code[closure.body:closure.end])
+                      and re.match(rf"function\s+{re.escape(called[1])}\s*\(", code[closure.start:])
+                      and resolver.scope_at(closure.start) in resolver.graph.ancestors(resolver.scope_at(offset))]
+        if len(candidates) != 1 or resolver.graph.visible_binding(
+            called[1], resolver.scope_at(offset), offset
+        ) is not None:
+            return True
+    # Parenthesized callee expressions are not ordinary direct closures.
+    for invoked in re.finditer(r"\)\s*\(", code[slice(*span)]):
+        opening = span[0] + invoked.end() - 1
+        if not any(closure.invocation_end is not None and closure.end <= opening
+                   and re.fullmatch(r"\s*\)*\s*\(", code[closure.end:opening + 1])
+                   for closure in closures):
+            return True
+    return False
+
+
+def request_execution_scope(resolver: SourceEndpointResolver, offset: int) -> int:
+    """Fold invoked closures, but not skipped defaults, into their caller."""
+    closures = request_closures(resolver)
+    containing = [closure for closure in closures if closure.start <= offset < closure.end]
+    for closure in containing:
+        if closure.arguments is None:
+            return -closure.start - 1
+        for index, (start, end) in enumerate(closure.parameters):
+            if not start <= offset < end:
+                continue
+            # Destructuring adds property-level defaults whose execution
+            # depends on the supplied/default object's shape. Do not lend
+            # those effects without resolving that additional condition.
+            if not re.match(r"\s*[A-Za-z_$][\w$]*\s*=", resolver.lexed.code[start:end]):
+                return -closure.start - 1
+            if index < len(closure.arguments):
+                if not request_argument_is_undefined(resolver, closure.arguments[index]):
+                    return -closure.start - 1
+    execution = resolver.graph.execution_scope(resolver.scope_at(offset))
+    while execution:
+        scope = resolver.graph.scopes[execution]
+        if not any(closure.body == scope.start for closure in containing):
+            break
+        execution = resolver.graph.execution_scope(scope.parent or 0)
+    return execution
+
+
+def request_write_events(
+    lexed: LexedSource, call: Call, suffix: str = ".js"
+) -> list[RequestWriteEvent]:
+    """Return write/end bodies belonging to this request handle's lifetime."""
+    chained = re.match(r"\s*\.\s*end\s*\(", lexed.code[call.end:])
+    if chained:
+        opening = call.end + chained.end() - 1
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is not None:
+            args = split_arguments(lexed.code, opening + 1, closing)
+            return [RequestWriteEvent(call.end, "init"),
+                    RequestWriteEvent(call.end, "end", args[0] if args else None)]
     prefix = lexed.code[max(0, call.start - 160):call.start]
-    match = ASSIGNED_HANDLE_RE.search(prefix)
+    match = re.search(
+        r"(?<![\w$.])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)"
+        r"\s*=\s*(?:new\s+)?(?:[A-Za-z_$][\w$]*\s*\.\s*)?$", prefix
+    )
     if match is None:
         return []
-    handle = match.group(1)
+    handle = re.sub(r"\s+", "", match.group(1))
+    resolver = SourceEndpointResolver(lexed, suffix)
+
+    def receiver_binding(receiver: str, offset: int) -> int | tuple[int | None, str] | None:
+        root, separator, members = re.sub(r"\s+", "", receiver).partition(".")
+        # Parameters are in scope during later initializers as well as the body.
+        parameter_owner = [closure for closure in request_closures(resolver)
+                           if closure.start <= offset < closure.body]
+        lookup = max(parameter_owner, key=lambda item: item.start).body if parameter_owner else offset
+        root_binding = resolver.graph.visible_binding(root, resolver.scope_at(lookup), lookup)
+        return ((root_binding, members if root_binding is not None else root + "." + members)
+                if separator else root_binding)
+
+    binding = receiver_binding(handle, call.start)
+    execution = request_execution_scope(resolver, call.start)
+    assignments: list[RequestWriteEvent] = []
+    # Direct invocation binds arguments before entering the closure body.
+    # Parameter bindings remain lexical, so a stored callback or shadowing
+    # parameter cannot acquire ownership from a similarly named request.
+    for closure in request_closures(resolver):
+        if closure.start <= call.end or closure.arguments is None or request_execution_scope(resolver, closure.body) != execution:
+            continue
+        for index, parameter in enumerate(closure.parameters):
+            declared = re.fullmatch(r"\s*([A-Za-z_$][\w$]*)\s*(?:=([\s\S]*))?", lexed.code[slice(*parameter)])
+            if declared is None:
+                continue
+            name = declared[1]
+            argument = closure.arguments[index] if index < len(closure.arguments) else None
+            defaulted = argument is None or request_argument_is_undefined(resolver, argument)
+            value = (declared[2] or "").strip() if defaulted else lexed.code[slice(*argument)].strip()
+            if not re.fullmatch(
+                r"[A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*", value
+            ):
+                continue
+            target = resolver.graph.visible_binding(name, resolver.scope_at(closure.body), closure.body)
+            source = receiver_binding(value, parameter[0] if defaulted else argument[0])
+            # Supplied arguments capture their value before subsequent
+            # arguments can rebind it; defaults run in parameter order later.
+            assigned_at = parameter[1] if defaulted else argument[1]
+            assignments.append(RequestWriteEvent(assigned_at, "assign", binding=target, source_binding=source))
+            if isinstance(binding, tuple):
+                assignments.append(RequestWriteEvent(
+                    assigned_at, "assign", binding=(target, binding[1]),
+                    source_binding=(source, binding[1]) if isinstance(source, int) else None,
+                ))
+    # A broad typed-declaration match can cross an object literal and swallow
+    # a later bare assignment. Recover those lifetime mutations independently
+    # of the endpoint graph's declaration parser.
+    root_assignments = {assignment.start(): assignment for assignment in resolver.root_assignments}
+    parameter_starts = {start + len(lexed.code[start:end]) - len(lexed.code[start:end].lstrip())
+                        for closure in request_closures(resolver) for start, end in closure.parameters}
+    for assignment in re.finditer(r"(?<![\w$.>])([A-Za-z_$][\w$]*)\s*=(?!=|>)", lexed.code):
+        if assignment.start() not in parameter_starts:
+            root_assignments.setdefault(assignment.start(), assignment)
+    for assignment in root_assignments.values():
+        if assignment.start() <= call.end:
+            continue
+        scope = resolver.scope_at(assignment.start())
+        if request_execution_scope(resolver, assignment.start()) != execution:
+            continue
+        assigned_binding = receiver_binding(assignment[1], assignment.start())
+        end = assignment_end(lexed, assignment.end(), suffix)
+        rhs = lexed.code[assignment.end():end].strip().rstrip(";").strip()
+        source_binding = (receiver_binding(rhs, assignment.start())
+                          if re.fullmatch(r"[A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*", rhs) else None)
+        assignments.append(RequestWriteEvent(assignment.start(), "assign",
+                                             binding=assigned_binding, source_binding=source_binding))
+        if isinstance(binding, tuple):
+            # Root aliases carry the owned member at this point in time.
+            # A later root rebind kills only that root's view, not aliases
+            # which still point at the original owner object.
+            assignments.append(RequestWriteEvent(
+                assignment.start(), "assign", binding=(assigned_binding, binding[1]),
+                source_binding=(source_binding, binding[1])
+                if isinstance(source_binding, int) else None,
+            ))
+    if isinstance(binding, tuple):
+        for reference, start, _, _ in direct_member_assignments(lexed, len(lexed.code), suffix):
+            if start <= call.end or request_execution_scope(resolver, start) != execution:
+                continue
+            target = receiver_binding(".".join(reference), start)
+            if isinstance(target, tuple) and (
+                target[1] == binding[1] or binding[1].startswith(target[1] + ".")
+            ):
+                assignments.append(RequestWriteEvent(start, "member_assign", binding=(target[0], binding[1])))
+    # Finite alias closure keeps unrelated assignments/branches out of the
+    # path product. Runtime ownership is still evaluated per environment below.
+    aliases = {binding}
+    for _ in range(len(assignments)):
+        expanded = aliases | {event.binding for event in assignments
+                              if event.source_binding is not None and event.source_binding in aliases}
+        if expanded == aliases:
+            break
+        aliases = expanded
     write_re = re.compile(
-        r"(?<![\w$])" + re.escape(handle) + r"\s*\.\s*write\s*\("
+        r"(?<![\w$.])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)"
+        r"\s*\.\s*(write|end)\s*\("
     )
-    spans: list[tuple[int, int]] = []
+    events = [RequestWriteEvent(call.end, "init", binding=binding)]
+    events.extend(event for event in assignments if event.binding in aliases)
+    for closure in request_closures(resolver):
+        for argument in closure.arguments or ():
+            if (argument[0] > call.end and request_execution_scope(resolver, argument[0]) == execution
+                    and request_argument_is_undefined(resolver, argument)
+                    and request_argument_has_unknown_call(resolver, argument)):
+                events.append(RequestWriteEvent(argument[1], "invalidate"))
+    # Abrupt completion skips the remainder of this closure on its active
+    # branch. Keep return-expression effects before the skip boundary.
+    for abrupt in re.finditer(r"\b(?:return|throw)\b", lexed.code[call.end:]):
+        position = call.end + abrupt.start()
+        if lexed.code[:position].rstrip().endswith("."):
+            continue
+        containing = [closure for closure in request_closures(resolver)
+                      if closure.body <= position < closure.end]
+        if not containing or request_execution_scope(resolver, position) != execution:
+            continue
+        closure = max(containing, key=lambda item: item.start)
+        after = position + len(abrupt[0])
+        while after < closure.end and lexed.code[after] not in ";\n}":
+            if lexed.code[after] in "([{":
+                closing = matching_delimiter(lexed.code, after, lexed.code[after],
+                                             {"(": ")", "[": "]", "{": "}"}[lexed.code[after]])
+                if closing is not None:
+                    after = closing + 1
+                    continue
+            after += 1
+        # Return leaves the closure only after enclosing finally bodies run.
+        # Preserve their writes AND lifetime mutations (e.g. req = other).
+        finalizers: list[tuple[int, int]] = []
+        for attempt in re.finditer(r"\btry\s*\{", lexed.code[closure.body:position]):
+            opening = closure.body + attempt.end() - 1
+            try_end = matching_delimiter(lexed.code, opening, "{", "}")
+            if try_end is None:
+                continue
+            protected = opening < position < try_end
+            tail = try_end + 1
+            catcher = re.match(r"\s*catch\s*(?:\([^()]*\)\s*)?\{", lexed.code[tail:])
+            if catcher:
+                catch_end = matching_delimiter(lexed.code, tail + catcher.end() - 1, "{", "}")
+                if catch_end is None:
+                    continue
+                protected = protected or tail + catcher.end() - 1 < position < catch_end
+                tail = catch_end + 1
+            if not protected:
+                continue
+            finalizer = re.match(r"\s*finally\s*\{", lexed.code[tail:])
+            if finalizer:
+                final_open = tail + finalizer.end() - 1
+                final_end = matching_delimiter(lexed.code, final_open, "{", "}")
+                if final_end is not None:
+                    finalizers.append((final_open, final_end + 1))
+        skip = after
+        for final_start, final_end in sorted(finalizers):
+            events.append(RequestWriteEvent(position, "terminate", (skip, final_start)))
+            skip = final_end
+        events.append(RequestWriteEvent(position, "terminate", (skip, closure.end)))
+        if abrupt[0] == "throw":
+            # Catch dispatch is not modelled as a callable return. It can
+            # change ownership before control resumes; do not certify later
+            # writes through handles whose lifetime crossed that exception.
+            events.append(RequestWriteEvent(position, "throw"))
     for found in write_re.finditer(lexed.code, call.end):
+        if lexed.code[:found.start()].rstrip().endswith("."):
+            continue
+        event_binding = receiver_binding(found[1], found.start())
+        if event_binding not in aliases or (event_binding is None and found[1] != handle):
+            continue
+        if request_execution_scope(resolver, found.start()) != execution:
+            continue
         open_paren = lexed.code.index("(", found.end() - 1)
         closing = matching_delimiter(lexed.code, open_paren, "(", ")")
         if closing is None:
             continue
         arguments = split_arguments(lexed.code, open_paren + 1, closing)
-        if arguments:
-            spans.append(arguments[0])
-    return spans
+        events.append(RequestWriteEvent(found.start(), found[2], arguments[0] if arguments else None,
+                                        binding=event_binding))
+    return sorted(events, key=lambda event: request_event_order(resolver, event.offset))
+
+
+def request_write_payload_spans(lexed: LexedSource, call: Call, suffix: str = ".js") -> list[tuple[int, int]]:
+    return [event.span for event in request_write_events(lexed, call, suffix) if event.span]
+
+
+def request_writes_have_profile(lexed: LexedSource, call: Call, suffix: str,
+                               resolver: PayloadStateResolver,
+                               events: list[RequestWriteEvent]) -> bool:
+    control = resolver.control
+    paths = [control.path(event.offset) for event in events]
+    environments = control.environments(paths, control.path(call.start))
+    # Refine literal conditions within the same branch model. Unknown tests
+    # retain every environment; no conditional write alone certifies a send.
+    literal: dict[int, bool] = {}
+    for path in paths:
+        for group, _ in path:
+            condition = re.match(r"if\s*\(\s*(true|false)\s*\)", lexed.code[group:])
+            if condition:
+                literal[group] = condition[1] == "true"
+    environments = [env for env in environments if all(
+        (env.get(group) == 0) == value for group, value in literal.items())]
+    if not environments:
+        return False
+    for environment in environments:
+        present = False
+        aliases: set[int | tuple[int | None, str] | None] = set()
+        terminated: list[tuple[int, int]] = []
+        for event, path in zip(events, paths):
+            if not control.active(path, environment) or any(
+                start <= event.offset < end for start, end in terminated
+            ):
+                continue
+            if event.method == "terminate":
+                if event.span:
+                    terminated.append(event.span)
+                continue
+            if event.method in {"throw", "invalidate"}:
+                aliases.clear()
+                continue
+            if event.method == "init":
+                aliases.add(event.binding)
+                continue
+            if event.method == "member_assign":
+                if event.binding in aliases:
+                    aliases = {alias for alias in aliases if not isinstance(alias, tuple)}
+                continue
+            if event.method == "assign":
+                if event.source_binding is not None and event.source_binding in aliases:
+                    aliases.add(event.binding)
+                else:
+                    aliases.discard(event.binding)
+                continue
+            if event.binding not in aliases:
+                continue
+            if event.span and resolver.span_presence(*event.span, event.offset).state == PRESENT:
+                present = True
+            if event.method == "end":
+                break
+        if not present:
+            return False
+    return True
 
 
 URL_CONSTRUCTOR_RE = re.compile(
@@ -7087,10 +7684,11 @@ def _request_url_spans(
         # ENDPOINT, unlike net/http.Post(url, contentType, body). Without this
         # the whole send was invisible.
         return args[0:1]
-    if callee == "NewRequest" and len(args) >= 2:
+    if callee in GO_REQUEST_METHOD_INDEX and len(args) >= GO_REQUEST_METHOD_INDEX[callee] + 3:
         # Go net/http: http.NewRequest(method, url, body) + client.Do(req).
         # The idiomatic non-shortcut form; only mutating methods matter here.
-        method = static_method_value(lexed, args[0], call.start, suffix)
+        method_index = GO_REQUEST_METHOD_INDEX[callee]
+        method = static_method_value(lexed, args[method_index], call.start, suffix)
         if method is not None and method not in MUTATING_HTTP_METHODS:
             return []
         # NOTE: http.NewRequest is NOT gated on a client.Do(req) execution link.
@@ -7100,7 +7698,7 @@ def _request_url_spans(
         # behaviour change beyond the scope of this work, so it is left as-is;
         # the execution requirement applies only to the clients newly modelled
         # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
-        return args[1:2]
+        return args[method_index + 1:method_index + 2]
     if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
         return args[0:1] if request_object_is_executed(lexed, call, suffix) else []
     if callee == "curl_init" and len(args) >= 1:
@@ -7525,12 +8123,27 @@ def c_function_headers(
     if suffix not in supported:
         return {}
     headers: dict[int, tuple[int, int]] = {}
+    if suffix in JS_TS_SUFFIXES:
+        # Grouping and default expressions can contain parentheses/braces
+        # before the function body; index its balanced parameter pair directly.
+        for function in re.finditer(r"\bfunction\s*\*?\s*(?:[A-Za-z_$][\w$]*\s*)?\(", lexed.code):
+            params_open = function.end() - 1
+            params_close = matching_delimiter(lexed.code, params_open, "(", ")")
+            if params_close is None:
+                continue
+            body = params_close + 1
+            while body < len(lexed.code) and lexed.code[body].isspace():
+                body += 1
+            if lexed.code[body:body + 1] == "{":
+                headers[body] = (params_open + 1, params_close)
     controls = {
         "catch", "checked", "fixed", "for", "foreach", "if", "lock",
         "switch", "synchronized", "try", "unchecked", "using", "while",
         "with",
     }
     for opening in (index for index, char in enumerate(lexed.code) if char == "{"):
+        if opening in headers:
+            continue
         statement_start = max(
             lexed.code.rfind(";", 0, opening),
             lexed.code.rfind("{", 0, opening),
@@ -7555,7 +8168,7 @@ def c_function_headers(
                 params_open = matching_opening(
                     lexed.code, cursor, "(", ")"
                 )
-                if params_open is not None and params_open >= statement_start:
+                if params_open is not None:
                     headers[opening] = (params_open + 1, cursor)
                 continue
             parameter = re.search(
@@ -10505,6 +11118,7 @@ class ControlIndex:
         self.lexed, self.suffix = lexed, suffix
         self.arms: list[ControlArm] = []
         self.exhaustive: set[int] = set()
+        self.logical_traces: list[list[dict[int, int | None]]] = []
         if suffix in self.C_SUFFIXES:
             self._curly()
             # Expression-level guards are not a JavaScript peculiarity: PHP,
@@ -10549,6 +11163,57 @@ class ControlIndex:
             index += 1
         return None
 
+    def _logical_expression_traces(self, start: int, end: int) -> None:
+        """Keep short-circuit choices correlated by expression evaluation.
+
+        In ``a && b || c``, skipping b forces c to run. Independent optional
+        guards invent a path which skips both. Leaves have unknown truthiness;
+        no API-specific return-value assumptions are needed.
+        """
+        code = self.lexed.code
+        if len(re.findall(r"&&|\|\|", code[start:end])) > 6:
+            return  # Preserve the existing conservative finite-path bound.
+
+        def traces(left: int, right: int) -> list[tuple[bool, dict[int, int | None]]]:
+            while left < right and code[left].isspace():
+                left += 1
+            while right > left and code[right - 1].isspace():
+                right -= 1
+            if left < right and code[left] == "(" and matching_delimiter(code, left, "(", ")") == right - 1:
+                return traces(left + 1, right - 1)
+            operators: list[tuple[int, str]] = []
+            index = left
+            while index < right:
+                if code[index] in "([{":
+                    closing = matching_delimiter(code, index, code[index], {"(": ")", "[": "]", "{": "}"}[code[index]])
+                    if closing is None:
+                        return [(True, {}), (False, {})]
+                    index = closing + 1
+                    continue
+                if code[index:index + 2] in {"&&", "||"} and code[index + 2:index + 3] != "=":
+                    operators.append((index, code[index:index + 2]))
+                    index += 2
+                    continue
+                index += 1
+            if not operators:
+                return [(True, {}), (False, {})]
+            # Lowest precedence, rightmost operator is the expression root.
+            position, operator = next((item for item in reversed(operators) if item[1] == "||"), operators[-1])
+            before, after = traces(left, position), traces(position + 2, right)
+            right_groups = {group for _, path in after for group in path}
+            result = []
+            for value, path in before:
+                evaluate = value if operator == "&&" else not value
+                if evaluate:
+                    result.extend((outcome, path | tail | {position: 0}) for outcome, tail in after)
+                else:
+                    result.append((value, path | dict.fromkeys(right_groups) | {position: None}))
+            return result
+
+        choices = [path for _, path in traces(start, end)]
+        if any(choices):
+            self.logical_traces.append(choices)
+
     def _expression_guards(self) -> None:
         """Index short-circuit and ternary expression arms in JS/TS.
 
@@ -10569,15 +11234,15 @@ class ControlIndex:
         word_ops = self.suffix in {".php", ".rb", ".py"}
         logical_re = (
             r"&&=?|\|\|=?|(?<![\w])(?:and|or)(?![\w])" if word_ops
-            else r"&&=?|\|\|=?"
+            else r"&&=?|\|\|=?|\?\?=?"
         )
         dangling = re.compile(
             r"(?:&&|\|\||\?|(?<![\w])(?:and|or))\s*$" if word_ops
-            else r"(?:&&|\|\||\?)\s*$"
+            else r"(?:&&|\|\||\?\?|\?)\s*$"
         )
         continuing = re.compile(
             r"[ \t]*(?:&&|\|\||\?|:|(?<![\w])(?:and|or)(?![\w]))" if word_ops
-            else r"[ \t]*(?:&&|\|\||\?|:)"
+            else r"[ \t]*(?:&&|\|\||\?\?|\?|:)"
         )
         statement_start = 0
         for match in re.finditer(r"[;\n]|$", code):
@@ -10596,26 +11261,99 @@ class ControlIndex:
             profile = PROFILE_IDENTIFIER_RE.search(
                 self.lexed.original[statement_start:statement_end]
             )
-            if profile is not None:
-                absolute_profile = statement_start + profile.start()
+            if profile is not None or self.suffix in JS_TS_SUFFIXES:
+                absolute_profile = statement_start + profile.start() if profile else statement_end
                 logical = list(re.finditer(logical_re, segment))
                 for operator in logical:
                     operator_end = statement_start + operator.end()
-                    if operator_end <= absolute_profile:
+                    if self.suffix in JS_TS_SUFFIXES or operator_end <= absolute_profile:
+                        guard_end = statement_end
+                        if self.suffix in JS_TS_SUFFIXES and not operator[0].endswith("="):
+                            # A logical RHS may be skipped, but a surrounding
+                            # ternary still chooses an arm after evaluating
+                            # its whole condition: `a ?? b ? yes : no`.
+                            # Logical assignments instead guard the entire
+                            # RHS ternary, due to their lower precedence.
+                            stack: list[int] = []
+                            for index in range(statement_start, operator_end):
+                                if code[index] in "([{":
+                                    stack.append(index)
+                                elif code[index] in ")]}" and stack:
+                                    stack.pop()
+                            expression_start = statement_start
+                            if stack:
+                                opening = stack[-1]
+                                closing = matching_delimiter(code, opening, code[opening], {"(": ")", "[": "]", "{": "}"}[code[opening]])
+                                if closing is not None:
+                                    expression_start, guard_end = opening + 1, closing
+                            outer = _top_level_ternary(code, expression_start, guard_end)
+                            if outer and operator_end < outer[0][0]:
+                                guard_end = outer[0][0] - 1
+                        if self.suffix in JS_TS_SUFFIXES:
+                            # The RHS stops at its own comma/closing delimiter
+                            # or an enclosing ternary's alternate arm. Nested
+                            # expressions keep their internal separators.
+                            depth = ternaries = 0
+                            for index in range(operator_end, guard_end):
+                                char = code[index]
+                                if char in "([{":
+                                    depth += 1
+                                elif char in ")]}":
+                                    if not depth:
+                                        guard_end = index
+                                        break
+                                    depth -= 1
+                                elif not depth:
+                                    if not operator[0].endswith("=") and (
+                                        code[index:index + 2] == "||" or
+                                        code[index:index + 2] == "&&" and operator[0] == "&&"
+                                    ):
+                                        guard_end = index
+                                        break
+                                    if char == "?" and code[index:index + 2] not in {"??", "?."} and code[index - 1] != "?":
+                                        ternaries += 1
+                                    elif char == ":" and ternaries:
+                                        ternaries -= 1
+                                    elif char == "," or char == ":":
+                                        guard_end = index
+                                        break
                         self.arms.append(
-                            ControlArm(statement_start, 0, operator_end, statement_end)
+                            ControlArm(statement_start + operator.start(), 0, operator_end, guard_end)
                         )
-                question = segment.find("?")
-                colon = segment.find(":", question + 1) if question >= 0 else -1
-                if question >= 0 and colon >= 0 and absolute_profile > statement_start + question:
-                    self.arms.append(
-                        ControlArm(
-                            statement_start,
-                            0 if absolute_profile < statement_start + colon else 1,
-                            statement_start + question + 1,
-                            statement_end,
-                        )
-                    )
+                # Visit balanced subexpressions too: a ternary inside `(…)`
+                # or a call argument still guards its mutations. Balanced
+                # extraction avoids mistaking object-key colons for `?:`.
+                pending = [(statement_start, statement_end)]
+                seen: set[tuple[int, int]] = set()
+                while pending:
+                    start, end = pending.pop()
+                    if (start, end) in seen:
+                        continue
+                    seen.add((start, end))
+                    if self.suffix in JS_TS_SUFFIXES:
+                        # Comma has lower precedence than ?:; a following
+                        # expression is outside both conditional arms.
+                        expressions = split_arguments(code, start, end)
+                        if len(expressions) > 1:
+                            pending.extend(expressions)
+                            continue
+                    ternary = _top_level_ternary(code, start, end)
+                    if self.suffix in JS_TS_SUFFIXES and ternary is None:
+                        self._logical_expression_traces(start, end)
+                    if ternary is not None:
+                        group = ternary[0][0] - 1
+                        for branch, (arm_start, arm_end) in enumerate(ternary):
+                            self.arms.append(ControlArm(group, branch, arm_start, arm_end))
+                        self.exhaustive.add(group)
+                        pending.extend(ternary)
+                    stack: list[int] = []
+                    for index in range(start, end):
+                        if code[index] in "([{":
+                            stack.append(index)
+                        elif code[index] in ")]}" and stack:
+                            opening = stack.pop()
+                            if not stack:
+                                pending.append((opening + 1, index))
             statement_start = match.end()
 
     def _body_arm(self, group: int, branch: int, after: int) -> int | None:
@@ -11402,7 +12140,11 @@ class ControlIndex:
             environments = expanded
             if len(environments) > 64:
                 return []
-        return environments
+        return [environment for environment in environments if all(
+            any(all(group not in environment or environment[group] == choice
+                    for group, choice in trace.items()) for trace in traces)
+            for traces in self.logical_traces
+        )]
 
     @staticmethod
     def active(path: tuple[tuple[int, int], ...], environment: dict[int, int | None]) -> bool:
@@ -12186,6 +12928,10 @@ def shell_embedded_command_span(
     """Bound the narrowest quoted shell command containing ``offset``."""
 
     candidates: list[tuple[int, int]] = []
+    for start, end, expands in _shell_heredoc_ranges(lexed.original):
+        if expands and start <= offset < end:
+            candidates.extend(span for span in _shell_command_substitution_ranges(lexed.original, start, end)
+                              if span[0] <= offset < span[1])
     for token in lexed.strings:
         if not (token.start < offset < token.end):
             continue

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -99,6 +99,21 @@ ci_glob() {
   esac
 }
 
+# grep returns 1 when it found no matches and >1 for an operational error.
+# Static-analysis discovery may accept the former, but must never translate
+# the latter into a clean migration result.
+grep_allow_no_match() {
+  local status
+  set +e
+  grep "$@"
+  status=$?
+  set -e
+  if [ "$status" -gt 1 ]; then
+    return "$status"
+  fi
+  return 0
+}
+
 # Extensionless executables with shebangs (package.json "bin" entry points,
 # repo CLIs) are source files no --include glob can ever match; the Phase-1
 # scanner greps without includes and sees them, so skipping them here made
@@ -153,7 +168,7 @@ grep_shebang_files() {
     list=$(shebang_files_for_glob "$glob")
     [ -z "$list" ] && continue
     while IFS= read -r _f; do
-      [ -n "$_f" ] && { grep -nH -E "$pattern" "$_f" 2>/dev/null || true; }
+      [ -n "$_f" ] && grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
     done <<< "$list"
   done
 }
@@ -180,14 +195,6 @@ expand_source_globs() {
   done
 }
 
-# Comment-leading lines are prose, not residual code: '# migrated from
-# twilio' must not fail a completed migration. Live code with a TRAILING
-# comment still matches, since only lines STARTING with a comment marker are
-# stripped.
-strip_comment_lines() {
-  grep -v '^\([^:]*:[0-9]*:\)[[:space:]]*\(#\|//\|/\*\|\*\|--\|%\|<!--\)' || true
-}
-
 # Filter grep hits through the same lexer used by the messaging-profile
 # analyzer.  Line-prefix filters cannot distinguish a trailing dead comment
 # from live code, and syntax checks must not treat a quoted migration note as
@@ -210,6 +217,7 @@ filter_backend_matches() {
   scripts_dir=$(cd "$(dirname "$0")" && pwd)
   python3 -B "$scripts_dir/filter-source-matches.py" \
     --mode comments --region backend --pattern "$pattern" \
+    --exclude-suffix .vue --exclude-suffix .svelte --exclude-suffix .astro \
     --analyzer "$scripts_dir/lint-required-messaging-profile.py"
 }
 
@@ -246,7 +254,7 @@ search_raw_files() {
   done
   # shellcheck disable=SC2086
   set +f
-  grep -rn $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep_allow_no_match -a -rnH --null $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT"
   grep_shebang_files "$pattern" "$@"
 }
 
@@ -357,17 +365,21 @@ hybrid_waiver_applies() {
     [ -n "$MIGRATED_FILES" ] || return 0
     while IFS= read -r match; do
       [ -n "$match" ] || continue
-      path=$(printf '%s\n' "$match" | sed -E 's/:[0-9]+:.*$//')
-      case "$path" in
-        "$PROJECT_ROOT"/*) path=${path#"$PROJECT_ROOT"/} ;;
-        ./*) path=${path#./} ;;
-      esac
       while IFS= read -r migrated_file; do
         [ -n "$migrated_file" ] || continue
+        migrated_path="$PROJECT_ROOT/$migrated_file"
+        # Filtered grep output is `<absolute path>:<line>:<text>`. Do not
+        # recover the path with a colon regex: POSIX paths may themselves
+        # contain `:<digits>:`. Instead compare each complete, known migrated
+        # path and then validate only its numeric locator suffix.
+        remainder=${match#"$migrated_path:"}
+        if [ "$remainder" != "$match" ] && [[ "$remainder" =~ ^[0-9]+: ]]; then
+          return 1
+        fi
         # A directory finding covers every file below it. Do not waive a
         # Twilio-named directory when any explicitly migrated file lives in
         # that directory, even though the grep finding names only the parent.
-        if [ "$migrated_file" = "$path" ] || [[ "$migrated_file" = "$path"/* ]]; then
+        if [ "$migrated_path" = "$match" ] || [[ "$migrated_path" = "$match"/* ]]; then
           return 1
         fi
       done <<<"$MIGRATED_FILES"
@@ -848,19 +860,16 @@ if product_applies "all"; then
   # cross-file heuristic after applying the normal executable-source filter.
   webhook_pattern="(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)"
   webhook_handlers=$(search_raw_files "$webhook_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-    | filter_backend_matches "$webhook_pattern" \
-    | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+    | filter_backend_matches "$webhook_pattern")
   webhook_count=$(count_matches "$webhook_handlers")
   if [ "$webhook_count" -gt 0 ]; then
     ed25519_pattern="(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)"
     ed25519_refs=$(search_raw_files "$ed25519_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-      | filter_backend_matches "$ed25519_pattern" \
-      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+      | filter_backend_matches "$ed25519_pattern")
     ed25519_count=$(count_matches "$ed25519_refs")
     webhook_parse_pattern="(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])"
     telnyx_webhook_parse=$(search_raw_files "$webhook_parse_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-      | filter_backend_matches "$webhook_parse_pattern" \
-      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+      | filter_backend_matches "$webhook_parse_pattern")
     telnyx_parse_count=$(count_matches "$telnyx_webhook_parse")
     if [ "$telnyx_parse_count" -gt 0 ] && [ "$ed25519_count" -eq 0 ]; then
       lint_issue "webhook_ed25519_missing" \

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -147,15 +147,16 @@ grep_shebang_files() {
 }
 
 # A caller asking for "*.js" means "JavaScript", not "files whose name ends in
-# .js". Node resolves .cjs/.mjs and bundlers resolve .jsx/.tsx/.mts/.cts as the
-# same source language, so a check that only globs the bare extension silently
-# passes any project using them. Expanding here fixes every call site at once;
-# per-call glob lists drift apart as checks are added.
+# .js". Node resolves .cjs/.mjs, bundlers resolve .jsx/.tsx/.mts/.cts, and
+# component frameworks embed JavaScript in .vue/.svelte/.astro files. A check
+# that only globs the bare extension silently passes projects using them.
+# Expanding here fixes every call site at once; per-call glob lists drift apart
+# as checks are added.
 expand_source_globs() {
   local glob
   for glob in "$@"; do
     case "$glob" in
-      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' ;;
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' ;;
       '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
       '*.py') echo '*.py' '*.pyw' ;;
       '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -48,7 +48,7 @@ HYBRID_PRODUCTS=""
 MIGRATED_FILES=""
 JSON_CHECKS="[]"
 
-EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build"
+EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build .next .nuxt coverage .tox"
 EXCLUDE_LOCK_FILES="--exclude=package-lock.json --exclude=yarn.lock --exclude=pnpm-lock.yaml --exclude=Gemfile.lock --exclude=Pipfile.lock --exclude=poetry.lock --exclude=go.sum"
 EXCLUDE_SCAN_FILES="--exclude=twilio-scan.json --exclude=twilio-deep-scan.json --exclude=migration-state.json --exclude=MIGRATION-PLAN.md --exclude=MIGRATION-REPORT.md"
 
@@ -70,21 +70,153 @@ build_exclude_args() {
   done
   args="$args $EXCLUDE_LOCK_FILES"
   args="$args $EXCLUDE_SCAN_FILES"
-  args="$args --exclude=*.md --exclude=*.min.js"
+  args="$args --exclude=*.md --exclude=*.min.js --exclude=*.min.css --exclude=*.bundle.js --exclude=*.chunk.js"
   echo "$args"
 }
 
 GREP_EXCLUDES=""
 
+
+# grep --include globs are case-sensitive; SEND.JS is the same JavaScript as
+# send.js. Rewrite '*.ext' into a character-class glob matching any casing.
+ci_glob() {
+  local glob="$1"
+  case "$glob" in
+    \*.*)
+      local ext="${glob#\*.}" out="*." i c upper
+      for ((i = 0; i < ${#ext}; i++)); do
+        c="${ext:$i:1}"
+        if [[ "$c" == [a-z] ]]; then
+          upper=$(printf '%s' "$c" | tr '[:lower:]' '[:upper:]')
+          out+="[${c}${upper}]"
+        else
+          out+="$c"
+        fi
+      done
+      echo "$out"
+      ;;
+    *) echo "$glob" ;;
+  esac
+}
+
+# Extensionless executables with shebangs (package.json "bin" entry points,
+# repo CLIs) are source files no --include glob can ever match; the Phase-1
+# scanner greps without includes and sees them, so skipping them here made
+# the validator certify trees the scanner had put in migration scope.
+SHEBANG_JS_FILES=""
+SHEBANG_PY_FILES=""
+SHEBANG_RB_FILES=""
+SHEBANG_SH_FILES=""
+
+collect_shebang_files() {
+  local _f _first
+  while IFS= read -r -d '' _f; do
+    IFS= read -r _first < "$_f" 2>/dev/null || _first=""
+    case "$_first" in
+      '#!'*node*)   SHEBANG_JS_FILES="${SHEBANG_JS_FILES}${_f}"$'\n' ;;
+      '#!'*python*) SHEBANG_PY_FILES="${SHEBANG_PY_FILES}${_f}"$'\n' ;;
+      '#!'*ruby*)   SHEBANG_RB_FILES="${SHEBANG_RB_FILES}${_f}"$'\n' ;;
+      '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
+    esac
+  done < <(find "$PROJECT_ROOT" \
+    \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
+       -o -name venv -o -name .venv -o -name dist -o -name build \
+       -o -name .next -o -name .nuxt -o -name coverage -o -name .tox \) -prune \
+    -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
+}
+
+shebang_files_for_glob() {
+  case "$1" in
+    '*.js'|'*.ts') printf '%s' "$SHEBANG_JS_FILES" ;;
+    '*.py')        printf '%s' "$SHEBANG_PY_FILES" ;;
+    '*.rb')        printf '%s' "$SHEBANG_RB_FILES" ;;
+    '*.sh')        printf '%s' "$SHEBANG_SH_FILES" ;;
+  esac
+}
+
+grep_shebang_files() {
+  local pattern="$1"; shift
+  local glob list _f
+  for glob in "$@"; do
+    list=$(shebang_files_for_glob "$glob")
+    [ -z "$list" ] && continue
+    while IFS= read -r _f; do
+      [ -n "$_f" ] && { grep -nH -E "$pattern" "$_f" 2>/dev/null || true; }
+    done <<< "$list"
+  done
+}
+
+# A caller asking for "*.js" means "JavaScript", not "files whose name ends in
+# .js". Node resolves .cjs/.mjs and bundlers resolve .jsx/.tsx/.mts/.cts as the
+# same source language, so a check that only globs the bare extension silently
+# passes any project using them. Expanding here fixes every call site at once;
+# per-call glob lists drift apart as checks are added.
+expand_source_globs() {
+  local glob
+  for glob in "$@"; do
+    case "$glob" in
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' ;;
+      '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
+      '*.py') echo '*.py' '*.pyw' ;;
+      '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;
+      '*.php') echo '*.php' '*.phtml' ;;
+      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' ;;
+      '*.cs') echo '*.cs' '*.cshtml' ;;
+      *) echo "$glob" ;;
+    esac
+  done
+}
+
+# Comment-leading lines are prose, not residual code: '# migrated from
+# twilio' must not fail a completed migration. Live code with a TRAILING
+# comment still matches, since only lines STARTING with a comment marker are
+# stripped.
+strip_comment_lines() {
+  grep -v '^\([^:]*:[0-9]*:\)[[:space:]]*\(#\|//\|/\*\|\*\|--\|%\|<!--\)' || true
+}
+
+# Filter grep hits through the same lexer used by the messaging-profile
+# analyzer.  Line-prefix filters cannot distinguish a trailing dead comment
+# from live code, and syntax checks must not treat a quoted migration note as
+# an executable builder call.  `comments` preserves string literals (needed
+# for imports, URLs, and configuration); `code` masks both comments and
+# strings (needed for identifiers such as VoiceResponse()).
+filter_source_matches() {
+  local mode="$1"
+  local pattern="$2"
+  local scripts_dir
+  scripts_dir=$(cd "$(dirname "$0")" && pwd)
+  python3 -B "$scripts_dir/filter-source-matches.py" \
+    --mode "$mode" --pattern "$pattern" \
+    --analyzer "$scripts_dir/lint-required-messaging-profile.py"
+}
+
+search_live_files() {
+  local mode="$1"
+  local pattern="$2"
+  shift 2
+  search_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
+}
+
 search_files() {
   local pattern="$1"
   shift
   local include_args=""
-  for glob in "$@"; do
-    include_args="$include_args --include=$glob"
+  local glob
+  # shellcheck disable=SC2046
+  # `for glob in $(...)` lets the shell PATHNAME-EXPAND each glob against the
+  # CALLER'S cwd: if a matching file happens to exist there the glob collapses
+  # to that basename, silently restricting grep to it; if none matches the glob
+  # survives. Either way whole languages could stop being scanned. set -f keeps
+  # the patterns literal.
+  set -f
+  for glob in $(expand_source_globs "$@"); do
+    include_args="$include_args --include=$(ci_glob "$glob")"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  set +f
+  grep -rn $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep_shebang_files "$pattern" "$@"
 }
 
 count_matches() {
@@ -231,6 +363,17 @@ while [ $# -gt 0 ]; do
     --product)
       if [ $# -lt 2 ]; then echo "Error: --product requires a value" >&2; usage; fi
       PRODUCT_FILTER="$2"
+      # An unvalidated value silently matches no check_products list, so a typo
+      # skips every product-scoped check and still exits 0 — a silent pass.
+      # Same accepted set as validate-migration.sh.
+      case "$PRODUCT_FILTER" in
+        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup) ;;
+        *)
+          echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
+          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup" >&2
+          exit 2
+          ;;
+      esac
       shift 2
       ;;
     --json)
@@ -288,6 +431,7 @@ fi
 
 PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
 GREP_EXCLUDES=$(build_exclude_args)
+collect_shebang_files
 
 if [ -z "$STATE_FILE" ] && [ -f "$PROJECT_ROOT/migration-state.json" ]; then
   STATE_FILE="$PROJECT_ROOT/migration-state.json"
@@ -326,9 +470,55 @@ fi
 ORIGINAL_HAD_WEBHOOK_VALIDATION="unknown"
 SCAN_PRODUCTS=""
 if [ -n "$SCAN_JSON" ] && [ -f "$SCAN_JSON" ] && command -v jq >/dev/null 2>&1; then
-  ORIGINAL_HAD_WEBHOOK_VALIDATION=$(jq -r '.has_webhook_validation // false' "$SCAN_JSON" 2>/dev/null || echo "unknown")
+  ORIGINAL_HAD_WEBHOOK_VALIDATION=$(jq -r 'if (.summary.has_webhook_validation != null) then .summary.has_webhook_validation elif (.has_webhook_validation != null) then .has_webhook_validation else "unknown" end' "$SCAN_JSON" 2>/dev/null || echo "unknown")
   SCAN_PRODUCTS=$(jq -r '.products_used // [] | map(ascii_downcase) | join(",")' "$SCAN_JSON" 2>/dev/null || true)
 fi
+
+# Hybrid awareness, mirroring validate-migration.sh: a product recorded as
+# kept on Twilio in migration-state.json is a skill-sanctioned deployment
+# state, so residual-Twilio findings for it are expected and must not hard-
+# fail Phase 4 forever.
+if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ] && command -v jq >/dev/null 2>&1; then
+  # Only products with a truthy keep reason stay in hybrid scope. An
+  # operator reverses a decision with `set kept_on_twilio.X false`
+  # (there is no unset command), so false/null/empty means NOT kept.
+  KEPT_ON_TWILIO=$(jq -r '.kept_on_twilio // {} | to_entries | map(select(.value != false and .value != null and .value != "")) | map(.key) | join(",")' "$STATE_FILE" 2>/dev/null || true)
+elif [ -n "$STATE_FILE" ] && [ ! -f "$STATE_FILE" ]; then
+  echo "Warning: --state-file '$STATE_FILE' not found, ignoring" >&2
+fi
+
+# Waive only for the product that is actually KEPT on Twilio.
+#
+# Testing `-n "$KEPT_ON_TWILIO"` alone made ANY hybrid state a GLOBAL waiver: in
+# a `--product messaging` run, a leftover Twilio messaging import was downgraded
+# to a warning - and the linter exited clean - merely because an unrelated
+# product such as voice was kept on Twilio. That is a silent pass on exactly the
+# residue the check exists to find.
+#
+# The product is passed per call site because these checks are not all inside a
+# product-scoped block; the global ones (residual imports, client instantiation,
+# directory names, docs) legitimately span products and pass "any", which waives
+# whenever ANY product is kept - the original behaviour, but now stated at the
+# call site rather than applied silently everywhere.
+kept_on_twilio() {
+  local product="$1"
+  [ -n "$KEPT_ON_TWILIO" ] || return 1
+  [ "$product" = "any" ] && return 0
+  case ",$KEPT_ON_TWILIO," in
+    *",$product,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+lint_issue_or_hybrid_warn() {
+  local product="$1"
+  shift
+  if kept_on_twilio "$product"; then
+    lint_warn "$1" "$2 (hybrid deployment — $KEPT_ON_TWILIO kept on Twilio)" "$3" "${4:-}"
+  else
+    lint_issue "$1" "$2" "$3" "${4:-}"
+  fi
+}
 
 # Helper: returns 0 if a product was detected in the scan (or if no scan data)
 scan_has_product() {
@@ -355,56 +545,78 @@ fi
 if product_applies "messaging"; then
   section_header "Messaging Correctness"
 
-  # Check 1: .messages.create( — Twilio pattern, Telnyx uses .send() or messages.create differently
-  matches=$(search_files '\.messages\.create\(' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
-  count=$(count_matches "$matches")
+  # Check 1: Twilio and Telnyx both expose messages.create() in some SDKs.
+  # Classify the call by its request field: Twilio uses `body`, while Telnyx
+  # uses `text`. Reuse the quote-aware source lexer so strings, comments, URLs,
+  # nested objects, and adjacent calls cannot create false classifications.
+  messaging_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
+  if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$messaging_source_analyzer" ]; then
+    echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
+    exit 2
+  fi
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields "$PROJECT_ROOT"); then
+    echo "Error: Twilio messages.create analysis failed" >&2
+    exit 2
+  fi
+  count=$(count_matches "$twilio_create_calls")
   if [ "$count" -gt 0 ]; then
-    lint_issue "twilio_messages_create" \
-      "Twilio .messages.create() pattern found in $count file(s)" \
-      "Use telnyx.messages.send() (Python) or telnyx.messages.create() with text parameter (JS/Ruby)" \
-      "$(matches_to_json "$matches")"
+    lint_issue_or_hybrid_warn "messaging" "twilio_messages_create" \
+      "Twilio .messages.create() request using body found at $count call site(s)" \
+      "Use telnyx.messages.send() (Python) or telnyx.messages.create() with the text parameter (JavaScript/Ruby)" \
+      "$(matches_to_json "$twilio_create_calls")"
   else
-    lint_pass "twilio_messages_create" "No Twilio .messages.create() pattern found"
+    lint_pass "twilio_messages_create" "No Twilio .messages.create() request using body found"
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  matches=$(search_files '(\.send\(|\.create\().*body[=:]' "*.py" "*.js" "*.ts" "*.rb")
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields "$PROJECT_ROOT"); then
+    echo "Error: messaging body-field analysis failed" >&2
+    exit 2
+  fi
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    # Filter to only lines that also reference telnyx or messaging context
-    telnyx_context=$(echo "$matches" | grep -iE "telnyx|message|sms|mms" || true)
-    tcount=$(count_matches "$telnyx_context")
-    if [ "$tcount" -gt 0 ]; then
-      lint_issue "body_not_text" \
-        "Message send with 'body' parameter found in $tcount file(s)" \
-        "Telnyx uses 'text' not 'body' for message content" \
-        "$(matches_to_json "$telnyx_context")"
-    else
-      lint_pass "body_not_text" "No 'body' parameter in Telnyx messaging context"
-    fi
+    lint_issue "body_not_text" \
+      "Message send with 'body' parameter found at $count call site(s)" \
+      "Telnyx uses 'text' not 'body' for message content" \
+      "$(matches_to_json "$matches")"
   else
     lint_pass "body_not_text" "No 'body' parameter in message send calls"
   fi
 
-  # Check 3: messaging_profile_id missing in send calls (skip if messaging not detected in scan)
-  if scan_has_product "messaging"; then
-    telnyx_send=$(search_files '(telnyx.*message|message.*send|messages\.create)' "*.py" "*.js" "*.ts" "*.rb" "*.go")
-    send_count=$(count_matches "$telnyx_send")
-    if [ "$send_count" -gt 0 ]; then
-      profile_refs=$(search_files 'messaging_profile_id' "*.py" "*.js" "*.ts" "*.rb" "*.go")
-      profile_count=$(count_matches "$profile_refs")
-      if [ "$profile_count" -eq 0 ]; then
-        lint_warn "missing_messaging_profile_id" \
-          "Telnyx messaging calls found but no messaging_profile_id reference" \
-          "Include messaging_profile_id in send calls or set a default on the messaging profile"
-      else
-        lint_pass "missing_messaging_profile_id" "messaging_profile_id referenced in code"
-      fi
-    fi
+  # Check 3: number-pool and alphanumeric-sender sends require a Messaging
+  # Profile ID. Normal phone-number sends may omit it when the sender already
+  # belongs to the intended profile, which source inspection cannot infer.
+  # Run the source analyzer unconditionally inside the messaging section.
+  # The scanner and analyzer intentionally recognize different evidence; using
+  # scanner attribution as a gate let newly-supported URL builders disappear
+  # before the analyzer could evaluate them (a silent false pass).
+  if ! required_profile_analysis=$(python3 -B "$messaging_source_analyzer" "$PROJECT_ROOT"); then
+    echo "Error: required Messaging Profile analysis failed" >&2
+    exit 2
+  fi
+  required_sender_count=$(printf '%s\n' "$required_profile_analysis" | sed -n '1p')
+  case "$required_sender_count" in
+    ''|*[!0-9]*)
+      echo "Error: required Messaging Profile analysis returned an invalid count" >&2
+      exit 2
+      ;;
+  esac
+  missing_profile_calls=$(printf '%s\n' "$required_profile_analysis" | sed '1d; /^$/d')
+  missing_profile_count=$(count_matches "$missing_profile_calls")
+
+  if [ "$missing_profile_count" -gt 0 ]; then
+    lint_issue "required_messaging_profile_id" \
+      "Number-pool or dedicated alphanumeric-sender call sites found without a messaging_profile_id ($missing_profile_count)" \
+      "Include messaging_profile_id for every number-pool or alphanumeric-sender send. Phone-number sends may omit it when from already resolves to the intended Messaging Profile." \
+      "$(matches_to_json "$missing_profile_calls")"
+  elif [ "$required_sender_count" -gt 0 ]; then
+    lint_pass "required_messaging_profile_id" "Every detected required-profile messaging call has a messaging_profile_id"
+  else
+    lint_pass "required_messaging_profile_id" "No dedicated number-pool or alphanumeric-sender call sites detected"
   fi
 
   # Check 4: MessagingResponse builder class (doesn't exist in Telnyx)
-  matches=$(search_files 'MessagingResponse\(' "*.py" "*.js" "*.ts" "*.rb")
+  matches=$(search_live_files code 'MessagingResponse\(' "*.py" "*.js" "*.ts" "*.rb")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     lint_issue "messaging_response_builder" \
@@ -423,7 +635,7 @@ if product_applies "voice"; then
   section_header "Voice Correctness"
 
   # Check 5: VoiceResponse builder (Twilio TwiML — doesn't exist in Telnyx SDK)
-  matches=$(search_files 'VoiceResponse\(' "*.py" "*.js" "*.ts" "*.rb" "*.java" "*.php")
+  matches=$(search_live_files code 'VoiceResponse\(' "*.py" "*.js" "*.ts" "*.rb" "*.java" "*.php")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     lint_issue "voice_response_builder" \
@@ -448,7 +660,7 @@ excluded = {
     ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__",
     "build", "coverage", "dist", "node_modules", "vendor", "venv",
 }
-suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
+  suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
 tag_pattern = re.compile(
     r"<(?P<closing>/)?\s*(?P<tag>[A-Za-z_][\w:.-]*)"
     r"(?P<attrs>(?:\"[^\"]*\"|'[^']*'|[^>])*)>",
@@ -549,7 +761,14 @@ if product_applies "verify"; then
 
   # Check 9: verify_profile_id missing (skip if verify not detected in scan)
   if scan_has_product "verify"; then
-    telnyx_verify=$(search_files '(telnyx.*verif|verif.*telnyx|verify_profile|verification)' "*.py" "*.js" "*.ts" "*.rb" "*.go")
+    # "verification" alone matched WEBHOOK SIGNATURE verification - which every
+    # correctly migrated app now has - so repos with no Verify product at all
+    # were told to add a verify_profile_id. Match the Verify PRODUCT's own API
+    # surface instead, and exclude the signature/webhook sense explicitly.
+    telnyx_verify=$(search_files \
+      '(telnyx.*\bverifications?\b|\bverifications?\b.*telnyx|verify_profile|/v2/verifications|verifications\.(create|by_phone_number)|\bVerifyProfile\b)' \
+      "*.py" "*.js" "*.ts" "*.rb" "*.go" \
+      | grep -v -iE '(webhook|signature|ed25519|unwrap|construct_event|verify_webhook|verification_key|public_key)' || true)
     verify_count=$(count_matches "$telnyx_verify")
     if [ "$verify_count" -gt 0 ]; then
       profile_refs=$(search_files 'verify_profile_id' "*.py" "*.js" "*.ts" "*.rb" "*.go")
@@ -655,7 +874,7 @@ fi
 if product_applies "voice"; then
   section_header "Polly Voice Compatibility"
 
-  # Check 14: Non-Neural Polly voices (may fall back to default voice)
+  # Check 14: Named Polly voices are valid and must retain caller-facing audio.
   polly_refs=$(search_files "Polly\.[A-Z][a-z]+" "*.xml" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
   polly_count=$(count_matches "$polly_refs")
   if [ "$polly_count" -gt 0 ]; then
@@ -679,18 +898,33 @@ section_header "Documentation Updates"
 
 # Check 15: README and docs still referencing Twilio
 doc_files=""
-for f in README.md README README.rst CONTRIBUTING.md; do
-  if [ -f "$PROJECT_ROOT/$f" ]; then
-    twilio_in_doc=$(grep -in "twilio" "$PROJECT_ROOT/$f" 2>/dev/null | grep -v -iE '(migrat|port|formerly|previously|was twilio|from twilio to)' || true)
+while IFS= read -r -d '' doc_path; do
+    # Prose EXPLAINING the migration is not residual Twilio. Two defects here:
+    #  - 'formerly' did not cover 'the former Twilio Verify SID', so an
+    #    operator's mapping note gated a correctly migrated repo with exit 1;
+    #  - bare 'port' matched inside 'support', 'important' and 'export', which
+    #    silently excluded real leftovers. Both are now word-anchored.
+    # A HYBRID deployment also documents its remaining Twilio use on purpose -
+    # the skill mandates recording it - so those lines are expected too.
+    # Upstream repository ownership is historical provenance, not a runtime
+    # dependency. Rewriting a TwilioDevEd badge/clone URL would create a dead
+    # link while leaving the actual migration unchanged.
+    # NOTE: no \b before 'behaviour change'. Markdown bold writes
+    # __Behavior change from the Twilio integration__, and '_' is a WORD
+    # character, so \bbehavior could never match after it - the same
+    # word-boundary trap that made (?<![\w$]) never match $var in shell.
+    doc_exclusions='(\bmigrat|\bported\b|\bporting\b|\bformer|\bpreviousl|\bwas twilio\b|from twilio to|\breplaces?\b|\bno longer\b|\binstead of\b|\bequivalent\b|behaviou?r change|\btwilio integration\b|\bcounterpart\b|\bunlike twilio\b|\bcompared (to|with)\b|\bhybrid\b|\bstill uses? twilio\b|\bno telnyx equivalent\b|github\.com[:/]twiliodeved/)'
+    twilio_in_doc=$(grep -in "twilio" "$doc_path" 2>/dev/null | grep -v -iE "$doc_exclusions" || true)
     if [ -n "$twilio_in_doc" ]; then
-      doc_files+="$PROJECT_ROOT/$f"$'\n'
+      doc_files+="$doc_path"$'\n'
     fi
-  fi
-done
+done < <(find "$PROJECT_ROOT" -maxdepth 1 -type f \
+  \( -iname README -o -iname README.md -o -iname README.rst -o -iname CONTRIBUTING.md \) \
+  -print0 2>/dev/null)
 doc_files=$(echo "$doc_files" | sed '/^$/d')
 doc_count=$(echo "$doc_files" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$doc_count" -gt 0 ]; then
-  lint_issue "docs_still_twilio" \
+  lint_issue_or_hybrid_warn "any" "docs_still_twilio" \
     "Documentation files still reference Twilio (not migration-related references) in $doc_count file(s)" \
     "Update README/docs: replace Twilio service names, env vars, setup instructions, and URLs with Telnyx equivalents" \
     "$(echo "$doc_files" | sed '/^$/d' | head -10 | jq -R -s '{files: (split("\n") | map(select(length > 0)))}' 2>/dev/null || echo '{"files":[]}')"
@@ -704,7 +938,7 @@ fi
 section_header "Residual Twilio Patterns"
 
 # Check 10: Residual Twilio imports still present alongside Telnyx code
-matches=$(search_files '(from twilio|import twilio|require.*twilio|using Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
+matches=$(search_live_files comments '(from twilio|import[ (].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then
@@ -723,7 +957,7 @@ else
 fi
 
 # Check 11: Twilio client instantiation patterns
-matches=$(search_files '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -1008,7 +1008,7 @@ else
 fi
 
 # Check 11: Twilio client instantiation patterns
-matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.|TwilioClient[[:space:]]*\.[[:space:]]*Init[[:space:]]*\()' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -142,38 +142,36 @@ grep_allow_no_match() {
 # repo CLIs) are source files no --include glob can ever match; the Phase-1
 # scanner greps without includes and sees them, so skipping them here made
 # the validator certify trees the scanner had put in migration scope.
-SHEBANG_JS_FILES=""
-SHEBANG_PY_FILES=""
-SHEBANG_RB_FILES=""
-SHEBANG_SH_FILES=""
+SHEBANG_FILES=()
+SHEBANG_CATEGORIES=()
 
 collect_shebang_files() {
-  local _f _first
+  local _f _first _category
   while IFS= read -r -d '' _f; do
-    IFS= read -r _first < "$_f" 2>/dev/null || _first=""
+    _first=""
+    IFS= read -r _first < "$_f" 2>/dev/null || [ -n "$_first" ] || _first=""
     case "$_first" in
-      '#!'*node*)   SHEBANG_JS_FILES="${SHEBANG_JS_FILES}${_f}"$'\n' ;;
-      '#!'*python*) SHEBANG_PY_FILES="${SHEBANG_PY_FILES}${_f}"$'\n' ;;
-      '#!'*ruby*)   SHEBANG_RB_FILES="${SHEBANG_RB_FILES}${_f}"$'\n' ;;
-      '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
+      '#!'*node*)   _category="javascript" ;;
+      '#!'*python*) _category="python" ;;
+      '#!'*ruby*)   _category="ruby" ;;
+      '#!'*sh*)     _category="shell" ;;
+      *)            _category="" ;;
     esac
+    if [ -n "$_category" ]; then
+      # Bash variables cannot contain NUL, and LF-delimited path lists cannot
+      # represent every legal pathname. Indexed arrays retain each `find
+      # -print0` record as one argument all the way through grep.
+      SHEBANG_FILES+=("$_f")
+      SHEBANG_CATEGORIES+=("$_category")
+    fi
   done < <(find "$PROJECT_ROOT" \
     \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
     -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
 }
 
-shebang_files_for_glob() {
-  case "$1" in
-    '*.js'|'*.ts') printf '%s' "$SHEBANG_JS_FILES" ;;
-    '*.py')        printf '%s' "$SHEBANG_PY_FILES" ;;
-    '*.rb')        printf '%s' "$SHEBANG_RB_FILES" ;;
-    '*.sh')        printf '%s' "$SHEBANG_SH_FILES" ;;
-  esac
-}
-
 grep_shebang_files() {
   local pattern="$1"; shift
-  local glob list _f category seen_categories=""
+  local glob _index _f category seen_categories=""
   for glob in "$@"; do
     case "$glob" in
       '*.js'|'*.ts') category="javascript" ;;
@@ -187,11 +185,11 @@ grep_shebang_files() {
       *" $category "*) continue ;;
     esac
     seen_categories="$seen_categories $category"
-    list=$(shebang_files_for_glob "$glob")
-    [ -z "$list" ] && continue
-    while IFS= read -r _f; do
-      [ -n "$_f" ] && grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
-    done <<< "$list"
+    for _index in "${!SHEBANG_FILES[@]}"; do
+      [ "${SHEBANG_CATEGORIES[$_index]}" = "$category" ] || continue
+      _f=${SHEBANG_FILES[$_index]}
+      grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
+    done
   done
 }
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -76,6 +76,18 @@ build_exclude_args() {
 
 GREP_EXCLUDES=""
 
+# Build every find(1) prune expression from the same policy as grep.  Keeping
+# literal copies in each traversal caused generated directories to re-enter
+# through the directory-name and shebang scans after source scanning excluded
+# them.
+FIND_EXCLUDE_EXPR=()
+for excluded_dir in $EXCLUDE_DIRS; do
+  if [ ${#FIND_EXCLUDE_EXPR[@]} -gt 0 ]; then
+    FIND_EXCLUDE_EXPR+=(-o)
+  fi
+  FIND_EXCLUDE_EXPR+=(-name "$excluded_dir")
+done
+
 
 # grep --include globs are case-sensitive; SEND.JS is the same JavaScript as
 # send.js. Rewrite '*.ext' into a character-class glob matching any casing.
@@ -134,9 +146,7 @@ collect_shebang_files() {
       '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
     esac
   done < <(find "$PROJECT_ROOT" \
-    \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
-       -o -name venv -o -name .venv -o -name dist -o -name build \
-       -o -name .next -o -name .nuxt -o -name coverage -o -name .tox \) -prune \
+    \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
     -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
 }
 
@@ -189,7 +199,7 @@ expand_source_globs() {
       '*.rb') echo '*.rb' '*.rake' 'Rakefile' 'rakefile' '*.erb' ;;
       '*.php') echo '*.php' '*.phtml' ;;
       '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' '*.jsp' ;;
-      '*.cs') echo '*.cs' '*.cshtml' ;;
+      '*.cs') echo '*.cs' '*.cshtml' '*.razor' ;;
       *) echo "$glob" ;;
     esac
   done
@@ -648,7 +658,7 @@ if product_applies "voice"; then
   # a documented attribute on a Language child of ConversationRelay. Inspect
   # tag ancestry instead of rejecting every textual occurrence.
   speech_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
-  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" <<'PYEOF'
+  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" "$EXCLUDE_DIRS" <<'PYEOF'
 import importlib.util
 import os
 import re
@@ -663,16 +673,13 @@ if spec is None or spec.loader is None:
 analyzer = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = analyzer
 spec.loader.exec_module(analyzer)
-excluded_dirs = {
-    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__", "build",
-    "coverage", "dist", "node_modules", "vendor", "venv",
-}
+excluded_dirs = set(sys.argv[3].split())
 excluded_files = {
     "MIGRATION-PLAN.md", "MIGRATION-REPORT.md", "migration-state.json",
     "twilio-deep-scan.json", "twilio-scan.json",
 }
 suffixes = {
-    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".dart", ".ejs", ".erb",
+    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".razor", ".dart", ".ejs", ".erb",
     ".ksh", ".zsh", ".go", ".handlebars", ".hbs", ".java", ".jinja",
     ".jinja2", ".cts", ".j2", ".js", ".jsp", ".jsx", ".kt", ".kts",
     ".mjs", ".mts", ".mustache", ".php", ".phtml", ".py", ".pyw",
@@ -1011,8 +1018,7 @@ fi
 
 # Check 12: Directory/path names containing "twilio"
 twilio_dirs=$(find "$PROJECT_ROOT" -mindepth 1 \
-  \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
-     -o -name venv -o -name .venv -o -name dist -o -name build \) -prune \
+  \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
   -o -type d -iname '*twilio*' -print 2>/dev/null || true)
 twilio_dir_count=$(echo "$twilio_dirs" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$twilio_dir_count" -gt 0 ] && [ -n "$(echo "$twilio_dirs" | sed '/^$/d')" ]; then

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -136,8 +136,20 @@ shebang_files_for_glob() {
 
 grep_shebang_files() {
   local pattern="$1"; shift
-  local glob list _f
+  local glob list _f category seen_categories=""
   for glob in "$@"; do
+    case "$glob" in
+      '*.js'|'*.ts') category="javascript" ;;
+      '*.py') category="python" ;;
+      '*.rb') category="ruby" ;;
+      '*.sh') category="shell" ;;
+      *) category="" ;;
+    esac
+    [ -z "$category" ] && continue
+    case " $seen_categories " in
+      *" $category "*) continue ;;
+    esac
+    seen_categories="$seen_categories $category"
     list=$(shebang_files_for_glob "$glob")
     [ -z "$list" ] && continue
     while IFS= read -r _f; do
@@ -156,12 +168,12 @@ expand_source_globs() {
   local glob
   for glob in "$@"; do
     case "$glob" in
-      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' ;;
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' '*.ejs' ;;
       '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
       '*.py') echo '*.py' '*.pyw' ;;
-      '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;
+      '*.rb') echo '*.rb' '*.rake' 'Rakefile' 'rakefile' '*.erb' ;;
       '*.php') echo '*.php' '*.phtml' ;;
-      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' ;;
+      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' '*.jsp' ;;
       '*.cs') echo '*.cs' '*.cshtml' ;;
       *) echo "$glob" ;;
     esac
@@ -192,14 +204,32 @@ filter_source_matches() {
     --analyzer "$scripts_dir/lint-required-messaging-profile.py"
 }
 
+filter_backend_matches() {
+  local pattern="$1"
+  local scripts_dir
+  scripts_dir=$(cd "$(dirname "$0")" && pwd)
+  python3 -B "$scripts_dir/filter-source-matches.py" \
+    --mode comments --region backend --pattern "$pattern" \
+    --analyzer "$scripts_dir/lint-required-messaging-profile.py"
+}
+
 search_live_files() {
   local mode="$1"
   local pattern="$2"
   shift 2
-  search_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
+  search_raw_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
 }
 
 search_files() {
+  local pattern="$1"
+  shift
+  # All source searches share the executable-region/comment contract. This
+  # keeps component markup and server-template prose out of semantic checks;
+  # callers needing identifiers with strings masked use search_live_files code.
+  search_raw_files "$pattern" "$@" | filter_source_matches comments "$pattern"
+}
+
+search_raw_files() {
   local pattern="$1"
   shift
   local include_args=""
@@ -368,10 +398,10 @@ while [ $# -gt 0 ]; do
       # skips every product-scoped check and still exits 0 — a silent pass.
       # Same accepted set as validate-migration.sh.
       case "$PRODUCT_FILTER" in
-        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup) ;;
+        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
         *)
           echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
-          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup" >&2
+          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
           exit 2
           ;;
       esac
@@ -425,8 +455,10 @@ if [ ! -d "$PROJECT_ROOT" ]; then
   exit 2
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "Error: python3 is required for correctness analysis" >&2
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c \
+  'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' \
+  >/dev/null 2>&1; then
+  echo "Error: Python 3.10+ is required for correctness analysis" >&2
   exit 2
 fi
 
@@ -466,7 +498,6 @@ if [ -n "$STATE_FILE" ]; then
     }
   fi
 fi
-
 # Load scan context if provided (for context-aware checks like webhook validation)
 ORIGINAL_HAD_WEBHOOK_VALIDATION="unknown"
 SCAN_PRODUCTS=""
@@ -555,7 +586,7 @@ if product_applies "messaging"; then
     echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
     exit 2
   fi
-  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields "$PROJECT_ROOT"); then
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
     echo "Error: Twilio messages.create analysis failed" >&2
     exit 2
   fi
@@ -570,7 +601,7 @@ if product_applies "messaging"; then
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields "$PROJECT_ROOT"); then
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
     echo "Error: messaging body-field analysis failed" >&2
     exit 2
   fi
@@ -650,18 +681,38 @@ if product_applies "voice"; then
   # Check 6: speechModel must be translated on Gather/Transcription, but it is
   # a documented attribute on a Language child of ConversationRelay. Inspect
   # tag ancestry instead of rejecting every textual occurrence.
-  matches=$(python3 - "$PROJECT_ROOT" <<'PYEOF'
+  speech_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
+  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" <<'PYEOF'
+import importlib.util
 import os
-import pathlib
 import re
 import sys
+from pathlib import Path
 
-root = pathlib.Path(sys.argv[1])
-excluded = {
-    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__",
-    "build", "coverage", "dist", "node_modules", "vendor", "venv",
+root = Path(sys.argv[1])
+analyzer_path = Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("telnyx_source_lexer", analyzer_path)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Could not load {analyzer_path}")
+analyzer = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = analyzer
+spec.loader.exec_module(analyzer)
+excluded_dirs = {
+    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__", "build",
+    "coverage", "dist", "node_modules", "vendor", "venv",
 }
-  suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
+excluded_files = {
+    "MIGRATION-PLAN.md", "MIGRATION-REPORT.md", "migration-state.json",
+    "twilio-deep-scan.json", "twilio-scan.json",
+}
+suffixes = {
+    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".dart", ".ejs", ".erb",
+    ".ksh", ".zsh", ".go", ".handlebars", ".hbs", ".java", ".jinja",
+    ".jinja2", ".cts", ".j2", ".js", ".jsp", ".jsx", ".kt", ".kts",
+    ".mjs", ".mts", ".mustache", ".php", ".phtml", ".py", ".pyw",
+    ".rb", ".rake", ".scala", ".sh", ".svelte", ".swift", ".texml",
+    ".tmpl", ".ts", ".tsx", ".twiml", ".twig", ".vue", ".xml",
+}
 tag_pattern = re.compile(
     r"<(?P<closing>/)?\s*(?P<tag>[A-Za-z_][\w:.-]*)"
     r"(?P<attrs>(?:\"[^\"]*\"|'[^']*'|[^>])*)>",
@@ -670,23 +721,33 @@ tag_pattern = re.compile(
 speech_model = re.compile(r"(?<![\w:.-])speechModel\s*(?:=|:)")
 
 for directory, child_dirs, filenames in os.walk(root):
-    child_dirs[:] = sorted(name for name in child_dirs if name not in excluded)
+    child_dirs[:] = sorted(name for name in child_dirs if name not in excluded_dirs)
     for filename in sorted(filenames):
-        path = pathlib.Path(directory, filename)
-        if path.suffix.lower() not in suffixes:
+        path = Path(directory, filename)
+        if filename in excluded_files or path.suffix.lower() not in suffixes:
             continue
         source = path.read_text(encoding="utf-8", errors="replace")
-        source = re.sub(
-            r"<!--.*?-->|<!\[CDATA\[.*?\]\]>",
+        executable = analyzer.executable_source(path, source)
+        masked_executable = analyzer.lex_source(
+            executable, analyzer.canonical_suffix(path)
+        ).without_comments
+        scan_source = "".join(
+            masked if code != " " or raw in "\r\n" else raw
+            for raw, code, masked in zip(source, executable, masked_executable)
+        )
+        scan_source = re.sub(
+            r"<!--.*?-->|<!\[CDATA\[.*?\]\]>|"
+            r"<%#.*?%>|<%--.*?--%>|"
+            r"\{\{!--.*?--\}\}|\{\{!.*?\}\}|\{#.*?#\}",
             lambda match: "".join(
                 char if char in "\r\n" else " " for char in match.group(0)
             ),
-            source,
+            scan_source,
             flags=re.DOTALL,
         )
         stack = []
         tagged_speech_model = set()
-        for match in tag_pattern.finditer(source):
+        for match in tag_pattern.finditer(scan_source):
             tag = match.group("tag").rsplit(":", 1)[-1]
             if match.group("closing"):
                 if stack and stack[-1] == tag:
@@ -699,20 +760,17 @@ for directory, child_dirs, filenames in os.walk(root):
             tagged_speech_model.update(
                 attr_start + occurrence.start() for occurrence in attr_occurrences
             )
-            if attr_occurrences:
-                if not (tag == "Language" and stack[-1:] == ["ConversationRelay"]):
-                    line = source.count("\n", 0, match.start()) + 1
-                    print(f"{path}:{line}: <{tag}> speechModel")
+            if attr_occurrences and not (
+                tag == "Language" and stack[-1:] == ["ConversationRelay"]
+            ):
+                line = scan_source.count("\n", 0, match.start()) + 1
+                print(f"{path}:{line}: <{tag}> speechModel")
             if not match.group("attrs").rstrip().endswith("/"):
                 stack.append(tag)
-        # Builder/object forms (for example `{speechModel: "phone_call"}`)
-        # are migration-sensitive even when no literal XML tag exists. Only
-        # suppress occurrences already classified inside an XML tag, including
-        # the valid ConversationRelay <Language> form above.
-        for occurrence in speech_model.finditer(source):
+        for occurrence in speech_model.finditer(scan_source):
             if occurrence.start() in tagged_speech_model:
                 continue
-            line = source.count("\n", 0, occurrence.start()) + 1
+            line = scan_source.count("\n", 0, occurrence.start()) + 1
             print(f"{path}:{line}: non-XML speechModel")
 PYEOF
 )
@@ -831,12 +889,24 @@ if product_applies "all"; then
   section_header "Webhook Signature Validation"
 
   # Check 12: Webhook handlers without Ed25519 signature verification
-  webhook_handlers=$(search_files "(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+  # Vue/Svelte/Astro expressions are executable client code, but never server
+  # route declarations. Exclude those component files from this backend-only
+  # cross-file heuristic after applying the normal executable-source filter.
+  webhook_pattern="(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)"
+  webhook_handlers=$(search_raw_files "$webhook_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+    | filter_backend_matches "$webhook_pattern" \
+    | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
   webhook_count=$(count_matches "$webhook_handlers")
   if [ "$webhook_count" -gt 0 ]; then
-    ed25519_refs=$(search_files "(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+    ed25519_pattern="(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)"
+    ed25519_refs=$(search_raw_files "$ed25519_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+      | filter_backend_matches "$ed25519_pattern" \
+      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
     ed25519_count=$(count_matches "$ed25519_refs")
-    telnyx_webhook_parse=$(search_files "(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+    webhook_parse_pattern="(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])"
+    telnyx_webhook_parse=$(search_raw_files "$webhook_parse_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+      | filter_backend_matches "$webhook_parse_pattern" \
+      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
     telnyx_parse_count=$(count_matches "$telnyx_webhook_parse")
     if [ "$telnyx_parse_count" -gt 0 ] && [ "$ed25519_count" -eq 0 ]; then
       lint_issue "webhook_ed25519_missing" \
@@ -939,7 +1009,7 @@ fi
 section_header "Residual Twilio Patterns"
 
 # Check 10: Residual Twilio imports still present alongside Telnyx code
-matches=$(search_live_files comments '(from twilio|import[ (].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
+matches=$(search_live_files comments '(from twilio|import[ (=].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -45,7 +45,7 @@ PROJECT_ROOT=""
 SCAN_JSON=""
 STATE_FILE=""
 HYBRID_PRODUCTS=""
-MIGRATED_FILES=""
+MIGRATED_FILES_JSON="[]"
 JSON_CHECKS="[]"
 
 EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build .next .nuxt coverage .tox"
@@ -75,6 +75,18 @@ build_exclude_args() {
 }
 
 GREP_EXCLUDES=""
+
+# Finding records are LF-delimited, so path identity uses a reversible display
+# encoding. Escape backslashes first to distinguish a literal `\n` filename
+# segment from an actual newline. The Python analyzer and grep adapter use this
+# exact contract too.
+escape_record_path() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\n'/\\n}
+  printf '%s' "$value"
+}
 
 # Build every find(1) prune expression from the same policy as grep.  Keeping
 # literal copies in each traversal caused generated directories to re-enter
@@ -372,12 +384,12 @@ hybrid_waiver_applies() {
     # A retained product never waives a residual inside a file explicitly
     # recorded as migrated. Only downgrade when every matched path is outside
     # that set; mixed or migrated-only results must keep the gate blocking.
-    [ -n "$MIGRATED_FILES" ] || return 0
+    [ "$MIGRATED_FILES_JSON" != "[]" ] || return 0
     while IFS= read -r match; do
       [ -n "$match" ] || continue
-      while IFS= read -r migrated_file; do
+      while IFS= read -r -d '' migrated_file; do
         [ -n "$migrated_file" ] || continue
-        migrated_path="$PROJECT_ROOT/$migrated_file"
+        migrated_path=$(escape_record_path "$PROJECT_ROOT/$migrated_file")
         # Filtered grep output is `<absolute path>:<line>:<text>`. Do not
         # recover the path with a colon regex: POSIX paths may themselves
         # contain `:<digits>:`. Instead compare each complete, known migrated
@@ -392,7 +404,7 @@ hybrid_waiver_applies() {
         if [ "$migrated_path" = "$match" ] || [[ "$migrated_path" = "$match"/* ]]; then
           return 1
         fi
-      done <<<"$MIGRATED_FILES"
+      done < <(printf '%s' "$MIGRATED_FILES_JSON" | jq -j '.[] | ., "\u0000"')
     done <<<"${1:-}"
     return 0
   fi
@@ -507,13 +519,13 @@ if [ -n "$STATE_FILE" ]; then
       echo "Error: --state-file '$STATE_FILE' is not valid migration state JSON" >&2
       exit 2
     }
-    MIGRATED_FILES=$(jq -r --arg root "$PROJECT_ROOT/" '
+    MIGRATED_FILES_JSON=$(jq -c --arg root "$PROJECT_ROOT/" '
       [(.migrated_files? // {}) | .. | arrays | .[]?
        | select(type == "string")
        | if startswith($root) then .[($root | length):]
          elif startswith("./") then .[2:]
          else . end]
-      | unique[]
+      | unique
     ' "$STATE_FILE" 2>/dev/null) || {
       echo "Error: --state-file '$STATE_FILE' has invalid migrated_files" >&2
       exit 2
@@ -1017,9 +1029,12 @@ else
 fi
 
 # Check 12: Directory/path names containing "twilio"
-twilio_dirs=$(find "$PROJECT_ROOT" -mindepth 1 \
+twilio_dirs=""
+while IFS= read -r -d '' twilio_dir; do
+  twilio_dirs+="$(escape_record_path "$twilio_dir")"$'\n'
+done < <(find "$PROJECT_ROOT" -mindepth 1 \
   \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
-  -o -type d -iname '*twilio*' -print 2>/dev/null || true)
+  -o -type d -iname '*twilio*' -print0 2>/dev/null || true)
 twilio_dir_count=$(echo "$twilio_dirs" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$twilio_dir_count" -gt 0 ] && [ -n "$(echo "$twilio_dirs" | sed '/^$/d')" ]; then
   if hybrid_waiver_applies "$twilio_dirs"; then

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -398,10 +398,10 @@ while [ $# -gt 0 ]; do
       # skips every product-scoped check and still exits 0 — a silent pass.
       # Same accepted set as validate-migration.sh.
       case "$PRODUCT_FILTER" in
-        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
+        all|voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
         *)
           echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
-          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
+          echo "Valid products: all, voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
           exit 2
           ;;
       esac
@@ -458,7 +458,7 @@ fi
 if ! command -v python3 >/dev/null 2>&1 || ! python3 -c \
   'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' \
   >/dev/null 2>&1; then
-  echo "Error: Python 3.10+ is required for correctness analysis" >&2
+  echo "Error: python3 is required for correctness analysis; Python 3.10+ is required for correctness analysis" >&2
   exit 2
 fi
 
@@ -506,52 +506,6 @@ if [ -n "$SCAN_JSON" ] && [ -f "$SCAN_JSON" ] && command -v jq >/dev/null 2>&1; 
   SCAN_PRODUCTS=$(jq -r '.products_used // [] | map(ascii_downcase) | join(",")' "$SCAN_JSON" 2>/dev/null || true)
 fi
 
-# Hybrid awareness, mirroring validate-migration.sh: a product recorded as
-# kept on Twilio in migration-state.json is a skill-sanctioned deployment
-# state, so residual-Twilio findings for it are expected and must not hard-
-# fail Phase 4 forever.
-if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ] && command -v jq >/dev/null 2>&1; then
-  # Only products with a truthy keep reason stay in hybrid scope. An
-  # operator reverses a decision with `set kept_on_twilio.X false`
-  # (there is no unset command), so false/null/empty means NOT kept.
-  KEPT_ON_TWILIO=$(jq -r '.kept_on_twilio // {} | to_entries | map(select(.value != false and .value != null and .value != "")) | map(.key) | join(",")' "$STATE_FILE" 2>/dev/null || true)
-elif [ -n "$STATE_FILE" ] && [ ! -f "$STATE_FILE" ]; then
-  echo "Warning: --state-file '$STATE_FILE' not found, ignoring" >&2
-fi
-
-# Waive only for the product that is actually KEPT on Twilio.
-#
-# Testing `-n "$KEPT_ON_TWILIO"` alone made ANY hybrid state a GLOBAL waiver: in
-# a `--product messaging` run, a leftover Twilio messaging import was downgraded
-# to a warning - and the linter exited clean - merely because an unrelated
-# product such as voice was kept on Twilio. That is a silent pass on exactly the
-# residue the check exists to find.
-#
-# The product is passed per call site because these checks are not all inside a
-# product-scoped block; the global ones (residual imports, client instantiation,
-# directory names, docs) legitimately span products and pass "any", which waives
-# whenever ANY product is kept - the original behaviour, but now stated at the
-# call site rather than applied silently everywhere.
-kept_on_twilio() {
-  local product="$1"
-  [ -n "$KEPT_ON_TWILIO" ] || return 1
-  [ "$product" = "any" ] && return 0
-  case ",$KEPT_ON_TWILIO," in
-    *",$product,"*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-lint_issue_or_hybrid_warn() {
-  local product="$1"
-  shift
-  if kept_on_twilio "$product"; then
-    lint_warn "$1" "$2 (hybrid deployment — $KEPT_ON_TWILIO kept on Twilio)" "$3" "${4:-}"
-  else
-    lint_issue "$1" "$2" "$3" "${4:-}"
-  fi
-}
-
 # Helper: returns 0 if a product was detected in the scan (or if no scan data)
 scan_has_product() {
   local product="$1"
@@ -586,13 +540,13 @@ if product_applies "messaging"; then
     echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
     exit 2
   fi
-  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$HYBRID_PRODUCTS" "$PROJECT_ROOT"); then
     echo "Error: Twilio messages.create analysis failed" >&2
     exit 2
   fi
   count=$(count_matches "$twilio_create_calls")
   if [ "$count" -gt 0 ]; then
-    lint_issue_or_hybrid_warn "messaging" "twilio_messages_create" \
+    lint_issue "twilio_messages_create" \
       "Twilio .messages.create() request using body found at $count call site(s)" \
       "Use telnyx.messages.send() (Python) or telnyx.messages.create() with the text parameter (JavaScript/Ruby)" \
       "$(matches_to_json "$twilio_create_calls")"
@@ -601,7 +555,7 @@ if product_applies "messaging"; then
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$HYBRID_PRODUCTS" "$PROJECT_ROOT"); then
     echo "Error: messaging body-field analysis failed" >&2
     exit 2
   fi
@@ -995,7 +949,7 @@ done < <(find "$PROJECT_ROOT" -maxdepth 1 -type f \
 doc_files=$(echo "$doc_files" | sed '/^$/d')
 doc_count=$(echo "$doc_files" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$doc_count" -gt 0 ]; then
-  lint_issue_or_hybrid_warn "any" "docs_still_twilio" \
+  lint_issue "docs_still_twilio" \
     "Documentation files still reference Twilio (not migration-related references) in $doc_count file(s)" \
     "Update README/docs: replace Twilio service names, env vars, setup instructions, and URLs with Telnyx equivalents" \
     "$(echo "$doc_files" | sed '/^$/d' | head -10 | jq -R -s '{files: (split("\n") | map(select(length > 0)))}' 2>/dev/null || echo '{"files":[]}')"

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/preflight-check.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/preflight-check.sh
@@ -240,32 +240,48 @@ echo -e "${BOLD}Twilio SDKs Detected (to be replaced)${NC}"
 
 TWILIO_FOUND=false
 
-# Python
-if python3 -c "import twilio" 2>/dev/null; then
+# Python. With a project root, report project manifests only; a globally
+# installed package belongs to the host and says nothing about this migration.
+if [ -n "$PROJECT_ROOT" ] && find "$PROJECT_ROOT" -maxdepth 3 \
+  \( -name requirements.txt -o -name pyproject.toml -o -name setup.py -o -name Pipfile \) \
+  -exec grep -liE '(^|[^A-Za-z0-9_-])twilio([^A-Za-z0-9_-]|$)' {} + \
+  2>/dev/null | head -1 | grep -q .; then
+  check_info "Python: twilio (declared in project)"
+  TWILIO_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && python3 -c "import twilio" 2>/dev/null; then
   TWILIO_VER=$(python3 -c "import twilio; print(twilio.__version__)" 2>/dev/null || echo "unknown")
   check_info "Python: twilio $TWILIO_VER"
   TWILIO_FOUND=true
-elif python -c "import twilio" 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && python -c "import twilio" 2>/dev/null; then
   check_info "Python: twilio (version unknown)"
   TWILIO_FOUND=true
 fi
 
 # Node.js
-if [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/twilio" ]; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/package.json" ] && \
+  grep -qE '"twilio"[[:space:]]*:' "$PROJECT_ROOT/package.json" 2>/dev/null; then
+  TWILIO_NODE_VER=$(sed -nE 's/.*"twilio"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$PROJECT_ROOT/package.json" | head -1)
+  check_info "Node.js: twilio ${TWILIO_NODE_VER:-version unknown} (declared in project)"
+  TWILIO_FOUND=true
+elif [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/twilio" ]; then
   TWILIO_NODE_VER=$(node -e "console.log(require('$PROJECT_ROOT/node_modules/twilio/package.json').version)" 2>/dev/null || echo "unknown")
   check_info "Node.js: twilio $TWILIO_NODE_VER"
   TWILIO_FOUND=true
-elif [ -d "node_modules/twilio" ] 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && [ -d "node_modules/twilio" ] 2>/dev/null; then
   TWILIO_NODE_VER=$(node -e "console.log(require('twilio/package.json').version)" 2>/dev/null || echo "unknown")
   check_info "Node.js: twilio $TWILIO_NODE_VER"
   TWILIO_FOUND=true
-elif npm list twilio 2>/dev/null | grep -q twilio; then
+elif [ -z "$PROJECT_ROOT" ] && npm list twilio 2>/dev/null | grep -q twilio; then
   check_info "Node.js: twilio (installed globally or in project)"
   TWILIO_FOUND=true
 fi
 
 # Ruby
-if gem list twilio-ruby 2>/dev/null | grep -q twilio-ruby; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/Gemfile" ] && \
+  grep -qE "gem[[:space:]]+['\"]twilio(-ruby)?['\"]" "$PROJECT_ROOT/Gemfile" 2>/dev/null; then
+  check_info "Ruby: twilio-ruby (declared in project Gemfile)"
+  TWILIO_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && gem list twilio-ruby 2>/dev/null | grep -q twilio-ruby; then
   TWILIO_RUBY_VER=$(gem list twilio-ruby 2>/dev/null | grep -o '([^)]*)')
   check_info "Ruby: twilio-ruby $TWILIO_RUBY_VER"
   TWILIO_FOUND=true
@@ -277,13 +293,17 @@ if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/go.mod" ]; then
     check_info "Go: twilio-go (found in project go.mod)"
     TWILIO_FOUND=true
   fi
-elif go list -m github.com/twilio/twilio-go 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && go list -m github.com/twilio/twilio-go 2>/dev/null; then
   check_info "Go: twilio-go (found in go.mod)"
   TWILIO_FOUND=true
 fi
 
-# Java (check for jar in common locations)
+# Java/Kotlin manifests and local jars.
 SEARCH_DIR="${PROJECT_ROOT:-.}"
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" twilio-jvm-declared "$PROJECT_ROOT"; then
+  check_info "Java/Kotlin: Twilio SDK (declared in project)"
+  TWILIO_FOUND=true
+fi
 if find "$SEARCH_DIR" -name "twilio-*.jar" -maxdepth 3 2>/dev/null | grep -q twilio; then
   check_info "Java: twilio jar found in project"
   TWILIO_FOUND=true
@@ -291,7 +311,7 @@ fi
 
 # PHP
 if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/composer.json" ]; then
-  if grep -q "twilio" "$PROJECT_ROOT/composer.json" 2>/dev/null; then
+  if grep -qE '"twilio/sdk"[[:space:]]*:' "$PROJECT_ROOT/composer.json" 2>/dev/null; then
     check_info "PHP: twilio/sdk found in composer.json"
     TWILIO_FOUND=true
   fi
@@ -315,29 +335,50 @@ echo -e "${BOLD}Telnyx SDKs Installed${NC}"
 
 TELNYX_FOUND=false
 
+# Composer declarations belong in require/require-dev, not metadata or scripts.
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" composer "$PROJECT_ROOT"; then
+  check_pass "PHP: telnyx/telnyx-php (declared in project)"
+  TELNYX_FOUND=true
+fi
+
 # Python
-if python3 -c "import telnyx" 2>/dev/null; then
+if [ -n "$PROJECT_ROOT" ] && find "$PROJECT_ROOT" -maxdepth 3 \
+  \( -name requirements.txt -o -name pyproject.toml -o -name setup.py -o -name Pipfile \) \
+  -exec grep -liE '(^|[^A-Za-z0-9_-])telnyx([^A-Za-z0-9_-]|$)' {} + \
+  2>/dev/null | head -1 | grep -q .; then
+  check_pass "Python: telnyx (declared in project)"
+  TELNYX_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && python3 -c "import telnyx" 2>/dev/null; then
   TELNYX_PY_VER=$(python3 -c "import telnyx; print(telnyx.VERSION)" 2>/dev/null || echo "unknown")
   check_pass "Python: telnyx $TELNYX_PY_VER"
   TELNYX_FOUND=true
 fi
 
 # Node.js
-if [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/telnyx" ]; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/package.json" ] && \
+  grep -qE '"telnyx"[[:space:]]*:' "$PROJECT_ROOT/package.json" 2>/dev/null; then
+  TELNYX_NODE_VER=$(sed -nE 's/.*"telnyx"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$PROJECT_ROOT/package.json" | head -1)
+  check_pass "Node.js: telnyx ${TELNYX_NODE_VER:-version unknown} (declared in project)"
+  TELNYX_FOUND=true
+elif [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/telnyx" ]; then
   TELNYX_NODE_VER=$(node -e "console.log(require('$PROJECT_ROOT/node_modules/telnyx/package.json').version)" 2>/dev/null || echo "unknown")
   check_pass "Node.js: telnyx $TELNYX_NODE_VER"
   TELNYX_FOUND=true
-elif [ -d "node_modules/telnyx" ] 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && [ -d "node_modules/telnyx" ] 2>/dev/null; then
   TELNYX_NODE_VER=$(node -e "console.log(require('telnyx/package.json').version)" 2>/dev/null || echo "unknown")
   check_pass "Node.js: telnyx $TELNYX_NODE_VER"
   TELNYX_FOUND=true
-elif npm list telnyx 2>/dev/null | grep -q telnyx; then
+elif [ -z "$PROJECT_ROOT" ] && npm list telnyx 2>/dev/null | grep -q telnyx; then
   check_pass "Node.js: telnyx (installed)"
   TELNYX_FOUND=true
 fi
 
 # Ruby
-if gem list telnyx 2>/dev/null | grep -q "^telnyx "; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/Gemfile" ] && \
+  grep -qE "gem[[:space:]]+['\"]telnyx['\"]" "$PROJECT_ROOT/Gemfile" 2>/dev/null; then
+  check_pass "Ruby: telnyx (declared in project Gemfile)"
+  TELNYX_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && gem list telnyx 2>/dev/null | grep -q "^telnyx "; then
   TELNYX_RUBY_VER=$(gem list telnyx 2>/dev/null | grep "^telnyx " | grep -o '([^)]*)')
   check_pass "Ruby: telnyx $TELNYX_RUBY_VER"
   TELNYX_FOUND=true
@@ -349,8 +390,14 @@ if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/go.mod" ]; then
     check_pass "Go: telnyx-go (found in project go.mod)"
     TELNYX_FOUND=true
   fi
-elif go list -m github.com/telnyx/telnyx-go 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && go list -m all 2>/dev/null | \
+  grep -E '^github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]' >/dev/null; then
   check_pass "Go: telnyx-go (found in go.mod)"
+  TELNYX_FOUND=true
+fi
+
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
+  check_pass "Java/Kotlin: Telnyx SDK (declared in project)"
   TELNYX_FOUND=true
 fi
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/run-discovery.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/run-discovery.sh
@@ -21,7 +21,7 @@
 #
 # Exit codes:
 #   0 — Discovery complete (scan succeeded; preflight may have warnings)
-#   2 — Invalid arguments (project root doesn't exist, etc.)
+#   2 — Invalid arguments or incomplete usage scan
 
 set -uo pipefail
 
@@ -83,11 +83,12 @@ echo -e "  ${BLUE}INFO${NC}  Scanning source code for Twilio patterns (no API ke
 echo ""
 
 SCAN_OUTPUT="$PROJECT_ROOT/twilio-scan.json"
-bash "$SCRIPT_DIR/scan-twilio-usage.sh" "$PROJECT_ROOT" > "$SCAN_OUTPUT" 2>/dev/null
+bash "$SCRIPT_DIR/scan-twilio-usage.sh" "$PROJECT_ROOT" > "$SCAN_OUTPUT"
 SCAN_EXIT=$?
 
 if [ "$SCAN_EXIT" -ne 0 ]; then
-  echo -e "  ${YELLOW}WARN${NC}  Scanner exited with code $SCAN_EXIT"
+  echo -e "  ${RED}ERROR${NC}  Discovery incomplete: scanner exited with code $SCAN_EXIT. Do not use $SCAN_OUTPUT as a complete inventory." >&2
+  exit 2
 fi
 
 if [ -f "$SCAN_OUTPUT" ] && [ -s "$SCAN_OUTPUT" ]; then
@@ -105,7 +106,8 @@ if [ -f "$SCAN_OUTPUT" ] && [ -s "$SCAN_OUTPUT" ]; then
     echo "  Files:      $FILE_COUNT files with Twilio patterns"
   fi
 else
-  echo -e "  ${YELLOW}WARN${NC}  Scan produced no output — the project may have no Twilio code"
+  echo -e "  ${RED}ERROR${NC}  Discovery incomplete: scanner produced no report." >&2
+  exit 2
 fi
 
 echo ""
@@ -143,7 +145,7 @@ DEEP_SCAN_OUTPUT="$PROJECT_ROOT/twilio-deep-scan.json"
 if command -v python3 &>/dev/null; then
   if [ -f "$SCRIPT_DIR/scan-twilio-deep.py" ]; then
     echo -e "  ${BLUE}INFO${NC}  Running scan-twilio-deep.py..."
-    python3 "$SCRIPT_DIR/scan-twilio-deep.py" "$PROJECT_ROOT" > "$DEEP_SCAN_OUTPUT" 2>/dev/null
+    python3 "$SCRIPT_DIR/scan-twilio-deep.py" "$PROJECT_ROOT" > "$DEEP_SCAN_OUTPUT"
     DEEP_EXIT=$?
     if [ "$DEEP_EXIT" -eq 0 ] && [ -f "$DEEP_SCAN_OUTPUT" ] && [ -s "$DEEP_SCAN_OUTPUT" ]; then
       echo -e "  ${GREEN}PASS${NC}  Deep scan results saved to: $DEEP_SCAN_OUTPUT"

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/run-validation.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/run-validation.sh
@@ -138,6 +138,34 @@ fi
 
 echo ""
 
+# --- Step 5.1b: Telnyx Correctness Linter ---
+# This integration belongs with the source-aware analyzer. Without it the full
+# Phase 5 wrapper can certify a required sender that lacks
+# messaging_profile_id even though the standalone linter would block it.
+echo -e "${BOLD}Step 5.1b: Telnyx Correctness${NC}"
+echo "────────────────────────────────"
+
+CORRECTNESS_ARGS=("$PROJECT_ROOT")
+# Discovery records whether the original app intentionally omitted webhook
+# validation. Preserve that context so the wrapper and standalone linter reach
+# the same verdict instead of upgrading an intentional warning to an issue.
+[ -f "$PROJECT_ROOT/twilio-scan.json" ] && \
+  CORRECTNESS_ARGS+=("--scan-json" "$PROJECT_ROOT/twilio-scan.json")
+bash "$SCRIPT_DIR/lint-telnyx-correctness.sh" "${CORRECTNESS_ARGS[@]}"
+CORRECTNESS_EXIT=$?
+if [ "$CORRECTNESS_EXIT" -eq 0 ]; then
+  echo ""
+  echo -e "  ${GREEN}PASS${NC}  Correctness checks passed"
+  RESULTS="${RESULTS}correctness:pass,"
+else
+  echo ""
+  echo -e "  ${RED}FAIL${NC}  Correctness checks failed (exit code: $CORRECTNESS_EXIT)"
+  OVERALL_PASS=false
+  RESULTS="${RESULTS}correctness:fail,"
+fi
+
+echo ""
+
 # --- Step 5.2: TeXML Validation (optional) ---
 if [ "$INCLUDE_TEXML" = true ]; then
   echo -e "${BOLD}Step 5.2: TeXML Validation${NC}"

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/run-validation.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/run-validation.sh
@@ -104,6 +104,9 @@ fi
 if [ -z "$STATE_FILE" ] && [ -f "$PROJECT_ROOT/migration-state.json" ]; then
   STATE_FILE="$PROJECT_ROOT/migration-state.json"
 fi
+if [ -z "$SCAN_JSON" ] && [ -f "$PROJECT_ROOT/twilio-scan.json" ]; then
+  SCAN_JSON="$PROJECT_ROOT/twilio-scan.json"
+fi
 
 OVERALL_PASS=true
 RESULTS=""
@@ -146,11 +149,13 @@ echo -e "${BOLD}Step 5.1b: Telnyx Correctness${NC}"
 echo "────────────────────────────────"
 
 CORRECTNESS_ARGS=("$PROJECT_ROOT")
+# Keep the correctness linter in the same hybrid scope as migration
+# validation. An external state file is not discoverable from PROJECT_ROOT.
+[ -n "$STATE_FILE" ] && CORRECTNESS_ARGS+=("--state-file" "$STATE_FILE")
 # Discovery records whether the original app intentionally omitted webhook
 # validation. Preserve that context so the wrapper and standalone linter reach
 # the same verdict instead of upgrading an intentional warning to an issue.
-[ -f "$PROJECT_ROOT/twilio-scan.json" ] && \
-  CORRECTNESS_ARGS+=("--scan-json" "$PROJECT_ROOT/twilio-scan.json")
+[ -n "$SCAN_JSON" ] && CORRECTNESS_ARGS+=("--scan-json" "$SCAN_JSON")
 bash "$SCRIPT_DIR/lint-telnyx-correctness.sh" "${CORRECTNESS_ARGS[@]}"
 CORRECTNESS_EXIT=$?
 if [ "$CORRECTNESS_EXIT" -eq 0 ]; then

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -181,7 +181,7 @@ GO_EXTENSIONS = {".go"}
 RUBY_EXTENSIONS = {".rb", ".rake"}
 JAVA_EXTENSIONS = {".java", ".kt", ".kts", ".scala"}
 PHP_EXTENSIONS = {".php", ".phtml"}
-CSHARP_EXTENSIONS = {".cs", ".cshtml"}
+CSHARP_EXTENSIONS = {".cs", ".cshtml", ".razor"}
 OTHER_TEXT_EXTENSIONS = {".xml", ".yaml", ".yml"}
 
 # Directories to skip
@@ -794,14 +794,14 @@ _CSHARP_ENV_RE = re.compile(
 _CSHARP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 
 
-def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
+def scan_go_file(filepath: Path, lines: List[str], go_clients: frozenset[str] = frozenset()) -> List[Detection]:
     """Regex-based scanning for Go files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
     source = "\n".join(lines)
     lexed = _ownership.lexed_source(source, ".go")
     lines = lexed.without_comments.split("\n")
-    for line, product in _ownership.contextual_calls(source, ".go"):
+    for line, product in _ownership.contextual_calls(source, ".go", go_clients=go_clients):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
             context=get_context_lines(lines, line), confidence="high", product=product))
@@ -1353,6 +1353,7 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
 
     paths = list(walk_project(project_root))
     global_usings = _ownership.CsharpGlobalUsings(project_root, paths)
+    go_clients = _ownership.GoPackageClients(paths)
     for filepath in paths:
         ext = filepath.suffix.lower()
         name = filepath.name
@@ -1471,11 +1472,12 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
                 text = filepath.read_text(errors="replace")
             except (OSError, PermissionError):
                 continue
-            if "twilio" not in text.lower():
+            package_clients = go_clients.for_file(filepath)
+            if "twilio" not in text.lower() and not package_clients:
                 continue
             lines = text.splitlines()
             rel = str(filepath.relative_to(project_root))
-            go_detections = scan_go_file(filepath, lines)
+            go_detections = scan_go_file(filepath, lines, package_clients)
             if go_detections:
                 fr = FileResult(rel, "go")
                 fr.detections = go_detections

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import importlib.util
 import json
 import os
 import re
@@ -26,6 +27,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 SCAN_VERSION = "1.0.0"
 SCANNER_NAME = "deep"
+
+_ownership_spec = importlib.util.spec_from_file_location(
+    "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+_ownership = importlib.util.module_from_spec(_ownership_spec)
+_ownership_spec.loader.exec_module(_ownership)
 
 # ---------------------------------------------------------------------------
 # Product mapping -- Twilio module path fragment -> product name
@@ -105,6 +111,14 @@ METHOD_PRODUCT_MAP: Dict[str, str] = {
     "CreateVerification": "verify",
     "FetchMessage": "messaging",
     "FetchCall": "voice",
+    "/Messages.json": "messaging",
+    "messaging.twilio.com": "messaging",
+    "/Calls.json": "voice",
+    "verify.twilio.com": "verify",
+    "lookups.twilio.com": "lookup",
+    "video.twilio.com": "video",
+    "fax.twilio.com": "fax",
+    "/IncomingPhoneNumbers.json": "phone-numbers",
 }
 
 # Twilio env var patterns
@@ -161,13 +175,13 @@ DEPENDENCY_FILE_NAMES = {
 }
 
 # File extensions to scan
-PY_EXTENSIONS = {".py"}
-JS_EXTENSIONS = {".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"}
+PY_EXTENSIONS = {".py", ".pyw"}
+JS_EXTENSIONS = {".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs", ".mts", ".cts"}
 GO_EXTENSIONS = {".go"}
-RUBY_EXTENSIONS = {".rb"}
-JAVA_EXTENSIONS = {".java", ".kt", ".scala"}
-PHP_EXTENSIONS = {".php"}
-CSHARP_EXTENSIONS = {".cs"}
+RUBY_EXTENSIONS = {".rb", ".rake"}
+JAVA_EXTENSIONS = {".java", ".kt", ".kts", ".scala"}
+PHP_EXTENSIONS = {".php", ".phtml"}
+CSHARP_EXTENSIONS = {".cs", ".cshtml"}
 OTHER_TEXT_EXTENSIONS = {".xml", ".yaml", ".yml"}
 
 # Directories to skip
@@ -276,8 +290,9 @@ def resolve_product(module_path: str) -> str:
 
 def infer_product_from_text(text: str) -> str:
     """Best-effort product inference from arbitrary text."""
+    lowered = text.lower()
     for pattern, product in METHOD_PRODUCT_MAP.items():
-        if pattern in text:
+        if pattern.lower() in lowered:
             return product
     return "general"
 
@@ -758,10 +773,6 @@ _RUBY_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # Java / Kotlin / Scala patterns
 _JAVA_IMPORT_RE = re.compile(r"import\s+(com\.twilio\.[^\s;]+)", re.IGNORECASE)
 _JAVA_INIT_RE = re.compile(r"Twilio\.init\s*\(", re.IGNORECASE)
-_JAVA_CREATOR_RE = re.compile(
-    r"com\.twilio\.rest\.api\.v2010\.account\.(Call|Message|IncomingPhoneNumber)\.creator",
-    re.IGNORECASE,
-)
 _JAVA_TWIML_RE = re.compile(r"com\.twilio\.twiml\.(VoiceResponse|MessagingResponse)", re.IGNORECASE)
 _JAVA_ENV_RE = re.compile(r'System\.getenv\s*\(\s*"(TWILIO_\w+)"', re.IGNORECASE)
 _JAVA_WEBHOOK_RE = re.compile(r"X-Twilio-Signature|RequestValidator", re.IGNORECASE)
@@ -770,7 +781,6 @@ _JAVA_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # PHP patterns
 _PHP_USE_RE = re.compile(r"use\s+Twilio\\([^\s;]+)", re.IGNORECASE)
 _PHP_CLIENT_RE = re.compile(r"new\s+Client\s*\(\s*\$\w+\s*,\s*\$\w+", re.IGNORECASE)
-_PHP_METHOD_RE = re.compile(r"\$twilio->\s*(\w+)", re.IGNORECASE)
 _PHP_ENV_RE = re.compile(r"""(?:getenv\s*\(\s*['"]|\$_ENV\[['"])(TWILIO_\w+)""", re.IGNORECASE)
 _PHP_WEBHOOK_RE = re.compile(r"RequestValidator", re.IGNORECASE)
 _PHP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
@@ -778,10 +788,6 @@ _PHP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # C# patterns
 _CSHARP_USING_RE = re.compile(r"using\s+(Twilio[^\s;]*)", re.IGNORECASE)
 _CSHARP_INIT_RE = re.compile(r"TwilioClient\.Init\s*\(", re.IGNORECASE)
-_CSHARP_RESOURCE_RE = re.compile(
-    r"(MessageResource|CallResource|IncomingPhoneNumberResource|AccountResource)\.(Create|Read|Update|Fetch)",
-    re.IGNORECASE,
-)
 _CSHARP_ENV_RE = re.compile(
     r'Environment\.GetEnvironmentVariable\s*\(\s*"(TWILIO_\w+)"', re.IGNORECASE
 )
@@ -792,8 +798,18 @@ def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
     """Regex-based scanning for Go files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, ".go")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, ".go"):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
 
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # Import statements
@@ -836,9 +852,10 @@ def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
         stripped = line.strip()
         if stripped.startswith("//"):
             continue
-        # Check for API method calls (e.g. CreateMessage, messages.create)
+        # SDK calls were attributed above. A generic application method name
+        # alone is not ownership evidence; retain explicit Twilio hints only.
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _GO_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -924,11 +941,22 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
 
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # import com.twilio.*
-        m = _JAVA_IMPORT_RE.search(stripped)
+        m = _JAVA_IMPORT_RE.search(syntax_lines[i - 1])
         if m:
             pkg = m.group(1).lower()
             product = "general"
@@ -963,26 +991,6 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
                     context=get_context_lines(lines, i), confidence="high", product="general",
-                )
-            )
-            detected_lines.add(i)
-            continue
-
-        # Creator patterns: Call.creator, Message.creator
-        m = _JAVA_CREATOR_RE.search(stripped)
-        if m:
-            resource = m.group(1).lower()
-            product = "general"
-            if resource == "call":
-                product = "voice"
-            elif resource == "message":
-                product = "messaging"
-            elif resource == "incomingphonenumber":
-                product = "phone-numbers"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
                 )
             )
             detected_lines.add(i)
@@ -1033,7 +1041,7 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _JAVA_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1059,11 +1067,22 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
 
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # use Twilio\* namespace imports
-        m = _PHP_USE_RE.search(stripped)
+        m = _PHP_USE_RE.search(syntax_lines[i - 1])
         if m:
             ns = m.group(1).lower()
             product = "general"
@@ -1106,30 +1125,6 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
             detected_lines.add(i)
             continue
 
-        # $twilio-> method calls
-        m = _PHP_METHOD_RE.search(stripped)
-        if m:
-            method = m.group(1).lower()
-            product = "general"
-            if method in ("messages", "message"):
-                product = "messaging"
-            elif method in ("calls", "call"):
-                product = "voice"
-            elif method in ("verify", "verification"):
-                product = "verify"
-            elif method in ("video",):
-                product = "video"
-            elif method in ("lookups", "lookup"):
-                product = "lookup"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
-                )
-            )
-            detected_lines.add(i)
-            continue
-
         # Env vars: getenv('TWILIO_*'), $_ENV['TWILIO_*']
         m = _PHP_ENV_RE.search(stripped)
         if m:
@@ -1161,7 +1156,7 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("#") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _PHP_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1186,12 +1181,23 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
     """Regex-based scanning for C# files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
 
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # using Twilio* imports
-        m = _CSHARP_USING_RE.search(stripped)
+        m = _CSHARP_USING_RE.search(syntax_lines[i - 1])
         if m:
             ns = m.group(1).lower()
             product = "general"
@@ -1234,26 +1240,6 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
             detected_lines.add(i)
             continue
 
-        # Resource method calls: MessageResource.Create, CallResource.Create, etc.
-        m = _CSHARP_RESOURCE_RE.search(stripped)
-        if m:
-            resource = m.group(1).lower()
-            product = "general"
-            if "message" in resource:
-                product = "messaging"
-            elif "call" in resource:
-                product = "voice"
-            elif "incomingphonenumber" in resource:
-                product = "phone-numbers"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
-                )
-            )
-            detected_lines.add(i)
-            continue
-
         # Env vars: Environment.GetEnvironmentVariable("TWILIO_*")
         m = _CSHARP_ENV_RE.search(stripped)
         if m:
@@ -1274,7 +1260,7 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _CSHARP_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1326,7 +1312,9 @@ def walk_project(root: Path):
     """Yield file paths, skipping common non-source directories."""
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune skip dirs in-place
-        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS and not d.startswith(".")]
+        # Hidden source folders (for example .github/scripts) are still source.
+        # Exclude named generated/tool directories, not every dot-directory.
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
         for fname in filenames:
             yield Path(dirpath) / fname
 
@@ -1523,7 +1511,7 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
             rel = str(filepath.relative_to(project_root))
             java_detections = scan_java_file(filepath, lines)
             if java_detections:
-                lang = "kotlin" if ext == ".kt" else "scala" if ext == ".scala" else "java"
+                lang = "kotlin" if ext in {".kt", ".kts"} else "scala" if ext == ".scala" else "java"
                 fr = FileResult(rel, lang)
                 fr.detections = java_detections
                 file_results.append(fr)

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -945,6 +945,9 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
     lexed = _ownership.lexed_source(source, filepath.suffix)
     syntax_lines = lexed.code.split("\n")
     lines = lexed.without_comments.split("\n")
+    scala_selectors = (_ownership.scala_import_bindings(lexed.code, {
+        "Message": "messaging", "Call": "voice",
+        "IncomingPhoneNumber": "phone-numbers"}) if filepath.suffix == ".scala" else [])
     for line, product in _ownership.contextual_calls(source, filepath.suffix):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
@@ -958,6 +961,21 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
         # import com.twilio.*
         m = _JAVA_IMPORT_RE.search(syntax_lines[i - 1])
         if m:
+            if filepath.suffix == ".scala" and re.search(
+                r"\bimport\s+(?:_root_\.)?com\.twilio\.rest\.api\.v2010\.account\.\s*\{",
+                syntax_lines[i - 1],
+            ):
+                # Selector text is not a package name: Message => _ excludes
+                # Message, while Message => Sms imports it under another name.
+                products = {product for offset, selected, _ in scala_selectors
+                            if source.count("\n", 0, offset) + 1 == i
+                            for product in selected.values() if product}
+                for product in sorted(products or {"general"}):
+                    detections.append(Detection(
+                        pattern=stripped, line=i, detection_method="regex",
+                        context=get_context_lines(lines, i), confidence="high", product=product))
+                detected_lines.add(i)
+                continue
             pkg = m.group(1).lower()
             product = "general"
             if "messaging" in pkg or "message" in pkg:

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -1195,7 +1195,7 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
     return detections
 
 
-def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
+def scan_csharp_file(filepath: Path, lines: List[str], global_using_code: str = "") -> List[Detection]:
     """Regex-based scanning for C# files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
@@ -1203,7 +1203,7 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
     lexed = _ownership.lexed_source(source, filepath.suffix)
     syntax_lines = lexed.code.split("\n")
     lines = lexed.without_comments.split("\n")
-    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+    for line, product in _ownership.contextual_calls(source, filepath.suffix, global_using_code):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
             context=get_context_lines(lines, line), confidence="high", product=product))
@@ -1351,7 +1351,9 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
     method_counts: Dict[str, int] = {"ast": 0, "regex": 0, "heuristic": 0}
     confidence_counts: Dict[str, int] = {"high": 0, "medium": 0, "low": 0}
 
-    for filepath in walk_project(project_root):
+    paths = list(walk_project(project_root))
+    global_usings = _ownership.CsharpGlobalUsings(project_root, paths)
+    for filepath in paths:
         ext = filepath.suffix.lower()
         name = filepath.name
 
@@ -1592,11 +1594,12 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
                 text = filepath.read_text(errors="replace")
             except (OSError, PermissionError):
                 continue
-            if "twilio" not in text.lower():
+            global_using_code = global_usings.for_file(filepath)
+            if "twilio" not in text.lower() and not global_using_code:
                 continue
             lines = text.splitlines()
             rel = str(filepath.relative_to(project_root))
-            csharp_detections = scan_csharp_file(filepath, lines)
+            csharp_detections = scan_csharp_file(filepath, lines, global_using_code)
             if csharp_detections:
                 fr = FileResult(rel, "csharp")
                 fr.detections = csharp_detections

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
@@ -118,6 +118,21 @@ run_grep() {
   grep -rnI "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
+run_source_fixed_grep() {
+  grep -rnI "${EXCLUDE_ARGS[@]}" --exclude='*.razor' --exclude='*.cshtml' "$@" "$PROJECT_ROOT" 2>/dev/null || true
+  # Razor mixes inert markup and executable C#. Recheck candidate lines on
+  # the shared executable view, retaining the original fixed-string semantics.
+  local filter_pattern script_dir filepath locator
+  filter_pattern="$(printf '%s' "$2" | sed 's/[][\\.^$*+?(){}|]/\\&/g')"
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  while IFS= read -r -d '' filepath && IFS= read -r locator; do
+    printf '%s\0%s\n' "$filepath" "$locator" |
+      python3 "$script_dir/filter-source-matches.py" --mode code \
+        --analyzer "$script_dir/lint-required-messaging-profile.py" --pattern "$filter_pattern"
+  done < <(grep -rnIH --null --include='*.razor' --include='*.cshtml' \
+    "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true)
+}
+
 # Detect language from file extension
 detect_language() {
   local f="$1"
@@ -130,7 +145,7 @@ detect_language() {
     *.java)                   echo "java" ;;
     *.php|*.phtml)             echo "php" ;;
     *.scala)                  echo "scala" ;;
-    *.cs|*.cshtml)             echo "csharp" ;;
+    *.cs|*.cshtml|*.razor)     echo "csharp" ;;
     *.sh|*.bash)              echo "shell" ;;
     *.xml)                    echo "xml" ;;
     *.json)                   echo "json" ;;
@@ -340,7 +355,7 @@ for pat in "${SDK_PATTERNS[@]}"; do
         record_file "$rel" "$lang" "$p" "$trimmed"
       done
     fi
-  done < <(run_grep -F "$pat")
+  done < <(run_source_fixed_grep -F "$pat")
 done
 
 for pat in "${SDK_REGEX_PATTERNS[@]}"; do
@@ -427,7 +442,7 @@ for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
     fi
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
-  done < <(run_grep -F "$pat")
+  done < <(run_source_fixed_grep -F "$pat")
 done
 
 # Case-insensitive regex patterns for common method calls

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
@@ -115,21 +115,22 @@ declare -A API_URL_MAP       # url -> comma-separated files
 # Runs grep -rn inside PROJECT_ROOT with standard excludes and returns
 # matching lines (path:lineno:content). Returns 0 even if nothing matched.
 run_grep() {
-  grep -rn "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Detect language from file extension
 detect_language() {
   local f="$1"
   case "$f" in
-    *.py)                     echo "python" ;;
-    *.js|*.mjs|*.cjs)        echo "javascript" ;;
-    *.ts|*.tsx)               echo "typescript" ;;
+    *.py|*.pyw)               echo "python" ;;
+    *.js|*.jsx|*.mjs|*.cjs)    echo "javascript" ;;
+    *.ts|*.tsx|*.mts|*.cts)    echo "typescript" ;;
     *.go)                     echo "go" ;;
-    *.rb)                     echo "ruby" ;;
+    *.rb|*.rake|*/Rakefile|Rakefile) echo "ruby" ;;
     *.java)                   echo "java" ;;
-    *.php)                    echo "php" ;;
-    *.cs)                     echo "csharp" ;;
+    *.php|*.phtml)             echo "php" ;;
+    *.scala)                  echo "scala" ;;
+    *.cs|*.cshtml)             echo "csharp" ;;
     *.sh|*.bash)              echo "shell" ;;
     *.xml)                    echo "xml" ;;
     *.json)                   echo "json" ;;
@@ -179,7 +180,7 @@ pattern_to_products() {
     products="$products fax"
   fi
   # Lookup
-  if echo "$pat" | grep -qiE 'twilio/rest/lookups|PhoneNumber|lookups'; then
+  if echo "$pat" | grep -qiE 'twilio/rest/lookups|lookups'; then
     products="$products lookup"
   fi
   # TeXML (TwiML)
@@ -293,8 +294,8 @@ SDK_PATTERNS=(
   'import com.twilio'
   'com.twilio.'
   # PHP
-  'use Twilio\\'
-  'Twilio\\'
+  "use Twilio\\"
+  "Twilio\\"
   # C# / .NET
   'using Twilio'
   'Twilio.'
@@ -407,8 +408,8 @@ PRODUCT_PATTERNS_FIXED=(
 )
 
 for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
-  pat="${entry%%:*}"
-  product="${entry#*:}"
+  pat="${entry%:*}"
+  product="${entry##*:}"
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     filepath="${line%%:*}"
@@ -416,6 +417,14 @@ for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
     content="${rest#*:}"
     rel="${filepath#"$PROJECT_ROOT"/}"
     lang="$(detect_language "$rel")"
+    # C# resource names can be application-defined. The shared scoped
+    # resolver below attributes these calls; a bare name is not SDK evidence.
+    if [[ "$lang" == csharp && ( "$pat" == MessageResource || "$pat" == CallResource || \
+      "$pat" == VerificationResource || "$pat" == FaxResource || "$pat" == SimResource || \
+      "$pat" == ConversationResource || "$pat" == NotificationResource || \
+      "$pat" == WorkflowResource ) ]]; then
+      continue
+    fi
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
   done < <(run_grep -F "$pat")
@@ -425,6 +434,14 @@ done
 PRODUCT_PATTERNS_REGEX=(
   'messages\.create:messaging'
   'messages\.list:messaging'
+  'api\.twilio\.com/.*/Messages(\.json)?:messaging'
+  'messaging\.twilio\.com:messaging'
+  'api\.twilio\.com/.*/Calls(\.json)?:voice'
+  'verify\.twilio\.com:verify'
+  'lookups\.twilio\.com:lookup'
+  'video\.twilio\.com:video'
+  'fax\.twilio\.com:fax'
+  'api\.twilio\.com/.*/IncomingPhoneNumbers(\.json)?:phone-numbers'
   '\.calls\.create:voice'
   '\.calls\.list:voice'
   'verify\.v2:verify'
@@ -438,7 +455,6 @@ PRODUCT_PATTERNS_REGEX=(
   'twiml\.voice:voice'
   'twiml\.messaging:messaging'
   'VoiceGrant:voice'
-  'SipGrant:voice'
   # SIP trunking
   'twilio\.rest\.trunking:sip'
   'trunking\.v1:sip'
@@ -496,8 +512,8 @@ PRODUCT_PATTERNS_REGEX=(
 )
 
 for entry in "${PRODUCT_PATTERNS_REGEX[@]}"; do
-  pat="${entry%%:*}"
-  product="${entry#*:}"
+  pat="${entry%:*}"
+  product="${entry##*:}"
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     filepath="${line%%:*}"
@@ -507,8 +523,22 @@ for entry in "${PRODUCT_PATTERNS_REGEX[@]}"; do
     lang="$(detect_language "$rel")"
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
-  done < <(run_grep -iE "$pat")
+  done < <(run_grep -iE -- "$pat")
 done
+
+# Ambiguous JVM class names and PHP receivers use the same ownership resolver
+# as deep discovery. NUL records preserve filenames and source text verbatim.
+while IFS= read -r -d '' filepath && IFS= read -r -d '' product && IFS= read -r -d '' content; do
+  rel="${filepath#"$PROJECT_ROOT"/}"
+  lang="$(detect_language "$rel")"
+  record_file "$rel" "$lang" "$product" "$content"
+done < <(python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sdk-source-ownership.py" "$PROJECT_ROOT")
+# A process-substitution failure does not propagate through `set -e`.
+# Do not serialize partial discovery as a successful complete scan.
+if ! wait "$!"; then
+  echo "SDK ownership discovery failed; scan is incomplete" >&2
+  exit 2
+fi
 
 # ---------------------------------------------------------------------------
 # 3. Environment variables

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Shared, bounded SDK ownership for ambiguous JVM/PHP/Go discovery call names.
+
+This is discovery evidence, not a whole-program type checker. A comment, string,
+unrelated import, or receiver name alone never establishes SDK ownership.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+import importlib.util
+from pathlib import Path
+import re
+import os
+import sys
+
+
+@lru_cache(maxsize=None)
+def load_script(name: str):
+    spec = importlib.util.spec_from_file_location(
+        name.replace("-", "_"), Path(__file__).with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def lexed_source(source: str, suffix: str):
+    analyzer = load_script("lint-required-messaging-profile")
+    path = Path("source" + suffix)
+    return analyzer.lex_source(analyzer.executable_source(path, source),
+                               analyzer.canonical_suffix(path), analyzer.source_dialect(path))
+
+
+def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
+    lexed = lexed_source(source, suffix)
+    code = lexed.code
+    if suffix == ".go":
+        return go_contextual_calls(source, lexed)
+    if suffix in {".cs", ".cshtml"}:
+        analyzer = load_script("lint-required-messaging-profile")
+        resolver = analyzer.SourceEndpointResolver(lexed, ".cs")
+        resources = (
+            ("Twilio.Rest.Api.V2010.Account.MessageResource", "messaging"),
+            ("Twilio.Rest.Api.V2010.Account.CallResource", "voice"),
+            ("Twilio.Rest.Api.V2010.Account.IncomingPhoneNumberResource", "phone-numbers"),
+            ("Twilio.Rest.Api.V2010.AccountResource", "general"),
+            ("Twilio.Rest.Verify.V2.Service.VerificationResource", "verify"),
+            ("Twilio.Rest.Fax.V1.FaxResource", "fax"),
+            ("Twilio.Rest.Supersim.V1.SimResource", "iot"),
+            ("Twilio.Rest.Wireless.V1.SimResource", "iot"),
+            ("Twilio.Rest.Conversations.V1.ConversationResource", "conversations"),
+            ("Twilio.Rest.Conversations.V1.Service.ConversationResource", "conversations"),
+            ("Twilio.Rest.Notify.V1.Service.NotificationResource", "notify"),
+            ("Twilio.Rest.Taskrouter.V1.Workspace.WorkflowResource", "taskrouter"),
+        )
+        methods = tuple(
+            method + suffix
+            for method in ("Create", "Read", "Update", "Fetch", "Delete", "List")
+            for suffix in ("", "Async")
+        )
+        return [(source.count("\n", 0, call.start) + 1, product)
+                for target, product in resources
+                for call in analyzer.csharp_twilio_resource_calls(lexed,
+                    target, methods, resolver)]
+    result = []
+    products = {"Message": "messaging", "Call": "voice",
+                "IncomingPhoneNumber": "phone-numbers"}
+    if suffix in {".java", ".kt", ".kts", ".scala"}:
+        analyzer = load_script("lint-required-messaging-profile")
+        resolver = analyzer.SourceEndpointResolver(lexed, ".java")
+        parameter_scopes = []
+        parameter_headers = []
+        if suffix != ".java":
+            # Kotlin/Scala name:type parameters differ from Java Type name.
+            # Keep that dialect distinction local to SDK ownership, without
+            # changing the endpoint resolver's advertised Java contract.
+            for function in re.finditer(r"\b(?:fun|def)\s+\w+\s*\(", code):
+                opening = code.rfind("(", function.start(), function.end())
+                closing = analyzer.matching_delimiter(code, opening, "(", ")")
+                if closing is None:
+                    continue
+                parameter_headers.append((opening, closing))
+                body = code.find("{", closing)
+                if body < 0 or not re.fullmatch(r"\s*(?::[^{}\n=]+)?\s*=?\s*", code[closing + 1:body]):
+                    continue
+                end = analyzer.matching_delimiter(code, body, "{", "}")
+                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
+                if end is not None:
+                    parameter_scopes.append((body, end, names))
+        prefix = "com.twilio.rest.api.v2010.account."
+        imports = {}
+        explicit = {}
+        for match in re.finditer(r"\bimport\s+(com\.twilio\.rest\.api\.v2010\.account\.\*|[\w.]+)(?:\s+as\s+(\w+))?", code):
+            target = match[1]
+            if target == prefix + "*":
+                imports.update(products)
+            elif target.startswith(prefix) and target[len(prefix):] in products:
+                explicit[match[2] or target.rsplit(".", 1)[-1]] = products[target[len(prefix):]]
+            else:
+                explicit[match[2] or target.rsplit(".", 1)[-1]] = None
+        imports.update(explicit)  # Single imports shadow wildcard imports in either order.
+        for match in re.finditer(r"(?<![\w.])([\w.]+)\s*\.\s*creator\s*\(", code):
+            receiver = match[1]
+            first = receiver.split(".", 1)[0]
+            binding_id = resolver.graph.visible_binding(first, resolver.scope_at(match.start()), match.start())
+            if binding_id is not None:
+                binding = resolver.graph.bindings[binding_id]
+                if ((suffix == ".java" or binding.kind != "parameter")
+                        and not any(start < binding.declaration_start < end
+                                    for start, end in parameter_headers)
+                        and analyzer.scope_contains(code, binding.declaration_start, match.start())):
+                    continue
+            if any(start < match.start() < end and first in names
+                   for start, end, names in parameter_scopes):
+                continue
+            product = imports.get(receiver)
+            if receiver.startswith(prefix):
+                product = products.get(receiver[len(prefix):])
+            if product:
+                result.append((source.count("\n", 0, match.start()) + 1, product))
+        return result
+
+    namespaces = list(re.finditer(r"\bnamespace(?:\s+[\w\\]+)?\s*[;{]", code))
+
+    def namespace_at(offset: int) -> int:
+        return next((match.start() for match in reversed(namespaces)
+                     if match.start() < offset), -1)
+
+    def global_namespace(offset: int) -> bool:
+        match = next((match for match in reversed(namespaces) if match.start() < offset), None)
+        return match is None or bool(re.fullmatch(r"namespace\s*\{", match[0]))
+
+    aliases = {}
+    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*;", code, re.I):
+        aliases[(namespace_at(match.start()), (match[2] or match[1]).lower())] = match[1].lower()
+    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\\{([^{};]+)\}\s*;", code, re.I):
+        for member in match[1].split(","):
+            imported = re.fullmatch(
+                r"\s*(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*",
+                member,
+                re.I,
+            )
+            if imported:
+                aliases[(namespace_at(match.start()),
+                         (imported[2] or imported[1]).lower())] = imported[1].lower()
+
+    def kind(type_name: str, offset: int) -> str | None:
+        normalized = type_name.lstrip("\\").lower()
+        if normalized in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"} and (type_name.startswith("\\") or global_namespace(offset)):
+            return normalized.rsplit("\\", 1)[-1]
+        return aliases.get((namespace_at(offset), normalized))
+
+    analyzer = load_script("lint-required-messaging-profile")
+    # Index braces once so bindings cannot leak between functions/classes.
+    braces = {}
+    stack = []
+    for offset, character in enumerate(code):
+        if character == "{":
+            stack.append(offset)
+        elif character == "}" and stack:
+            braces[stack.pop()] = offset
+    functions = []
+    classes = []
+    for pattern, spans in ((r"\bfunction\s*\w*\s*\([^;{]*\)[^;{]*\{", functions),
+                           (r"\bclass\s+\w+[^;{]*\{", classes)):
+        for match in re.finditer(pattern, code):
+            opening = match.end() - 1
+            if opening in braces:
+                spans.append((match.start(), braces[opening]))
+
+    def owner(offset: int, spans: list[tuple[int, int]]):
+        return next((span for span in reversed(spans) if span[0] <= offset < span[1]), None)
+
+    variable = r"\$[A-Za-z_]\w*(?:\s*->\s*[A-Za-z_]\w*)?"
+    assignments = list(re.finditer(r"(" + variable + r")\s*=(?!=|>)\s*([^;\n]+)", code))
+    typed = list(re.finditer(r"(?<![\w\\])([\\\w]+)\s+(\$\w+)\b", code))
+
+    def compact(value: str) -> str:
+        return re.sub(r"\s+", "", value)
+
+    def resolve(expression: str, use: int, seen: frozenset = frozenset()) -> str | None:
+        expression = expression.strip()
+        identity = (expression, use)
+        if identity in seen or len(seen) > 32:
+            return None
+        seen = seen | {identity}
+        constructed = re.match(r"new\s+([\\\w]+)\s*\(", expression, re.I)
+        if constructed:
+            return kind(constructed[1], use)
+        factory = re.match(r"(" + variable + r")\s*->\s*create\s*\(", expression, re.I)
+        if factory:
+            return "client" if resolve(factory[1], use, seen) == "clientfactory" else None
+        if not re.fullmatch(variable, expression):
+            return None
+        name = compact(expression)
+        candidates = []
+        for match in assignments:
+            if compact(match[1]) != name:
+                continue
+            if name.startswith("$this->"):
+                # Only a constructor initializes an instance property for a
+                # later method; arbitrary other method writes are not definite.
+                function = owner(match.start(), functions)
+                same_function = function == owner(use, functions)
+                constructor = function and re.match(r"function\s+__construct\b", code[function[0]:], re.I)
+                if owner(use, classes) is None or owner(use, classes) != owner(match.start(), classes) or not (same_function or constructor):
+                    continue
+                if same_function and match.start() >= use:
+                    continue
+            elif owner(use, functions) != owner(match.start(), functions):
+                continue
+            elif match.start() >= use:
+                continue
+            if namespace_at(match.start()) != namespace_at(use):
+                continue
+            if not name.startswith("$this->") and not analyzer.scope_contains(code, match.start(), use):
+                continue
+            # An assignment in the currently executing method overrides a
+            # constructor initializer regardless of source declaration order.
+            candidates.append((owner(match.start(), functions) == owner(use, functions), match.start(), match[2]))
+        if candidates:
+            _, offset, value = max(candidates)
+            return resolve(value, offset, seen)
+        for match in reversed(typed):
+            if namespace_at(match.start()) != namespace_at(use):
+                continue
+            function = owner(match.start(), functions)
+            # A type hint is in the parameter header, not `return $client` or
+            # another keyword/expression in the function body.
+            parameter = function is not None and match.start() < code.find("{", function[0])
+            if parameter and match.start() < use and compact(match[2]) == name and owner(use, functions) == function:
+                return kind(match[1], match.start())
+            promoted = False
+            if parameter:
+                parameter_start = max(code.rfind("(", function[0], match.start()),
+                                      code.rfind(",", function[0], match.start()))
+                promoted = bool(re.search(
+                    r"\b(?:public|protected|private)\b",
+                    code[parameter_start + 1:match.start()],
+                    re.I,
+                ))
+            if (promoted and name == "$this->" + match[2][1:]
+                    and re.match(r"function\s+__construct\b", code[function[0]:], re.I)
+                    and owner(use, classes) == owner(match.start(), classes)):
+                return kind(match[1], match.start())
+            if name == "$this->" + match[2][1:] and owner(match.start(), functions) is None and owner(use, classes) is not None and owner(use, classes) == owner(match.start(), classes):
+                return kind(match[1], match.start())
+        return None
+
+    php_products = {"messages": "messaging", "calls": "voice", "verify": "verify",
+                    "video": "video", "lookups": "lookup"}
+    for match in re.finditer(r"(" + variable + r")\s*->\s*(messages|calls|verify|video|lookups)\b", code, re.I):
+        if resolve(match[1], match.start()) == "client":
+            result.append((source.count("\n", 0, match.start()) + 1, php_products[match[2].lower()]))
+    return result
+
+
+def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
+    """Attribute standard Go SDK service calls through local client bindings."""
+    analyzer = load_script("lint-required-messaging-profile")
+    code = lexed.code
+    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+    # The shared graph already indexes initialized locals and parameters. Add
+    # Go's uninitialized `var client Type` form so it shadows an outer SDK
+    # binding in exactly the same lexical lookup.
+    for declaration in re.finditer(
+            r"(?m)\bvar\s+([A-Za-z_]\w*)\s+(?![=(])[^=;\n]+(?=;|\n|$)", code):
+        scope = resolver.scope_at(declaration.start())
+        resolver.graph.add_binding(
+            declaration[1], scope, declaration.start(), declaration.start(),
+            "declaration")
+    packages = set()
+    for token in lexed.strings:
+        if token.contents != "github.com/twilio/twilio-go":
+            continue
+        line_start = code.rfind("\n", 0, token.start) + 1
+        prefix = code[line_start:token.start]
+        single = re.fullmatch(r"\s*import\s+(?:(\w+)\s+)?", prefix)
+        grouped = re.fullmatch(r"\s*(?:(\w+)\s+)?", prefix)
+        group_start = code.rfind("import", 0, token.start)
+        in_group = group_start >= 0 and re.match(r"import\s*\(", code[group_start:])
+        if in_group:
+            opening = code.find("(", group_start)
+            closing = analyzer.matching_delimiter(code, opening, "(", ")")
+            in_group = closing is not None and token.start < closing
+        imported = single or (grouped if in_group else None)
+        if imported:
+            packages.add(imported[1] or "twilio")
+    # This shared pattern excludes selector suffixes (`holder.client = ...`),
+    # which are mutations of a different binding.
+    assignments = resolver.root_assignments
+
+    def assignment(name: str, before: int):
+        use_binding = resolver.graph.visible_binding(
+            name, resolver.scope_at(before), before)
+        for match in reversed(assignments):
+            if (match[1].lstrip("$") != name or match.start() >= before
+                    or not analyzer.scope_contains(code, match.start(), before)):
+                continue
+            binding = resolver.assignment_bindings.get(match.start())
+            if binding is None:
+                binding = resolver.graph.visible_binding(
+                    name, resolver.scope_at(match.start()), match.start())
+            if binding == use_binding:
+                value = re.match(r"([^;\n]+)", code[match.end():])
+                return (match, value[1].strip()) if value else None
+        return None
+
+    def client(name: str, before: int, seen: frozenset = frozenset()) -> bool:
+        identity = (name, before)
+        if identity in seen or len(seen) >= 32:
+            return False
+        resolved = assignment(name, before)
+        if resolved is None:
+            return False
+        match, value = resolved
+        created = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", value)
+        if created:
+            package_binding = resolver.graph.visible_binding(
+                created[1], resolver.scope_at(match.start()), match.start())
+            return created[1] in packages and package_binding is None
+        return bool(re.fullmatch(r"\w+", value) and client(value, match.start(), seen | {identity}))
+
+    products = {"Api": {"Message": "messaging", "Call": "voice", "IncomingPhoneNumber": "phone-numbers"},
+                "VerifyV2": {"Verification": "verify"},
+                "LookupsV2": {"PhoneNumber": "lookup"},
+                "VideoV1": {"Room": "video"}}
+    result = []
+    for match in re.finditer(r"\b(\w+)\s*\.\s*(\w+)\s*\.\s*"
+                            r"(?:Create|Fetch|Update|Delete|Read|List)(\w+)\s*\(", code):
+        product = products.get(match[2], {}).get(match[3])
+        if product and client(match[1], match.start()):
+            result.append((source.count("\n", 0, match.start()) + 1, product))
+    return result
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        return 2
+    root = Path(sys.argv[1])
+    scanner = load_script("scan-twilio-deep")
+    failed = False
+    for path in scanner.walk_project(root):
+        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
+            continue
+        try:
+            if not path.stat().st_mode & 0o444 or not os.access(path, os.R_OK):
+                raise OSError("source is not readable")
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            print(f"Cannot inspect SDK ownership in {str(path)!r}: {error}", file=sys.stderr)
+            failed = True
+            continue
+        if "\x00" in source:
+            continue
+        lines = source.splitlines()
+        for line, product in contextual_calls(source, path.suffix):
+            for value in (str(path), product, lines[line - 1].strip()):
+                sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
+    return 2 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -93,7 +93,61 @@ def scala_indent_regions(code: str) -> list[tuple[int, int]]:
     return regions
 
 
-def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
+class CsharpGlobalUsings:
+    """Index unconditional source global usings within project-directory bounds.
+
+    This does not evaluate MSBuild or preprocessor symbols. Conditional imports
+    are not promoted to project-wide evidence. Without a csproj, the scan root
+    is the boundary; nested/sibling csproj directories never share imports.
+    """
+
+    def __init__(self, root: Path, paths: list[Path]):
+        self.root = root
+        self.projects = {path.parent for path in paths if path.suffix.lower() == ".csproj"}
+        self.imports: dict[Path, list[str]] = {}
+        for path in paths:
+            if path.suffix.lower() != ".cs":
+                continue
+            try:
+                source = path.read_text(encoding="utf-8-sig")
+            except (OSError, UnicodeError):
+                continue  # The scanner retains its own read-error policy.
+            if "global" not in source or "\x00" in source:
+                continue
+            code = lexed_source(source, ".cs").code
+            # Preserve offsets while removing conditional regions. A using in
+            # one possible build configuration is not definite ownership.
+            depth, unconditional = 0, []
+            for line in code.splitlines(keepends=True):
+                directive = re.match(r"\s*#\s*(if|endif)\b", line)
+                if directive and directive[1] == "if":
+                    depth += 1
+                unconditional.append("\n" if depth or directive else line)
+                if directive and directive[1] == "endif":
+                    depth = max(0, depth - 1)
+            code = "".join(unconditional)
+            analyzer = load_script("lint-required-messaging-profile")
+            for match in re.finditer(
+                r"\bglobal\s+using\s+(?:static\s+)?(?:\w+\s*=\s*)?"
+                r"(?:global\s*::\s*)?\w+(?:\s*\.\s*\w+)*\s*;", code
+            ):
+                # Global directives are compilation-unit declarations, never
+                # members of a namespace/type body.
+                if analyzer.curly_ancestry(code, match.start()):
+                    continue
+                self.imports.setdefault(self.owner(path), []).append(match[0])
+        self.contexts = {owner: "\n".join(dict.fromkeys(imports))
+                         for owner, imports in self.imports.items()
+                         if any(re.search(r"\bTwilio\s*\.", item) for item in imports)}
+
+    def owner(self, path: Path) -> Path:
+        return next((parent for parent in path.parents if parent in self.projects), self.root)
+
+    def for_file(self, path: Path) -> str:
+        return self.contexts.get(self.owner(path), "")
+
+
+def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
     if suffix == ".go":
@@ -123,7 +177,7 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
         return [(source.count("\n", 0, call.start) + 1, product)
                 for target, product in resources
                 for call in analyzer.csharp_twilio_resource_calls(lexed,
-                    target, methods, resolver)]
+                    target, methods, resolver, global_using_code)]
     result = []
     products = {"Message": "messaging", "Call": "voice",
                 "IncomingPhoneNumber": "phone-numbers"}
@@ -458,7 +512,9 @@ def main() -> int:
     root = Path(sys.argv[1])
     scanner = load_script("scan-twilio-deep")
     failed = False
-    for path in scanner.walk_project(root):
+    paths = list(scanner.walk_project(root))
+    global_usings = CsharpGlobalUsings(root, paths)
+    for path in paths:
         if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
             continue
         try:
@@ -472,7 +528,7 @@ def main() -> int:
         if "\x00" in source:
             continue
         lines = source.splitlines()
-        for line, product in contextual_calls(source, path.suffix):
+        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path)):
             for value in (str(path), product, lines[line - 1].strip()):
                 sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
     return 2 if failed else 0

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -31,6 +31,68 @@ def lexed_source(source: str, suffix: str):
                                analyzer.canonical_suffix(path), analyzer.source_dialect(path))
 
 
+def scala_import_bindings(code: str, products: dict[str, str]) -> list[tuple[int, dict, dict]]:
+    """Read Scala 2/3 selectors, preserving renames and wildcard exclusions.
+
+    Import positions are retained because Scala permits block-local imports.
+    This recognizes literal package imports, not arbitrary stable-path aliases.
+    """
+    analyzer = load_script("lint-required-messaging-profile")
+    prefix = "com.twilio.rest.api.v2010.account"
+    result = []
+    for statement in re.finditer(r"\bimport\s+((?:[.,]\s*\n\s*|[^;\n{}]|\{[^{}]*\})+)", code):
+        for start, end in analyzer.split_arguments(code, statement.start(1), statement.end(1)):
+            expression = code[start:end].strip()
+            grouped = re.fullmatch(r"([\w.]+)\.\s*\{([^{}]*)\}", expression)
+            if grouped:
+                package, selectors = grouped[1], grouped[2].split(",")
+            else:
+                single = re.fullmatch(r"([\w.]+)\.\s*([\w*]+)(?:\s+as\s+(\w+))?", expression)
+                if not single:
+                    continue
+                package = single[1]
+                selectors = [single[2] + (" as " + single[3] if single[3] else "")]
+            package = package.removeprefix("_root_.")
+            explicit, wildcard, excluded = {}, False, set()
+            for selector in selectors:
+                member = re.fullmatch(r"\s*([\w*]+)(?:\s*(?:=>|\bas\b)\s*(\w+))?\s*", selector)
+                if not member:
+                    continue
+                name, alias = member[1], member[2]
+                if name in {"_", "*"} and alias is None:
+                    wildcard = True
+                else:
+                    excluded.add(name)
+                    if alias != "_":
+                        explicit[alias or name] = products.get(name) if package == prefix else None
+            wildcards = ({name: product for name, product in products.items() if name not in excluded}
+                         if wildcard and package == prefix else {})
+            result.append((statement.start(), explicit, wildcards))
+    return result
+
+
+def scala_indent_regions(code: str) -> list[tuple[int, int]]:
+    """Index Scala 3 indentation regions alongside (not instead of) braces."""
+    regions, stack = [], []
+    previous, previous_indent, offset = "", 0, 0
+    for line in code.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped:
+            indent = len(line) - len(line.lstrip(" \t"))
+            while stack and indent < stack[-1][0]:
+                _, start = stack.pop()
+                regions.append((start, offset))
+            if indent > previous_indent and re.search(
+                r"(?::|=|=>|\bthen|\bdo|\bmatch|\btry|\bcatch|\bfinally|\belse|\byield)$",
+                previous,
+            ):
+                stack.append((indent, offset))
+            previous, previous_indent = stripped, indent
+        offset += len(line)
+    regions.extend((start, len(code)) for _, start in stack)
+    return regions
+
+
 def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
@@ -68,6 +130,12 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
     if suffix in {".java", ".kt", ".kts", ".scala"}:
         analyzer = load_script("lint-required-messaging-profile")
         resolver = analyzer.SourceEndpointResolver(lexed, ".java")
+        indent_regions = scala_indent_regions(code) if suffix == ".scala" else []
+
+        def scope_path(offset: int) -> tuple[int, ...]:
+            return tuple(sorted((*analyzer.curly_ancestry(code, offset),
+                                 *(start for start, end in indent_regions if start <= offset < end))))
+
         parameter_scopes = []
         parameter_headers = []
         if suffix != ".java":
@@ -80,11 +148,22 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
                 if closing is None:
                     continue
                 parameter_headers.append((opening, closing))
+                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
+                expression = re.match(r"\s*(?::[^{}\n=]+)?\s*=\s*", code[closing + 1:])
+                if expression:
+                    start = closing + 1 + expression.end()
+                    if start < len(code) and code[start] != "{":
+                        end = analyzer.assignment_end(lexed, start, ".java")
+                        # A multiline indentation body includes following
+                        # expressions, but not a dedented sibling definition.
+                        body_regions = [end for begin, end in indent_regions
+                                        if closing < begin <= start < end]
+                        parameter_scopes.append((start - 1, min(body_regions) if body_regions else end, names))
+                        continue
                 body = code.find("{", closing)
                 if body < 0 or not re.fullmatch(r"\s*(?::[^{}\n=]+)?\s*=?\s*", code[closing + 1:body]):
                     continue
                 end = analyzer.matching_delimiter(code, body, "{", "}")
-                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
                 if end is not None:
                     parameter_scopes.append((body, end, names))
         prefix = "com.twilio.rest.api.v2010.account."
@@ -99,21 +178,48 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
             else:
                 explicit[match[2] or target.rsplit(".", 1)[-1]] = None
         imports.update(explicit)  # Single imports shadow wildcard imports in either order.
+        scala_imports = scala_import_bindings(code, products) if suffix == ".scala" else []
+        scala_objects = list(re.finditer(r"\bobject\s+(\w+)", code)) if suffix == ".scala" else []
         for match in re.finditer(r"(?<![\w.])([\w.]+)\s*\.\s*creator\s*\(", code):
             receiver = match[1]
             first = receiver.split(".", 1)[0]
+            use_scope = scope_path(match.start()) if suffix == ".scala" else ()
             binding_id = resolver.graph.visible_binding(first, resolver.scope_at(match.start()), match.start())
-            if binding_id is not None:
-                binding = resolver.graph.bindings[binding_id]
+            bindings = ([resolver.graph.bindings[index]
+                         for index in resolver.graph.bindings_by_name.get(first, [])]
+                        if suffix == ".scala" else
+                        [resolver.graph.bindings[binding_id]] if binding_id is not None else [])
+            shadowed = False
+            for binding in bindings:
+                binding_scope = scope_path(binding.declaration_start) if suffix == ".scala" else ()
                 if ((suffix == ".java" or binding.kind != "parameter")
                         and not any(start < binding.declaration_start < end
                                     for start, end in parameter_headers)
-                        and analyzer.scope_contains(code, binding.declaration_start, match.start())):
-                    continue
+                        and (use_scope[:len(binding_scope)] == binding_scope if suffix == ".scala"
+                             else analyzer.scope_contains(code, binding.declaration_start, match.start()))):
+                    shadowed = True
+                    break
+            if shadowed or any(obj[1] == first and use_scope[:len(scope_path(obj.start()))] == scope_path(obj.start())
+                               for obj in scala_objects):
+                continue
             if any(start < match.start() < end and first in names
                    for start, end, names in parameter_scopes):
                 continue
             product = imports.get(receiver)
+            if suffix == ".scala":
+                # A deeper lexical scope wins; within a scope, explicit
+                # selectors take precedence over wildcard selectors.
+                candidates = []
+                for position, selected, wildcard in scala_imports:
+                    import_scope = scope_path(position)
+                    if position >= match.start() or use_scope[:len(import_scope)] != import_scope:
+                        continue
+                    depth = len(import_scope)
+                    if receiver in selected:
+                        candidates.append((depth, 1, position, selected[receiver]))
+                    elif receiver in wildcard:
+                        candidates.append((depth, 0, position, wildcard[receiver]))
+                product = max(candidates, key=lambda item: item[:3])[3] if candidates else None
             if receiver.startswith(prefix):
                 product = products.get(receiver[len(prefix):])
             if product:

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -237,24 +237,18 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
         return match is None or bool(re.fullmatch(r"namespace\s*\{", match[0]))
 
     aliases = {}
-    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*;", code, re.I):
-        aliases[(namespace_at(match.start()), (match[2] or match[1]).lower())] = match[1].lower()
-    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\\{([^{};]+)\}\s*;", code, re.I):
-        for member in match[1].split(","):
-            imported = re.fullmatch(
-                r"\s*(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*",
-                member,
-                re.I,
-            )
-            if imported:
-                aliases[(namespace_at(match.start()),
-                         (imported[2] or imported[1]).lower())] = imported[1].lower()
 
     def kind(type_name: str, offset: int) -> str | None:
         normalized = type_name.lstrip("\\").lower()
         if normalized in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"} and (type_name.startswith("\\") or global_namespace(offset)):
             return normalized.rsplit("\\", 1)[-1]
-        return aliases.get((namespace_at(offset), normalized))
+        if not type_name.startswith("\\"):
+            first, separator, rest = normalized.partition("\\")
+            imported = aliases.get((namespace_at(offset), first))
+            expanded = imported + separator + rest if imported else ""
+            if expanded in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"}:
+                return expanded.rsplit("\\", 1)[-1]
+        return None
 
     analyzer = load_script("lint-required-messaging-profile")
     # Index braces once so bindings cannot leak between functions/classes.
@@ -265,6 +259,24 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
             stack.append(offset)
         elif character == "}" and stack:
             braces[stack.pop()] = offset
+    namespace_braces = {match.end() - 1 for match in namespaces if match[0].endswith("{")}
+    for statement in re.finditer(r"\buse\s+([^;()]+);", code, re.I):
+        # Trait uses and closure captures are not namespace imports.
+        if re.match(r"(?:function|const)\b", statement[1], re.I):
+            continue
+        if any(start < statement.start() < end and start not in namespace_braces
+               for start, end in braces.items()):
+            continue
+        for start, end in analyzer.split_arguments(code, statement.start(1), statement.end(1)):
+            item = code[start:end].strip()
+            group = re.fullmatch(r"(\\?[\w\\]+\\)\s*\{([^{}]*)\}", item)
+            members = [(group[1], member) for member in group[2].split(",")] if group else [("", item)]
+            for prefix, member in members:
+                imported = re.fullmatch(r"\s*(\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+([A-Za-z_]\w*))?\s*", member, re.I)
+                if imported:
+                    qualified = (prefix + imported[1]).lstrip("\\").lower()
+                    alias = (imported[2] or imported[1].rsplit("\\", 1)[-1]).lower()
+                    aliases[(namespace_at(statement.start()), alias)] = qualified
     functions = []
     classes = []
     for pattern, spans in ((r"\bfunction\s*\w*\s*\([^;{]*\)[^;{]*\{", functions),

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -147,13 +147,21 @@ class CsharpGlobalUsings:
         return self.contexts.get(self.owner(path), "")
 
 
-def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> list[tuple[int, str]]:
+def contextual_calls(source: str, suffix: str, global_using_code: str = "",
+                     go_clients: frozenset[str] = frozenset()) -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
     if suffix == ".go":
-        return go_contextual_calls(source, lexed)
-    if suffix in {".cs", ".cshtml"}:
+        return go_contextual_calls(source, lexed, go_clients)
+    if suffix in {".cs", ".cshtml", ".razor"}:
         analyzer = load_script("lint-required-messaging-profile")
+        if suffix in {".cshtml", ".razor"}:
+            # Razor @using directives are newline-terminated, unlike C# using
+            # declarations. Only executable lexer output can supply imports.
+            directives = re.findall(
+                r"(?m)^\s*@using\s+((?:static\s+)?(?:\w+\s*=\s*)?"
+                r"(?:global\s*::\s*)?\w+(?:\s*\.\s*\w+)*)\s*;?\s*$", code)
+            global_using_code += "\n" + "\n".join("using " + item + ";" for item in directives)
         resolver = analyzer.SourceEndpointResolver(lexed, ".cs")
         resources = (
             ("Twilio.Rest.Api.V2010.Account.MessageResource", "messaging"),
@@ -427,20 +435,10 @@ def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> l
     return result
 
 
-def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
-    """Attribute standard Go SDK service calls through local client bindings."""
+def go_import_packages(lexed) -> set[str]:
+    """Return file-local names importing the actual Twilio Go SDK."""
     analyzer = load_script("lint-required-messaging-profile")
     code = lexed.code
-    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
-    # The shared graph already indexes initialized locals and parameters. Add
-    # Go's uninitialized `var client Type` form so it shadows an outer SDK
-    # binding in exactly the same lexical lookup.
-    for declaration in re.finditer(
-            r"(?m)\bvar\s+([A-Za-z_]\w*)\s+(?![=(])[^=;\n]+(?=;|\n|$)", code):
-        scope = resolver.scope_at(declaration.start())
-        resolver.graph.add_binding(
-            declaration[1], scope, declaration.start(), declaration.start(),
-            "declaration")
     packages = set()
     for token in lexed.strings:
         if token.contents != "github.com/twilio/twilio-go":
@@ -458,9 +456,117 @@ def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
         imported = single or (grouped if in_group else None)
         if imported:
             packages.add(imported[1] or "twilio")
+    return packages
+
+
+def go_var_declarations(code: str):
+    """Yield Go var bindings; multi-name declarations only establish shadows."""
+    analyzer = load_script("lint-required-messaging-profile")
+    declaration = re.compile(r"([A-Za-z_]\w*)[ \t]*(?:[^=;,\n)]+)?(?P<equals>=)?")
+    for keyword in re.finditer(r"\bvar\s+", code):
+        start = keyword.end()
+        if code[start:start + 1] == "(":
+            end = analyzer.matching_delimiter(code, start, "(", ")")
+            if end is None:
+                continue
+            starts, stack = [start + 1], []
+            for position in range(start + 1, end):
+                char = code[position]
+                if char in "([{":
+                    stack.append(char)
+                elif char in ")]}":
+                    if stack:
+                        stack.pop()
+                elif char in ";\n" and not stack:
+                    starts.append(position + 1)
+        else:
+            starts, end = [start], len(code)
+        for position in starts:
+            while position < end and code[position] in " \t\r":
+                position += 1
+            multiple = re.compile(r"(?:\w+[ \t]*,[ \t]*)+\w+").match(code, position, end)
+            if multiple:
+                yield from re.compile(r"(\w+)(?P<equals>=)?").finditer(code, position, multiple.end())
+                continue
+            match = declaration.match(code, position, end)
+            if match:
+                yield match
+
+
+class GoPackageClients:
+    """Resolve static package client initializers without sharing file imports."""
+
+    def __init__(self, paths: list[Path]):
+        self.keys: dict[Path, tuple[Path, str]] = {}
+        declarations: dict[tuple[Path, str], dict[str, list[tuple[bool, str]]]] = {}
+        analyzer = load_script("lint-required-messaging-profile")
+        for path in paths:
+            if path.suffix != ".go":
+                continue
+            try:
+                source = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            lexed = lexed_source(source, ".go")
+            package = re.search(r"\bpackage\s+(\w+)", lexed.code)
+            if package is None:
+                continue
+            key = (path.parent, package[1])
+            self.keys[path] = key
+            # Test declarations and build-constrained variants must not seed
+            # unconditional ownership in production files.
+            if path.name.endswith("_test.go") or re.search(r"(?m)^\s*//\s*(?:go:build|\+build)\b", source):
+                continue
+            imports = go_import_packages(lexed)
+            resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+            assignments = list(resolver.root_assignments)
+            known_ends = {(match[1], match.end()) for match in assignments}
+            assignments.extend(match for match in go_var_declarations(lexed.code)
+                               if match["equals"] and (match[1], match.end()) not in known_ends)
+            for match in assignments:
+                if analyzer.curly_ancestry(lexed.code, match.start()):
+                    continue
+                value = re.match(r"[^;\n]+", lexed.code[match.end():])
+                if not value:
+                    continue
+                expression = value[0].strip()
+                constructor = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", expression)
+                owned = bool(constructor and constructor[1] in imports)
+                declarations.setdefault(key, {}).setdefault(match[1], []).append((owned, expression))
+        self.clients: dict[tuple[Path, str], frozenset[str]] = {}
+        for key, bindings in declarations.items():
+            known: set[str] = set()
+            for _ in range(len(bindings) + 1):
+                added = {name for name, values in bindings.items() if len(values) == 1
+                         and (values[0][0] or values[0][1] in known)} - known
+                if not added:
+                    break
+                known.update(added)
+            self.clients[key] = frozenset(known)
+
+    def for_file(self, path: Path) -> frozenset[str]:
+        return self.clients.get(self.keys.get(path), frozenset())
+
+
+def go_contextual_calls(source: str, lexed, package_clients: frozenset[str] = frozenset()) -> list[tuple[int, str]]:
+    """Attribute SDK calls through local bindings, then package initializers."""
+    analyzer = load_script("lint-required-messaging-profile")
+    code = lexed.code
+    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+    assignments = list(resolver.root_assignments)
+    known_ends = {(match[1], match.end()) for match in assignments}
+    for declaration in go_var_declarations(code):
+        if declaration["equals"] and (declaration[1], declaration.end()) in known_ends:
+            continue
+        scope = resolver.scope_at(declaration.start())
+        binding = resolver.graph.add_binding(declaration[1], scope, declaration.start(), declaration.start(), "declaration")
+        if declaration["equals"]:
+            assignments.append(declaration)
+            resolver.assignment_bindings[declaration.start()] = binding
+    packages = go_import_packages(lexed)
     # This shared pattern excludes selector suffixes (`holder.client = ...`),
     # which are mutations of a different binding.
-    assignments = resolver.root_assignments
+    assignments.sort(key=lambda match: match.start())
 
     def assignment(name: str, before: int):
         use_binding = resolver.graph.visible_binding(
@@ -484,7 +590,10 @@ def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
             return False
         resolved = assignment(name, before)
         if resolved is None:
-            return False
+            binding = resolver.graph.visible_binding(name, resolver.scope_at(before), before)
+            return name in package_clients and (binding is None or (
+                resolver.graph.bindings[binding].kind != "parameter"
+                and not analyzer.curly_ancestry(code, resolver.graph.bindings[binding].declaration_start)))
         match, value = resolved
         created = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", value)
         if created:
@@ -514,8 +623,9 @@ def main() -> int:
     failed = False
     paths = list(scanner.walk_project(root))
     global_usings = CsharpGlobalUsings(root, paths)
+    go_clients = GoPackageClients(paths)
     for path in paths:
-        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
+        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml", ".razor"}:
             continue
         try:
             if not path.stat().st_mode & 0o444 or not os.access(path, os.R_OK):
@@ -528,7 +638,7 @@ def main() -> int:
         if "\x00" in source:
             continue
         lines = source.splitlines()
-        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path)):
+        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path), go_clients.for_file(path)):
             for value in (str(path), product, lines[line - 1].strip()):
                 sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
     return 2 if failed else 0

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -20,6 +20,7 @@
 #   2 — Usage error
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # --- Colors (disabled if not a terminal) ---
 # shellcheck disable=SC2034  # BLUE reserved for info lines; kept for palette consistency
@@ -204,7 +205,7 @@ search_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Search helper that excludes .md files and minified JS (for config/env var checks)
@@ -217,7 +218,18 @@ search_source_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+}
+
+# Auth-related names are common in unrelated SDKs. Require Telnyx context in
+# the same file before reporting static evidence, not cryptographic assurance.
+search_telnyx_auth_files() {
+  local pattern="$1" file
+  while IFS= read -r -d '' file; do
+    if grep -qiE 'telnyx' "$file"; then
+      grep -nH -E "$pattern" "$file" || true
+    fi
+  done < <(grep -rlI --null $GREP_EXCLUDES --exclude='*.md' -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true)
 }
 
 # Search helper that filters out comment-only lines to reduce false positives.
@@ -407,10 +419,52 @@ fi
 # ============================================================
 section_header "Residual Twilio References"
 
+# Grep suppresses permission errors below; make scan incompleteness visible.
+# Use the same exclusions as the content checks, including caller exclusions.
+unreadable_files=$(python3 - "$PROJECT_ROOT" "$EXCLUDE_DIRS $EXTRA_EXCLUDE_DIRS" "$EXCLUDE_FILES" "$EXCLUDE_LOCK_FILES" <<'PY'
+import fnmatch
+import json
+import os
+import stat
+import sys
+root, excluded_dirs, excluded_files, excluded_locks = sys.argv[1:]
+excluded_dirs = excluded_dirs.split()
+excluded_files = excluded_files.split() + [arg.removeprefix("--exclude=") for arg in excluded_locks.split()]
+unreadable = []
+def excluded(name, patterns):
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+def walk_error(error):
+    unreadable.append(error.filename)
+for directory, dirs, files in os.walk(root, onerror=walk_error):
+    dirs[:] = [name for name in dirs if not excluded(name, excluded_dirs)]
+    for name in files:
+        if excluded(name, excluded_files):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            mode = os.stat(path).st_mode
+            if stat.S_ISREG(mode) and (not mode & 0o444 or not os.access(path, os.R_OK)):
+                unreadable.append(path)
+        except OSError:
+            unreadable.append(path)
+print(json.dumps({"files": unreadable}))
+PY
+)
+if [ "$(jq '.files | length' <<< "$unreadable_files")" -gt 0 ]; then
+  check_fail "source_readability" "Files could not be read; migration validation is incomplete:" "$unreadable_files"
+fi
+
+# Rust is not a supported SDK analyzer. Concrete Twilio imports must not be
+# hidden by an unrelated supported-language Telnyx dependency.
+matches=$(search_code_only '(^|[;[:space:]])(use|extern[[:space:]]+crate)[[:space:]]+twilio([[:space:]:;]|$)' "*.rs")
+if [ -n "$matches" ]; then
+  check_residual_matches_with_hybrid_scope "unsupported_twilio_source" "Twilio Rust source found; this validator cannot analyse Rust SDK migration completeness. Manual review is required:" "$matches"
+fi
+
 # --- Check 1: Twilio SDK imports ---
 # Python
 if product_applies "all"; then
-  matches=$(search_files "(from twilio|import twilio)" "*.py")
+  matches=$(search_files "(from twilio|import twilio)" "*.py" "*.pyw")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_python_imports" "Twilio Python imports found in $count file(s):" "$matches"
@@ -421,7 +475,7 @@ fi
 
 # JavaScript / TypeScript
 if product_applies "all"; then
-  matches=$(search_files "(require\(['\"]twilio['\"]|from ['\"]twilio['\"])" "*.js" "*.ts" "*.jsx" "*.tsx" "*.mjs" "*.cjs")
+  matches=$(search_files "(require\(['\"]twilio['\"]|from ['\"]twilio['\"])" "*.js" "*.ts" "*.jsx" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_js_imports" "Twilio JS/TS imports found in $count file(s):" "$matches"
@@ -443,7 +497,7 @@ fi
 
 # Ruby
 if product_applies "all"; then
-  matches=$(search_files "(require ['\"]twilio-ruby['\"]|require ['\"]twilio['\"])" "*.rb")
+  matches=$(search_files "(require ['\"]twilio-ruby['\"]|require ['\"]twilio['\"])" "*.rb" "*.rake")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_ruby_imports" "Twilio Ruby imports found in $count file(s):" "$matches"
@@ -454,7 +508,7 @@ fi
 
 # Java
 if product_applies "all"; then
-  matches=$(search_files "import com\.twilio\." "*.java" "*.kt" "*.scala")
+  matches=$(search_files "import com\.twilio\." "*.java" "*.kt" "*.kts" "*.scala")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_java_imports" "Twilio Java imports found in $count file(s):" "$matches"
@@ -465,7 +519,7 @@ fi
 
 # PHP
 if product_applies "all"; then
-  matches=$(search_files "(use Twilio|require.*twilio.php)" "*.php")
+  matches=$(search_files "(use Twilio|require.*twilio.php)" "*.php" "*.phtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_php_imports" "Twilio PHP imports found in $count file(s):" "$matches"
@@ -476,7 +530,7 @@ fi
 
 # C#
 if product_applies "all"; then
-  matches=$(search_files "using Twilio" "*.cs")
+  matches=$(search_files "using Twilio" "*.cs" "*.cshtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_csharp_imports" "Twilio C# imports found in $count file(s):" "$matches"
@@ -487,7 +541,7 @@ fi
 
 # --- Check 2: Twilio API URLs (excludes .md docs and minified JS) ---
 if product_applies "all"; then
-  matches=$(search_source_files "(api\.twilio\.com|verify\.twilio\.com|video\.twilio\.com|taskrouter\.twilio\.com|chat\.twilio\.com|conversations\.twilio\.com|sync\.twilio\.com|proxy\.twilio\.com|studio\.twilio\.com)")
+  matches=$(search_source_files "(api\.twilio\.com|verify\.twilio\.com|video\.twilio\.com|taskrouter\.twilio\.com|chat\.twilio\.com|conversations\.twilio\.com|sync\.twilio\.com|proxy\.twilio\.com|studio\.twilio\.com|twimlets\.com)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope \
@@ -549,11 +603,15 @@ if product_applies "all"; then
   # Go
   dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/go.mod 2>/dev/null || true)
   # Java/Kotlin (build.gradle, build.gradle.kts, pom.xml, libs.versions.toml)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 4 \( -name pom.xml -o -name build.gradle -o -name build.gradle.kts -o -name "libs.versions.toml" \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/build/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
+    dep_matches+=$'\nJVM dependency declaration\n'
+  fi
   # iOS (Swift Package Manager — project.pbxproj, Package.swift)
   dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 4 \( -name "project.pbxproj" -o -name "Package.swift" \) -not -path "*/.git/*" -exec grep -l -i "telnyx" {} \; 2>/dev/null || true)
   # PHP
-  dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/composer.json 2>/dev/null || true)
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" composer "$PROJECT_ROOT"; then
+    dep_matches+=$'\nComposer dependency declaration\n'
+  fi
   # C#
   dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name "*.csproj" -exec grep -l "Telnyx" {} \; 2>/dev/null || true)
   # Flutter
@@ -570,7 +628,10 @@ if product_applies "all"; then
   else
     # Before failing, check if Telnyx imports exist in source — if so, SDK is present
     # but in a dependency file we don't recognize (e.g., monorepo, custom build system)
-    source_imports=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/telnyx|@telnyx/|com\.telnyx\.|TelnyxRTC|TelnyxClient)")
+    source_imports=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/(team-)?telnyx|@telnyx/|com\.telnyx\.|TelnyxRTC|TelnyxClient)" \
+      "*.py" "*.pyw" "*.js" "*.jsx" "*.ts" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts" "*.rb" "*.rake" \
+      "*.go" "*.java" "*.kt" "*.kts" "*.scala" "*.php" "*.phtml" "*.cs" "*.cshtml" \
+      "*.swift" "*.dart")
     source_count=$(count_matches "$source_imports")
     if [ "$source_count" -gt 0 ]; then
       check_warn "telnyx_sdk_dependency" "Telnyx SDK not found in standard dependency files, but Telnyx imports found in $source_count source file(s) — likely using a non-standard dependency manager"
@@ -593,9 +654,19 @@ if product_applies "all"; then
   if grep -qE "gem\s+['\"]telnyx['\"].*~>" "$PROJECT_ROOT"/Gemfile 2>/dev/null; then
     version_pinned=true
   fi
+  # Go modules always require an explicit semantic version. Recognize both the
+  # current /v4 module path and an eventual later major-version path.
+  if grep -qE 'github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]+v[0-9]+\.' "$PROJECT_ROOT"/go.mod 2>/dev/null; then
+    version_pinned=true
+  fi
+  # Inspect dependency fields structurally. App/parent/unrelated versions are
+  # not evidence that this SDK dependency has a constrained version.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-pinned "$PROJECT_ROOT"; then
+    version_pinned=true
+  fi
   # If no dependency files found at all, skip the check
   has_deps=false
-  for f in requirements.txt setup.py setup.cfg pyproject.toml Pipfile package.json Gemfile go.mod; do
+  for f in requirements.txt setup.py setup.cfg pyproject.toml Pipfile package.json Gemfile go.mod pom.xml build.gradle build.gradle.kts composer.json; do
     if [ -f "$PROJECT_ROOT/$f" ]; then has_deps=true; break; fi
   done
   if [ "$has_deps" = true ]; then
@@ -637,7 +708,9 @@ fi
 
 # --- Check 7: Telnyx imports in source code ---
 if product_applies "all"; then
-  matches=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/telnyx)")
+  matches=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/(team-)?telnyx|com\.telnyx\.)" \
+    "*.py" "*.pyw" "*.js" "*.jsx" "*.ts" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts" "*.rb" "*.rake" \
+    "*.go" "*.java" "*.kt" "*.kts" "*.scala" "*.php" "*.phtml" "*.cs" "*.cshtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_pass "telnyx_source_imports" "Telnyx imports found in $count source file(s)"
@@ -655,10 +728,10 @@ section_header "Auth Patterns"
 
 # --- Check 8: Bearer auth ---
 if product_applies "all"; then
-  matches=$(search_files "(Authorization.*Bearer|bearer.*auth|Bearer.*TELNYX|TELNYX.*Bearer)")
+  matches=$(search_telnyx_auth_files "(Authorization.*Bearer|bearer.*auth|Bearer.*TELNYX|TELNYX.*Bearer)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    check_pass "bearer_auth" "Bearer auth pattern found in $count file(s)"
+    check_pass "bearer_auth" "Bearer auth pattern found in $count Telnyx-related match(es) (static evidence only)"
   else
     check_pass "bearer_auth" "No explicit Bearer auth pattern (SDK may handle this)"
   fi
@@ -682,10 +755,10 @@ section_header "Webhook Validation"
 
 # --- Check 10: Ed25519 signature validation ---
 if product_applies "voice,messaging,verify,sip,fax"; then
-  matches=$(search_files "(ed25519|Ed25519|telnyx-signature-ed25519|verify_signature|construct_event|webhooks\.unwrap|webhook.*signature.*telnyx)")
+  matches=$(search_telnyx_auth_files "(telnyx-signature-ed25519|verify_signature|construct_event|webhooks\.unwrap|webhook.*signature.*telnyx|ed25519.*[Vv]erify|Ed25519.*[Vv]erify)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    check_pass "ed25519_validation" "Ed25519 webhook signature validation found in $count file(s)"
+    check_pass "ed25519_validation" "Telnyx webhook verification pattern found in $count match(es) (static evidence only; review signature enforcement)"
   else
     # Check if the project has webhook handlers — if so, missing validation is a FAIL
     webhook_handlers=$(search_files "(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|HandleFunc|post '/)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -204,8 +204,10 @@ search_files() {
   for glob in "$@"; do
     include_args="$include_args --include=$glob"
   done
+  # GNU grep defaults unmatched files to included if an exclusion comes first.
+  # Put the allowlist first and exclusions last so both GNU and BSD grep agree.
   # shellcheck disable=SC2086
-  grep -rnI $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Search helper that excludes .md files and minified JS (for config/env var checks)
@@ -218,7 +220,7 @@ search_source_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rnI $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $include_args $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Auth-related names are common in unrelated SDKs. Require Telnyx context in

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -594,14 +594,10 @@ section_header "Telnyx SDK Present"
 # --- Check 6: Telnyx SDK in dependency files ---
 if product_applies "all"; then
   dep_matches=""
-  # Python (root + subdirectories)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 \( -name requirements.txt -o -name setup.py -o -name setup.cfg -o -name pyproject.toml -o -name Pipfile \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/vendor/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
-  # Node (root + subdirectories)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name package.json -not -path "*/node_modules/*" -not -path "*/.git/*" -exec grep -l '"telnyx"\|"@telnyx/' {} \; 2>/dev/null || true)
-  # Ruby
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name Gemfile -not -path "*/vendor/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
-  # Go
-  dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/go.mod 2>/dev/null || true)
+  # Python, Node, Ruby and Go: dependency declarations, not comments or metadata.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" other-declared "$PROJECT_ROOT"; then
+    dep_matches+=$'\nSDK dependency declaration\n'
+  fi
   # Java/Kotlin (build.gradle, build.gradle.kts, pom.xml, libs.versions.toml)
   if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
     dep_matches+=$'\nJVM dependency declaration\n'
@@ -642,26 +638,18 @@ if product_applies "all"; then
 
   # --- Check 6a: Telnyx SDK version pinning ---
   version_pinned=false
-  # Python: check for version constraint (>=, <, ~=, ==)
-  if grep -qE 'telnyx[><=~!]+' "$PROJECT_ROOT"/{requirements.txt,setup.py,setup.cfg,pyproject.toml,Pipfile} 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Node: check package.json for version constraint (^, ~, >=)
-  if grep -qE '"telnyx"\s*:\s*"[\^~>=]' "$PROJECT_ROOT"/package.json 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Ruby: check Gemfile for version constraint (~>)
-  if grep -qE "gem\s+['\"]telnyx['\"].*~>" "$PROJECT_ROOT"/Gemfile 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Go modules always require an explicit semantic version. Recognize both the
-  # current /v4 module path and an eventual later major-version path.
-  if grep -qE 'github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]+v[0-9]+\.' "$PROJECT_ROOT"/go.mod 2>/dev/null; then
+  # Reuse the declaration owners for literal versions and supported ranges.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" other-pinned "$PROJECT_ROOT"; then
     version_pinned=true
   fi
   # Inspect dependency fields structurally. App/parent/unrelated versions are
   # not evidence that this SDK dependency has a constrained version.
   if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-pinned "$PROJECT_ROOT"; then
+    version_pinned=true
+  fi
+  # Composer accepts caret/tilde/range constraints as well as exact versions.
+  # Only require/require-dev links for the SDK count, never unrelated metadata.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" composer-pinned "$PROJECT_ROOT"; then
     version_pinned=true
   fi
   # If no dependency files found at all, skip the check

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -81,7 +81,9 @@ for entry in "${PLUGIN_PATTERNS[@]}"; do
     fi
 
     if [ "$match" = "1" ]; then
-      cp -R "$skill_dir" "$skills_dir/$skill_name"
+      # Preserve source modes so provider trees are deterministic even when
+      # the caller has a restrictive umask (for example Claude's 077).
+      cp -Rp "$skill_dir" "$skills_dir/$skill_name"
       ((++count))
     fi
   done
@@ -101,7 +103,7 @@ mkdir -p "$CURSOR_SKILLS"
 for skill_dir in "$SKILLS_SRC"/*/; do
   [ -d "$skill_dir" ] || continue
   skill_name=$(basename "$skill_dir")
-  cp -R "$skill_dir" "$CURSOR_SKILLS/$skill_name"
+  cp -Rp "$skill_dir" "$CURSOR_SKILLS/$skill_name"
 done
 
 total_cursor=$(find "$CURSOR_SKILLS" -name "SKILL.md" | wc -l | tr -d ' ')

--- a/skills/telnyx-twilio-migration/SKILL.md
+++ b/skills/telnyx-twilio-migration/SKILL.md
@@ -10,7 +10,7 @@ user_invocable: true
 metadata:
   author: telnyx
   product: migration
-  compatibility: "Requires bash 4+, jq, curl, python3. macOS ships bash 3.2 — scripts auto-upgrade via Homebrew bash if available (brew install bash). python3 is mandatory: the scanners and the correctness linter exit 2 without it."
+  compatibility: "Requires bash 4+, Python 3.10+, jq, curl. macOS ships bash 3.2 — scripts auto-upgrade via Homebrew bash if available (brew install bash)."
 ---
 
 # Twilio to Telnyx Migration

--- a/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Filter ``grep -nH`` matches through the migration source lexer.
+
+The shell validators use grep for breadth, but grep cannot distinguish live
+syntax from comments or quoted prose.  This adapter keeps the shell tools on
+the same lexical contract as the messaging-profile analyzer while preserving
+the familiar ``path:line:text`` output used in reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+MATCH_RE = re.compile(r"^(.*?):([0-9]+):(.*)$")
+
+
+def load_analyzer(path: Path):
+    spec = importlib.util.spec_from_file_location("telnyx_source_contract", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("comments", "code"), default="comments")
+    parser.add_argument("--analyzer", type=Path, required=True)
+    parser.add_argument("--pattern", required=True)
+    args = parser.parse_args()
+
+    analyzer = load_analyzer(args.analyzer)
+    cache: dict[Path, object] = {}
+    for raw in sys.stdin:
+        raw = raw.rstrip("\n")
+        match = MATCH_RE.match(raw)
+        if not match:
+            continue
+        filename, line_number, original = match.groups()
+        path = Path(filename)
+        try:
+            if path not in cache:
+                source = path.read_text(encoding="utf-8", errors="replace")
+                suffix = analyzer.canonical_suffix(path)
+                if (
+                    path.name == ".env"
+                    or path.name.startswith(".env.")
+                    or path.suffix.lower() in {
+                        ".conf",
+                        ".env",
+                        ".ini",
+                        ".properties",
+                        ".toml",
+                        ".yaml",
+                        ".yml",
+                    }
+                ):
+                    suffix = ".sh"
+                cache[path] = analyzer.lex_source(source, suffix)
+            lexed = cache[path]
+            view = lexed.code if args.mode == "code" else lexed.without_comments
+            lines = view.splitlines()
+            index = int(line_number) - 1
+            filtered = lines[index] if 0 <= index < len(lines) else ""
+        except OSError:
+            filtered = original
+        live_match = subprocess.run(
+            ["grep", "-E", "-q", args.pattern],
+            input=filtered,
+            text=True,
+            check=False,
+        ).returncode == 0
+        if filtered.strip() and live_match:
+            print(f"{filename}:{line_number}:{filtered}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -35,6 +35,7 @@ def main() -> int:
     parser.add_argument("--mode", choices=("comments", "code"), default="comments")
     parser.add_argument("--analyzer", type=Path, required=True)
     parser.add_argument("--pattern", required=True)
+    parser.add_argument("--region", choices=("all", "backend"), default="all")
     args = parser.parse_args()
 
     analyzer = load_analyzer(args.analyzer)
@@ -49,6 +50,10 @@ def main() -> int:
         try:
             if path not in cache:
                 source = path.read_text(encoding="utf-8", errors="replace")
+                if args.region == "backend":
+                    source = analyzer.backend_executable_source(path, source)
+                else:
+                    source = analyzer.executable_source(path, source)
                 suffix = analyzer.canonical_suffix(path)
                 if (
                     path.name == ".env"

--- a/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -47,7 +47,12 @@ def grep_records(data: bytes) -> Iterator[tuple[Path, int]]:
 def display_path(path: Path) -> str:
     """Keep one finding per output line even for control characters in paths."""
 
-    return str(path).replace("\r", "\\r").replace("\n", "\\n")
+    return (
+        str(path)
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
 
 
 def load_analyzer(path: Path):

--- a/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -83,7 +83,13 @@ def main() -> int:
             continue
         try:
             if path not in cache:
-                source = path.read_text(encoding="utf-8", errors="replace")
+                # Preserve physical newlines exactly. grep -n counts LF bytes;
+                # universal-newline translation would turn a preceding bare CR
+                # into a synthetic LF and make the lexer index a different row.
+                with path.open(
+                    "r", encoding="utf-8", errors="replace", newline=""
+                ) as source_file:
+                    source = source_file.read()
                 if args.region == "backend":
                     source = analyzer.backend_executable_source(path, source)
                 else:

--- a/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
+++ b/skills/telnyx-twilio-migration/scripts/filter-source-matches.py
@@ -11,13 +11,43 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import re
+import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterator
 
 
-MATCH_RE = re.compile(r"^(.*?):([0-9]+):(.*)$")
+def grep_records(data: bytes) -> Iterator[tuple[Path, int]]:
+    """Parse ``grep -nH --null`` records without interpreting path bytes.
+
+    Grep terminates the filename with NUL, then writes ``line:text\n``.  A
+    filename may legally contain colons or newlines on POSIX, so neither can be
+    used to find the filename boundary.  Match text cannot contain a newline;
+    grep removes that source delimiter from each emitted record.
+    """
+
+    cursor = 0
+    while cursor < len(data):
+        nul = data.find(b"\0", cursor)
+        if nul < 0:
+            raise ValueError("grep record has no NUL filename delimiter")
+        newline = data.find(b"\n", nul + 1)
+        if newline < 0:
+            newline = len(data)
+        locator = data[nul + 1 : newline]
+        colon = locator.find(b":")
+        if colon <= 0 or not locator[:colon].isdigit():
+            raise ValueError("grep record has no numeric line field")
+        filename = os.fsdecode(data[cursor:nul])
+        yield Path(filename), int(locator[:colon])
+        cursor = newline + 1
+
+
+def display_path(path: Path) -> str:
+    """Keep one finding per output line even for control characters in paths."""
+
+    return str(path).replace("\r", "\\r").replace("\n", "\\n")
 
 
 def load_analyzer(path: Path):
@@ -36,17 +66,21 @@ def main() -> int:
     parser.add_argument("--analyzer", type=Path, required=True)
     parser.add_argument("--pattern", required=True)
     parser.add_argument("--region", choices=("all", "backend"), default="all")
+    parser.add_argument("--exclude-suffix", action="append", default=[])
     args = parser.parse_args()
 
     analyzer = load_analyzer(args.analyzer)
+    try:
+        records = list(grep_records(sys.stdin.buffer.read()))
+    except ValueError as error:
+        print(f"Error: malformed NUL-delimited grep input: {error}", file=sys.stderr)
+        return 2
+
     cache: dict[Path, object] = {}
-    for raw in sys.stdin:
-        raw = raw.rstrip("\n")
-        match = MATCH_RE.match(raw)
-        if not match:
+    excluded_suffixes = {suffix.lower() for suffix in args.exclude_suffix}
+    for path, line_number in records:
+        if path.suffix.lower() in excluded_suffixes:
             continue
-        filename, line_number, original = match.groups()
-        path = Path(filename)
         try:
             if path not in cache:
                 source = path.read_text(encoding="utf-8", errors="replace")
@@ -72,19 +106,27 @@ def main() -> int:
                 cache[path] = analyzer.lex_source(source, suffix)
             lexed = cache[path]
             view = lexed.code if args.mode == "code" else lexed.without_comments
-            lines = view.splitlines()
-            index = int(line_number) - 1
-            filtered = lines[index] if 0 <= index < len(lines) else ""
-        except OSError:
-            filtered = original
-        live_match = subprocess.run(
+            lines = view.split("\n")
+            index = line_number - 1
+            if not 0 <= index < len(lines):
+                raise ValueError(
+                    f"grep line {line_number} is outside the lexed source"
+                )
+            filtered = lines[index]
+        except (OSError, ValueError) as error:
+            print(f"Error: could not filter {display_path(path)}: {error}", file=sys.stderr)
+            return 2
+        match_result = subprocess.run(
             ["grep", "-E", "-q", args.pattern],
             input=filtered,
             text=True,
             check=False,
-        ).returncode == 0
-        if filtered.strip() and live_match:
-            print(f"{filename}:{line_number}:{filtered}")
+        )
+        if match_result.returncode > 1:
+            print("Error: grep could not evaluate the filter pattern", file=sys.stderr)
+            return 2
+        if filtered.strip() and match_result.returncode == 0:
+            print(f"{display_path(path)}:{line_number}:{filtered}")
     return 0
 
 

--- a/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Read local dependency declarations; never resolve packages over the network.
+
+Exit zero only for positive evidence. Unresolved external Maven parents,
+properties, and unsupported Gradle expressions deliberately remain warnings.
+Gradle version catalogs use stdlib tomllib on Python 3.11+; older Python still
+supports Maven, Composer and literal Gradle coordinates without extra packages.
+"""
+from __future__ import annotations
+
+import json
+import importlib.util
+import os
+from pathlib import Path
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+try:
+    import tomllib
+except ImportError:
+    tomllib = None
+
+JVM_ARTIFACTS = {"telnyx", "telnyx-core", "telnyx-client-okhttp"}
+
+
+def version_is_constrained(value: object) -> bool:
+    return isinstance(value, str) and bool(re.fullmatch(
+        r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?", value.strip()
+    ))
+
+
+def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    try:
+        data = json.loads((root / "composer.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and any(
+        isinstance(data.get(section), dict)
+        and isinstance(data[section].get(package), str)
+        and bool(data[section][package].strip())
+        for section in ("require", "require-dev")
+    )
+
+
+def maven_dependencies(path: Path) -> list[tuple[str, str, str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+        # Manifests need no entities. Avoid entity expansion on untrusted input.
+        if "<!DOCTYPE" in text or "<!ENTITY" in text:
+            return []
+        project = ET.fromstring(text)
+    except (OSError, ValueError, ET.ParseError):
+        return []
+    for node in project.iter():
+        node.tag = node.tag.rsplit("}", 1)[-1]
+    if project.tag != "project":
+        return []
+    properties = {node.tag: (node.text or "").strip()
+                  for node in project.findall("./properties/*")}
+
+    def resolve(value: str) -> str:
+        seen = set()
+        while re.fullmatch(r"\$\{[^}]+\}", value) and value not in seen:
+            seen.add(value)
+            value = properties.get(value[2:-1], "")
+        return value
+
+    def field(node: ET.Element, name: str) -> str:
+        return resolve((node.findtext(name) or "").strip())
+
+    managed = {
+        (field(dep, "groupId"), field(dep, "artifactId")): field(dep, "version")
+        for dep in project.findall("./dependencyManagement/dependencies/dependency")
+    }
+    dependencies = []
+    for dep in project.findall("./dependencies/dependency"):
+        group, artifact = field(dep, "groupId"), field(dep, "artifactId")
+        # An explicit unresolved version must not fall back to management.
+        version = (field(dep, "version") if dep.find("version") is not None
+                   else managed.get((group, artifact), ""))
+        dependencies.append((group, artifact, version))
+    return dependencies
+
+
+def maven_pinned(path: Path) -> bool:
+    return any(group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS
+               and version_is_constrained(version)
+               for group, artifact, version in maven_dependencies(path))
+
+
+def groovy_slashy_ranges(source: str, code: str) -> list[tuple[int, int]]:
+    """Exclude Groovy's additional string delimiters from declaration evidence.
+
+    Ordinary quotes/comments are already masked by the shared lexer. Slashy
+    strings are expressions, so a division operator after an operand isn't an
+    opener. This does not evaluate interpolation or arbitrary build programs.
+    """
+    ranges = []
+    end = 0
+    for match in re.finditer(r"\$/|/(?![/*])", code):
+        start = match.start()
+        if start < end:
+            continue
+        dollar = match[0] == "$/"
+        prefix = code[:start].rstrip()
+        if not dollar and prefix and prefix[-1] not in "=(:,[!?{" and not re.search(r"\breturn$", prefix):
+            continue
+        cursor = match.end()
+        while cursor < len(source):
+            if dollar and source.startswith("/$", cursor):
+                cursor += 2
+                break
+            if not dollar and source[cursor] == "/":
+                cursor += 1
+                break
+            if (dollar and source[cursor] == "$" and cursor + 1 < len(source)
+                    and source[cursor + 1] in "$/") or (not dollar and source[cursor] == "\\"):
+                cursor += 2
+            else:
+                cursor += 1
+        end = cursor
+        ranges.append((start, end))
+    return ranges
+
+
+def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tuple[str, str, object]]:
+    spec = importlib.util.spec_from_file_location(
+        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+    ownership = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ownership)
+    analyzer = ownership.load_script("lint-required-messaging-profile")
+    dependencies = []
+    accessors = set()
+    for name in ("build.gradle", "build.gradle.kts"):
+        try:
+            source = (root / name).read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        # Reuse source masking: inline comments and help strings aren't code.
+        lexed = ownership.lexed_source(source, ".kt" if name.endswith(".kts") else ".java")
+        strings = {token.start: token for token in lexed.strings}
+        inert_ranges = groovy_slashy_ranges(source, lexed.code) if name == "build.gradle" else []
+        declaration = r"\b(?:implementation|api|compileOnly|runtimeOnly|testImplementation)\b"
+        for match in re.finditer(declaration, lexed.code):
+            if any(start <= match.start() < end for start, end in inert_ranges):
+                continue
+            prefix = re.match(r"\s*\(?\s*", lexed.without_comments[match.end():])
+            start = match.end() + prefix.end()
+            token = strings.get(start)
+            if token:
+                parts = token.contents.split(":")
+                if len(parts) in {2, 3}:
+                    dependencies.append((parts[0], parts[1], parts[2] if len(parts) == 3 else ""))
+            else:
+                accessor = re.match(r"libs\.([\w.]+)", lexed.code[start:])
+                if accessor:
+                    accessors.add(accessor[1])
+                    continue
+                # Groovy also accepts named-map dependency notation:
+                # implementation group: 'g', name: 'a', version: '1.2.3'
+                # and the equivalent parenthesized call. Read only string
+                # tokens belonging to this declaration, so comments and prose
+                # cannot contribute coordinates.
+                cursor = match.end()
+                while (cursor < len(lexed.code)
+                       and lexed.code[cursor] in " \t\r"):
+                    cursor += 1
+                parenthesized = (cursor < len(lexed.code)
+                                 and lexed.code[cursor] == "(")
+                if parenthesized:
+                    closing = analyzer.matching_delimiter(
+                        lexed.code, cursor, "(", ")")
+                    if closing is None:
+                        continue
+                    argument_start, argument_end = cursor + 1, closing
+                else:
+                    argument_start, argument_end = cursor, len(lexed.code)
+                fields = {}
+                cursor = argument_start
+                continued = parenthesized
+                while cursor < argument_end:
+                    while (cursor < argument_end
+                           and lexed.code[cursor].isspace()
+                           and (continued or lexed.code[cursor] != "\n")):
+                        cursor += 1
+                    field = re.match(r"(group|name|version)\s*:",
+                                     lexed.code[cursor:argument_end])
+                    if field is None:
+                        break
+                    value_start = cursor + field.end()
+                    while (value_start < argument_end
+                           and lexed.without_comments[value_start].isspace()):
+                        value_start += 1
+                    token = strings.get(value_start)
+                    if token and token.end <= argument_end:
+                        fields[field[1]] = token.contents
+                        cursor = token.end
+                    else:
+                        # Dynamic/unsupported values invalidate an earlier
+                        # duplicate literal instead of leaving stale evidence.
+                        fields[field[1]] = None
+                        boundary = re.search(r"[,;\n})]",
+                                             lexed.code[value_start:argument_end])
+                        cursor = (argument_end if boundary is None else
+                                  value_start + boundary.start())
+                    while (cursor < argument_end
+                           and lexed.code[cursor] in " \t\r"):
+                        cursor += 1
+                    if cursor >= argument_end or lexed.code[cursor] != ",":
+                        break
+                    cursor += 1
+                    continued = True
+                if "group" in fields and "name" in fields:
+                    dependencies.append((fields["group"], fields["name"],
+                                         fields.get("version", "")))
+    if tomllib is None:
+        return dependencies
+    try:
+        catalog = tomllib.loads(((catalog_root or root) / "gradle/libs.versions.toml").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return dependencies
+    libraries, versions = catalog.get("libraries", {}), catalog.get("versions", {})
+    if not isinstance(libraries, dict) or not isinstance(versions, dict):
+        return dependencies
+    for alias, entry in libraries.items():
+        accessor = re.sub(r"[-_]", ".", alias)
+        if accessor not in accessors:
+            continue
+        if isinstance(entry, str):
+            parts = entry.split(":")
+            if len(parts) != 3:
+                continue
+            group, artifact, version = parts
+        elif isinstance(entry, dict):
+            module = entry.get("module")
+            if isinstance(module, str) and module.count(":") == 1:
+                group, artifact = module.split(":")
+            else:
+                group, artifact = entry.get("group"), entry.get("name")
+            version = entry.get("version")
+            if isinstance(version, dict):
+                reference = version.get("ref")
+                version = versions.get(reference) if isinstance(reference, str) else None
+        else:
+            continue
+        dependencies.append((group, artifact, version))
+    return dependencies
+
+
+def gradle_pinned(root: Path) -> bool:
+    return any(group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS
+               and version_is_constrained(version)
+               for group, artifact, version in gradle_dependencies(root))
+
+
+def jvm_declared(root: Path, vendor: str) -> bool:
+    for directory, dirs, names in os.walk(root):
+        relative = Path(directory).relative_to(root)
+        dirs[:] = [name for name in dirs if name not in {
+            ".git", "node_modules", "build", "vendor", ".gradle", ".venv"}
+            and len(relative.parts) < 3]
+        path = Path(directory)
+        dependencies = maven_dependencies(path / "pom.xml") if "pom.xml" in names else []
+        if "build.gradle" in names or "build.gradle.kts" in names:
+            dependencies.extend(gradle_dependencies(path, root))
+        if any((group == "com.telnyx.sdk" and artifact in JVM_ARTIFACTS)
+               if vendor == "telnyx" else (group == "com.twilio.sdk" and artifact == "twilio")
+               for group, artifact, _ in dependencies):
+            return True
+    return False
+
+
+def main() -> int:
+    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "jvm-pinned", "jvm-declared", "twilio-jvm-declared"}:
+        return 2
+    root = Path(sys.argv[2])
+    mode = sys.argv[1]
+    if mode == "composer":
+        found = composer_declared(root)
+    elif mode.endswith("declared"):
+        found = jvm_declared(root, "twilio" if mode.startswith("twilio") else "telnyx")
+    else:
+        found = maven_pinned(root / "pom.xml") or gradle_pinned(root)
+    return 0 if found else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -9,6 +9,7 @@ on older Python. Gradle catalogs still require tomllib; no packages are installe
 from __future__ import annotations
 
 import ast
+import codecs
 import configparser
 from functools import lru_cache
 import json
@@ -17,6 +18,7 @@ import os
 from pathlib import Path
 import re
 import sys
+import tokenize
 import xml.etree.ElementTree as ET
 
 try:
@@ -43,8 +45,26 @@ def version_is_constrained(value: object) -> bool:
 
 def read_text(path: Path) -> str:
     try:
-        return path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError):
+        # Python source and pip requirements honor PEP 263 declarations. npm's
+        # JSON reader accepts a leading UTF-8 BOM; TOML does not share that rule.
+        if path.name == "setup.py":
+            with tokenize.open(path) as source:
+                return source.read()
+        if path.name == "requirements.txt":
+            data = path.read_bytes()
+            # pip checks BOMs before coding comments, and UTF-32 before UTF-16.
+            for boms, encoding in (((codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE), "utf-32"),
+                                   ((codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE), "utf-16"),
+                                   ((codecs.BOM_UTF8,), "utf-8-sig")):
+                if data.startswith(boms):
+                    return data.decode(encoding)
+            for line in data.split(b"\n")[:2]:
+                cookie = re.search(br"coding[:=]\s*([-\w.]+)", line) if line.startswith(b"#") else None
+                if cookie:
+                    return data.decode(cookie[1].decode("ascii"))
+            return data.decode("utf-8")
+        return path.read_text(encoding="utf-8-sig" if path.name == "package.json" else "utf-8")
+    except (OSError, UnicodeError, SyntaxError, LookupError):
         return ""
 
 
@@ -252,6 +272,36 @@ def python_requirement(value: object) -> list[str]:
     return [suffix.split(";", 1)[0].strip().strip("() ")]
 
 
+_SETUP_FUNCTION = object()
+
+
+class _SetupModule:
+    """Static import identity, never an imported or executed Python module."""
+
+
+_SETUP_MODULE = _SetupModule()
+
+
+def setup_import_bindings(statement: ast.Import | ast.ImportFrom) -> dict:
+    """Names replaced by an import; None denotes an unrecognized owner."""
+    result = {}
+    for alias in statement.names:
+        name = alias.asname or alias.name.split(".")[0]
+        result[name] = None
+        if isinstance(statement, ast.Import):
+            if alias.name == "setuptools" or (not alias.asname and alias.name.startswith("setuptools.")):
+                result[name] = _SETUP_MODULE
+        elif not statement.level and statement.module in {"setuptools", "distutils.core"} and alias.name == "setup":
+            result[name] = _SETUP_FUNCTION
+        elif not statement.level and statement.module == "setuptools" and alias.name == "*":
+            # setuptools explicitly exports these names through __all__. Do
+            # not erase unrelated local requirements or aliases on this import.
+            result = dict.fromkeys(("Command", "Distribution", "Extension", "Require",
+                                    "SetuptoolsDeprecationWarning", "find_namespace_packages", "find_packages"))
+            result["setup"] = _SETUP_FUNCTION
+    return result
+
+
 def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
     """Resolve only local literal data, never execute setup code or imports."""
     if depth > 20:
@@ -259,6 +309,8 @@ def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
     resolve = lambda child: setup_literal(child, bindings, depth + 1)
     if isinstance(node, ast.Name):
         return bindings[node.id]
+    if isinstance(node, ast.Attribute) and node.attr == "setup" and isinstance(resolve(node.value), _SetupModule):
+        return _SETUP_FUNCTION
     if isinstance(node, (ast.List, ast.Tuple)):
         values = [resolve(child) for child in node.elts]
         return tuple(values) if isinstance(node, ast.Tuple) else values
@@ -293,29 +345,72 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
         for child in ast.iter_child_nodes(node):
             yield from local_nodes(child)
 
-    def invalidate(names):
+    def invalidate(names, mutation=False):
         # Containers can own aliases too, e.g. config={"requires": requirements}.
         def mutable_objects(value):
-            objects = {id(value)} if isinstance(value, (list, dict)) else set()
+            objects = {id(value)} if isinstance(value, (list, dict, _SetupModule)) else set()
             children = value.values() if isinstance(value, dict) else value if isinstance(value, (list, tuple)) else ()
             for child in children:
                 objects.update(mutable_objects(child))
             return objects
 
         objects = set().union(*(mutable_objects(bindings[name]) for name in names if name in bindings))
+        if mutation and class_outer is not None:
+            # Class-local rebinding stays local; mutating a shared outer module
+            # or container does not. Never restore its stale entry snapshot.
+            for name in list(class_outer):
+                if mutable_objects(class_outer[name]) & objects:
+                    del class_outer[name]
         for name in list(bindings):
             if name in names or mutable_objects(bindings[name]) & objects:
                 del bindings[name]
 
     def preceding(statement):
+        nonlocal bindings
+        common_imports = {}
+        if isinstance(statement, (ast.If, ast.Try)):
+            # Reuse the same statement handling on each alternative, but merge
+            # only import identity -- never conditional literal requirements.
+            paths = []
+            if isinstance(statement, ast.If):
+                paths = [(statement.body, None, []), (statement.orelse, None, [])]
+                headers = [statement.test]
+            else:
+                paths = [(statement.body + statement.orelse, None, statement.finalbody)]
+                paths += [(handler.body, handler.name, statement.finalbody) for handler in statement.handlers]
+                headers = [handler.type for handler in statement.handlers if handler.type is not None]
+            if not any(isinstance(node, (ast.Call, ast.NamedExpr)) for header in headers for node in ast.walk(header)):
+                incoming, alternatives = bindings, []
+                try:
+                    for body, exception_name, finalbody in paths:
+                        bindings = incoming.copy()
+                        if exception_name:
+                            bindings.pop(exception_name, None)
+                        for item in body:
+                            preceding(item)
+                        if exception_name:
+                            bindings.pop(exception_name, None)
+                        for item in finalbody:
+                            preceding(item)
+                        alternatives.append({name: value for name, value in bindings.items()
+                                             if value is _SETUP_FUNCTION or value is _SETUP_MODULE})
+                finally:
+                    bindings = incoming
+                common_imports = {name: value for name, value in alternatives[0].items()
+                                  if all(other.get(name) is value for other in alternatives[1:])}
         nodes = list(local_nodes(statement))
         mutated = set()
         for node in nodes:
             if isinstance(node, ast.Call):
-                mutated.update(item.id for item in ast.walk(node) if isinstance(item, ast.Name))
+                try:
+                    known_setup = setup_literal(node.func, bindings) is _SETUP_FUNCTION
+                except (KeyError, ValueError, TypeError, SyntaxError):
+                    known_setup = False
+                operands = [*node.args, *(kw.value for kw in node.keywords)] if known_setup else [node]
+                mutated.update(item.id for operand in operands for item in ast.walk(operand) if isinstance(item, ast.Name))
             elif isinstance(node, (ast.Attribute, ast.Subscript)) and isinstance(node.ctx, (ast.Store, ast.Del)):
                 mutated.update(item.id for item in ast.walk(node.value) if isinstance(item, ast.Name))
-        invalidate(mutated)
+        invalidate(mutated, mutation=True)
         if isinstance(statement, (ast.Assign, ast.AnnAssign)):
             targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
             try:
@@ -333,13 +428,36 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
             return
         invalidate({node.id for node in nodes if isinstance(node, ast.Name)
                     and isinstance(node.ctx, (ast.Store, ast.Del))})
-        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            bindings.pop(statement.name, None)
+        # Conditional imports/definitions also replace names, even though the
+        # AST represents them without Name(Store) nodes.
+        for node in nodes:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                effects = setup_import_bindings(node)
+                if "*" in effects:
+                    bindings.clear()
+                invalidate(set(effects))
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                bindings.pop(node.name, None)
         if isinstance(statement, (ast.Import, ast.ImportFrom)):
-            for alias in statement.names:
-                bindings.pop(alias.asname or alias.name.split(".")[0], None)
+            bindings.update({name: value for name, value in setup_import_bindings(statement).items() if value is not None})
+        bindings.update(common_imports)
 
+    class_outer = None
     for parent, child in reversed(path):
+        if class_outer is not None and isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            # Only the outermost iterator is evaluated in the class namespace;
+            # the comprehension body has its own enclosing lexical scope.
+            if not any(node is call for node in ast.walk(parent.generators[0].iter)):
+                bindings = class_outer
+                class_outer = None
+        if isinstance(parent, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            # A class body executes with its own locals, but is not a closure
+            # for methods or nested classes. Preserve the outer lexical scope.
+            if class_outer is not None:
+                bindings = class_outer
+                class_outer = None
+            if isinstance(parent, ast.ClassDef):
+                class_outer = bindings.copy()
         if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             # Python locals shadow outer names throughout the function, including
             # before their assignment. Parameters are unknown, not outer literals.
@@ -348,6 +466,12 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
                        for node in local_nodes(statement) if isinstance(node, ast.Name)
                        and isinstance(node.ctx, (ast.Store, ast.Del))}
             locals_.update(node.arg for node in ast.walk(parent.args) if isinstance(node, ast.arg))
+            for statement in statements:
+                for node in local_nodes(statement):
+                    if isinstance(node, (ast.Import, ast.ImportFrom)):
+                        locals_.update(alias.asname or alias.name.split(".")[0] for alias in node.names)
+                    elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                        locals_.add(node.name)
             for name in locals_:
                 bindings.pop(name, None)
         if isinstance(parent, (ast.For, ast.AsyncFor, ast.With, ast.AsyncWith,
@@ -356,13 +480,23 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
             targets = [parent.target] if isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension)) else (
                 [item.optional_vars for item in parent.items if item.optional_vars is not None]
                 if isinstance(parent, (ast.With, ast.AsyncWith)) else [])
+            if isinstance(parent, ast.comprehension) and child is parent.iter:
+                targets = []
             names = {node.id for target in targets for node in ast.walk(target) if isinstance(node, ast.Name)}
             if isinstance(parent, ast.ExceptHandler) and parent.name:
                 names.add(parent.name)
             for name in names:
                 bindings.pop(name, None)
         if isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
-            for generator in parent.generators:
+            visible = parent.generators
+            for index, generator in enumerate(parent.generators):
+                if any(node is call for node in ast.walk(generator.iter)):
+                    visible = parent.generators[:index]
+                    break
+                if any(node is call for condition in generator.ifs for node in ast.walk(condition)):
+                    visible = parent.generators[:index + 1]
+                    break
+            for generator in visible:
                 for node in ast.walk(generator.target):
                     if isinstance(node, ast.Name):
                         bindings.pop(node.id, None)
@@ -372,7 +506,7 @@ def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
                 [parent.iter] if isinstance(parent, (ast.For, ast.AsyncFor)) else
                 [item.context_expr for item in parent.items])
             invalidate({name.id for header in headers for node in ast.walk(header)
-                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)})
+                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)}, mutation=True)
         for _, children in ast.iter_fields(parent):
             if isinstance(children, list) and child in children and isinstance(child, ast.stmt):
                 for previous in children[:children.index(child)]:
@@ -439,17 +573,19 @@ def python_dependencies(root: Path) -> list[tuple[str, bool]]:
     try:
         tree = ast.parse(read_text(root / "setup.py"))
         for call in ast.walk(tree):
-            if not isinstance(call, ast.Call) or not (
-                isinstance(call.func, ast.Name) and call.func.id == "setup"
-                or isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name)
-                and call.func.value.id == "setuptools" and call.func.attr == "setup"
-            ):
+            if not isinstance(call, ast.Call):
+                continue
+            bindings = setup_bindings(tree, call)
+            try:
+                if setup_literal(call.func, bindings) is not _SETUP_FUNCTION:
+                    continue
+            except (KeyError, ValueError, TypeError, SyntaxError):
                 continue
             for keyword in call.keywords:
                 if keyword.arg not in {"install_requires", "extras_require"}:
                     continue
                 try:
-                    value = setup_literal(keyword.value, setup_bindings(tree, call))
+                    value = setup_literal(keyword.value, bindings)
                 except (KeyError, ValueError, TypeError, SyntaxError):
                     continue
                 if keyword.arg == "extras_require" and isinstance(value, dict):

--- a/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
+++ b/skills/telnyx-twilio-migration/scripts/inspect-sdk-dependencies.py
@@ -3,11 +3,14 @@
 
 Exit zero only for positive evidence. Unresolved external Maven parents,
 properties, and unsupported Gradle expressions deliberately remain warnings.
-Gradle version catalogs use stdlib tomllib on Python 3.11+; older Python still
-supports Maven, Composer and literal Gradle coordinates without extra packages.
+TOML manifests use stdlib tomllib on Python 3.11+ and a bounded literal fallback
+on older Python. Gradle catalogs still require tomllib; no packages are installed.
 """
 from __future__ import annotations
 
+import ast
+import configparser
+from functools import lru_cache
 import json
 import importlib.util
 import os
@@ -25,22 +28,650 @@ JVM_ARTIFACTS = {"telnyx", "telnyx-core", "telnyx-client-okhttp"}
 
 
 def version_is_constrained(value: object) -> bool:
-    return isinstance(value, str) and bool(re.fullmatch(
-        r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?", value.strip()
+    """Literal JVM releases and numeric hard requirements, not dynamic selectors."""
+    if not isinstance(value, str):
+        return False
+    release = r"\d+\.\d+(?:[.][0-9]+)*(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?"
+    value = value.strip()
+    if re.fullmatch(release, value) or re.fullmatch(r"\[" + release + r"\]", value):
+        return True
+    interval = re.fullmatch(r"[\[(]\s*(.*?)\s*,\s*(.*?)\s*[\])]", value)
+    return bool(interval and any(interval.groups()) and all(
+        not bound or re.fullmatch(release, bound) for bound in interval.groups()
     ))
 
 
-def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+
+
+def toml_string(raw: str) -> str:
+    """Decode TOML 1.0 string escapes without Python's extra escape forms."""
+    quote = raw[0]
+    width = 3 if raw.startswith(quote * 3) else 1
+    if not raw.endswith(quote * width):
+        raise ValueError("unterminated TOML string")
+    value = raw[width:-width]
+    if width == 3:
+        value = re.sub(r"^\r?\n", "", value)
+    if re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", value):
+        raise ValueError("control character in TOML string")
+    if width == 1 and ("\n" in value or "\r" in value):
+        raise ValueError("newline in single-line TOML string")
+    if quote == "'":
+        return value
+    escapes = {'b': '\b', 't': '\t', 'n': '\n', 'f': '\f', 'r': '\r', '"': '"', '\\': '\\'}
+
+    def decode(match):
+        escaped = match[0][1:]
+        if escaped in escapes:
+            return escapes[escaped]
+        if re.fullmatch(r"u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}", escaped):
+            number = int(escaped[1:], 16)
+            if number <= 0x10ffff and not 0xd800 <= number <= 0xdfff:
+                return chr(number)
+        if width == 3 and re.fullmatch(r"[ \t]*\r?\n[ \t\r\n]*", escaped):
+            return ""
+        raise ValueError("invalid TOML escape")
+
+    return re.sub(r'\\(?:u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|[ \t]*\r?\n[ \t\r\n]*|.|$)',
+                  decode, value)
+
+
+def literal_toml_mapping(source: str) -> dict:
+    """Python 3.10 fallback: tables, literal strings, arrays and inline tables.
+
+    This is intentionally not a general TOML implementation. It accepts the
+    dependency forms used below without evaluating code. Unsupported
+    values remain unresolved; masked strings cannot introduce table headers.
+    """
+    ownership = source_ownership()
+    analyzer = ownership.load_script("lint-required-messaging-profile")
+    lexed = ownership.lexed_source(source, ".py")
+    strings = {token.start: token for token in lexed.strings}
+    key = r'''(?:[A-Za-z0-9_-]+|"(?:[^"\\\n]|\\.)*"|'[^'\n]*')'''
+    data, cursor = {}, 0
+    table = data
+    headers = set()
+
+    def table_at(parts: list[str]) -> dict | None:
+        target = data
+        for part in parts:
+            if not isinstance(target.setdefault(part, {}), dict):
+                return None
+            target = target[part]
+        return target
+
+    while cursor < len(source):
+        whitespace = re.match(r"\s*", lexed.without_comments[cursor:])
+        cursor += whitespace.end()
+        if cursor >= len(source):
+            break
+        end = source.find("\n", cursor)
+        end = len(source) if end < 0 else end
+        line = lexed.without_comments[cursor:end].strip()
+        if lexed.code[cursor:cursor + 1] == "[":
+            header = re.fullmatch(r"\[\s*(" + key + r"(?:\s*\.\s*" + key + r")*)\s*\]", line)
+            if header:
+                try:
+                    parts = tuple(toml_string(part) if part.startswith(('"', "'")) else part
+                                  for part in re.findall(key, header[1]))
+                except ValueError:
+                    return {}
+                if parts in headers:
+                    return {}
+                headers.add(parts)
+                table = table_at(list(parts))
+            else:
+                table = None
+            cursor = end
+            continue
+        assignment = re.match(r"(" + key + r"(?:\s*\.\s*" + key + r")*)\s*=\s*", lexed.without_comments[cursor:])
+        if assignment is None:
+            cursor = end
+            continue
+        try:
+            parts = [toml_string(part) if part.startswith(('"', "'")) else part
+                     for part in re.findall(key, assignment[1])]
+        except ValueError:
+            return {}
+        start = cursor + assignment.end()
+        token = strings.get(start)
+        if token:
+            end = token.end
+        elif source[start:start + 1] in {"[", "{"}:
+            opening = source[start]
+            closing = analyzer.matching_delimiter(lexed.code, start, opening, "]" if opening == "[" else "}")
+            if closing is None:
+                return {}  # Cannot safely find the next declaration.
+            end = closing + 1
+        expression = lexed.without_comments[start:end]
+        replacements = []
+        supported = True
+        for token in lexed.strings:
+            if start <= token.start < end:
+                try:
+                    decoded = toml_string(source[token.start:token.end])
+                except ValueError:
+                    supported = False
+                    decoded = ""
+                replacements.append((token.start - start, token.end - start, repr(decoded)))
+        code = lexed.code[start:end]
+        if any(character in code for character in "():"):
+            return {}  # Python tuples and JSON colon maps are not TOML.
+        for field in re.finditer(r"\b([A-Za-z_][\w-]*)\s*(?==)", code):
+            replacements.append((field.start(1), field.end(1), repr(field[1])))
+        for equal in re.finditer("=", code):
+            replacements.append((equal.start(), equal.end(), ":"))
+        for boolean in re.finditer(r"\b(true|false)\b", code):
+            replacements.append((boolean.start(), boolean.end(), boolean[1].title()))
+        for first, last, replacement in sorted(replacements, reverse=True):
+            expression = expression[:first] + replacement + expression[last:]
+        cursor = end
+        line_end = source.find("\n", end)
+        line_end = len(source) if line_end < 0 else line_end
+        if lexed.without_comments[end:line_end].strip():
+            cursor = line_end
+            continue  # Do not certify a prefix of an unsupported expression.
+        if table is None or not supported:
+            continue
+        try:
+            tree = ast.parse(expression.strip(), mode="eval")
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Dict):
+                    keys = [ast.literal_eval(key) for key in node.keys]
+                    if not all(isinstance(key, str) for key in keys) or len(keys) != len(set(keys)):
+                        return {}
+            value = ast.literal_eval(tree)
+        except (ValueError, SyntaxError):
+            continue
+        target = table
+        for part in parts[:-1]:
+            target = target.setdefault(part, {})
+            if not isinstance(target, dict):
+                break
+        if isinstance(target, dict):
+            if parts[-1] in target:
+                return {}  # Duplicate keys are invalid TOML, not extra evidence.
+            target[parts[-1]] = value
+    return data
+
+
+def read_mapping(path: Path, toml: bool = False) -> dict:
+    try:
+        if toml:
+            source = read_text(path)
+            data = tomllib.loads(source) if tomllib else literal_toml_mapping(source)
+        else:
+            data = json.loads(read_text(path))
+    except ValueError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def node_dependencies(root: Path) -> list[tuple[str, str]]:
+    data = read_mapping(root / "package.json")
+    return [(name, value.strip())
+            for section in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies")
+            if isinstance(data.get(section), dict)
+            for name, value in data[section].items()
+            if (name == "telnyx" or name.startswith("@telnyx/"))
+            and isinstance(value, str)]
+
+
+def node_version_is_constrained(value: str) -> bool:
+    # Registry versions/ranges only; tags, URLs and workspace expressions stay
+    # warnings. Every OR branch must provide numeric version evidence.
+    release = r"v?\d+(?:\.\d+){0,2}(?:-[A-Za-z0-9.-]+)?(?:\+[A-Za-z0-9.-]+)?"
+    wildcard = r"\d+(?:\.\d+)?\.[xX*]"
+    for branch in value.split("||"):
+        branch = re.sub(r"([~^<>=]+)\s+", r"\1", branch.strip())
+        if re.fullmatch(release + r"\s+-\s+" + release, branch):
+            continue
+        if not branch or not all(re.fullmatch(
+            r"(?:\^|~|>=|<=|>|<|=)?(?:" + release + "|" + wildcard + ")", token)
+            for token in branch.split()):
+            return False
+    return True
+
+
+def python_requirement(value: object) -> list[str]:
+    if not isinstance(value, str):
+        return []
+    requirement = re.fullmatch(r"telnyx\s*(?:\[[\w, -]+\])?\s*(.*)",
+                               value.strip(), re.IGNORECASE)
+    if not requirement:
+        return []
+    suffix = requirement[1]
+    # Do not mistake a different distribution, e.g. telnyx-tools, for Telnyx.
+    if suffix and suffix[0] not in "<>=~!(@;":
+        return []
+    return [suffix.split(";", 1)[0].strip().strip("() ")]
+
+
+def setup_literal(node: ast.AST, bindings: dict, depth: int = 0):
+    """Resolve only local literal data, never execute setup code or imports."""
+    if depth > 20:
+        raise ValueError("literal binding depth")
+    resolve = lambda child: setup_literal(child, bindings, depth + 1)
+    if isinstance(node, ast.Name):
+        return bindings[node.id]
+    if isinstance(node, (ast.List, ast.Tuple)):
+        values = [resolve(child) for child in node.elts]
+        return tuple(values) if isinstance(node, ast.Tuple) else values
+    if isinstance(node, ast.Dict) and all(key is not None for key in node.keys):
+        return {resolve(key): resolve(value) for key, value in zip(node.keys, node.values)}
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left, right = resolve(node.left), resolve(node.right)
+        if type(left) is type(right) and isinstance(left, (str, list, tuple)):
+            return left + right
+        raise ValueError("nonliteral concatenation")
+    return ast.literal_eval(node)
+
+
+def setup_bindings(tree: ast.AST, call: ast.Call) -> dict:
+    """Snapshot preceding straight-line assignments in the call's own scopes.
+
+    Conditional writes and unknown mutations invalidate evidence. In particular,
+    never borrow a later assignment or a binding from an unrelated function.
+    """
+    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
+    path, child = [], call
+    while child in parents:
+        parent = parents[child]
+        path.append((parent, child))
+        child = parent
+    bindings = {}
+
+    def local_nodes(node):
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            return
+        for child in ast.iter_child_nodes(node):
+            yield from local_nodes(child)
+
+    def invalidate(names):
+        # Containers can own aliases too, e.g. config={"requires": requirements}.
+        def mutable_objects(value):
+            objects = {id(value)} if isinstance(value, (list, dict)) else set()
+            children = value.values() if isinstance(value, dict) else value if isinstance(value, (list, tuple)) else ()
+            for child in children:
+                objects.update(mutable_objects(child))
+            return objects
+
+        objects = set().union(*(mutable_objects(bindings[name]) for name in names if name in bindings))
+        for name in list(bindings):
+            if name in names or mutable_objects(bindings[name]) & objects:
+                del bindings[name]
+
+    def preceding(statement):
+        nodes = list(local_nodes(statement))
+        mutated = set()
+        for node in nodes:
+            if isinstance(node, ast.Call):
+                mutated.update(item.id for item in ast.walk(node) if isinstance(item, ast.Name))
+            elif isinstance(node, (ast.Attribute, ast.Subscript)) and isinstance(node.ctx, (ast.Store, ast.Del)):
+                mutated.update(item.id for item in ast.walk(node.value) if isinstance(item, ast.Name))
+        invalidate(mutated)
+        if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+            try:
+                value = setup_literal(statement.value, bindings)
+                resolved = True
+            except (KeyError, ValueError, TypeError, SyntaxError):
+                resolved = False
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    bindings.pop(target.id, None)
+                    if resolved:
+                        bindings[target.id] = value
+                else:
+                    invalidate({node.id for node in ast.walk(target) if isinstance(node, ast.Name)})
+            return
+        invalidate({node.id for node in nodes if isinstance(node, ast.Name)
+                    and isinstance(node.ctx, (ast.Store, ast.Del))})
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bindings.pop(statement.name, None)
+        if isinstance(statement, (ast.Import, ast.ImportFrom)):
+            for alias in statement.names:
+                bindings.pop(alias.asname or alias.name.split(".")[0], None)
+
+    for parent, child in reversed(path):
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            # Python locals shadow outer names throughout the function, including
+            # before their assignment. Parameters are unknown, not outer literals.
+            statements = parent.body if isinstance(parent.body, list) else []
+            locals_ = {node.id for statement in statements
+                       for node in local_nodes(statement) if isinstance(node, ast.Name)
+                       and isinstance(node.ctx, (ast.Store, ast.Del))}
+            locals_.update(node.arg for node in ast.walk(parent.args) if isinstance(node, ast.arg))
+            for name in locals_:
+                bindings.pop(name, None)
+        if isinstance(parent, (ast.For, ast.AsyncFor, ast.With, ast.AsyncWith,
+                               ast.ExceptHandler, ast.comprehension)):
+            # These names are rebound by the header, before its body executes.
+            targets = [parent.target] if isinstance(parent, (ast.For, ast.AsyncFor, ast.comprehension)) else (
+                [item.optional_vars for item in parent.items if item.optional_vars is not None]
+                if isinstance(parent, (ast.With, ast.AsyncWith)) else [])
+            names = {node.id for target in targets for node in ast.walk(target) if isinstance(node, ast.Name)}
+            if isinstance(parent, ast.ExceptHandler) and parent.name:
+                names.add(parent.name)
+            for name in names:
+                bindings.pop(name, None)
+        if isinstance(parent, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            for generator in parent.generators:
+                for node in ast.walk(generator.target):
+                    if isinstance(node, ast.Name):
+                        bindings.pop(node.id, None)
+        if isinstance(parent, (ast.If, ast.While, ast.For, ast.AsyncFor, ast.With, ast.AsyncWith)):
+            # Calls in a control-flow header may mutate the incoming data.
+            headers = [parent.test] if isinstance(parent, (ast.If, ast.While)) else (
+                [parent.iter] if isinstance(parent, (ast.For, ast.AsyncFor)) else
+                [item.context_expr for item in parent.items])
+            invalidate({name.id for header in headers for node in ast.walk(header)
+                        if isinstance(node, ast.Call) for name in ast.walk(node) if isinstance(name, ast.Name)})
+        for _, children in ast.iter_fields(parent):
+            if isinstance(children, list) and child in children and isinstance(child, ast.stmt):
+                for previous in children[:children.index(child)]:
+                    if isinstance(previous, ast.stmt):
+                        preceding(previous)
+    return bindings
+
+
+def python_dependencies(root: Path) -> list[tuple[str, bool]]:
+    """Read declared literal requirements; never execute setup.py or imports."""
+    result = []
+
+    def requirements(values: object) -> None:
+        if isinstance(values, (list, tuple)):
+            for value in values:
+                result.extend((constraint, False) for constraint in python_requirement(value))
+
+    def package_table(table: object, poetry: bool = False) -> None:
+        if not isinstance(table, dict):
+            return
+        for name, value in table.items():
+            if name.lower() == "telnyx":
+                if isinstance(value, dict):
+                    value = value.get("version", "")
+                if isinstance(value, str):
+                    result.append((value.strip(), poetry))
+
+    # pip joins physical lines before removing comments. Per-requirement options
+    # belong to pip, not to the PEP 440 version constraint (nor another package).
+    source = re.sub(r"\\\r?\n", "", read_text(root / "requirements.txt"))
+    requirements([re.split(r"\s+--(?:hash|config-settings)(?==|\s|$)",
+                          re.sub(r"(^|\s+)#.*", "", line), maxsplit=1)[0]
+                  for line in source.splitlines()])
+    pipfile = read_mapping(root / "Pipfile", toml=True)
+    for section in ("packages", "dev-packages"):
+        package_table(pipfile.get(section))
+    project = read_mapping(root / "pyproject.toml", toml=True)
+    metadata = project.get("project", {})
+    if isinstance(metadata, dict):
+        requirements(metadata.get("dependencies"))
+        optional = metadata.get("optional-dependencies", {})
+        if isinstance(optional, dict):
+            for values in optional.values():
+                requirements(values)
+    tool = project.get("tool", {})
+    poetry = tool.get("poetry", {}) if isinstance(tool, dict) else {}
+    if isinstance(poetry, dict):
+        for section in ("dependencies", "dev-dependencies"):
+            package_table(poetry.get(section), poetry=True)
+        groups = poetry.get("group", {})
+        if isinstance(groups, dict):
+            for group in groups.values():
+                if isinstance(group, dict):
+                    package_table(group.get("dependencies"), poetry=True)
+    config = configparser.ConfigParser(interpolation=None)
+    try:
+        config.read_string(read_text(root / "setup.cfg"))
+        requirements(config.get("options", "install_requires", fallback="").splitlines())
+        if config.has_section("options.extras_require"):
+            for _, values in config.items("options.extras_require"):
+                requirements(values.splitlines())
+    except configparser.Error:
+        pass
+    try:
+        tree = ast.parse(read_text(root / "setup.py"))
+        for call in ast.walk(tree):
+            if not isinstance(call, ast.Call) or not (
+                isinstance(call.func, ast.Name) and call.func.id == "setup"
+                or isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "setuptools" and call.func.attr == "setup"
+            ):
+                continue
+            for keyword in call.keywords:
+                if keyword.arg not in {"install_requires", "extras_require"}:
+                    continue
+                try:
+                    value = setup_literal(keyword.value, setup_bindings(tree, call))
+                except (KeyError, ValueError, TypeError, SyntaxError):
+                    continue
+                if keyword.arg == "extras_require" and isinstance(value, dict):
+                    for values in value.values():
+                        requirements(values)
+                elif keyword.arg == "install_requires":
+                    requirements(value)
+    except (ValueError, SyntaxError):
+        pass
+    return result
+
+
+def python_version_is_constrained(value: str, poetry: bool = False) -> bool:
+    """Bounded PEP 440 specifiers, with Poetry's table-only caret/tilde syntax."""
+    numeric = r"(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*"
+    release = (r"v?" + numeric
+               + r"(?:[-_.]?(?:a|b|c|rc|alpha|beta|pre|preview)[-_.]?[0-9]*)?"
+               + r"(?:-[0-9]+|[-_.]?(?:post|rev|r)[-_.]?[0-9]*)?"
+               + r"(?:[-_.]?dev[-_.]?[0-9]*)?")
+    local = r"(?:\+[a-z0-9]+(?:[-_.][a-z0-9]+)*)?"
+    for token in value.split(","):
+        match = re.fullmatch(r"(===|==|~=|>=|<=|!=|>|<|\^|~)?\s*(\S+)", token.strip())
+        if not match:
+            return False
+        operator, version = match.groups()
+        if operator == "===":
+            continue  # PEP 440 explicitly permits arbitrary equality strings.
+        if operator in {None, "^", "~"} and not poetry:
+            return False
+        if re.fullmatch(numeric + r"\.\*", version):
+            if operator not in ({None, "==", "!="} if poetry else {"==", "!="}):
+                return False
+            continue
+        if not re.fullmatch(release + local, version, re.IGNORECASE):
+            return False
+        if "+" in version and operator not in {None, "==", "!="}:
+            return False
+        if operator == "~=" and not re.match(r"v?(?:[0-9]+!)?[0-9]+\.[0-9]+", version):
+            return False
+    return True
+
+
+@lru_cache(maxsize=1)
+def source_ownership():
+    spec = importlib.util.spec_from_file_location(
+        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+    ownership = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ownership)
+    return ownership
+
+
+def ruby_dependencies(root: Path) -> list[str]:
+    """Literal gem calls, bounded by arguments rather than whole source lines."""
+    source = read_text(root / "Gemfile")
+    if not source:
+        return []
+    ownership = source_ownership()
+    lexed = ownership.lexed_source(source, ".rb")
+    strings = {token.start: token for token in lexed.strings}
+    result = []
+
+    def literal(token) -> bool:
+        raw = source[token.start:token.end]
+        return (raw.startswith(("'", '"', "%q", "%Q"))
+                and "#{" not in token.contents and "\\" not in token.contents)
+
+    def skip_space(cursor: int) -> int:
+        # The shared lexer masks percent strings even in without_comments.
+        # Stop at their token boundary rather than eating the literal as space.
+        while cursor < len(source) and cursor not in strings and lexed.without_comments[cursor].isspace():
+            cursor += 1
+        return cursor
+
+    for call in re.finditer(r"(?<![\w.:])gem\b", lexed.code):
+        cursor = skip_space(call.end())
+        if source[cursor:cursor + 1] == "(":
+            cursor = skip_space(cursor + 1)
+        token = strings.get(cursor)
+        if token is None or not literal(token) or token.contents != "telnyx":
+            continue
+        if not re.match(r"[ \t]*(?=[,;\n)]|(?:if|unless)\b|$)", lexed.without_comments[token.end:]):
+            continue  # The package name is an expression, not this literal.
+        cursor, constraints = token.end, []
+        while True:
+            comma = re.match(r"[ \t]*(?:\r?\n[ \t]*)?,", lexed.without_comments[cursor:])
+            if comma is None:
+                break
+            token = strings.get(skip_space(cursor + comma.end()))
+            if token is None or not literal(token):
+                break
+            if not re.match(r"[ \t]*(?=[,;\n)]|(?:if|unless)\b|$)", lexed.without_comments[token.end:]):
+                break
+            constraints.append(token.contents)
+            cursor = token.end
+        result.append(",".join(constraints))
+    return result
+
+
+def ruby_version_is_constrained(value: str) -> bool:
+    return bool(value and all(re.fullmatch(
+        r"(?:~>|>=|<=|!=|>|<|=)?\s*\d+(?:\.[0-9A-Za-z]+)*(?:-[0-9A-Za-z.-]+)?",
+        token.strip()) for token in value.split(",")))
+
+
+def go_dependencies(root: Path) -> list[str]:
+    source = read_text(root / "go.mod")
+    result, block = [], False
+    for line in source.splitlines():
+        line = line.split("//", 1)[0].strip()
+        if re.fullmatch(r"require\s*\(", line):
+            block = True
+            continue
+        if line == ")":
+            block = False
+            continue
+        if not block:
+            match = re.match(r"require\s+(.+)", line)
+            if not match:
+                continue
+            line = match[1]
+        dependency = re.fullmatch(
+            r'"?github\.com/team-telnyx/telnyx-go(?:/v[0-9]+)?"?\s+"?(v[^"\s]+)"?', line)
+        if dependency:
+            result.append(dependency[1])
+    return result
+
+
+def other_declared(root: Path) -> bool:
+    # Match the validator's existing root + two directory levels for these
+    # manifests. Version checking remains root-scoped, as before.
+    for directory, dirs, _ in os.walk(root):
+        path = Path(directory)
+        dirs[:] = [name for name in dirs if name not in {
+            ".git", "node_modules", "vendor", ".venv", "build"}
+            and len(path.relative_to(root).parts) < 2]
+        if python_dependencies(path) or node_dependencies(path) or ruby_dependencies(path):
+            return True
+    return bool(go_dependencies(root))
+
+
+def other_pinned(root: Path) -> bool:
+    return (any(python_version_is_constrained(value, poetry) for value, poetry in python_dependencies(root))
+            or any(name == "telnyx" and node_version_is_constrained(value)
+                   for name, value in node_dependencies(root))
+            or any(ruby_version_is_constrained(value) for value in ruby_dependencies(root))
+            or any(re.fullmatch(r"v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?", value)
+                   for value in go_dependencies(root)))
+
+
+def composer_constraints(root: Path, package: str = "telnyx/telnyx-php") -> list[str]:
+    """Read only real dependency links, shared by presence and version checks."""
     try:
         data = json.loads((root / "composer.json").read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return False
-    return isinstance(data, dict) and any(
-        isinstance(data.get(section), dict)
+        return []
+    if not isinstance(data, dict):
+        return []
+    return [
+        data[section][package].strip()
+        for section in ("require", "require-dev")
+        if isinstance(data.get(section), dict)
         and isinstance(data[section].get(package), str)
         and bool(data[section][package].strip())
-        for section in ("require", "require-dev")
-    )
+    ]
+
+
+def composer_declared(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    return bool(composer_constraints(root, package))
+
+
+def composer_version_is_constrained(value: object) -> bool:
+    """Recognize common Composer constraints, not resolve or solve them.
+
+    Exact releases, numeric ranges/wildcards, and explicit dev branches supply
+    version evidence. Bare wildcards and stability-only flags do not. Every OR
+    alternative must constrain a version; an AND may contain a neutral wildcard.
+    Unsupported syntax (including inline aliases) conservatively stays a warning.
+    A constraint is not a lockfile or a guarantee against breaking upgrades.
+    See https://getcomposer.org/doc/articles/versions.md and the schema's links.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return False
+    release = (r"v?[0-9]+(?:\.[0-9]+){0,3}"
+               r"(?:[._-]?(?:stable|alpha|a|beta|b|RC|patch|pl|p)"
+               r"(?:[.-]?[0-9]+(?:[.-][0-9]+)*)?)?(?:[.-]?dev)?"
+               r"(?:\+[A-Za-z0-9.-]+)?")
+    wildcard = r"v?[0-9]+(?:\.[0-9]+){0,2}(?:\.[x*]){1,3}"
+    stability = r"@(dev|stable|alpha|beta|RC)$"
+
+    def atom(token: str) -> bool | None:
+        if not token:
+            return None
+        token = re.sub(stability, "", token, flags=re.IGNORECASE)
+        if not token or re.fullmatch(r"[x*](?:\.[x*])*", token, re.IGNORECASE):
+            return False
+        if re.fullmatch(r"(?:dev-[A-Za-z0-9_][A-Za-z0-9_./-]*|"
+                        + wildcard + r"-dev)(?:#[A-Za-z0-9]+)?",
+                        token, re.IGNORECASE):
+            return True
+        if re.fullmatch(r"(?:\^|~|>=|<=|!=|<>|==|=|>|<)?" + release,
+                        token, re.IGNORECASE):
+            return True
+        if re.fullmatch(wildcard, token, re.IGNORECASE):
+            return True
+        return None
+
+    for alternative in re.split(r"\|\|?", value.strip()):
+        alternative = alternative.strip()
+        if re.fullmatch(release + r"\s+-\s+" + release,
+                        alternative, re.IGNORECASE):
+            continue
+        # Whitespace after an operator belongs to that atom, not to an AND.
+        alternative = re.sub(r"([~^<>=!]+)\s+", r"\1", alternative)
+        atoms = [atom(token) for token in re.split(r"\s*,\s*|\s+", alternative)]
+        if None in atoms or not any(atoms):
+            return False
+    return True
+
+
+def composer_pinned(root: Path, package: str = "telnyx/telnyx-php") -> bool:
+    return any(composer_version_is_constrained(value)
+               for value in composer_constraints(root, package))
 
 
 def maven_dependencies(path: Path) -> list[tuple[str, str, str]]:
@@ -125,10 +756,7 @@ def groovy_slashy_ranges(source: str, code: str) -> list[tuple[int, int]]:
 
 
 def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tuple[str, str, object]]:
-    spec = importlib.util.spec_from_file_location(
-        "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
-    ownership = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(ownership)
+    ownership = source_ownership()
     analyzer = ownership.load_script("lint-required-messaging-profile")
     dependencies = []
     accessors = set()
@@ -241,7 +869,12 @@ def gradle_dependencies(root: Path, catalog_root: Path | None = None) -> list[tu
             version = entry.get("version")
             if isinstance(version, dict):
                 reference = version.get("ref")
-                version = versions.get(reference) if isinstance(reference, str) else None
+                if isinstance(reference, str):
+                    version = versions.get(reference)
+                if isinstance(version, dict):
+                    # Rich catalog versions are still attached to the consumed
+                    # library. Preferences alone are not a hard requirement.
+                    version = version.get("strictly", version.get("require"))
         else:
             continue
         dependencies.append((group, artifact, version))
@@ -272,12 +905,18 @@ def jvm_declared(root: Path, vendor: str) -> bool:
 
 
 def main() -> int:
-    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "jvm-pinned", "jvm-declared", "twilio-jvm-declared"}:
+    if len(sys.argv) != 3 or sys.argv[1] not in {"composer", "composer-pinned", "jvm-pinned", "jvm-declared", "twilio-jvm-declared", "other-declared", "other-pinned"}:
         return 2
     root = Path(sys.argv[2])
     mode = sys.argv[1]
-    if mode == "composer":
+    if mode == "other-declared":
+        found = other_declared(root)
+    elif mode == "other-pinned":
+        found = other_pinned(root)
+    elif mode == "composer":
         found = composer_declared(root)
+    elif mode == "composer-pinned":
+        found = composer_pinned(root)
     elif mode.endswith("declared"):
         found = jvm_declared(root, "twilio" if mode.startswith("twilio") else "telnyx")
     else:

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -14552,6 +14552,7 @@ def csharp_twilio_message_calls(
 def csharp_twilio_resource_calls(
     lexed: LexedSource, target: str, methods: tuple[str, ...],
     source: SourceEndpointResolver | None = None,
+    global_using_code: str = "",
 ) -> list[Call]:
     """Resolve the SDK resource's C# using/alias forms before checking its body.
 
@@ -14567,27 +14568,54 @@ def csharp_twilio_resource_calls(
         return max((span for span in namespaces if span[0] < offset < span[1]),
                    key=lambda span: span[0], default=None)
 
-    imports = []
-    for match in re.finditer(
+    using_pattern = re.compile(
         r"\b(?:global\s+)?using\s+(?:(?P<static>static)\s+)?"
         r"(?:(?P<alias>\w+)\s*=\s*)?(?:global\s*::\s*)?"
-        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;", code
-    ):
+        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;"
+    )
+    global_imports = [(match, re.sub(r"\s+", "", match.group("target")))
+                      for match in using_pattern.finditer(global_using_code)]
+    imports = []
+    for match in using_pattern.finditer(code):
         imports.append((match, re.sub(r"\s+", "", match.group("target")),
                         namespace_at(match.start())))
     candidates = calls_matching(lexed, re.compile(
         r"(?<![\w$.])(?:global\s*::\s*)?(?:\w+\s*\.\s*)*(?:"
         + "|".join(re.escape(method) for method in methods) + r")\s*\("
     ))
+    # Unqualified static imports lose to local methods/delegates. Keep method
+    # declarations out of call evidence and retain their enclosing scope.
+    local_methods = []
+    for candidate in candidates:
+        if not re.fullmatch(r"\w+", code[candidate.start:candidate.open_paren].strip()):
+            continue
+        closing = matching_delimiter(code, candidate.open_paren, "(", ")")
+        if closing is None:
+            continue
+        tail = code[closing + 1:]
+        prefix = code[max(0, candidate.start - 100):candidate.start]
+        if (re.match(r"\s*(?:\{|=>)", tail)
+                and re.search(r"\b[\w<>?\[\].]+\s+$", prefix)
+                and not re.search(r"\bnew\s+$", prefix)):
+            local_methods.append(candidate)
     result = []
     for call in candidates:
         head = re.sub(r"\s+", "", code[call.start:call.open_paren])
         receiver = head.rsplit(".", 1)[0] if "." in head else ""
+        if not receiver:
+            if re.search(r"\bnew\s+$", code[max(0, call.start - 100):call.start]):
+                continue
+            if any(code[item.start:item.open_paren].strip() == head
+                   and scope_contains(code, item.start, call.start)
+                   for item in local_methods):
+                continue
+            if source.graph.visible_binding(head, source.scope_at(call.start), call.start) is not None:
+                continue
         if receiver.startswith("global::"):
             if receiver.removeprefix("global::") == target:
                 result.append(call)
             continue
-        visible = [(match, name) for match, name, scope in imports
+        visible = global_imports + [(match, name) for match, name, scope in imports
                    if scope is None or scope[0] < call.start < scope[1]]
         aliases = {match.group("alias"): name for match, name in visible
                    if match.group("alias")}

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1520,33 +1520,6 @@ _HEREDOC_OPENER_RE = re.compile(
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
-_SHELL_HEREDOC_REDIRECTION_RE = re.compile(
-    r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
-    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"\\])*\"|"
-    r"(?:\\.|[^\\ \t\r\n;<>&|])+)",
-)
-
-
-def _shell_heredoc_redirection_tail(tail: str) -> bool:
-    """Accept only shell redirections after a heredoc delimiter.
-
-    A delimiter need not end the physical command: `cat <<EOF >out 2>&1` is
-    valid shell.  The lexer must mask that body, while still rejecting an
-    arbitrary expression containing `<< WORD`.  Consuming a sequence of
-    concrete redirections keeps that boundary explicit.
-    """
-
-    position = 0
-    while position < len(tail):
-        if tail[position:].strip() == "":
-            return True
-        if tail[position:].lstrip().startswith("#"):
-            return True
-        match = _SHELL_HEREDOC_REDIRECTION_RE.match(tail, position)
-        if match is None or match.end() == position:
-            return False
-        position = match.end()
-    return True
 
 
 def _heredoc_opener_at(
@@ -1561,15 +1534,19 @@ def _heredoc_opener_at(
     match = _HEREDOC_OPENER_RE.match(source, index)
     if match is None:
         return None
+    # In shell, three opening angle brackets introduce an inline here-string,
+    # not a multiline heredoc body. Treating `<<<WORD` as an opener can mask
+    # every request below it when no line contains the pseudo terminator.
+    if suffix == ".sh" and (
+        source.startswith("<<<", index)
+        or (index > 0 and source[index - 1] == "<")
+    ):
+        return None
     line_start = source.rfind("\n", 0, index) + 1
     line_end = source.find("\n", match.end())
     if line_end < 0:
         line_end = len(source)
-    tail = source[match.end():line_end]
-    if suffix == ".sh":
-        if not _shell_heredoc_redirection_tail(tail):
-            return None
-    elif tail.strip():
+    if suffix != ".sh" and source[match.end():line_end].strip():
         return None
     if suffix == ".rb":
         if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
@@ -1578,7 +1555,139 @@ def _heredoc_opener_at(
 
 
 def _heredoc_langs(suffix: str) -> bool:
-    return suffix in {".sh", ".php", ".rb"}
+    return suffix in {".php", ".rb"}
+
+
+def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
+    """Return shell heredoc body ranges in one command-aware linear pass.
+
+    The scan follows quotes, arithmetic contexts and backslash continuations,
+    collects every delimiter in one logical command, then consumes their
+    bodies in declaration order. It intentionally does not parse shell
+    expressions beyond the boundaries needed to distinguish heredocs from
+    arithmetic shifts and here-strings.
+    """
+
+    ranges: list[tuple[int, int]] = []
+    pending: list[tuple[str, bool]] = []
+    quote = ""
+    escaped = False
+    parenthesis_depth = 0
+    bracket_depth = 0
+    comment_start: int | None = None
+    command_start = 0
+    index = 0
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif quote == '"' and character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if parenthesis_depth:
+            if character == "(":
+                parenthesis_depth += 1
+            elif character == ")":
+                parenthesis_depth -= 1
+            index += 1
+            continue
+        if bracket_depth:
+            if character == "[":
+                bracket_depth += 1
+            elif character == "]":
+                bracket_depth -= 1
+            index += 1
+            continue
+        if source.startswith("$((", index):
+            parenthesis_depth = 2
+            index += 3
+            continue
+        if source.startswith("((", index):
+            parenthesis_depth = 2
+            index += 2
+            continue
+        if source.startswith("$[", index):
+            bracket_depth = 1
+            index += 2
+            continue
+        if character == "\\":
+            if index + 1 < len(source) and source[index + 1] == "\n":
+                index += 2
+            else:
+                index += 2
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            index += 1
+            continue
+        if character == "#" and (
+            index == command_start or source[index - 1].isspace()
+        ):
+            comment_start = index
+            newline = source.find("\n", index + 1)
+            index = len(source) if newline < 0 else newline
+            continue
+        if source.startswith("<<<", index):
+            index += 3
+            continue
+        opener = _HEREDOC_OPENER_RE.match(source, index)
+        if opener is not None and (
+            index == 0 or source[index - 1] != "<"
+        ):
+            pending.append((opener.group("tag"), "<<-" in opener.group(0)))
+            index = opener.end()
+            continue
+        if character != "\n":
+            index += 1
+            continue
+
+        command_end = index if comment_start is None else comment_start
+        command = source[command_start:command_end].rstrip()
+        comment_start = None
+        if command.endswith(("|", "&&")):
+            index += 1
+            continue
+        if not pending:
+            index += 1
+            command_start = index
+            continue
+
+        body_start = index + 1
+        for tag, strips_tabs in pending:
+            cursor = body_start
+            terminator_start: int | None = None
+            terminator_end: int | None = None
+            while cursor <= len(source):
+                line_end = source.find("\n", cursor)
+                line_end = len(source) if line_end < 0 else line_end
+                line = source[cursor:line_end].removesuffix("\r")
+                delimiter = line.lstrip("\t") if strips_tabs else line
+                if delimiter == tag:
+                    terminator_start = cursor
+                    terminator_end = line_end
+                    break
+                if line_end == len(source):
+                    break
+                cursor = line_end + 1
+            body_end = len(source) if terminator_start is None else terminator_start
+            if body_start < body_end:
+                ranges.append((body_start, body_end))
+            if terminator_end is None:
+                body_start = len(source)
+                break
+            body_start = (
+                len(source)
+                if terminator_end == len(source)
+                else terminator_end + 1
+            )
+        pending.clear()
+        index = body_start
+        command_start = index
+    return ranges
 
 
 _JS_REGEX_PREFIX_WORDS = {
@@ -1762,10 +1871,29 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     c_line_comments = suffix in JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
     c_block_comments = c_line_comments
     hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
+    shell_heredoc_ranges = _shell_heredoc_ranges(source) if suffix == ".sh" else []
+    shell_heredoc_index = 0
     index = 0
     last_js_opaque_end = 0
 
     while index < len(source):
+        while (
+            shell_heredoc_index < len(shell_heredoc_ranges)
+            and shell_heredoc_ranges[shell_heredoc_index][1] <= index
+        ):
+            shell_heredoc_index += 1
+        if shell_heredoc_index < len(shell_heredoc_ranges):
+            body_start, body_end = shell_heredoc_ranges[shell_heredoc_index]
+            if body_start <= index < body_end:
+                _blank(code, body_start, body_end)
+                strings.append(
+                    StringToken(
+                        body_start, body_end, source[body_start:body_end]
+                    )
+                )
+                index = body_end
+                shell_heredoc_index += 1
+                continue
         if (
             suffix in JS_TS_SUFFIXES
             and source[index] == "/"
@@ -1879,21 +2007,35 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         # and masked the send that followed.
         heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
         if heredoc is not None:
-            tag = heredoc.group("tag")
             body_start = source.find("\n", heredoc.end())
             if body_start < 0:
                 index = heredoc.end()
                 continue
             body_start += 1
-            terminator = re.compile(rf"^[ \t]*{re.escape(tag)}\b", re.M).search(
-                source, body_start
-            )
-            body_end = len(source) if terminator is None else terminator.start()
-            _blank(code, body_start, body_end)
-            strings.append(
-                StringToken(body_start, body_end, source[body_start:body_end])
-            )
-            index = body_end
+            openers = [heredoc]
+            for opener in openers:
+                tag = opener.group("tag")
+                terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
+                terminator = re.compile(terminator_pattern, re.M).search(
+                    source, body_start
+                )
+                body_end = (
+                    len(source) if terminator is None else terminator.start()
+                )
+                _blank(code, body_start, body_end)
+                strings.append(
+                    StringToken(
+                        body_start, body_end, source[body_start:body_end]
+                    )
+                )
+                if terminator is None:
+                    body_start = len(source)
+                    break
+                terminator_end = source.find("\n", terminator.end())
+                body_start = (
+                    len(source) if terminator_end < 0 else terminator_end + 1
+                )
+            index = body_start
             continue
 
         quote = source[index]
@@ -4220,22 +4362,41 @@ def request_object_is_executed(
     tail = lexed.code[call.end:]
     ruby_spans = _ruby_function_spans(lexed.code) if suffix == ".rb" else []
     for name in names:
-        execution = re.search(pattern.format(name=re.escape(name)), tail)
-        if execution is None:
-            continue
-        execution_offset = call.end + execution.start()
-        if suffix == ".rb" and not _same_ruby_function_scope(
-            lexed.code, call.start, execution_offset, ruby_spans
-        ):
-            continue
-        # A new reaching definition supersedes this request object. A later
-        # execution of the same variable must not retroactively execute the
-        # discarded constructor.
-        rebound = re.search(
-            rf"(?<![\w@$]){re.escape(name)}\s*=(?!=)", tail[:execution.start()]
+        execution_pattern = pattern.format(name=re.escape(name))
+        # Ruby member assignments such as `self.req = ...` do not rebind the
+        # local `req`. Include member/namespace separators in the boundary so
+        # a suffix match cannot discard the local request object.
+        binding_boundary = (
+            r"(?<![\w@$.])(?<!::)" if suffix == ".rb" else r"(?<![\w@$])"
         )
-        if rebound is None:
-            return True
+        rebound_pattern = re.compile(
+            rf"{binding_boundary}{re.escape(name)}\s*=(?!=)"
+        )
+        for execution in re.finditer(execution_pattern, tail):
+            execution_offset = call.end + execution.start()
+            # Ruby locals belong to one method/top-level scope. Instance,
+            # class and global variables retain their identity across methods.
+            local_ruby_binding = suffix == ".rb" and not name.startswith(
+                ("@", "$")
+            )
+            if local_ruby_binding and not _same_ruby_function_scope(
+                lexed.code, call.start, execution_offset, ruby_spans
+            ):
+                continue
+            # A new reaching definition supersedes this request object. Check
+            # every exact-binding assignment before THIS execution; for Ruby
+            # locals, assignments in unrelated methods do not rebind it.
+            rebound = False
+            for candidate in rebound_pattern.finditer(tail, 0, execution.start()):
+                candidate_offset = call.end + candidate.start()
+                if local_ruby_binding and not _same_ruby_function_scope(
+                    lexed.code, call.start, candidate_offset, ruby_spans
+                ):
+                    continue
+                rebound = True
+                break
+            if not rebound:
+                return True
     return False
 
 

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -2644,8 +2644,14 @@ def finding_row(path: Path, line: int, detail: str) -> str:
     # The analyzer-to-shell protocol is LF-delimited. POSIX permits CR and LF
     # in filenames, so emitting a raw path can turn one finding into several
     # records and inflate both counts and details.files. Escape only the record
-    # delimiters; keep the rest of the path byte-for-byte displayable.
-    display_path = str(path).replace("\r", "\\r").replace("\n", "\\n")
+    # delimiters. Escape backslashes first so a literal `\n` path segment and
+    # an actual newline cannot collapse to the same display identity.
+    display_path = (
+        str(path)
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
     return f"{display_path}:{line}:{detail}"
 
 
@@ -11365,12 +11371,53 @@ def external_static_values(
     return resolved
 
 
-def external_reference_names(source: str, suffix: str) -> set[str]:
+def _matches_js_alias_key(module: str, key: str) -> bool:
+    pattern = re.escape(key).replace(r"\*", ".*")
+    return re.fullmatch(pattern, module) is not None
+
+
+def _js_module_has_local_provenance(module: str, project_root: Path) -> bool:
+    """Return whether a JS module spelling denotes project-controlled code."""
+
+    if module.startswith((".", "@/", "~/", "#")):
+        return True
+    for filename in ("tsconfig.json", "jsconfig.json"):
+        try:
+            config = json.loads((project_root / filename).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(config, dict):
+            continue
+        compiler_options = config.get("compilerOptions", {})
+        if not isinstance(compiler_options, dict):
+            continue
+        paths = compiler_options.get("paths", {})
+        if isinstance(paths, dict) and any(
+            isinstance(key, str) and _matches_js_alias_key(module, key)
+            for key in paths
+        ):
+            return True
+    try:
+        package = json.loads((project_root / "package.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        package = {}
+    imports = package.get("imports", {}) if isinstance(package, dict) else {}
+    return isinstance(imports, dict) and any(
+        isinstance(key, str) and _matches_js_alias_key(module, key)
+        for key in imports
+    )
+
+
+def external_reference_names(
+    source: str, suffix: str, project_root: Path
+) -> set[str]:
     """Return local names whose values originate outside the current file.
 
-    Exact static exports are resolved separately. This index covers the wider
-    language-level import boundary so an unresolved mutating request fails
-    closed instead of silently passing. Sentinels are intentionally narrow:
+    Exact relative static exports are resolved separately. This index covers
+    the wider language-level import boundary—including configured aliases
+    such as ``@/``, ``~/``, tsconfig paths, and package
+    ``imports``—so an unresolved mutating request fails closed instead of
+    silently passing. Sentinels are intentionally narrow:
     uppercase constants after require/include, qualified package/class members,
     and shell variables only when a source command is present.
     """
@@ -11383,16 +11430,23 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
             for match in re.finditer(
                 r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
                 r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
-                r"from\s*(['\"])\.[^'\"]*\2",
+                r"from\s*(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         for match in re.finditer(
             r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
             r"\{(?P<members>[^{}]*)\}\s*from\s*"
-            r"(['\"])\.[^'\"]*\2",
+            r"(['\"])(?P<module>[^'\"]+)\2",
             visible,
         ):
+            if not _js_module_has_local_provenance(
+                match.group("module"), project_root
+            ):
+                continue
             for member in match.group("members").split(","):
                 parsed = re.fullmatch(
                     r"\s*([A-Za-z_$]\w*)(?:\s+as\s+([A-Za-z_$]\w*))?\s*",
@@ -11405,23 +11459,33 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
             for match in re.finditer(
                 r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
                 r"\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
-                r"(['\"])\.[^'\"]*\2",
+                r"(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         names.update(
             match.group(1)
             for match in re.finditer(
                 r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
-                r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+                r"require\s*\(\s*(['\"])(?P<module>[^'\"]+)\2",
                 visible,
+            )
+            if _js_module_has_local_provenance(
+                match.group("module"), project_root
             )
         )
         for match in re.finditer(
             r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
-            r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+            r"require\s*\(\s*(['\"])(?P<module>[^'\"]+)\2",
             visible,
         ):
+            if not _js_module_has_local_provenance(
+                match.group("module"), project_root
+            ):
+                continue
             for member in match.group("members").split(","):
                 parsed = re.fullmatch(
                     r"\s*([A-Za-z_$]\w*)(?:\s*:\s*([A-Za-z_$]\w*))?\s*",
@@ -11499,7 +11563,7 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
         lexed,
         suffix,
         external_static_values(path, project_root, source, suffix),
-        external_reference_names(source, suffix),
+        external_reference_names(source, suffix, project_root),
     )
     profile_resolver = PayloadStateResolver(
         lexed,

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1,0 +1,10277 @@
+#!/usr/bin/env python3
+"""Find required-profile messaging calls whose own payload omits the profile.
+
+This is intentionally a small lexer, not a language parser. It preserves byte
+offsets while masking comments and string literals, which is enough to match
+call/assignment boundaries without confusing URLs, comment markers, or
+semicolons inside strings for source syntax. Payload variables are resolved to
+their nearest real assignment in the same file.
+"""
+
+from __future__ import annotations
+
+import bisect
+import json
+import os
+import posixpath
+import re
+import shlex
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, TypeAlias
+from urllib.parse import urljoin, urlsplit
+
+
+# Node module-system extensions (.cjs/.mjs) and the TypeScript equivalents
+# (.cts/.mts) are the same language as .js/.ts. SKILL.md documents a CommonJS
+# flow, and scan-twilio-deep.py already treats them as JavaScript, so omitting
+# them here made the two tools disagree about what counts as source.
+JS_TS_SUFFIXES = {
+    ".cjs",
+    ".cts",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".mts",
+    ".ts",
+    ".tsx",
+}
+TYPESCRIPT_SUFFIXES = {".ts", ".tsx", ".mts", ".cts"}
+# Keys a request-style config object may carry its URL under. Shared so the
+# named-argument path and the config-object path cannot recognise different
+# spellings, which is how `uri` came to work as a named argument but not as
+# an object member.
+URL_MEMBER_NAMES = ("url", "uri", "requestUri", "request_uri")
+# Extensions that are aliases of a language this linter already analyses, not
+# new languages. A `.bash` file is a shell script and a `.phtml` file is PHP,
+# but every downstream check compares against the canonical suffix, so an
+# alias was read as an unknown language and silently produced no findings.
+# Normalising in one place beats widening each comparison: there are dozens.
+SUFFIX_LANGUAGE_ALIASES = {
+    ".bash": ".sh",
+    ".ksh": ".sh",
+    ".zsh": ".sh",
+    ".phtml": ".php",
+    ".pyw": ".py",
+    ".rake": ".rb",
+    ".cshtml": ".cs",
+    ".scala": ".java",
+    # Kotlin shares Java's grammar for everything this linter models - the
+    # OkHttp/java.net.http builder chains, the braced control-flow arms, the
+    # execution links. Three branches already name `.kt`/`.kts` explicitly, but
+    # the discovery layer never yielded such a file, so a Kotlin migration was
+    # scanned as zero files and passed silently no matter what it contained.
+    ".kt": ".java",
+    ".kts": ".java",
+    # Single-file components and server templates embed the SAME JS/Ruby a
+    # sibling .js/.rb file would hold, but the allow-list excluded the whole
+    # file type, so a number-pool send inside a Vue/Svelte/Astro component or
+    # an ERB view was never opened at all. The lexer already stops a single
+    # quote at end of line for JS, so surrounding markup prose does not mask
+    # the script blocks.
+    ".vue": ".js",
+    ".svelte": ".js",
+    ".astro": ".js",
+    ".erb": ".rb",
+}
+INCLUDED_SUFFIXES = {
+    ".cs",
+    ".go",
+    ".java",
+    ".php",
+    ".py",
+    ".rb",
+    ".sh",
+} | JS_TS_SUFFIXES | set(SUFFIX_LANGUAGE_ALIASES)
+
+
+# package.json "bin" entry points and repo CLIs are extensionless; the
+# shebang is their file identity. The Phase-1 scanner greps without include
+# filters and reports them, so refusing to open them here let the pipeline
+# contradict itself on the same tree.
+SHEBANG_LANGUAGE_SUFFIXES = (
+    ("node", ".js"),
+    ("python", ".py"),
+    ("ruby", ".rb"),
+    ("bash", ".sh"),
+    ("zsh", ".sh"),
+    ("ksh", ".sh"),
+    ("sh", ".sh"),
+)
+
+
+def shebang_suffix(path: Path) -> str | None:
+    """Return the canonical suffix an extensionless executable maps to."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            first_line = handle.readline(200)
+    except OSError:
+        return None
+    if not first_line.startswith("#!"):
+        return None
+    for token, suffix in SHEBANG_LANGUAGE_SUFFIXES:
+        if token in first_line:
+            return suffix
+    return None
+
+
+def canonical_suffix(path: Path) -> str:
+    """Return the language suffix a file should be analysed as."""
+    suffix = path.suffix.lower()
+    if not suffix:
+        return shebang_suffix(path) or ""
+    return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
+# Kept in step with the EXCLUDE_DIRS list in scan-twilio-usage.sh. Generated
+# output belongs here as much as node_modules: a stale compiled bundle under
+# .next carrying a pre-fix number-pool send would fail Phase 4 after the
+# source had already been corrected, and the scanner that produced the plan
+# never looked at it.
+EXCLUDED_DIRS = {
+    ".git",
+    ".next",
+    ".nuxt",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "vendor",
+    "venv",
+}
+EXCLUDED_FILES = {
+    "Gemfile.lock",
+    "Pipfile.lock",
+    "migration-state.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "twilio-deep-scan.json",
+    "twilio-scan.json",
+    "yarn.lock",
+}
+
+PROFILE_NAMES = (
+    "messaging_profile_id",
+    "messagingProfileId",
+    "messagingProfileID",
+    "MessagingProfileId",
+    "MessagingProfileID",
+)
+PROFILE_NAME_PATTERN = "|".join(map(re.escape, PROFILE_NAMES))
+PROFILE_IDENTIFIER_RE = re.compile(
+    rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
+)
+PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
+SDK_CALL_RE = re.compile(
+    r"(?:\?\.|\.|->)\s*(?:"
+    r"sendNumberPool|send_number_pool|SendNumberPool|"
+    r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
+    r"SendWithAlphanumericSender"
+    r")\s*(?:\?\.)?\s*\("
+)
+FETCH_CALL_RE = re.compile(
+    r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
+    # curl_init($url) is the documented one-liner that sets CURLOPT_URL
+    # directly. Listing only the setopt spellings made that whole shape
+    # invisible: no endpoint resolved, so the send was never counted and the
+    # fail-safe could not fire - the linter reported "no number-pool call sites
+    # detected" on a number-pool POST.
+    # Net::HTTP::Post.new(uri) is the ONLY Net::HTTP form that can set request
+    # headers (an Authorization header, for instance), so it is what real
+    # migrated Ruby uses. Modelling only Net::HTTP.post made the whole shape
+    # invisible: zero sends detected, so the fail-safe could not fire either.
+    r"Net::HTTP::(?:Post|Put|Patch)\s*\.\s*new|"
+    r"NewRequest|curl_setopt_array|curl_setopt|curl_init|"
+    r"HttpRequestMessage|RestRequest|Request|open|file_get_contents|"
+    r"axios\s*\.\s*post|axios)\s*\("
+)
+TWILIO_MESSAGE_CREATE_RE = re.compile(
+    r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
+    r"create\s*(?:\?\.)?\s*\("
+)
+MESSAGE_BODY_CALL_RE = re.compile(
+    r"(?:"
+    r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
+    r"(?:create|send|send_)\s*(?:\?\.)?\s*\("
+    r"|(?:\?\.|\.|->)\s*Messages\s*(?:\?\.|\.|->)\s*"
+    r"Send\s*\("
+    r"|(?:\?\.|\.|->)\s*messages\s*\(\s*\)\s*"
+    r"(?:\?\.|\.|->)\s*send\s*\("
+    r")"
+)
+SIMPLE_VARIABLE_RE = re.compile(r"(?:\.\.\.|\*\*|[&*])?\s*(\$?[A-Za-z_]\w*)\s*$")
+STRINGIFIED_VARIABLE_RE = re.compile(
+    r"(?:JSON\s*\.\s*stringify|json\s*\.\s*dumps|json\s*\.\s*Marshal|"
+    r"json_encode|JsonSerializer\s*\.\s*Serialize|"
+    r"JsonConvert\s*\.\s*SerializeObject)\s*\(\s*"
+    r"(\$?[A-Za-z_]\w*)\s*\)"
+)
+NAMED_PAYLOAD_VARIABLE_RE = re.compile(
+    r"(?:\bbody|\bdata|\bjson|\bpayload)\s*[:=]\s*(\$?[A-Za-z_]\w*)"
+)
+SOURCE_IDENTIFIER_RE = re.compile(r"(?<![\w$.])(\$?[A-Za-z_]\w*)(?!\w)")
+SPREAD_VARIABLE_RE = re.compile(r"\.\.\.\s*(\$?[A-Za-z_]\w*)")
+# Matched against RAW source offsets, so it has to tolerate the leading
+# whitespace a member span keeps after `{ a, ...base }` is split.
+SPREAD_MEMBER_RE = re.compile(r"\s*(?:\.\.\.|\*\*)\s*")
+VARIABLE_ASSIGNMENT_RE = re.compile(
+    r"(?<![\w$.>])(\$?[A-Za-z_]\w*)(?!\w)"
+    r"(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+)
+SHELL_VARIABLE_RE = re.compile(r"^\$(?:\{([A-Za-z_]\w*)\}|([A-Za-z_]\w*))$")
+SHELL_STATIC_REFERENCE_RE = re.compile(
+    r"\$(?:\{([A-Za-z_]\w*)(?:\[([^\]]+)\])?\}|([A-Za-z_]\w*))"
+)
+SHELL_CURL_RE = re.compile(r"(?<![\w-])(curl)(?=\s|$)")
+SHELL_DATA_OPTIONS = {
+    "-d",
+    "--data",
+    "--data-ascii",
+    "--data-binary",
+    "--data-raw",
+    "--data-urlencode",
+    "--json",
+}
+SHELL_FORM_OPTIONS = {"-F", "--form", "--form-string"}
+SHELL_UPLOAD_OPTIONS = {"-T", "--upload-file"}
+SHELL_CURL_URL_OPTIONS = {"--url"}
+SHELL_CURL_SHORT_VALUE_OPTIONS = set("AbcCdDeEFHKmoPqrtTuUwXxyzY")
+SHELL_CURL_VALUE_OPTIONS = (
+    SHELL_DATA_OPTIONS
+    | SHELL_FORM_OPTIONS
+    | SHELL_UPLOAD_OPTIONS
+    | SHELL_CURL_URL_OPTIONS
+    | {
+        "-A",
+        "--cacert",
+        "--cert",
+        "--connect-timeout",
+        "-H",
+        "--header",
+        "--key",
+        "--max-time",
+        "-o",
+        "--output",
+        "--proxy",
+        "--resolve",
+        "--retry",
+        "--retry-delay",
+        "-u",
+        "--user",
+        "-w",
+        "--write-out",
+        "-X",
+        "--request",
+    }
+)
+SHELL_ASSIGNMENT_TOKEN_RE = re.compile(r"[A-Za-z_]\w*=.*")
+MUTATING_HTTP_METHODS = frozenset({"POST", "PUT", "PATCH"})
+
+
+@dataclass(frozen=True)
+class StringToken:
+    start: int
+    end: int
+    contents: str
+
+
+@dataclass(frozen=True)
+class LexedSource:
+    original: str
+    code: str
+    without_comments: str
+    strings: tuple[StringToken, ...]
+
+
+@dataclass(frozen=True)
+class Call:
+    start: int
+    open_paren: int
+    end: int
+    parenthesized: bool = True
+
+
+EndpointReference = tuple[str, ...]
+
+
+REQUIRED = "required"
+SAFE = "safe"
+UNKNOWN = "unknown"
+MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class EndpointValue:
+    kind: str
+    exact: str | None = None
+
+
+UNKNOWN_VALUE = EndpointValue(UNKNOWN)
+MISSING_VALUE = EndpointValue(MISSING)
+
+
+@dataclass(frozen=True)
+class EndpointLiteral:
+    value: str
+
+
+@dataclass(frozen=True)
+class EndpointUnknown:
+    reason: str = "unsupported"
+
+
+@dataclass(frozen=True)
+class EndpointRef:
+    binding_id: int
+    members: EndpointReference = ()
+
+
+@dataclass(frozen=True)
+class EndpointObject:
+    entries: tuple[tuple[str, "EndpointExpression"], ...]
+
+
+@dataclass(frozen=True)
+class EndpointArray:
+    items: tuple["EndpointExpression", ...]
+
+
+@dataclass(frozen=True)
+class EndpointDefault:
+    primary: "EndpointExpression"
+    fallback: "EndpointExpression"
+
+
+@dataclass(frozen=True)
+class EndpointConcat:
+    parts: tuple["EndpointExpression", ...]
+
+
+@dataclass(frozen=True)
+class EndpointProjected:
+    expression: "EndpointExpression"
+    members: EndpointReference
+
+
+EndpointExpression: TypeAlias = (
+    EndpointLiteral
+    | EndpointUnknown
+    | EndpointRef
+    | EndpointObject
+    | EndpointArray
+    | EndpointDefault
+    | EndpointConcat
+    | EndpointProjected
+)
+
+
+@dataclass(frozen=True)
+class IndexedScope:
+    id: int
+    parent: int | None
+    start: int
+    end: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class IndexedBinding:
+    id: int
+    name: str
+    scope_id: int
+    declaration_start: int
+    visibility_start: int
+    kind: str
+
+
+@dataclass(frozen=True)
+class IndexedDefinition:
+    binding_id: int
+    member_path: EndpointReference
+    start: int
+    expression: EndpointExpression
+    scope_id: int
+    execution_scope: int
+    kind: str
+    guarded: bool = False
+
+
+@dataclass(frozen=True)
+class EndpointAccessState:
+    binding_id: int
+    path: EndpointReference
+    before: int
+    use_scope: int
+
+
+@dataclass(frozen=True)
+class EndpointExpressionState:
+    expression: EndpointExpression
+    projection: EndpointReference
+    before: int
+    use_scope: int
+
+
+EndpointState: TypeAlias = EndpointAccessState | EndpointExpressionState
+
+
+@dataclass
+class EndpointExpansion:
+    dependencies: tuple[EndpointState, ...] = ()
+    combine: Callable[[tuple[EndpointValue, ...]], EndpointValue] | None = None
+    immediate: EndpointValue | None = None
+
+
+@dataclass
+class EndpointFrame:
+    state: EndpointState
+    expansion: EndpointExpansion | None = None
+    next_dependency: int = 0
+    values: list[EndpointValue] = field(default_factory=list)
+
+
+def _blank(buffer: list[str], start: int, end: int) -> None:
+    for index in range(start, end):
+        if buffer[index] != "\n":
+            buffer[index] = " "
+
+
+# Heredoc openers: shell/ruby `<<TAG`, `<<-TAG`, `<<~TAG`, `<<'TAG'`; PHP
+# `<<<TAG` / `<<<'TAG'`. The body is data and must be masked like a string.
+# NO whitespace is permitted between `<<`/`<<<` and the tag in any of these
+# languages. Allowing it made Ruby's append operator (`audit_log << recipient`),
+# PHP's left shift (`1 << OFFSET`) and shell arithmetic (`$((1 << SHIFT))`) parse
+# as heredoc openers, and since no later line matched the pseudo-tag the "body"
+# ran to EOF and blanked every send below it - a silent pass.
+_HEREDOC_OPENER_RE = re.compile(
+    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)[ \t]*(?=\r?\n|$)"
+)
+# Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
+# singleton-class syntax `class <<self` also puts a bare word straight after
+# `<<` at end of line, so it parsed as a heredoc opening a body that never
+# closed - blanking the rest of the file and silently passing every send below
+# it. That is the same defect the end-of-line anchor was added to fix, one
+# spelling sideways, so the opener needs its LEFT context checked too.
+_NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+
+
+def _heredoc_opener_at(
+    source: str, index: int, suffix: str
+) -> "re.Match[str] | None":
+    """Match a heredoc opener at `index`, rejecting Ruby's `class <<self`.
+
+    Scoped to Ruby: `class` is not a keyword before `<<` in shell or PHP, so
+    applying the rejection there would disable heredoc masking on any opener
+    line that merely ENDS with the word `class` (`echo class <<EOT`).
+    """
+    match = _HEREDOC_OPENER_RE.match(source, index)
+    if match is None:
+        return None
+    if suffix == ".rb":
+        line_start = source.rfind("\n", 0, index) + 1
+        if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
+            return None
+    return match
+
+
+def _heredoc_langs(suffix: str) -> bool:
+    return suffix in {".sh", ".php", ".rb"}
+
+
+def lex_source(source: str, suffix: str) -> LexedSource:
+    """Mask comments and strings while preserving offsets and newlines."""
+
+    code = list(source)
+    without_comments = list(source)
+    strings: list[StringToken] = []
+    c_line_comments = suffix in JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
+    c_block_comments = c_line_comments
+    hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
+    index = 0
+
+    while index < len(source):
+        if c_block_comments and source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            end = len(source) if end < 0 else end + 2
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        if c_line_comments and source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            end = len(source) if end < 0 else end
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        if hash_comments and source[index] == "#":
+            if suffix == ".sh" and index == 0 and source.startswith("#!", index):
+                end = source.find("\n", index + 2)
+                index = len(source) if end < 0 else end
+                continue
+            end = source.find("\n", index + 1)
+            end = len(source) if end < 0 else end
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        # Ruby block comments. Without this, `=begin ... =end` prose was lexed
+        # as code, so one apostrophe in it opened a string that swallowed the
+        # sends below (the fail-safe above cannot help when the stray quote
+        # finds a LATER quote to pair with).
+        if (
+            suffix == ".rb"
+            and source.startswith("=begin", index)
+            and (index == 0 or source[index - 1] == "\n")
+        ):
+            terminator = re.search(r"^=end\b.*$", source[index:], re.M)
+            end = (
+                len(source)
+                if terminator is None
+                else index + terminator.end()
+            )
+            _blank(code, index, end)
+            _blank(without_comments, index, end)
+            index = end
+            continue
+
+        # Heredoc bodies are DATA, not code. They were lexed as code, so an
+        # apostrophe inside one ("Don't edit by hand") paired with a later quote
+        # and masked the send that followed.
+        heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
+        if heredoc is not None:
+            tag = heredoc.group("tag")
+            body_start = source.find("\n", heredoc.end())
+            if body_start < 0:
+                index = heredoc.end()
+                continue
+            body_start += 1
+            terminator = re.compile(rf"^[ \t]*{re.escape(tag)}\b", re.M).search(
+                source, body_start
+            )
+            body_end = len(source) if terminator is None else terminator.start()
+            _blank(code, body_start, body_end)
+            strings.append(
+                StringToken(body_start, body_end, source[body_start:body_end])
+            )
+            index = body_end
+            continue
+
+        quote = source[index]
+        if quote not in {"'", '"', "`"}:
+            index += 1
+            continue
+
+        delimiter = quote
+        if quote in {"'", '"'} and source.startswith(quote * 3, index):
+            delimiter = quote * 3
+        string_start = index
+        index += len(delimiter)
+        contents_start = index
+        # A backtick delimits a Go RAW string, which has no escape sequences, so
+        # a literal `\` inside one previously consumed the closing backtick and
+        # ran the "string" to end of file.
+        honours_escapes = not (suffix == ".go" and delimiter == "`")
+        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
+            JS_TS_SUFFIXES | {".py"}
+        )
+        terminated = False
+        while index < len(source):
+            if source.startswith(delimiter, index):
+                contents_end = index
+                index += len(delimiter)
+                terminated = True
+                break
+            if honours_escapes and source[index] == "\\":
+                index = min(len(source), index + 2)
+                continue
+            if source[index] == "\n" and line_bounded:
+                # A single/double-quoted JS/TS or Python literal cannot contain a
+                # raw newline, so hitting one means the quote never opened a
+                # string at all (an apostrophe in JSX text, prose, or a comment).
+                # Stop here rather than pairing it with some LATER quote, which
+                # masked every send in between.
+                break
+            index += 1
+        else:
+            contents_end = len(source)
+
+        if not terminated:
+            # FAIL SAFE. An unterminated quote used to blank everything to EOF,
+            # so a single apostrophe in JSX text, a heredoc body, or a Ruby
+            # =begin comment deleted every send below it and the file was
+            # reported clean. Treat the lone quote as ordinary code and resume
+            # immediately after it: the damage is one character, not the file.
+            index = string_start + 1
+            continue
+
+        _blank(code, string_start, index)
+        strings.append(
+            StringToken(string_start, index, source[contents_start:contents_end])
+        )
+
+    return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
+
+
+def matching_delimiter(code: str, opening: int, left: str, right: str) -> int | None:
+    depth = 0
+    for index in range(opening, len(code)):
+        character = code[index]
+        if character == left:
+            depth += 1
+        elif character == right:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def calls_matching(lexed: LexedSource, pattern: re.Pattern[str]) -> list[Call]:
+    calls: list[Call] = []
+    for match in pattern.finditer(lexed.code):
+        opening = lexed.code.rfind("(", match.start(), match.end())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None:
+            closing = lexed.code.find("\n", opening)
+            closing = len(lexed.code) - 1 if closing < 0 else closing
+        calls.append(Call(match.start(), opening, closing + 1))
+    return calls
+
+
+def serialized_payload_string(
+    lexed: LexedSource, token: StringToken, region_start: int
+) -> bool:
+    prefix_start = max(region_start, token.start - 120)
+    code_prefix = lexed.code[prefix_start : token.start]
+    source_prefix = lexed.without_comments[prefix_start : token.start]
+    return bool(
+        re.search(r"(?:\bbody|\bdata)\s*[:=]\s*$", code_prefix)
+        or re.search(
+            r"(?:^|\s)(?:-d|--data(?:-raw|-binary)?)\s*$", source_prefix
+        )
+    )
+
+
+def structural_depth(code: str, start: int, offset: int) -> tuple[int, int, int]:
+    round_depth = square_depth = curly_depth = 0
+    for character in code[start:offset]:
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+    return round_depth, square_depth, curly_depth
+
+
+def curly_ancestry(code: str, offset: int) -> tuple[int, ...]:
+    """Return the unmatched opening-brace positions containing offset."""
+
+    ancestry: list[int] = []
+    for index, character in enumerate(code[:offset]):
+        if character == "{":
+            ancestry.append(index)
+        elif character == "}" and ancestry:
+            ancestry.pop()
+    return tuple(ancestry)
+
+
+def scope_contains(code: str, binding: int, use: int) -> bool:
+    """Return true when binding's lexical brace path contains use."""
+
+    binding_scope = curly_ancestry(code, binding)
+    use_scope = curly_ancestry(code, use)
+    return use_scope[: len(binding_scope)] == binding_scope
+
+
+def payload_root_depth(code: str, start: int, end: int) -> tuple[int, int, int]:
+    """Return the direct-member depth for an object payload or argument list."""
+
+    round_depth = square_depth = curly_depth = 0
+    named_value = False
+    for character in code[start:end]:
+        at_argument_root = round_depth == square_depth == curly_depth == 0
+        if at_argument_root and character == ",":
+            return 0, 0, 0
+        if at_argument_root and character in {":", "="}:
+            named_value = True
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+            if not named_value:
+                return round_depth, square_depth, curly_depth
+            return 0, 0, 0
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+            if not named_value:
+                return round_depth, square_depth, curly_depth
+            return 0, 0, 0
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+    return 0, 0, 0
+
+
+def at_payload_root(
+    code: str,
+    start: int,
+    end: int,
+    offset: int,
+) -> bool:
+    return structural_depth(code, start, offset) == payload_root_depth(code, start, end)
+
+
+def serialized_json_has_profile(value: str) -> bool:
+    candidates = [value]
+    try:
+        decoded_literal = json.loads(f'"{value}"')
+    except (TypeError, ValueError):
+        pass
+    else:
+        if decoded_literal != value:
+            candidates.append(decoded_literal)
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict) and any(
+            _is_usable_profile_value(payload.get(name))
+            for name in PROFILE_NAMES
+            if name in payload
+        ):
+            return True
+    return False
+
+
+def _is_usable_profile_value(value: Any) -> bool:
+    """Return whether a decoded JSON profile value is usable.
+
+    `value not in {None, ""}` raised TypeError on a dict or list value, and
+    nothing between here and main() caught it, so ONE payload carrying
+    `"messaging_profile_id": {...}` aborted the entire scan - every other file
+    in the project went unanalysed and the run reported nothing at all.
+    A non-scalar is also not a usable profile id, so it is simply False.
+    """
+    return isinstance(value, (str, int)) and not isinstance(value, bool) and str(value).strip() != ""
+
+
+def token_is_entire_expression(
+    lexed: LexedSource, token: StringToken, start: int, end: int
+) -> bool:
+    """Return true when a string token is the assignment value, not nested data."""
+
+    return not (
+        lexed.code[start:token.start].strip()
+        or lexed.code[token.end:end].strip()
+    )
+
+
+def region_has_profile(
+    lexed: LexedSource,
+    start: int,
+    end: int,
+    *,
+    serialized_assignment: bool = False,
+    allow_js_shorthand: bool = False,
+) -> bool:
+    code_region = lexed.code[start:end]
+    if PROFILE_CLI_RE.search(code_region):
+        return True
+    for match in PROFILE_IDENTIFIER_RE.finditer(lexed.code, start, end):
+        if not at_payload_root(lexed.code, start, end, match.start()):
+            continue
+        after = lexed.code[match.end():end]
+        if re.match(r"\s*(?::|=(?!=)|\()", after):
+            return True
+        if allow_js_shorthand and re.match(r"\s*(?=[,}])", after):
+            return True
+
+    for token in lexed.strings:
+        if token.start < start or token.end > end:
+            continue
+        after = lexed.without_comments[token.end:end]
+        if (
+            token.contents in PROFILE_NAMES
+            and at_payload_root(lexed.code, start, end, token.start)
+            and re.match(r"\s*(?::|=>|=(?!=))", after)
+        ):
+            return True
+        serialized_value = serialized_payload_string(lexed, token, start) or (
+            serialized_assignment
+            and token_is_entire_expression(lexed, token, start, end)
+        )
+        if serialized_value and serialized_json_has_profile(token.contents):
+            return True
+    return False
+
+
+def split_arguments(code: str, start: int, end: int) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    segment_start = start
+    round_depth = square_depth = curly_depth = 0
+    for index in range(start, end):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == "," and not (round_depth or square_depth or curly_depth):
+            spans.append((segment_start, index))
+            segment_start = index + 1
+    spans.append((segment_start, end))
+    return spans
+
+
+def entry_value_end(code: str, start: int, limit: int) -> int:
+    """End of one `key => value` entry inside an enclosing literal.
+
+    The entry stops at its own top-level `,`/`;` or at the first closer that
+    belongs to the CONTAINER rather than to the value, so a nested literal
+    value is kept whole while a trailing `]]);` is not swallowed.
+    """
+    depth = 0
+    for index in range(start, limit):
+        character = code[index]
+        if character in "([{":
+            depth += 1
+        elif character in ")]}":
+            if depth == 0:
+                return index
+            depth -= 1
+        elif depth == 0 and character in ",;":
+            return index
+    return limit
+
+
+def named_payload_spans(
+    code: str,
+    spans: list[tuple[int, int]],
+    *,
+    allow_js_shorthand: bool = False,
+) -> list[tuple[int, int]]:
+    """Return only body/data/json/payload values from argument/object spans."""
+
+    payloads: list[tuple[int, int]] = []
+    name_pattern = re.compile(r"\s*(?:body|data|json|payload)\s*[:=](?!=)")
+    shorthand_pattern = re.compile(r"\s*(?:body|data|json|payload)\s*$")
+    for start, end in spans:
+        match = name_pattern.match(code, start, end)
+        if match is not None:
+            payloads.append((match.end(), end))
+            continue
+        if allow_js_shorthand and shorthand_pattern.fullmatch(code, start, end):
+            payloads.append((start, end))
+            continue
+        opening = code.find("{", start, end)
+        if opening < 0:
+            continue
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is None or closing >= end:
+            continue
+        for member_start, member_end in split_arguments(code, opening + 1, closing):
+            member_match = name_pattern.match(code, member_start, member_end)
+            if member_match is not None:
+                payloads.append((member_match.end(), member_end))
+            elif allow_js_shorthand and shorthand_pattern.fullmatch(
+                code, member_start, member_end
+            ):
+                payloads.append((member_start, member_end))
+    return payloads
+
+
+def assigned_payload_member_span(
+    lexed: LexedSource,
+    variable: str,
+    after: int,
+    before: int,
+    suffix: str,
+) -> list[tuple[int, int]]:
+    """Return the latest body-like property assigned to an options variable."""
+
+    escaped = re.escape(variable)
+    pattern = re.compile(
+        rf"(?<![\w$.>]){escaped}(?!\w)\s*(?:\.|->)\s*"
+        r"(?:body|data|json|payload)\s*(?::=|=(?!=|>))"
+    )
+    matches = list(pattern.finditer(lexed.code, after, before))
+    if not matches:
+        return []
+    latest = matches[-1]
+    return [(latest.end(), assignment_end(lexed, latest.end(), suffix))]
+
+
+def assigned_named_payload_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> list[tuple[int, int]]:
+    """Resolve an options variable and return only its request-body member."""
+
+    candidate = lexed.code[span[0] : span[1]].strip()
+    variable_match = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+    if variable_match is None:
+        return []
+    variable = variable_match.group(1)
+    if variable in seen:
+        return []
+    matches = assignment_matches(lexed.code, variable, before)
+    if not matches:
+        return []
+    assignment = matches[-1]
+    rhs_start = assignment.end()
+    rhs_end = assignment_end(lexed, rhs_start, suffix)
+    named = named_payload_spans(
+        lexed.code,
+        [(rhs_start, rhs_end)],
+        allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+    )
+    mutation = assigned_payload_member_span(
+        lexed, variable, rhs_end, before, suffix
+    )
+    if mutation:
+        return mutation
+    if named:
+        return named
+    return assigned_named_payload_spans(
+        lexed,
+        (rhs_start, rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def argument_string_value(
+    lexed: LexedSource, span: tuple[int, int]
+) -> str | None:
+    """Return a sole string literal argument's value."""
+
+    tokens = [
+        token
+        for token in lexed.strings
+        if span[0] <= token.start and token.end <= span[1]
+    ]
+    if len(tokens) != 1 or lexed.code[span[0] : span[1]].strip():
+        return None
+    return tokens[0].contents
+
+
+_KTOR_BODY_LINK_RE = re.compile(r"\b(?:setBody|body)\s*(?:\(|=)")
+
+
+def _trailing_lambda_span(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Span of a Kotlin trailing lambda immediately following `call`."""
+    tail = lexed.code[call.end:call.end + 40]
+    brace = re.match(r"\s*\{", tail)
+    if brace is None:
+        return None
+    opening = call.end + brace.end() - 1
+    closing = matching_delimiter(lexed.code, opening, "{", "}")
+    return None if closing is None else (opening, closing)
+
+
+def ktor_trailing_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Body attached inside a Ktor builder lambda: `post(url) { setBody(x) }`.
+
+    Ktor's send takes the ENDPOINT as its only argument and configures the body
+    in the trailing lambda, so neither the argument list nor any earlier chain
+    link carries the payload.
+    """
+    block = _trailing_lambda_span(lexed, call)
+    if block is None:
+        return None
+    inner_text = lexed.code[block[0]:block[1]]
+    link = _KTOR_BODY_LINK_RE.search(inner_text)
+    if link is None:
+        return None
+    base = block[0] + link.end()
+    if inner_text[link.end() - 1] == "(":
+        closing = matching_delimiter(lexed.code, base - 1, "(", ")")
+        if closing is None:
+            return None
+        arguments = split_arguments(lexed.code, base, closing)
+        span = payload_argument(lexed, arguments) if arguments else None
+    else:
+        end = lexed.code.find("\n", base)
+        span = (base, end if end > 0 else block[1])
+    if span is None:
+        return None
+    return resolve_wrapped_payload(lexed, span, span[0], suffix)
+
+
+def ruby_request_body_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Body assigned to a Ruby request object after construction.
+
+    `req = Net::HTTP::Post.new(uri)` carries only the endpoint; the payload
+    arrives in a later statement as `req.body = ...`, so the constructor's own
+    arguments never reveal it.
+    """
+    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    binding = re.search(
+        r"([A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+    )
+    if binding is None:
+        return []
+    name = re.escape(binding.group(1))
+    match = re.search(
+        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*", lexed.code[call.end:]
+    )
+    if match is None:
+        return []
+    start = call.end + match.end()
+    end = lexed.code.find("\n", start)
+    span = (start, end if end > 0 else len(lexed.code))
+    return [resolve_wrapped_payload(lexed, span, span[0], suffix)]
+
+
+def rest_payload_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select request-body expressions without accepting query/config fields."""
+
+    args_start = call.open_paren + 1
+    args_end = max(args_start, call.end - 1)
+    arguments = split_arguments(lexed.code, args_start, args_end)
+    if not arguments:
+        return []
+
+    # Guzzle's canonical body shape is an options array with a quoted `json`
+    # key: `$client->post($url, ['json' => ['messaging_profile_id' => $mp]])`.
+    # Quoted keys are blanked in `lexed.code`, so the generic named-member
+    # regex cannot recover them. Project the literal container through the
+    # lexer's token-aware key resolver instead.
+    if suffix == ".php":
+        for argument in arguments[1:]:
+            projected = literal_value_span(
+                lexed, argument[0], argument[1], ("json",), suffix
+            )
+            if projected is not None:
+                return [projected]
+
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    if suffix == ".php" and callee == "file_get_contents":
+        region = php_stream_context_region(lexed, call, suffix)
+        if region is None:
+            return []
+        key = re.search(
+            r"[\'\"]content[\'\"]\s*=>", lexed.original[region[0]:region[1]]
+        )
+        if key is None:
+            return []
+        start = region[0] + key.end()
+        # `region[1]` is the end of the whole stream_context_create(...)
+        # statement, so an unbounded span reads `$json]]);` rather than the
+        # entry's value: no variable is recognised, the hop to the body is lost
+        # and a compliant send is reported as missing the profile. Bound the
+        # value at the entry's own `,`/`]` first.
+        end = entry_value_end(lexed.code, start, region[1])
+        return [resolve_wrapped_payload(lexed, (start, end), start, suffix)]
+    if suffix in JS_TS_SUFFIXES and callee.split(".")[-1] == "open":
+        body = xhr_send_body_span(lexed, call, suffix)
+        return [body] if body else []
+    if suffix == ".py" and callee.split(".")[-1] == "Request":
+        data = named_argument_spans(lexed, arguments, "data")
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in data[-1:]
+        ]
+    if callee in {"HttpRequestMessage", "RestRequest"}:
+        body = csharp_request_body_span(lexed, call, suffix)
+        return [body] if body else []
+    if suffix == ".go" and callee in {"Post", "Put", "Patch"} and len(arguments) == 1:
+        body = builder_body_span(lexed, call, "SetBody|SetJSONBody|SetFormData")
+        return [resolve_wrapped_payload(lexed, body, body[0], suffix)] if body else []
+    if suffix == ".go" and callee == "Post" and len(arguments) >= 3:
+        # net/http.Post(url, contentType, body) carries the request body in
+        # its third argument, unlike the common post(url, body, config) form.
+        # Gating on the receiver being literally "http" missed every
+        # (*http.Client).Post call — client.Post(...), httpClient.Post(...),
+        # http.DefaultClient.Post(...) — which fell through to the generic
+        # rule and had its content-type string inspected as the payload,
+        # reporting a compliant body as missing messaging_profile_id.
+        receiver = (call_receiver(lexed, call) or "").lower()
+        second = lexed.code[arguments[1][0]:arguments[1][1]].strip()
+        looks_like_content_type = bool(
+            re.fullmatch(r"""["'][A-Za-z0-9.+-]+/[A-Za-z0-9.+;=\s-]+["']""", second)
+        )
+        if (
+            receiver == "http"
+            or receiver.endswith("client")
+            or looks_like_content_type
+        ):
+            # Follow reader/stringifier wrappers to the literal, as the curl
+            # branch does. Returning the raw span only worked when the literal
+            # sat textually inside it: the idiomatic
+            # `body := []byte(...); http.Post(url, ct, bytes.NewBuffer(body))`
+            # left the span at the wrapper, so a compliant body was reported as
+            # missing messaging_profile_id.
+            return [
+                resolve_wrapped_payload(
+                    lexed, arguments[2], arguments[2][0], suffix
+                )
+            ]
+    if callee == "fetch":
+        inline = named_payload_spans(
+            lexed.code,
+            arguments[1:2],
+            allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+        )
+        if inline:
+            return inline
+        if len(arguments) > 1:
+            return assigned_named_payload_spans(
+                lexed, arguments[1], call.start, suffix
+            )
+        return []
+    if callee == "axios.post":
+        return arguments[1:2]
+    if callee == "axios":
+        inline = named_payload_spans(
+            lexed.code,
+            arguments[:1],
+            allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+        )
+        if inline:
+            return inline
+        return assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+    named = named_payload_spans(
+        lexed.code,
+        arguments,
+        allow_js_shorthand=suffix in JS_TS_SUFFIXES,
+    )
+    if named:
+        return named
+    if callee == "request" and len(arguments) >= 3:
+        method = argument_string_value(lexed, arguments[0])
+        if method is None or method.upper() in MUTATING_HTTP_METHODS:
+            return arguments[2:3]
+
+    if callee == "NewRequest" and len(arguments) >= 3:
+        # http.NewRequest(method, url, body): the body is the third argument,
+        # normally wrapped (bytes.NewBuffer(json.Marshal output)).
+        return [
+            resolve_wrapped_payload(lexed, arguments[2], call.start, suffix)
+        ]
+    if callee.split(".")[-1] == "post_form":
+        # Net::HTTP.post_form(uri, k => v, ...): every pair after the URI is
+        # form data. Returning only the first pair would report a compliant
+        # send whose profile arrives in a later pair.
+        return arguments[1:]
+    if callee.endswith("new") and "Net::HTTP::" in callee:
+        # The endpoint is this call's argument (handled in request_url_spans);
+        # the BODY arrives later as `req.body = ...` on the binding, exactly
+        # like the C# `req.Content = ...` shape.
+        return ruby_request_body_spans(lexed, call, suffix)
+    if callee == "curl_init":
+        # `$ch = curl_init($url)` names its handle on the LEFT of the
+        # assignment, not in the argument list, so the sibling
+        # CURLOPT_POSTFIELDS lookup needs the binding. Without it the endpoint
+        # resolved but the body never did, and a COMPLIANT send was reported as
+        # missing the profile.
+        line_start = lexed.code.rfind("\n", 0, call.start) + 1
+        binding = re.search(
+            r"(\$[A-Za-z_]\w*)\s*=\s*$",
+            lexed.code[line_start:call.start].rstrip()[-120:] + "=",
+        ) or re.search(
+            r"(\$[A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+        )
+        if binding is None:
+            return []
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in curl_postfields_spans(
+                lexed, binding.group(1), call.start, suffix
+            )
+        ]
+    if callee == "curl_setopt" and len(arguments) >= 3:
+        option = lexed.code[arguments[1][0]:arguments[1][1]].strip()
+        if option != "CURLOPT_URL":
+            return []
+        handle = lexed.code[arguments[0][0]:arguments[0][1]].strip()
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in curl_postfields_spans(
+                lexed, handle, call.start, suffix
+            )
+        ]
+    if callee == "curl_setopt_array" and len(arguments) >= 2:
+        # The array form carries the body in the SAME literal as the URL, and
+        # may also have been set by earlier per-option calls on the handle.
+        handle = lexed.code[arguments[0][0]:arguments[0][1]].strip()
+        spans = curl_option_array_value_spans(
+            lexed, arguments[1], suffix, "CURLOPT_POSTFIELDS"
+        ) or curl_postfields_spans(lexed, handle, call.start, suffix)
+        return [
+            resolve_wrapped_payload(lexed, span, span[0], suffix)
+            for span in spans
+        ]
+    # `.kt`/`.kts` are CANONICALISED to `.java` before reaching here, so this
+    # must test the canonical suffix - keying on ".kt" meant the branch never
+    # ran. Gating on the trailing lambda keeps it Kotlin-only in practice:
+    # Java has no trailing-lambda call syntax for this shape.
+    if suffix in {".java", ".kt", ".kts", ".scala"} and callee.lower() in {
+        "post", "put", "patch", "request", "submitform"
+    }:
+        ktor_body = ktor_trailing_body_span(lexed, call, suffix)
+        if ktor_body is not None:
+            return [ktor_body]
+    if (
+        callee.lower() == "post"
+        and suffix in {".java", ".kt", ".kts", ".scala"}
+        # ONE argument only. Both idioms below pass the body alone, because the
+        # endpoint came from an earlier `.uri(...)`/`.url(...)` link. A
+        # positional two-argument `post(url, body)` - the shape used by Ktor and
+        # by most thin JVM wrappers - puts the ENDPOINT first, so taking
+        # argument 0 as the payload read the URL as the body and reported
+        # compliant code as missing the profile. Matching on the case-insensitive
+        # verb widened this branch to exactly those calls, so it must now check
+        # the arity the branch actually assumes.
+        and len(arguments) == 1
+        # Ktor spells the send `client.post(url) { setBody(json) }` - ONE
+        # argument, but that argument is the ENDPOINT and the body lives in the
+        # trailing lambda. The arity gate alone still read the URL as the
+        # payload, so a compliant Kotlin send was flagged. A trailing lambda
+        # means the single argument is not the body.
+        and _trailing_lambda_span(lexed, call) is None
+    ):
+        # .POST(HttpRequest.BodyPublishers.ofString(json)) for java.net.http and
+        # .post(RequestBody.create(json, TYPE)) for OkHttp — in both the payload
+        # is the wrapper's inner argument, not the wrapper itself.
+        # The canonical OkHttp idiom binds the body first — `RequestBody body =
+        # RequestBody.create(json, MediaType.parse(...)); ....post(body)` — and
+        # `unwrap_body_publisher` returns a bare variable untouched, leaving the
+        # whole `create(json, mediaType)` right-hand side to be inspected as the
+        # payload, where the media-type string won and a compliant send was
+        # reported as missing the profile. Resolve the variable hop first.
+        return [
+            unwrap_body_publisher(
+                lexed, resolve_wrapped_payload(lexed, span, span[0], suffix)
+            )
+            for span in arguments[:1]
+        ]
+    if callee == "request" and len(arguments) == 1:
+        resolved = assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+        if resolved:
+            return resolved
+        # Node core http(s).request: the body never rides in the options
+        # object — it is written afterwards via <handle>.write(payload).
+        written = request_write_payload_spans(lexed, call)
+        if written:
+            return written
+        return []
+
+    if callee.split(".")[-1].lower() in {"post", "postasync"}:
+        # Request-style config object held in a variable:
+        #   const cfg = {url: ..., json: {...}}; request.post(cfg)
+        # The inline form is already covered by named_payload_spans above,
+        # which reads json/body/data straight out of the literal. Once the URL
+        # side learned to resolve the variable, this side had to as well —
+        # otherwise the call was recognised as targeting the endpoint but its
+        # body could never be proven compliant, turning a silent miss into a
+        # false report on exactly the shape that was just fixed.
+        #
+        # Only returned when a body member is actually found. For
+        # post(urlVariable, bodyVariable) the first argument resolves to a
+        # string with no body member, so this yields nothing and the
+        # positional rule below still applies.
+        resolved = assigned_named_payload_spans(
+            lexed, arguments[0], call.start, suffix
+        )
+        if resolved:
+            return resolved
+
+    # For post(url, payload, config)-style clients, only the second positional
+    # argument is request data. Later arguments are transport/query options.
+    return arguments[1:2]
+
+
+def payload_variables(
+    lexed: LexedSource, start: int, end: int, *, sdk_call: bool = False
+) -> list[str]:
+    variables: list[str] = []
+    for arg_start, arg_end in reversed(split_arguments(lexed.code, start, end)):
+        argument = lexed.code[arg_start:arg_end].strip()
+        match = SIMPLE_VARIABLE_RE.fullmatch(argument)
+        if match:
+            variables.append(match.group(1))
+        for nested in STRINGIFIED_VARIABLE_RE.finditer(argument):
+            variables.append(nested.group(1))
+        if not sdk_call:
+            for named in NAMED_PAYLOAD_VARIABLE_RE.finditer(argument):
+                variables.append(named.group(1))
+    for spread in SPREAD_VARIABLE_RE.finditer(lexed.code, start, end):
+        depth = structural_depth(lexed.code, start, spread.start())
+        if depth[2] and depth == payload_root_depth(lexed.code, start, end):
+            variables.append(spread.group(1))
+    variables = list(dict.fromkeys(variables))
+    if not sdk_call:
+        return variables
+
+    non_payload_names = {
+        "cancellationToken",
+        "context",
+        "ctx",
+        "options",
+        "requestOptions",
+    }
+    return [
+        variable
+        for variable in variables
+        if variable.lstrip("$") not in non_payload_names
+    ][:1]
+
+
+def assignment_matches(code: str, variable: str, before: int) -> list[re.Match[str]]:
+    escaped = re.escape(variable)
+    # The optional annotation covers TypeScript/Python declarations without
+    # allowing the search to cross a statement boundary.
+    pattern = re.compile(
+        rf"(?<![\w$.>]){escaped}(?!\w)(?:\s*,\s*\$?[A-Za-z_]\w*)*"
+        rf"(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+    )
+    return list(pattern.finditer(code, 0, before))
+
+
+def assignment_end(lexed: LexedSource, rhs_start: int, suffix: str) -> int:
+    code = lexed.code
+    round_depth = square_depth = curly_depth = 0
+    c_style = suffix in JS_TS_SUFFIXES | {".cs", ".java", ".php"}
+    for index in range(rhs_start, len(code)):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == "}" and not (round_depth or square_depth or curly_depth):
+            return index
+        elif character == ";" and not (round_depth or square_depth or curly_depth):
+            return index
+        elif character == "\n" and not (round_depth or square_depth or curly_depth):
+            if c_style:
+                next_line = code[index + 1 :].lstrip(" \t")
+                if next_line.startswith((".", "?")):
+                    continue
+            return index
+    return len(code)
+
+
+def shell_jq_assignment_has_profile(
+    lexed: LexedSource, start: int, end: int
+) -> bool:
+    """Recognize a top-level profile key emitted by a jq command substitution."""
+
+    try:
+        shell_source = re.sub(
+            r"\\\r?\n", "", lexed.original[start:end]
+        )
+        tokens = shlex.split(
+            shell_source, comments=True, posix=True
+        )
+    except ValueError:
+        return False
+
+    jq_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if token.lstrip("$(").rsplit("/", 1)[-1] == "jq"
+        ),
+        None,
+    )
+    if jq_index is None:
+        return False
+
+    two_value_options = {
+        "--arg",
+        "--argjson",
+        "--slurpfile",
+        "--rawfile",
+    }
+    one_value_options = {
+        "-f",
+        "--from-file",
+        "-L",
+        "--library-path",
+        "--indent",
+    }
+    index = jq_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in two_value_options:
+            index += 3
+            continue
+        if token in one_value_options:
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    if index >= len(tokens):
+        return False
+
+    program = tokens[index]
+    program_lexed = lex_source(program, ".sh")
+    return region_has_profile(program_lexed, 0, len(program))
+
+
+def shell_curl_get_mode(tokens: list[str]) -> bool:
+    """Return curl's final -G/--get state without reading option values as flags."""
+
+    enabled = False
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        option, separator, _ = token.partition("=")
+        if separator and option in SHELL_CURL_VALUE_OPTIONS:
+            index += 1
+            continue
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            index += 2
+            continue
+        if token == "--get":
+            enabled = True
+        elif token == "--no-get":
+            enabled = False
+        elif token.startswith("-") and not token.startswith("--"):
+            for short_option in token[1:]:
+                if short_option == "G":
+                    enabled = True
+                if short_option in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                    break
+        index += 1
+    return enabled
+
+
+def shell_curl_http_method(lexed: LexedSource, call: Call) -> str | None:
+    """Return curl's effective HTTP method, or None when it is dynamic.
+
+    curl defaults to GET, switches to POST for data/form options and PUT for
+    uploads, while an explicit request method wins.  A dynamic -X value stays
+    unresolved so callers can conservatively keep the request in scope.
+    """
+
+    try:
+        tokens = shlex.split(
+            lexed.original[call.start:call.end], comments=True, posix=True
+        )
+    except ValueError:
+        return None
+    curl_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if re.search(r"(?:^|[/$(])curl$", token)
+        ),
+        None,
+    )
+    if curl_index is None:
+        return None
+
+    explicit: str | None = None
+    inferred = "GET"
+    index = curl_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"-X", "--request"}:
+            if index + 1 >= len(tokens):
+                return None
+            explicit = tokens[index + 1]
+            index += 2
+            continue
+        if token.startswith("--request="):
+            explicit = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token.startswith("-X") and len(token) > 2:
+            explicit = token[2:]
+            index += 1
+            continue
+        option = token.split("=", 1)[0]
+        if (
+            option in SHELL_DATA_OPTIONS | SHELL_FORM_OPTIONS
+            or token.startswith("-d") and len(token) > 2
+            or token.startswith("-F") and len(token) > 2
+        ):
+            inferred = "POST"
+        elif (
+            option in SHELL_UPLOAD_OPTIONS
+            or token.startswith("-T") and len(token) > 2
+        ):
+            inferred = "PUT"
+        elif option in {"-I", "--head"}:
+            inferred = "HEAD"
+        elif option in {"-G", "--get"}:
+            inferred = "GET"
+        elif (
+            token.startswith("-")
+            and not token.startswith("--")
+            and len(token) > 1
+        ):
+            # BUNDLED short options: `curl -fsSd '<json>' <url>` means -f -s -S
+            # -d. Only a bare or `-d<value>` form was inferred as POST, so a
+            # clustered -d left the method at GET and the send was dropped
+            # from the scan entirely.
+            for short_option in token[1:]:
+                if short_option not in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                    continue
+                if short_option == "d":
+                    inferred = "POST"
+                elif short_option == "F":
+                    inferred = "POST"
+                elif short_option == "T":
+                    inferred = "PUT"
+                break
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            index += 2
+        else:
+            index += 1
+
+    if explicit is None:
+        return "GET" if shell_curl_get_mode(tokens[curl_index + 1:]) else inferred
+    if re.search(r"[$`{}()]", explicit):
+        return None
+    return explicit.upper()
+
+
+def shell_payload_values(source: str, start: int, end: int) -> list[str]:
+    """Return curl request-body arguments without executing shell syntax."""
+
+    try:
+        tokens = shlex.split(source[start:end], comments=True, posix=True)
+    except ValueError:
+        return []
+    if shell_curl_get_mode(tokens):
+        return []
+
+    values: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in SHELL_DATA_OPTIONS:
+            if index + 1 < len(tokens):
+                values.append(tokens[index + 1])
+                index += 2
+                continue
+        for option in sorted(SHELL_DATA_OPTIONS, key=len, reverse=True):
+            separator = "=" if token.startswith(f"{option}=") else ""
+            if separator:
+                values.append(token[len(option) + 1 :])
+                break
+            if option == "-d" and token.startswith("-d") and len(token) > 2:
+                values.append(token[2:])
+                break
+        else:
+            # BUNDLED short options: `curl -fsSd '<json>' <url>` is the same as
+            # `-f -s -S -d '<json>'`. Only a bare `-d` or a `-d<value>` prefix
+            # was recognised, so a clustered -d hid the body entirely and the
+            # send was never treated as carrying a payload.
+            if (
+                token.startswith("-")
+                and not token.startswith("--")
+                and len(token) > 1
+            ):
+                for position, short_option in enumerate(token[1:], start=1):
+                    if short_option not in SHELL_CURL_SHORT_VALUE_OPTIONS:
+                        continue
+                    if short_option == "d":
+                        inline = token[position + 1:]
+                        if inline:
+                            values.append(inline)
+                        elif index + 1 < len(tokens):
+                            values.append(tokens[index + 1])
+                            index += 1
+                    break  # a value-taking option consumes the rest
+        index += 1
+    return values
+
+
+def shell_payload_variable(value: str) -> str | None:
+    candidate = value[1:] if value.startswith("@") else value
+    match = SHELL_VARIABLE_RE.fullmatch(candidate)
+    if match is None:
+        return None
+    return match.group(1) or match.group(2)
+
+
+def shell_payload_file_has_profile(
+    value: str, source_path: Path, project_root: Path
+) -> bool:
+    if not value.startswith("@") or "$" in value or value == "@-":
+        return False
+    relative = Path(value[1:])
+    candidates = (
+        relative if relative.is_absolute() else source_path.parent / relative,
+        project_root / relative,
+    )
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+            resolved.relative_to(project_root)
+        except (OSError, ValueError):
+            continue
+        if not resolved.is_file():
+            continue
+        try:
+            payload = resolved.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if serialized_json_has_profile(payload[:1_000_000]):
+            return True
+    return False
+
+
+def _parses_as_json_object(value: str) -> bool:
+    """Return whether the text is a complete JSON object we can judge by value."""
+    try:
+        return isinstance(json.loads(value), dict)
+    except (TypeError, ValueError):
+        return False
+
+
+def shell_inline_payload_has_profile(value: str) -> bool:
+    """Recognize a literal JSON object passed through a curl data option."""
+    return serialized_json_has_profile(value)
+
+
+def payload_spans(
+    lexed: LexedSource,
+    call: Call,
+    suffix: str,
+    mode: str,
+) -> list[tuple[int, int]]:
+    """Select the payload for each supported official request signature."""
+
+    start = call.open_paren + 1
+    end = max(start, call.end - 1 if call.parenthesized else call.end)
+    if mode == "rest":
+        return rest_payload_spans(lexed, call, suffix)
+    arguments = split_arguments(lexed.code, start, end)
+    if suffix == ".go":
+        # Idiomatic Go passes a context first, so the payload is the second
+        # argument - but a single-argument send has its payload in the ONLY
+        # argument. Reading argument 1 there yields no span at all, and a
+        # compliant send is reported missing.
+        return arguments[1:2] or arguments[:1]
+    if suffix in {".py", ".rb", ".php"}:
+        spans = [(start, end)]
+        if mode == "body" and suffix == ".php" and len(arguments) > 1:
+            # twilio-php declares `create(string $to, array $options = [])`
+            # (twilio/twilio-php MessageList::create), so the canonical send
+            # keeps `body` inside the trailing options array - one level below
+            # the argument list this region covers.
+            spans.append(arguments[-1])
+        return spans
+    return arguments[:1]
+
+
+def call_has_profile(
+    lexed: LexedSource,
+    call: Call,
+    suffix: str,
+    source_path: Path,
+    project_root: Path,
+    *,
+    sdk_call: bool,
+    resolver: PayloadStateResolver | None = None,
+) -> bool:
+    resolver = resolver or PayloadStateResolver(
+        lexed, suffix, PROFILE_NAMES, require_value=True
+    )
+    if suffix == ".sh" and not sdk_call:
+        for value in shell_payload_values(lexed.original, call.start, call.end):
+            variable = shell_payload_variable(value)
+            if variable is not None and resolver.presence_for_name(
+                variable, call.start
+            ).state == PRESENT:
+                return True
+            if shell_payload_file_has_profile(value, source_path, project_root):
+                return True
+            # When the body is parseable JSON its VALUE can be checked, so that
+            # verdict is authoritative. text_presence only sees the key, so a
+            # structurally-present but unusable value - `"messaging_profile_id":
+            # {"id": "x"}` - was accepted and the send certified.
+            if _parses_as_json_object(value):
+                if serialized_json_has_profile(value):
+                    return True
+                continue
+            if resolver.text_presence(value).state == PRESENT:
+                return True
+        return False
+    return any(
+        resolver.span_presence(start, end, call.start).state == PRESENT
+        for start, end in payload_spans(
+            lexed, call, suffix, "sdk" if sdk_call else "rest"
+        )
+    )
+
+
+def line_number(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def line_bounds(source: str, offset: int) -> tuple[int, int]:
+    start = source.rfind("\n", 0, offset) + 1
+    end = source.find("\n", offset)
+    return start, len(source) if end < 0 else end
+
+
+def finding_row(path: Path, line: int, detail: str) -> str:
+    """Format ONE findings row - the single site that decides the path shape.
+
+    Every row the analyzer prints goes through here, so the whole run uses one
+    path convention: the path exactly as `iter_source_files` yielded it. Callers
+    depend on that - lint-telnyx-correctness.sh copies these strings verbatim
+    into both `details.files[]` and the printed bullets, so mixing conventions
+    in one run leaves a consumer unable to group, dedupe or open by file.
+    """
+
+    return f"{path}:{line}:{detail}"
+
+
+def call_detail(path: Path, lexed: LexedSource, call: Call) -> str:
+    line_start, line_end = line_bounds(lexed.original, call.start)
+    code_line = lexed.code[line_start:line_end]
+    relative = call.start - line_start
+    statement_start = code_line.rfind(";", 0, relative) + 1
+    statement_end = code_line.find(";", relative)
+    statement_end = len(code_line) if statement_end < 0 else statement_end + 1
+    detail = " ".join(
+        lexed.original[line_start + statement_start : line_start + statement_end].split()
+    )
+    return finding_row(path, line_number(lexed.original, call.start), detail)
+
+
+def static_references(
+    lexed: LexedSource, start: int, end: int
+) -> list[EndpointReference]:
+    """Return identifier/member chains whose property names are static."""
+
+    references: list[EndpointReference] = []
+    strings = {token.start: token for token in lexed.strings}
+    for match in SOURCE_IDENTIFIER_RE.finditer(lexed.code, start, end):
+        if re.search(r"(?:\.|->)\s*$", lexed.code[start:match.start()]):
+            continue
+        parts = [match.group(1)]
+        cursor = match.end()
+        while cursor < end:
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            bracket = False
+            if lexed.code.startswith("?.", cursor):
+                cursor += 2
+                while cursor < end and lexed.code[cursor].isspace():
+                    cursor += 1
+                bracket = cursor < end and lexed.code[cursor] == "["
+            elif lexed.code.startswith("->", cursor):
+                cursor += 2
+            elif cursor < end and lexed.code[cursor] == ".":
+                cursor += 1
+            elif cursor < end and lexed.code[cursor] == "[":
+                bracket = True
+            else:
+                break
+
+            if bracket:
+                cursor += 1
+                while (
+                    cursor < end
+                    and cursor not in strings
+                    and lexed.code[cursor].isspace()
+                ):
+                    cursor += 1
+                token = strings.get(cursor)
+                if token is not None:
+                    key = token.contents
+                    cursor = token.end
+                else:
+                    numeric = re.match(r"\d+", lexed.code[cursor:end])
+                    symbol = re.match(
+                        r":\s*([A-Za-z_]\w*)", lexed.code[cursor:end]
+                    )
+                    if numeric is not None:
+                        key = numeric.group(0)
+                        cursor += len(numeric.group(0))
+                    elif symbol is not None:
+                        key = symbol.group(1)
+                        cursor += len(symbol.group(0))
+                    else:
+                        break
+                while cursor < end and lexed.code[cursor].isspace():
+                    cursor += 1
+                if cursor >= end or lexed.code[cursor] != "]":
+                    break
+                parts.append(key)
+                cursor += 1
+                continue
+
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            member = re.match(r"[A-Za-z_]\w*", lexed.code[cursor:end])
+            if member is None:
+                break
+            member_name = member.group(0)
+            cursor += len(member_name)
+            lookup_cursor = cursor
+            while lookup_cursor < end and lexed.code[lookup_cursor].isspace():
+                lookup_cursor += 1
+            if (
+                member_name in {"fetch", "get", "Get"}
+                and lookup_cursor < end
+                and lexed.code[lookup_cursor] == "("
+            ):
+                closing = matching_delimiter(
+                    lexed.code, lookup_cursor, "(", ")"
+                )
+                if closing is None or closing >= end:
+                    break
+                key = static_lookup_key(
+                    lexed, lookup_cursor + 1, closing
+                )
+                if key is None:
+                    break
+                parts.append(key)
+                cursor = closing + 1
+            else:
+                parts.append(member_name)
+        references.append(tuple(parts))
+
+    for token in lexed.strings:
+        if (
+            token.start < start
+            or token.end > end
+            or lexed.original[token.start] != "`"
+        ):
+            continue
+        for interpolation in re.finditer(r"\$\{([^{}]+)\}", token.contents):
+            expression = interpolation.group(1).strip()
+            root = re.match(r"(\$?[A-Za-z_]\w*)", expression)
+            if root is None:
+                continue
+            parts = [root.group(1)]
+            cursor = root.end()
+            valid = True
+            while cursor < len(expression):
+                whitespace = re.match(r"\s*", expression[cursor:])
+                cursor += len(whitespace.group(0)) if whitespace else 0
+                dot = re.match(
+                    r"(?:\?\.|\.)\s*([A-Za-z_]\w*)",
+                    expression[cursor:],
+                )
+                bracket = re.match(
+                    r"\[\s*(?:['\"]([^'\"]+)['\"]|(\d+))\s*\]",
+                    expression[cursor:],
+                )
+                if dot is not None:
+                    parts.append(dot.group(1))
+                    cursor += len(dot.group(0))
+                elif bracket is not None:
+                    parts.append(bracket.group(1) or bracket.group(2))
+                    cursor += len(bracket.group(0))
+                else:
+                    valid = False
+                    break
+            if valid:
+                references.append(tuple(parts))
+    return references
+
+
+def direct_member_assignments(
+    lexed: LexedSource, before: int, suffix: str
+) -> list[tuple[EndpointReference, int, int, int]]:
+    """Return assignments to static dot/bracket member chains."""
+
+    target = (
+        r"(\$?[A-Za-z_]\w*(?:(?:\s*(?:\.|->)\s*[A-Za-z_]\w*)|"
+        r"(?:\s*\[\s*(?:\"[^\"]*\"|'[^']*'|`[^`]*`|"
+        r":\s*[A-Za-z_]\w*|\d+)\s*\]))+)"
+    )
+    pattern = re.compile(target + r"\s*(?::=|=(?!=|>))")
+    assignments: list[tuple[EndpointReference, int, int, int]] = []
+    for match in pattern.finditer(lexed.without_comments, 0, before):
+        if lexed.code[match.start(1)].isspace():
+            continue
+        references = static_references(lexed, match.start(1), match.end(1))
+        if not references:
+            continue
+        rhs_start = match.end()
+        assignments.append(
+            (
+                references[0],
+                match.start(),
+                rhs_start,
+                assignment_end(lexed, rhs_start, suffix),
+            )
+        )
+    return assignments
+
+
+def top_level_colon(code: str, start: int, end: int) -> int | None:
+    round_depth = square_depth = curly_depth = 0
+    for index in range(start, end):
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif character == ":" and not (round_depth or square_depth or curly_depth):
+            return index
+    return None
+
+
+def static_object_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    code = lexed.code[start:end].strip()
+    if re.fullmatch(r"[A-Za-z_]\w*", code):
+        return code
+    if re.fullmatch(r"\d+", code):
+        return code
+    symbol = re.fullmatch(r":\s*([A-Za-z_]\w*)", code)
+    if symbol is not None:
+        return symbol.group(1)
+    tokens = [
+        token for token in lexed.strings
+        if start <= token.start and token.end <= end
+    ]
+    if len(tokens) != 1:
+        return None
+    residual = (
+        lexed.code[start:tokens[0].start] + lexed.code[tokens[0].end:end]
+    ).strip()
+    return tokens[0].contents if residual in {"", "[]"} else None
+
+
+def static_lookup_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    """Return only literal lookup keys, never a runtime identifier."""
+
+    code = lexed.code[start:end].strip()
+    if re.fullmatch(r"\d+", code):
+        return code
+    symbol = re.fullmatch(r":\s*([A-Za-z_]\w*)", code)
+    if symbol is not None:
+        return symbol.group(1)
+    tokens = [
+        token for token in lexed.strings
+        if start <= token.start and token.end <= end
+    ]
+    if len(tokens) != 1:
+        return None
+    residual = (
+        lexed.code[start:tokens[0].start] + lexed.code[tokens[0].end:end]
+    ).strip()
+    return tokens[0].contents if not residual else None
+
+
+def top_level_assignment_separator(
+    code: str, start: int, end: int
+) -> tuple[int, int] | None:
+    round_depth = square_depth = curly_depth = 0
+    index = start
+    while index < end:
+        character = code[index]
+        if character == "(":
+            round_depth += 1
+        elif character == ")" and round_depth:
+            round_depth -= 1
+        elif character == "[":
+            square_depth += 1
+        elif character == "]" and square_depth:
+            square_depth -= 1
+        elif character == "{":
+            curly_depth += 1
+        elif character == "}" and curly_depth:
+            curly_depth -= 1
+        elif not (round_depth or square_depth or curly_depth):
+            if code.startswith("=>", index):
+                return index, index + 2
+            if (
+                character == "="
+                and not code.startswith(("==", "=>"), index)
+                and (index == start or code[index - 1] not in "!<>=")
+            ):
+                return index, index + 1
+        index += 1
+    return None
+
+
+def matching_opening(
+    code: str, closing: int, left: str, right: str
+) -> int | None:
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == right:
+            depth += 1
+        elif code[index] == left:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def first_argument_is_object(
+    lexed: LexedSource, span: tuple[int, int]
+) -> bool:
+    """Return whether an argument span is an object/dict literal."""
+    text = lexed.code[span[0]:span[1]].strip()
+    return text.startswith("{")
+
+
+def resolved_config_object_span(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> tuple[int, int] | None:
+    """Return the object literal behind an inline or local config alias."""
+
+    if first_argument_is_object(lexed, span):
+        return span
+
+    candidate = lexed.code[span[0]:span[1]].strip()
+    variable_match = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+    if variable_match is None:
+        return None
+    variable = variable_match.group(1)
+    if variable in seen:
+        return None
+    matches = assignment_matches(lexed.code, variable, before)
+    if not matches:
+        return None
+    assignment = matches[-1]
+    rhs_start = assignment.end()
+    rhs_end = assignment_end(lexed, rhs_start, suffix)
+    return resolved_config_object_span(
+        lexed,
+        (rhs_start, rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def config_object_member_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    names: tuple[str, ...],
+) -> list[tuple[int, int]]:
+    """Return selected members of an inline or aliased config object."""
+
+    resolved = resolved_config_object_span(
+        lexed, span, before, suffix
+    )
+    return (
+        named_object_member_spans(lexed, resolved, names)
+        if resolved is not None
+        else []
+    )
+
+
+def config_object_url_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> list[tuple[int, int]]:
+    """Return the URL member of a request-style config object."""
+
+    return config_object_member_spans(
+        lexed, span, before, suffix, URL_MEMBER_NAMES
+    )
+
+
+def named_object_member_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    name: str | tuple[str, ...],
+) -> list[tuple[int, int]]:
+    names = (name,) if isinstance(name, str) else name
+    opening = lexed.code.find("{", span[0], span[1])
+    if opening < 0:
+        return []
+    closing = matching_delimiter(lexed.code, opening, "{", "}")
+    if closing is None or closing >= span[1]:
+        return []
+    values: list[tuple[int, int]] = []
+    for member_start, member_end in split_arguments(
+        lexed.code, opening + 1, closing
+    ):
+        colon = top_level_colon(lexed.code, member_start, member_end)
+        if colon is None:
+            shorthand = lexed.code[member_start:member_end].strip()
+            if shorthand in names:
+                values.append((member_start, member_end))
+            continue
+        if (
+            static_object_key(lexed, member_start, colon) in names
+        ):
+            values.append((colon + 1, member_end))
+    return values
+
+
+def named_argument_spans(
+    lexed: LexedSource,
+    spans: list[tuple[int, int]],
+    name: str,
+) -> list[tuple[int, int]]:
+    """Return top-level keyword/named-argument value spans."""
+
+    values: list[tuple[int, int]] = []
+    for start, end in spans:
+        separator = top_level_assignment_separator(lexed.code, start, end)
+        if separator is None:
+            colon = top_level_colon(lexed.code, start, end)
+            separator = (colon, colon + 1) if colon is not None else None
+        if separator is None:
+            continue
+        separator_start, value_start = separator
+        if lexed.code[start:separator_start].strip().lstrip("$") == name:
+            values.append((value_start, end))
+    return values
+
+
+def call_receiver(lexed: LexedSource, call: Call) -> str | None:
+    # The optional `?` covers optional chaining - JS `client?.post(...)` and
+    # PHP nullsafe `$client?->post(...)`. Without it the receiver reads as
+    # anonymous and the send is discarded by the anonymous-receiver guard,
+    # which is a false negative on a defensive but perfectly ordinary send.
+    match = re.search(
+        r"(\$?[A-Za-z_]\w*)\s*\??\s*(?:\.|->|::)\s*$",
+        lexed.code[max(0, call.start - 120):call.start],
+    )
+    return match.group(1).lstrip("$") if match is not None else None
+
+
+# Factory methods that build an HTTP client which then sends. A `.post()` on
+# such a factory (requests.Session().post, httpx.Client().post,
+# axios.create(...).post) is a real send; a `.post()` on a mock/assertion
+# factory (nock, expect) is not. Distinguishing on the factory method keeps
+# the mocks out of scope without dropping the clients.
+HTTP_CLIENT_FACTORY_METHODS = frozenset(
+    {
+        "Session",
+        "session",  # requests.session() is the documented lowercase alias
+        "Client",
+        "AsyncClient",
+        # aiohttp's client class is named ClientSession, not Client or
+        # Session, so `aiohttp.ClientSession().post(url, json=...)` fell
+        # through the allowlist and the send was discarded entirely.
+        "ClientSession",
+        "create",
+        "Http",
+        "HTTP",
+        # resty builds the request through a chain - client.R().SetBody(x).Post(url)
+        # - so the IMMEDIATE receiver of the send is the last builder link, not
+        # the client. Each link must be recognised or the send is discarded by
+        # the anonymous-receiver guard.
+        "R",
+        "SetBody",
+        "SetJSONBody",
+        "SetFormData",
+        "SetHeader",
+        "SetHeaders",
+        "SetQueryParam",
+        "SetResult",
+    }
+)
+
+
+def factory_receiver_method(lexed: LexedSource, call: Call) -> str | None:
+    """Return the method name of a factory-call receiver, or None.
+
+    For `axios.create(...).post(...)` the receiver is the call `create(...)`,
+    so `call_receiver` returns None; this recovers `create`. For a receiver
+    that is not a call (`foo.post`) it returns None.
+    """
+    prefix = lexed.code[:call.start]
+    accessor = re.search(r"(?:\.|->|::)\s*$", prefix)
+    if accessor is None:
+        return None
+    before = prefix[: accessor.start()].rstrip()
+    if not before.endswith(")"):
+        return None
+    # Walk back to the matching '(' of the factory call.
+    depth = 0
+    index = len(before) - 1
+    while index >= 0:
+        char = before[index]
+        if char == ")":
+            depth += 1
+        elif char == "(":
+            depth -= 1
+            if depth == 0:
+                break
+        index -= 1
+    if index < 0:
+        return None
+    # The factory method sits immediately before the call parens:
+    # requests.Session() -> "Session", axios.create(...) -> "create",
+    # new Client() -> "Client". A receiver wrapped in an extra paren group,
+    # e.g. PHP `(new Client())`, is not recovered here and stays skipped
+    # rather than risking a misread; that shape is left to a future change.
+    name = re.search(r"([A-Za-z_]\w*)\s*$", before[:index])
+    return name.group(1) if name is not None else None
+
+
+def static_method_value(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> str | None:
+    value = argument_string_value(lexed, span)
+    if value is not None:
+        return value.upper()
+    member_constant = re.fullmatch(
+        r"\s*(?:[A-Za-z_]\w*\s*\.\s*)*(?:Http|Request)?Method"
+        r"\s*\.?\s*(Get|Head|Options|Delete|Post|Put|Patch)\s*",
+        lexed.code[slice(*span)],
+        re.IGNORECASE,
+    )
+    if member_constant is not None:
+        return member_constant.group(1).upper()
+    symbol = re.fullmatch(r"\s*:\s*([A-Za-z_]\w*)\s*", lexed.code[slice(*span)])
+    if symbol is not None:
+        return symbol.group(1).upper()
+    variable_match = re.fullmatch(
+        r"\s*(\$?[A-Za-z_]\w*)\s*", lexed.code[slice(*span)]
+    )
+    if variable_match is None or variable_match.group(1) in seen:
+        return None
+    variable = variable_match.group(1)
+    assignments = assignment_matches(lexed.code, variable, before)
+    if not assignments:
+        return None
+    assignment = assignments[-1]
+    rhs_end = assignment_end(lexed, assignment.end(), suffix)
+    return static_method_value(
+        lexed,
+        (assignment.end(), rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+def static_string_value(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+    seen: frozenset[str] = frozenset(),
+) -> str | None:
+    """Resolve a string literal through a bounded local alias chain."""
+
+    value = argument_string_value(lexed, span)
+    if value is not None:
+        return value
+    variable_match = re.fullmatch(
+        r"\s*(\$?[A-Za-z_]\w*)\s*", lexed.code[slice(*span)]
+    )
+    if variable_match is None or variable_match.group(1) in seen:
+        return None
+    variable = variable_match.group(1)
+    assignments = assignment_matches(lexed.code, variable, before)
+    if not assignments:
+        return None
+    assignment = assignments[-1]
+    rhs_end = assignment_end(lexed, assignment.end(), suffix)
+    return static_string_value(
+        lexed,
+        (assignment.end(), rhs_end),
+        assignment.start(),
+        suffix,
+        seen | {variable},
+    )
+
+
+_CSHARP_BODY_RE = re.compile(
+    r"\.\s*(?:Content\s*=|AddJsonBody\s*\(|AddStringBody\s*\(|AddBody\s*\()"
+)
+
+
+# A request OBJECT is not a request. Each client has an explicit execution step;
+# without it the object is constructed and discarded (a builder in a factory, a
+# test fixture, dead code), and reporting it is a false positive.
+_EXECUTION_LINK_RE = {
+    # OkHttp executes via newCall(req).execute()/.enqueue(); java.net.http via
+    # client.send(req, ...) / sendAsync(req, ...).
+    # `\??\s*\.` accepts Kotlin's null-safe call: the .kt/.kts files that now
+    # reach this table spell the same link `client?.newCall(req)?.execute()`,
+    # and requiring a plain dot dropped the send entirely - a silent pass on
+    # idiomatic Kotlin.
+    # `(?:\?|!!)?` accepts both Kotlin null-handling spellings between the call
+    # and the link - `client?.newCall(req)?.execute()` and the non-null
+    # assertion `client!!.newCall(req)!!.execute()`. Requiring a plain dot
+    # dropped the send entirely on idiomatic Kotlin, a silent pass.
+    ".java": (
+        r"newCall\s*\(\s*{name}\s*\)\s*(?:\?|!!)?\s*\.\s*(?:execute|enqueue)\s*\("
+        r"|(?:send|sendAsync)\s*\(\s*{name}\b"
+    ),
+    ".cs": (
+        r"(?:SendAsync|Send)\s*\(\s*{name}\b"
+        r"|Execute\w*\s*(?:<[^>()]*>)?\s*\(\s*(?:[A-Za-z_]\w*\s*,\s*)?{name}\b"
+    ),
+    ".py": r"urlopen\s*\(\s*{name}\b",
+    ".go": r"\.\s*Do\s*\(\s*{name}\b",
+}
+_INLINE_EXECUTION_RE = re.compile(
+    # The constructor may be namespaced inside the execution call, as in
+    # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
+    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do)\s*\(\s*"
+    r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
+)
+
+
+def request_object_is_executed(
+    lexed: LexedSource, call: Call, suffix: str
+) -> bool:
+    """Return whether a constructed request object is actually sent.
+
+    OkHttp needs newCall(req).execute()/.enqueue(), HttpRequestMessage needs
+    SendAsync(req), RestSharp needs Execute*/ExecuteAsync*, urllib needs
+    urlopen(req) and net/http needs client.Do(req). Construction alone is not a
+    send.
+    """
+    canonical = ".java" if suffix in {".kt", ".kts", ".scala"} else suffix
+    pattern = _EXECUTION_LINK_RE.get(canonical)
+    if pattern is None:
+        return True
+
+    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)).
+    prefix = lexed.code[max(0, call.start - 160):call.start]
+    if _INLINE_EXECUTION_RE.search(prefix):
+        return True
+
+    # Otherwise the object must be bound and that binding executed. The bound
+    # name is searched for SPECIFICALLY so two request objects in one scope
+    # cannot borrow each other's execution.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        chain_newline_boundary(lexed.code, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    ) + 1
+    head = lexed.code[statement_start:call.start]
+    assignment = re.search(r"^(.*?)(?::=|=(?!=))", head, re.S)
+    if assignment is None:
+        # An UNBOUND chain can still be executed inline:
+        #   client.send(HttpRequest.newBuilder()...build(), handler)
+        return re.search(
+            r"(?:send|sendAsync|newCall|execute|enqueue|urlopen|Do)\s*\(", head
+        ) is not None
+    # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
+    # never the one executed, so every candidate must be tried.
+    names = [
+        name
+        for name in re.findall(r"[A-Za-z_]\w*", assignment.group(1))
+        if name != "_"
+    ]
+    return any(
+        re.search(pattern.format(name=re.escape(name)), lexed.code[statement_start:])
+        for name in names
+    )
+
+
+def php_stream_context_region(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the stream-context array backing a file_get_contents() call.
+
+    `$ctx = stream_context_create(["http" => ["method" => "POST", "content" =>
+    $json]]); file_get_contents($url, false, $ctx);` - the verb and the body live
+    in the CONTEXT, not in the call, so the call alone looks like a plain read.
+    """
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    if len(args) < 3:
+        return None
+    text = lexed.code[args[2][0]:args[2][1]].strip()
+    if "stream_context_create" in text:
+        return args[2]
+    name = re.fullmatch(r"\$?([A-Za-z_]\w*)", text)
+    if name is None:
+        return None
+    # A PHP variable is written `$ctx`, and assignment_matches' lookbehind
+    # rejects a leading `$`, so the bare name alone never resolves.
+    candidates = [
+        match
+        for form in (text, name.group(1))
+        for match in assignment_matches(lexed.code, form, call.start)
+    ]
+    for assignment in sorted(candidates, key=lambda m: m.start(), reverse=True):
+        start = assignment.end()
+        end = assignment_end(lexed, start, suffix)
+        if "stream_context_create" in lexed.code[start:end]:
+            return (start, end)
+    return None
+
+
+def xhr_send_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the body passed to `.send(...)` after an XHR `.open(...)`.
+
+    XMLHttpRequest splits one request across two calls on the same object:
+    `x.open('POST', url)` carries the endpoint and method, `x.send(body)` the
+    payload. Neither call alone describes the send.
+    """
+    receiver = call_receiver(lexed, call)
+    if receiver is None:
+        return None
+    # `call_receiver` strips a leading `$` (PHP/JS sigil), so the name is
+    # searched back into source that still spells it `$xhr`. Keeping `$` in the
+    # lookbehind without allowing the sigil made every `$`-prefixed JS
+    # identifier ($xhr, $http) unmatchable, losing the `.send(...)` body and
+    # reporting a compliant send as missing the profile.
+    match = re.search(
+        rf"(?<![\w$])\$?{re.escape(receiver)}\s*(?:\?\.|\.)\s*send\s*\(",
+        lexed.code[call.end:],
+    )
+    if match is None:
+        return None
+    open_paren = call.end + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    if not inner:
+        return None
+    return resolve_wrapped_payload(lexed, inner[0], inner[0][0], suffix)
+
+
+def csharp_request_body_span(
+    lexed: LexedSource, call: Call, suffix: str
+) -> tuple[int, int] | None:
+    """Return the body attached to a C# request object after construction.
+
+    `new HttpRequestMessage(HttpMethod.Post, url)` and `new RestRequest(url,
+    Method.Post)` carry only the endpoint; the body arrives in a LATER statement
+    (`req.Content = new StringContent(json)`, `req.AddJsonBody(...)`), so the
+    constructor's own arguments never reveal it.
+    """
+    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    assigned = re.search(
+        r"([A-Za-z_][\w]*)\s*=\s*$", lexed.code[line_start:call.start].rstrip()[:200]
+    ) or re.search(
+        r"(?:var|[A-Za-z_][\w<>\[\]]*)\s+([A-Za-z_][\w]*)\s*=",
+        lexed.code[line_start:call.start],
+    )
+    if assigned is None:
+        return None
+    name = assigned.group(1)
+    for match in re.finditer(
+        rf"(?<![\w]){re.escape(name)}\s*(?=\.)", lexed.code[call.end:]
+    ):
+        tail = lexed.code[call.end + match.end():]
+        body = _CSHARP_BODY_RE.match(tail)
+        if body is None:
+            continue
+        base = call.end + match.end() + body.end()
+        if tail[body.end() - 1] == "(":
+            closing = matching_delimiter(lexed.code, base - 1, "(", ")")
+            if closing is None:
+                continue
+            inner = split_arguments(lexed.code, base, closing)
+            span = inner[0] if inner else None
+        else:
+            end = lexed.code.find(";", base)
+            span = (base, end if end > 0 else len(lexed.code))
+        if span is not None:
+            return resolve_wrapped_payload(lexed, span, span[0], suffix)
+    return None
+
+
+# A wrapped fluent chain is ONE statement written two ways. Go (and Python
+# inside brackets) puts the dot at the END of the previous line; Java, Kotlin,
+# C#, JavaScript and TypeScript put it at the START of the next one, which is
+# by far the more common formatting:
+#
+#     Request r = new Request.Builder().url(URL)
+#         .post(body).build();
+#
+# Only the trailing-dot half used to be recognised, so every window bounded by
+# a newline was truncated at the first wrap. That cost the chain its own
+# binding (`Request r =`), which is what the execution-link check searches for
+# - so a multi-line OkHttp builder was unresolvable while the byte-identical
+# single-line spelling resolved fine, and the fail-safe backstop then reported
+# a correct send as "could not verify".
+#
+# The leading-dot form requires the identifier to touch the dot (`.post`, never
+# `. post`). That is how fluent chains are written, and it keeps shell's `.`
+# source command (`. env.sh`) from reading as a continuation.
+_LEADING_CHAIN_LINK_RE = re.compile(r"\.[A-Za-z_]")
+
+
+def newline_continues_chain(code: str, newline: int) -> bool:
+    """Whether the newline at `newline` is a chain wrap rather than a boundary.
+
+    Both halves look only at the text either side of the newline itself. An
+    earlier draft bounded the lookahead at the CALLER's position, which for the
+    leading-dot form is the dot itself - so the identifier that proves it is a
+    chain link sat outside the window and the test could never fire.
+    """
+    if code[max(0, newline - 200):newline].rstrip().endswith("."):
+        return True
+    following = code[newline:newline + 200].lstrip()
+    return bool(_LEADING_CHAIN_LINK_RE.match(following))
+
+
+def chain_newline_boundary(code: str, position: int) -> int:
+    """Index of the newline that really ends the statement before `position`.
+
+    Walks back over newlines that only wrap a fluent chain. Callers combine
+    this with `rfind(";")`/`rfind("{")` under `max()`, so a genuine terminator
+    on an earlier line still wins and the widened window cannot swallow a
+    preceding statement.
+    """
+    index = code.rfind("\n", 0, position)
+    while index > 0 and newline_continues_chain(code, index):
+        index = code.rfind("\n", 0, index)
+    return index
+
+
+def _go_block_brace(code: str, start: int) -> int:
+    """Index of the `{` that opens a Go statement BODY, scanning from `start`.
+
+    Go headers are brace-ambiguous: a composite literal (`cfg{A: 1}`,
+    `map[string]int{...}`, `[]T{...}`) puts a brace in the header that does not
+    open the block. A literal's brace is always preceded by a type expression -
+    an identifier, or the `]` closing a slice/map type - whereas a block's brace
+    follows an operator, a paren, or nothing. Balanced runs of `()`/`[]` are
+    skipped so a brace nested inside them is never mistaken for either.
+
+    Returns -1 when no body brace is found before the statement ends.
+    """
+    index, depth = start, 0
+    while index < len(code):
+        char = code[index]
+        if char in "([":
+            depth += 1
+        elif char in ")]":
+            depth -= 1
+            if depth < 0:
+                return -1
+        elif char == "}" and depth == 0:
+            return -1
+        elif char == "{" and depth == 0:
+            # ADJACENCY is the discriminator, not the preceding token class:
+            # `switch mode {` also puts an identifier before the brace, so
+            # testing the token alone classified every ordinary switch as a
+            # composite literal. Go composite literals are written with the
+            # brace touching the type (`cfg{`, `map[string]int{`), and a block
+            # brace is always separated by whitespace.
+            prefix = code[max(0, index - 200):index]
+            if prefix and (prefix[-1].isalnum() or prefix[-1] in "_]"):
+                # A composite literal: skip its balanced body and keep looking.
+                closing = matching_delimiter(code, index, "{", "}")
+                if closing is None:
+                    return -1
+                index = closing
+            else:
+                return index
+        index += 1
+    return -1
+
+
+def _top_level_ternary(
+    code: str, start: int, end: int
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    """Split `cond ? a : b` into its two arms, or None if this is not a ternary.
+
+    Skips balanced brackets so a `?` inside an argument list is not mistaken for
+    the operator, and ignores JS optional chaining (`?.`) and nullish
+    coalescing (`??`).
+    """
+    depth = question = -1
+    depth = 0
+    for index in range(start, end):
+        char = code[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "?" and depth == 0:
+            if code[index + 1:index + 2] in (".", "?"):
+                continue
+            question = index
+            break
+    if question < 0:
+        return None
+    depth = 0
+    for index in range(question + 1, end):
+        char = code[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == ":" and depth == 0:
+            return (question + 1, index), (index + 1, end)
+    return None
+
+
+def chain_statement_start(code: str, position: int) -> int:
+    """Index of the statement boundary preceding a chained call.
+
+    A raw `rfind` for `;`/`{`/newline stops inside the chain's own arguments:
+    `SetBody(map[string]string{...}).Post(url)` puts a `{` between the body
+    link and the send, so the search window began AFTER the very link being
+    looked for. Scan backwards instead, skipping balanced `()`/`{}`/`[]` runs,
+    and treat a newline as a boundary only when it is not a chain wrap in
+    either of the two spellings above.
+    """
+    depth = 0
+    index = position - 1
+    while index >= 0:
+        char = code[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth == 0:
+                return index
+            depth -= 1
+        elif depth == 0 and char in ";\n":
+            if char == "\n" and newline_continues_chain(code, index):
+                index -= 1
+                continue
+            return index
+        index -= 1
+    return -1
+
+
+def builder_body_span(
+    lexed: LexedSource, call: Call, methods: str
+) -> tuple[int, int] | None:
+    """Return the body argument set by an earlier link of the same chain.
+
+    resty spells it `client.R().SetBody(payload).Post(url)`: the endpoint is the
+    send call's argument while the BODY was attached upstream, the mirror image
+    of the java/OkHttp builders.
+    """
+    statement_start = chain_statement_start(lexed.code, call.start)
+    window = lexed.code[statement_start + 1:call.start]
+    last = None
+    for match in re.finditer(rf"\.\s*(?:{methods})\s*\(", window):
+        last = match
+    if last is None:
+        return None
+    open_paren = statement_start + 1 + last.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > call.start:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else None
+
+
+def builder_uri_span(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Return the .uri(...)/.url(...) argument preceding a builder send call.
+
+    java.net.http uses `.uri(URI.create(URL))`; OkHttp uses `.url(URL)`. Both
+    put the endpoint in an EARLIER link of the same chain than the call that
+    performs the send, so the send argument alone never reveals the endpoint.
+    """
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    )
+    window = lexed.code[statement_start + 1:call.start]
+    last = None
+    matched_link = None
+    for match in re.finditer(r"\.\s*(?:uri|url)\s*\(", window):
+        last = match
+        matched_link = "url" if "url" in match.group(0) else "uri"
+    if last is None:
+        return None
+    open_paren = statement_start + 1 + last.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > call.start:
+        return None
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    if not inner:
+        return None
+    _BUILDER_LINK_KIND[(id(lexed), call.start)] = matched_link
+    return inner[0]
+
+
+# Which builder link supplied the endpoint for a given call: "uri" for
+# java.net.http, "url" for OkHttp. Recorded rather than re-sniffed, because a
+# substring search for ".url" in the preceding source also matches an unrelated
+# `this.url` / `cfg.url` and silently rerouted java.net.http chains into the
+# OkHttp branch, where the execution-link requirement then discarded the send.
+_BUILDER_LINK_KIND: dict[tuple[int, int], str | None] = {}
+
+
+PAYLOAD_WRAPPER_RE = re.compile(
+    # `new` is optional so the C# constructor forms below match the same way
+    # the static factories above do.
+    r"^\s*(?:new\s+)?(?:bytes\s*\.\s*NewBuffer|bytes\s*\.\s*NewReader|"
+    r"strings\s*\.\s*NewReader|json\s*\.\s*Marshal|json_encode|"
+    r"RequestBody\s*\.\s*create|okhttp3\s*\.\s*RequestBody\s*\.\s*create|"
+    # C# attaches the body as `req.Content = new StringContent(json, ...)`.
+    # `csharp_request_body_span` already resolved that span, but without the
+    # wrapper listed here the presence check ran against the CONSTRUCTOR text
+    # rather than the JSON inside it - so a compliant HttpRequestMessage send
+    # was reported as missing the profile, and a non-compliant one was flagged
+    # for the wrong reason.
+    r"StringContent|JsonContent\s*\.\s*Create|"
+    # .NET serializers. Without these the resolver stopped at
+    # `JsonSerializer.Serialize(payload)` and never reached the payload
+    # variable, so every field written via Dictionary.Add was invisible and a
+    # compliant C# send was reported as missing the profile.
+    r"JsonSerializer\s*\.\s*Serialize|JsonConvert\s*\.\s*SerializeObject)"
+    r"\s*\("
+)
+
+
+# A wrapper's payload is not always its FIRST argument. OkHttp ships both
+# `RequestBody.create(body, mediaType)` and the deprecated
+# `RequestBody.create(mediaType, body)` - and Kotlin code overwhelmingly uses
+# the latter. Taking argument 0 unconditionally resolved the MEDIA TYPE as the
+# payload, so `messaging_profile_id` was invisible and a compliant send was
+# reported as missing it.
+#
+# Selection is POSITIVE - identify the argument that looks like a BODY - rather
+# than a deny-list of media-type spellings. An earlier draft enumerated the
+# media-type factories instead, and each spelling it did not list reopened the
+# same false positive: a bound `static final MediaType JSON` constant (the
+# spelling in OkHttp's own README), and Kotlin's `"application/json"
+# .toMediaType()`. Enumerating producers cannot terminate; asking what a
+# payload looks like can.
+_MEDIA_TYPE_FACTORY_RE = re.compile(
+    r"(?:[\w.]*\bMediaType\s*\.\s*(?:parse|get)\s*\(|\bContentType\s*\.|"
+    r"\.\s*toMediaTypeOrNull\s*\(|\.\s*toMediaType\s*\(|"
+    r"\bMediaTypeHeaderValue\s*\()"
+)
+# A MIME literal is `type/subtype` with an optional parameter tail, and nothing
+# else. A JSON body is never shaped like that, so a real payload cannot be
+# skipped by this test.
+_MIME_LITERAL_RE = re.compile(
+    r"""^\s*(["'])[\w.+-]+/[\w.+-]+(?:\s*;[^"']*)?\1\s*$"""
+)
+# A body announces itself: a quoted literal whose content opens a JSON object or
+# array, or an inline object/array/map literal.
+_BODY_LITERAL_RE = re.compile(r"""^\s*(?:["'`]\s*[\{\[]|[\{\[])""")
+# Last-resort tiebreak only (see payload_argument). Names that read as a content
+# type rather than a payload. Deliberately narrow: it must not match a name a
+# real body would plausibly carry, so `body`, `payload`, `data` and `content`
+# are absent - `content` in particular appears in `StringContent`, a body.
+_CONTENT_TYPE_NAME_RE = re.compile(
+    r"(?i)(?:\bmedia[_]?type|\bmime\b|\bcontent[_]?type|\bJSON_TYPE\b|\bTYPE\b)"
+)
+# Postfix wrapper: the payload is the RECEIVER. Kotlin/OkHttp 4 spells body
+# construction this way (`json.toRequestBody(contentType)`), the mirror image of
+# every prefix wrapper above.
+# Anchored on the CALL, with the receiver taken as everything before it. A
+# pattern that tried to capture the receiver directly matched the blanks inside
+# a masked string literal instead: lex_source blanks the quotes as well as the
+# content, so on `"{...}".toRequestBody(...)` the receiver is indistinguishable
+# from whitespace in `lexed.code` and must be delimited by offset, not by shape.
+_POSTFIX_PAYLOAD_WRAPPER_RE = re.compile(
+    r"\.\s*(?:toRequestBody|toResponseBody)\s*\("
+)
+# `new X(...)` is NOT evidence of a body: `new MediaTypeHeaderValue("application
+# /json")` and `new StringContent(...)` are both spelled that way, so accepting
+# every constructor let a CONTENT-TYPE argument win the positive body test and
+# outrank the real payload. Only composite literals - Go maps and struct/object
+# literals, which are brace-initialised - count here; a constructor has to earn
+# it through PAYLOAD_WRAPPER_RE like every other wrapper.
+_MAP_LITERAL_RE = re.compile(r"^\s*(?:map\[|new\s+\w[\w.<>\[\]]*\s*\{|\w+\s*\{)")
+
+
+def _is_media_type_argument(
+    lexed: LexedSource, span: tuple[int, int], before: int
+) -> bool:
+    """Whether an argument denotes a CONTENT TYPE rather than a payload."""
+    code_text = lexed.code[span[0]:span[1]]
+    if _MEDIA_TYPE_FACTORY_RE.search(code_text):
+        return True
+    if _MIME_LITERAL_RE.match(lexed.original[span[0]:span[1]]):
+        return True
+    # An identifier reveals nothing by itself; resolve what it was assigned.
+    # `static final MediaType JSON = MediaType.parse(...)` is the OkHttp README
+    # spelling, and without this hop the constant read as the payload. The name
+    # may be QUALIFIED (`HttpConstants.JSON`, `this.jsonType`, `Companion.JSON`)
+    # - resolving only the bare form left every qualified constant unclassified,
+    # so it fell through as "not a media type" and won the argument.
+    bare = code_text.strip().rsplit(".", 1)[-1].strip()
+    variable = SIMPLE_VARIABLE_RE.fullmatch(bare)
+    if variable is None:
+        return False
+    # Searched across the WHOLE file, not just above the send. A media-type
+    # constant is conventionally declared at the BOTTOM of the class in Kotlin
+    # (`companion object { val JSON = ... }`) and in Java, so bounding the
+    # lookup at the call site left those unclassified and the media type won the
+    # argument. Safe here because the result only decides which argument is the
+    # CONTENT TYPE - it never decides whether a profile value is present.
+    matches = assignment_matches(lexed.code, variable.group(1), len(lexed.code))
+    if not matches:
+        matches = assignment_matches(lexed.code, variable.group(1), before)
+    if not matches:
+        return False
+    rhs_start = matches[-1].end()
+    rhs_code = lexed.code[rhs_start:rhs_start + 200]
+    if _MEDIA_TYPE_FACTORY_RE.search(rhs_code.split("\n")[0]):
+        return True
+    rhs_original = lexed.original[rhs_start:rhs_start + 200].split("\n")[0]
+    return bool(_MIME_LITERAL_RE.match(rhs_original.strip().rstrip(";,")))
+
+
+def _is_body_argument(lexed: LexedSource, span: tuple[int, int]) -> bool:
+    """Whether an argument positively looks like a request payload."""
+    if _BODY_LITERAL_RE.match(lexed.original[span[0]:span[1]]):
+        return True
+    code_text = lexed.code[span[0]:span[1]]
+    if _BODY_LITERAL_RE.match(code_text) or _MAP_LITERAL_RE.match(code_text):
+        return True
+    return bool(PAYLOAD_WRAPPER_RE.match(code_text) or
+                STRINGIFIED_VARIABLE_RE.search(code_text))
+
+
+def payload_argument(
+    lexed: LexedSource, inner: list[tuple[int, int]]
+) -> tuple[int, int] | None:
+    """Pick the argument carrying the BODY, skipping content-type arguments."""
+    if len(inner) <= 1:
+        return inner[0] if inner else None
+    before = inner[0][0]
+    bodies = [span for span in inner if _is_body_argument(lexed, span)]
+    if bodies:
+        return bodies[0]
+    for span in inner:
+        if not _is_media_type_argument(lexed, span, before):
+            return span
+    # Nothing was positively identified either way. That happens when both
+    # arguments are plain identifiers and the media-type constant could not be
+    # resolved - a qualified name whose last segment collides with an unrelated
+    # variable, or a declaration in another file. Falling through to argument 0
+    # then picked the MEDIA TYPE for the deprecated
+    # `RequestBody.create(mediaType, body)` order. As a last resort only, prefer
+    # the argument whose NAME does not read as a content type. This is a
+    # tiebreak, never an override: any positively identified body above wins.
+    named = [
+        span for span in inner
+        if not _CONTENT_TYPE_NAME_RE.search(lexed.code[span[0]:span[1]])
+    ]
+    if named:
+        return named[0]
+    return inner[0]
+
+
+def resolve_wrapped_payload(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> tuple[int, int]:
+    """Follow reader/stringifier wrappers and variables to the payload.
+
+    bytes.NewBuffer(body) -> body -> json.Marshal(payload) -> payload -> the
+    map literal. The literal is where messaging_profile_id is provably
+    present or absent; stopping at any earlier hop reports compliant code as
+    missing the profile.
+    """
+    for _ in range(6):
+        text = lexed.code[span[0]:span[1]]
+        # Kotlin/OkHttp 4 wraps the body as an EXTENSION on it -
+        # `body.toRequestBody(mediaType)` - so the payload is the receiver, not
+        # an argument. Every wrapper above is prefix-shaped, so without this the
+        # whole expression was treated as the payload and the JSON inside it was
+        # never inspected.
+        postfix = _POSTFIX_PAYLOAD_WRAPPER_RE.search(text)
+        if postfix is not None and postfix.start() > 0:
+            start, end = span[0], span[0] + postfix.start()
+            # Trim against the ORIGINAL: a masked literal is blank in `code`,
+            # so trimming there would consume the payload itself.
+            while start < end and lexed.original[start].isspace():
+                start += 1
+            while end > start and lexed.original[end - 1].isspace():
+                end -= 1
+            if end > start:
+                span = (start, end)
+                continue
+        wrapper = PAYLOAD_WRAPPER_RE.match(text)
+        if wrapper is not None:
+            open_paren = span[0] + wrapper.end() - 1
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None or closing > span[1]:
+                return span
+            inner = split_arguments(lexed.code, open_paren + 1, closing)
+            if not inner:
+                return span
+            chosen = payload_argument(lexed, inner)
+            if chosen is None:
+                return span
+            span = chosen
+            continue
+        candidate = text.strip()
+        variable = SIMPLE_VARIABLE_RE.fullmatch(candidate)
+        if variable is None:
+            return span
+        matches = assignment_matches(lexed.code, variable.group(1), before)
+        if not matches:
+            return span
+        assignment = matches[-1]
+        rhs_start = assignment.end()
+        rhs = (rhs_start, assignment_end(lexed, rhs_start, suffix))
+        rhs_text = lexed.code[rhs[0]:rhs[1]]
+        # The postfix wrapper counts as a wrapper hop too. Kotlin binds the body
+        # first as often as it inlines it (`val body = json.toRequestBody(type)`
+        # then `.post(body)`), and recognising only prefix wrappers here left the
+        # variable unresolved, so a compliant Kotlin/OkHttp-4 send was always
+        # reported as missing the profile.
+        if (
+            PAYLOAD_WRAPPER_RE.match(rhs_text) is None
+            and _POSTFIX_PAYLOAD_WRAPPER_RE.search(rhs_text) is None
+        ):
+            # Only serializer/reader hops need chasing: the resolver cannot see
+            # through json.Marshal/json_encode. Collapsing a plain variable to
+            # its declaration literal instead DISCARDS every later mutation
+            # (`payload["messaging_profile_id"] = ""`), certifying a send whose
+            # profile was emptied. Stop here and let the mutation-aware
+            # resolver evaluate the variable itself.
+            return span
+        span = rhs
+        before = assignment.start()
+    return span
+
+
+BODY_PUBLISHER_RE = re.compile(
+    r"^\s*(?:(?:HttpRequest\s*\.\s*)?BodyPublishers\s*\.\s*of\w+"
+    r"|(?:okhttp3\s*\.\s*)?RequestBody\s*\.\s*create)\s*\("
+)
+
+
+def unwrap_body_publisher(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel BodyPublishers.ofString(...) down to the payload expression."""
+    text = lexed.code[span[0]:span[1]]
+    match = BODY_PUBLISHER_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else span
+
+
+def php_curl_transaction_bounds(
+    lexed: LexedSource, handle: str, anchor: int
+) -> tuple[int, int]:
+    """Bound the handle transaction containing a URL-setting call."""
+
+    exec_pattern = re.compile(
+        r"curl_exec\s*\(\s*" + re.escape(handle) + r"\s*\)"
+    )
+    previous_exec = list(exec_pattern.finditer(lexed.code, 0, anchor))
+    start = previous_exec[-1].end() if previous_exec else 0
+    next_exec = exec_pattern.search(lexed.code, anchor)
+    return start, next_exec.start() if next_exec is not None else len(lexed.code)
+
+
+def curl_postfields_spans(
+    lexed: LexedSource, handle: str, anchor: int, suffix: str
+) -> list[tuple[int, int]]:
+    """Return POSTFIELDS spans from the same curl handle transaction."""
+
+    transaction_start, transaction_end = php_curl_transaction_bounds(
+        lexed, handle, anchor
+    )
+    pattern = re.compile(
+        r"curl_setopt\s*\(\s*" + re.escape(handle)
+        + r"\s*,\s*CURLOPT_POSTFIELDS\s*,"
+    )
+    # The two curl option forms mix freely on one handle. Reading only the
+    # per-option form here made the body invisible whenever the URL arrived
+    # through curl_setopt(CURLOPT_URL) but the body through
+    # curl_setopt_array() - a compliant send was then reported as missing its
+    # profile. Spans are ordered by position so the last write still wins.
+    array_pattern = re.compile(
+        r"curl_setopt_array\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+
+    def collect(start: int, end: int) -> list[tuple[int, int]]:
+        found: list[tuple[int, tuple[int, int]]] = []
+        for match in pattern.finditer(lexed.code, start, end):
+            open_paren = lexed.code.index("(", match.start())
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None:
+                continue
+            arguments = split_arguments(lexed.code, open_paren + 1, closing)
+            if len(arguments) >= 3:
+                found.append((open_paren, arguments[2]))
+        for match in array_pattern.finditer(lexed.code, start, end):
+            open_paren = lexed.code.index("(", match.start())
+            closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+            if closing is None:
+                continue
+            arguments = split_arguments(lexed.code, open_paren + 1, closing)
+            if len(arguments) >= 2:
+                found.extend(
+                    (open_paren, span)
+                    for span in curl_option_array_value_spans(
+                        lexed, arguments[1], suffix, "CURLOPT_POSTFIELDS"
+                    )
+                )
+        return [span for _, span in sorted(found)]
+
+    spans = collect(transaction_start, transaction_end)
+    if not spans:
+        # POSTFIELDS persists on the handle across exec until overwritten or
+        # reset, so a transaction that only changes CURLOPT_URL still sends the
+        # body set earlier. Fall back to the most recent carried value.
+        state_start = php_curl_handle_state_start(lexed, handle, anchor)
+        carried = collect(state_start, transaction_start)
+        if carried:
+            spans = carried[-1:]
+    return spans
+
+
+_CURL_ARRAY_OPTION_RE = re.compile(
+    r"\s*['\"]?(CURLOPT_[A-Z_]+)['\"]?\s*=>"
+)
+
+
+def curl_option_array_value_spans(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    suffix: str,
+    option: str,
+) -> list[tuple[int, int]]:
+    """Return the value spans for one option inside a curl option ARRAY.
+
+    curl_setopt_array($ch, [CURLOPT_URL => ..., CURLOPT_POSTFIELDS => ...]) is
+    as idiomatic as repeated curl_setopt() calls, but only the per-option call
+    form was recognized, so a number-pool send configured this way was never
+    visited at all. Keys are read from the ORIGINAL source (the masked view
+    blanks string contents); values stay offset-accurate for the resolvers.
+    """
+    container = root_literal_container(lexed, span[0], span[1], suffix)
+    if container is None:
+        return []
+    _, opening, closing = container
+    spans: list[tuple[int, int]] = []
+    for element in split_arguments(lexed.code, opening + 1, closing):
+        match = _CURL_ARRAY_OPTION_RE.match(
+            lexed.original, element[0], element[1]
+        )
+        if match is not None and match.group(1) == option:
+            spans.append((match.end(), element[1]))
+    return spans
+
+
+def php_curl_handle_state_start(
+    lexed: LexedSource, handle: str, anchor: int
+) -> int:
+    """Return where the handle's CARRIED option state begins.
+
+    ext-curl options persist on a handle across curl_exec() until they are
+    overwritten or curl_reset() is called — they are NOT cleared by the exec.
+    State therefore begins at the last curl_reset()/curl_init() before the
+    anchor, not after the previous exec.
+    """
+    latest = 0
+    for pattern in (
+        r"curl_reset\s*\(\s*" + re.escape(handle) + r"\s*\)",
+        re.escape(handle) + r"\s*=\s*curl_init\s*\(",
+    ):
+        matches = list(re.finditer(pattern, lexed.code, 0))
+        for match in matches:
+            if match.end() <= anchor and match.end() > latest:
+                latest = match.end()
+    return latest
+
+
+def php_curl_handle_method(
+    lexed: LexedSource, handle: str, url_call_start: int, suffix: str
+) -> str | None:
+    """Return the method used by the handle's next curl_exec transaction."""
+
+    transaction_start, transaction_end = php_curl_transaction_bounds(
+        lexed, handle, url_call_start
+    )
+    # Options set before an earlier exec are STILL IN EFFECT unless overwritten
+    # or reset, so a handle that posted once and then only changes CURLOPT_URL
+    # is still POSTing. Scanning from the previous exec made that second
+    # transaction look like a fresh GET, and the required send escaped.
+    state_start = php_curl_handle_state_start(lexed, handle, url_call_start)
+    if state_start < transaction_start:
+        transaction_start = state_start
+    setter_pattern = re.compile(
+        r"curl_setopt\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+    array_pattern = re.compile(
+        r"curl_setopt_array\s*\(\s*" + re.escape(handle) + r"\s*,"
+    )
+
+    # Both option forms must be applied in SOURCE ORDER so that later settings
+    # win. Scanning only curl_setopt() left the array form's method invisible,
+    # so an array-configured GET looked like a required send.
+    events: list[tuple[int, str, tuple[int, int]]] = []
+    for match in setter_pattern.finditer(
+        lexed.code, transaction_start, transaction_end
+    ):
+        opening = lexed.code.index("(", match.start())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None or closing > transaction_end:
+            continue
+        arguments = split_arguments(lexed.code, opening + 1, closing)
+        if len(arguments) < 3:
+            continue
+        events.append(
+            (match.start(), lexed.code[slice(*arguments[1])].strip(), arguments[2])
+        )
+    for match in array_pattern.finditer(
+        lexed.code, transaction_start, transaction_end
+    ):
+        opening = lexed.code.index("(", match.start())
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is None or closing > transaction_end:
+            continue
+        arguments = split_arguments(lexed.code, opening + 1, closing)
+        if len(arguments) < 2:
+            continue
+        container = root_literal_container(
+            lexed, arguments[1][0], arguments[1][1], suffix
+        )
+        if container is None:
+            continue
+        _, array_open, array_close = container
+        for element in split_arguments(lexed.code, array_open + 1, array_close):
+            key = _CURL_ARRAY_OPTION_RE.match(
+                lexed.original, element[0], element[1]
+            )
+            if key is not None:
+                events.append(
+                    (element[0], key.group(1), (key.end(), element[1]))
+                )
+
+    method = "GET"
+    custom_method: str | None = None
+    for position, option, value_span in sorted(events, key=lambda event: event[0]):
+        value = lexed.code[slice(*value_span)].strip().lower()
+        if option == "CURLOPT_CUSTOMREQUEST":
+            resolved = static_method_value(
+                lexed, value_span, position, suffix
+            )
+            if resolved is None:
+                return None
+            custom_method = resolved
+        elif option == "CURLOPT_POSTFIELDS":
+            method = "POST"
+        elif option == "CURLOPT_POST":
+            if value in {"true", "1"}:
+                method = "POST"
+            elif value in {"false", "0"}:
+                method = "GET"
+            else:
+                return None
+        elif option == "CURLOPT_HTTPGET" and value in {"true", "1"}:
+            method = "GET"
+        elif option == "CURLOPT_NOBODY" and value in {"true", "1"}:
+            method = "HEAD"
+        elif option in {"CURLOPT_UPLOAD", "CURLOPT_PUT"}:
+            if value in {"true", "1"}:
+                method = "PUT"
+            elif value not in {"false", "0"}:
+                return None
+    return custom_method or method
+
+
+ASSIGNED_HANDLE_RE = re.compile(
+    r"([A-Za-z_$][\w$]*)\s*=\s*(?:new\s+)?(?:[A-Za-z_$][\w$]*\s*\.\s*)?$"
+)
+
+
+def request_write_payload_spans(
+    lexed: LexedSource, call: Call
+) -> list[tuple[int, int]]:
+    """Return <handle>.write(...) payload spans after a request(...) call."""
+    prefix = lexed.code[max(0, call.start - 160):call.start]
+    match = ASSIGNED_HANDLE_RE.search(prefix)
+    if match is None:
+        return []
+    handle = match.group(1)
+    write_re = re.compile(
+        r"(?<![\w$])" + re.escape(handle) + r"\s*\.\s*write\s*\("
+    )
+    spans: list[tuple[int, int]] = []
+    for found in write_re.finditer(lexed.code, call.end):
+        open_paren = lexed.code.index("(", found.end() - 1)
+        closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+        if closing is None:
+            continue
+        arguments = split_arguments(lexed.code, open_paren + 1, closing)
+        if arguments:
+            spans.append(arguments[0])
+    return spans
+
+
+URL_CONSTRUCTOR_RE = re.compile(
+    r"^\s*(?:new\s+)?(?:URI|URL)(?:\s*\.\s*(?:create|parse|join))?\s*\("
+)
+
+
+def unwrap_url_constructor(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel URI(...) / URI.create(...) / new URL(...) down to the URL itself.
+
+    Ruby's Net::HTTP and Java's HttpRequest REQUIRE the wrapped form, so a
+    resolver that only reads bare strings treated the mandatory spelling as
+    an unknown expression and dropped the call entirely.
+    """
+    text = lexed.code[span[0]:span[1]]
+    match = URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if inner else span
+
+
+def unwrap_bound_url_constructor(
+    lexed: LexedSource, span: tuple[int, int]
+) -> tuple[int, int]:
+    """Peel a URI/URL constructor held in a BINDING's right-hand side.
+
+    `uri = URI(URL); Net::HTTP.post(uri, body)` is as idiomatic as the inline
+    spelling, but unwrapping only ran on the call-argument span, so the binding
+    stayed an unknown expression and the send resolved to nothing.
+
+    Narrower than `unwrap_url_constructor` on purpose: a binding carries no
+    companion base lookup, so the two-argument `new URL(path, base)` form must
+    stay unresolved rather than collapse to its (safe-looking) path, and a
+    trailing member call (`URI.create(u).resolve(x)`) must not be discarded.
+    """
+    text = lexed.code[span[0]:span[1]]
+    match = URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return span
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing >= span[1]:
+        return span
+    if lexed.code[closing + 1:span[1]].strip():
+        return span
+    inner = split_arguments(lexed.code, open_paren + 1, closing)
+    return inner[0] if len(inner) == 1 else span
+
+
+# Only JS/TS `new URL(path, base)` — the WHATWG constructor whose second
+# argument is a base. Java/Python `URI(...)` multi-argument constructors have
+# different semantics (Java's two-arg form is (scheme, ssp), NOT (path, base)),
+# so combining their arguments would misclassify unrelated calls.
+_JS_URL_CONSTRUCTOR_RE = re.compile(r"^\s*(?:new\s+)?URL\s*\(")
+
+
+def url_constructor_base(
+    lexed: LexedSource, span: tuple[int, int], suffix: str
+) -> str | None:
+    """Return the static base of a JS/TS `new URL(path, base)` span."""
+    if suffix not in JS_TS_SUFFIXES:
+        return None
+    text = lexed.code[span[0]:span[1]]
+    match = _JS_URL_CONSTRUCTOR_RE.match(text)
+    if match is None:
+        return None
+    open_paren = span[0] + match.end() - 1
+    closing = matching_delimiter(lexed.code, open_paren, "(", ")")
+    if closing is None or closing > span[1]:
+        return None
+    arguments = split_arguments(lexed.code, open_paren + 1, closing)
+    if len(arguments) < 2:
+        return None
+    base_start, base_end = arguments[1]
+    for token in lexed.strings:
+        if base_start <= token.start and token.end <= base_end:
+            return token.contents
+    # `new URL(path, BASE)` with the base held in a constant is the idiomatic
+    # spelling; reading only a raw string token left the whole send
+    # unresolvable. Resolve the alias chain the same way every other base does.
+    return static_string_value(lexed, arguments[1], span[0], suffix)
+
+
+# A base URL carried by a client factory: axios.create({baseURL: '...'}),
+# httpx.Client(base_url='...'). The request path is then relative, so the
+# effective endpoint is base + path. The KEY name is code (preserved), but the
+# value is a string whose contents the lexer masks, so it is read from the
+# string token rather than from the masked code.
+# Stops at the separator: the lexer masks the value string to blanks, so a
+# trailing \s* would run past it and miss the token.
+# The left boundary excludes `\w` and `-` so the bare `url` alternative cannot
+# match the TAIL of an unrelated key (`callback_url:`, `'X-Callback-Url' =>`),
+# whose value would otherwise be read as the client's base. `$` is deliberately
+# NOT excluded: PHP's `$base_url =` must still match.
+_BASE_URL_KEY_RE = re.compile(
+    r"(?<![\w\-])(?:base[_]?url|base_uri|BaseAddress|url)['\"]?\s*(?::|=>|=)",
+    re.I,
+)
+_CLIENT_FACTORY_CALL_RE = re.compile(
+    r"(?:\.\s*create|\bClient|\bAsyncClient|\bHttpClient|\bSession|"
+    r"\bsession|\bFaraday\s*\.\s*new)\s*\("
+)
+
+
+def _paren_group_span_before_accessor(
+    lexed: LexedSource, call: Call
+) -> tuple[int, int] | None:
+    """Return the offset span inside the receiver's trailing call parens."""
+    accessor = re.search(r"(?:\.|->|::)\s*$", lexed.code[: call.start])
+    if accessor is None:
+        return None
+    end = len(lexed.code[: accessor.start()].rstrip())
+    if end == 0 or lexed.code[end - 1] != ")":
+        return None
+    depth = 0
+    index = end - 1
+    while index >= 0:
+        if lexed.code[index] == ")":
+            depth += 1
+        elif lexed.code[index] == "(":
+            depth -= 1
+            if depth == 0:
+                break
+        index -= 1
+    if index < 0:
+        return None
+    return index + 1, end - 1
+
+
+def _base_url_in_region(
+    lexed: LexedSource, region: tuple[int, int]
+) -> str | None:
+    """Return the base URL string literal declared within an offset region."""
+    start, end = region
+    # Some languages commonly quote option keys (`'base_uri' =>` in PHP),
+    # which the masked-code view deliberately blanks. Key syntax is safe to
+    # inspect in the original source here; the value still comes from the
+    # lexer's string-token table rather than from regex parsing.
+    key = _BASE_URL_KEY_RE.search(lexed.original, start, end)
+    if key is None:
+        return None
+    value_start = key.end()
+    value_end = _option_value_end(lexed, value_start, end)
+    following = [
+        token
+        for token in lexed.strings
+        if value_start <= token.start and token.end <= value_end
+    ]
+    if not following:
+        return None
+    return min(following, key=lambda token: token.start).contents
+
+
+def _option_value_end(lexed: LexedSource, start: int, limit: int) -> int:
+    """End of ONE option's value: the next separator at its own nesting depth.
+
+    Without this bound the scan took the first string ANYWHERE after the key,
+    so a non-literal base (`url: base`, `baseURL: process.env.X`) silently
+    adopted the next option's value - `headers: {'X-Doc' => '<base>'}` became
+    the base URL and a relative path was joined against it.
+    """
+    depth = 0
+    cursor = start
+    while cursor < limit:
+        char = lexed.code[cursor]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            if depth == 0:
+                return cursor
+            depth -= 1
+        elif char in ",;" and depth == 0:
+            return cursor
+        cursor += 1
+    return limit
+
+
+# An Axios METHOD HELPER takes a per-request config whose baseURL overrides the
+# instance one (axios.post(url, data, {baseURL}) / api.post(url, data, {baseURL})).
+# Body-carrying helpers put that config third; the rest put it second.
+_AXIOS_HELPER_CONFIG_INDEX = {
+    "post": 2,
+    "put": 2,
+    "patch": 2,
+    "get": 1,
+    "delete": 1,
+    "head": 1,
+    "options": 1,
+}
+
+
+def config_object_base_url(
+    lexed: LexedSource,
+    span: tuple[int, int],
+    before: int,
+    suffix: str,
+) -> str | None:
+    """Resolve a static baseURL/base_uri from an inline or aliased config."""
+
+    base_spans = config_object_member_spans(
+        lexed, span, before, suffix, ("baseURL", "baseUrl", "base_uri")
+    )
+    if not base_spans:
+        return None
+    return static_string_value(
+        lexed, base_spans[-1], before, suffix
+    )
+
+
+def client_base_url(lexed: LexedSource, call: Call, suffix: str) -> str | None:
+    """Return the static base URL of the client a `.post()` is sent through.
+
+    Handles the client created inline —
+    axios.create({baseURL: '...'}).post(path) — and bound to a variable —
+    const api = axios.create({baseURL: '...'}); api.post(path). The idiomatic
+    variable form is as common as the inline one, so both must resolve or a
+    base-URL send is silently classified as safe.
+    """
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren]).lower()
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    receiver = call_receiver(lexed, call)
+    if (
+        callee in {"axios", "axios.request"}
+        or (callee == "request" and receiver == "axios")
+    ) and args:
+        return config_object_base_url(
+            lexed, args[0], call.start, suffix
+        )
+
+    # A per-request config on a method helper — axios.post(url, data, {baseURL})
+    # or api.post(url, data, {baseURL}) — sets the effective base and OVERRIDES
+    # the instance baseURL. Only the one-shot axios(config) form was read, so a
+    # required send addressed this way resolved to the bare path and was
+    # silently classified as safe. Checked first for that precedence.
+    # Member access differs by language (obj.post, $obj->post, Obj::post).
+    method_name = re.split(r"->|::|\.", callee)[-1]
+    config_index = _AXIOS_HELPER_CONFIG_INDEX.get(method_name)
+    if config_index is not None and len(args) > config_index:
+        base = config_object_base_url(
+            lexed, args[config_index], call.start, suffix
+        )
+        if base is not None:
+            return base
+
+    if receiver is None:
+        region = _paren_group_span_before_accessor(lexed, call)
+        return _base_url_in_region(lexed, region) if region is not None else None
+
+    # C# commonly configures HttpClient in a separate member assignment:
+    # `client.BaseAddress = new Uri("..."); client.PostAsync(path, ...)`.
+    member_base_pattern = re.compile(
+        rf"\b{re.escape(receiver)}\s*\.\s*BaseAddress\s*="
+    )
+    member_base = list(
+        member_base_pattern.finditer(lexed.code, 0, call.start)
+    )
+    if member_base:
+        start = member_base[-1].end()
+        end = assignment_end(lexed, start, suffix)
+        values = [
+            token.contents
+            for token in lexed.strings
+            if start <= token.start and token.end <= end
+        ]
+        if values:
+            return values[0]
+
+    for assignment in reversed(assignment_matches(lexed.code, receiver, call.start)):
+        rhs_start = assignment.end()
+        rhs_end = assignment_end(lexed, rhs_start, suffix)
+        if _CLIENT_FACTORY_CALL_RE.search(lexed.code, rhs_start, rhs_end):
+            base = _base_url_in_region(lexed, (rhs_start, rhs_end))
+            if base is not None:
+                return base
+    return None
+
+
+def join_base_and_path(base: str, path: str) -> str:
+    return base.rstrip("/") + "/" + path.lstrip("/")
+
+
+def request_url_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select URL expressions, unwrapping URI/URL constructor spellings."""
+    return [
+        unwrap_url_constructor(lexed, span)
+        for span in _request_url_spans(lexed, call, suffix)
+    ]
+
+
+def _request_url_spans(
+    lexed: LexedSource, call: Call, suffix: str
+) -> list[tuple[int, int]]:
+    """Select URL expressions for the supported REST client signatures."""
+
+    args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+    if not args:
+        return []
+    callee = re.sub(
+        r"\s+", "", lexed.code[call.start:call.open_paren]
+    )
+    callee_lower = callee.lower()
+    receiver = call_receiver(lexed, call)
+    explicit_receiver = bool(
+        re.search(r"(?:\.|->|::)\s*$", lexed.code[:call.start])
+    )
+    if callee_lower == "post" and suffix in {".java", ".kt", ".kts", ".scala"}:
+        # Builder chain: the endpoint is set by an EARLIER link in the same
+        # statement — .uri(URI.create(url)) for java.net.http, .url(url) for
+        # OkHttp — so the send call's own arguments never carry it. The chain
+        # has no simple receiver, so this must run before the anonymous-receiver
+        # guard below or the call is discarded exactly because it is a builder.
+        # Keyed on the PRESENCE of that link rather than on the method's case,
+        # since java.net.http spells it .POST and OkHttp spells it .post.
+        uri_span = builder_uri_span(lexed, call)
+        if uri_span is not None:
+            # The execution-link requirement applies to OkHttp (`.url(...)` +
+            # newCall/enqueue), which is newly modelled here. java.net.http
+            # (`.uri(...)`) keeps its existing contract, where the builder chain
+            # itself is treated as the send - changing that is out of scope for
+            # this fix and its behaviour is pinned by existing tests.
+            okhttp_style = _BUILDER_LINK_KIND.get((id(lexed), call.start)) == "url"
+            if not okhttp_style or request_object_is_executed(
+                lexed, call, suffix
+            ):
+                return [uri_span]
+            return []
+        if callee == "POST":
+            return []
+    # A `.post()` whose receiver is not a simple identifier is a factory call.
+    # Two kinds exist: HTTP-client factories that DO send —
+    # requests.Session().post(...), httpx.Client().post(...),
+    # axios.create(...).post(...) — and mock/assertion factories that do NOT —
+    # nock(API).post(...), expect(x)... . Skipping every anonymous receiver
+    # missed the real clients (a common shape); analysing every one flags the
+    # mocks. Discriminate on the factory METHOD name: analyse only the known
+    # client factories, keep skipping the rest.
+    if (
+        callee_lower in {"post", "postasync", "request"}
+        and explicit_receiver
+        and receiver is None
+        and factory_receiver_method(lexed, call) not in HTTP_CLIENT_FACTORY_METHODS
+    ):
+        return []
+    if callee_lower in {"post", "postasync"} and receiver in {
+        "app", "console", "expect", "nock", "router"
+    }:
+        return []
+    if callee_lower in {"axios", "axios.request"}:
+        return config_object_url_spans(
+            lexed, args[0], call.start, suffix
+        )
+    named_method = named_argument_spans(lexed, args, "method")
+    named_url = [
+        span
+        for name in URL_MEMBER_NAMES
+        for span in named_argument_spans(lexed, args, name)
+    ]
+    if callee_lower in {"post", "postasync"} and named_url:
+        return named_url[-1:]
+    if suffix == ".php" and callee == "file_get_contents" and args:
+        region = php_stream_context_region(lexed, call, suffix)
+        if region is None:
+            return []
+        blob = lexed.original[region[0]:region[1]]
+        verb = re.search(r"[\'\"]method[\'\"]\s*=>\s*[\'\"](\w+)[\'\"]", blob)
+        if verb is None or verb.group(1).upper() not in MUTATING_HTTP_METHODS:
+            return []
+        return args[0:1]
+    if (
+        suffix in JS_TS_SUFFIXES
+        and callee.split(".")[-1] == "open"
+        and len(args) >= 2
+    ):
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        if method is None or method.upper() not in MUTATING_HTTP_METHODS:
+            return []
+        return args[1:2]
+    if suffix == ".py" and callee.split(".")[-1] == "Request" and args:
+        # urllib.request.Request(url, data=..., method="POST") - the stdlib
+        # client. Default method is GET unless data= is present or method=
+        # names a mutating verb.
+        blob = lexed.original[call.start:call.end]
+        method = re.search(r"method\s*=\s*[\'\"](\w+)[\'\"]", blob)
+        if method is not None:
+            if method.group(1).upper() not in MUTATING_HTTP_METHODS:
+                return []
+        elif not re.search(r"(?<![\w])data\s*=", blob):
+            return []
+        if not request_object_is_executed(lexed, call, suffix):
+            return []
+        return args[0:1]
+    if callee in {"HttpRequestMessage", "RestRequest"} and args:
+        # HttpRequestMessage(HttpMethod.Post, url) puts the endpoint SECOND;
+        # RestRequest(url, Method.Post) puts it FIRST. Only a mutating method
+        # makes the request a send.
+        blob = lexed.original[call.start:call.end]
+        mutating = re.search(
+            r"(?:HttpMethod|Method)\s*\.\s*(?:Post|Put|Patch)", blob
+        ) is not None
+        if not mutating:
+            # The verb may be assigned AFTER construction:
+            #   var req = new RestRequest(url);  req.Method = Method.Post;
+            # Treating the constructor alone as authoritative made that a
+            # silent pass.
+            statement_start = max(
+                lexed.code.rfind(";", 0, call.start),
+                chain_newline_boundary(lexed.code, call.start),
+            ) + 1
+            binding = re.search(
+                r"([A-Za-z_]\w*)\s*=(?!=)", lexed.code[statement_start:call.start]
+            )
+            if binding is None:
+                return []
+            mutating = re.search(
+                rf"(?<![\w]){re.escape(binding.group(1))}\s*\.\s*Method\s*="
+                r"\s*(?:HttpMethod|Method)\s*\.\s*(?:Post|Put|Patch)\b",
+                lexed.code[call.end:],
+            ) is not None
+            if not mutating:
+                return []
+        if not request_object_is_executed(lexed, call, suffix):
+            return []
+        return args[1:2] if callee == "HttpRequestMessage" else args[0:1]
+    if suffix == ".go" and callee in {"Post", "Put", "Patch"} and len(args) == 1:
+        # resty: client.R().SetBody(...).Post(url) - a single argument is the
+        # ENDPOINT, unlike net/http.Post(url, contentType, body). Without this
+        # the whole send was invisible.
+        return args[0:1]
+    if callee == "NewRequest" and len(args) >= 2:
+        # Go net/http: http.NewRequest(method, url, body) + client.Do(req).
+        # The idiomatic non-shortcut form; only mutating methods matter here.
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return []
+        # NOTE: http.NewRequest is NOT gated on a client.Do(req) execution link.
+        # An existing contract (test_http_method_gate_is_consistent_across_
+        # transports, fixture go-method-post.go) pins the behaviour that
+        # NewRequest alone counts as a required send. Adding the gate here was a
+        # behaviour change beyond the scope of this work, so it is left as-is;
+        # the execution requirement applies only to the clients newly modelled
+        # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
+        return args[1:2]
+    if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
+        return args[0:1]
+    if callee == "curl_init" and len(args) >= 1:
+        # `curl_init($url)` sets CURLOPT_URL directly - it is the documented
+        # one-liner form and is at least as common as the setopt spelling.
+        # Modelling only curl_setopt(CURLOPT_URL) made the whole send invisible:
+        # the endpoint was never resolved, so the call was not counted as a send
+        # and the fail-safe could not fire either. The linter reported "no
+        # number-pool call sites detected" on a number-pool POST.
+        return args[0:1]
+    if callee == "curl_setopt" and len(args) >= 3:
+        # PHP ext-curl is stateful: the URL and the payload arrive in
+        # separate curl_setopt calls on the same handle. The CURLOPT_URL call
+        # carries the endpoint; rest_payload_spans finds the sibling
+        # CURLOPT_POSTFIELDS for the same handle. Every other option is not
+        # an HTTP send and is skipped outright.
+        option = lexed.code[args[1][0]:args[1][1]].strip()
+        return args[2:3] if option == "CURLOPT_URL" else []
+    if callee == "curl_setopt_array" and len(args) >= 2:
+        # Same statefulness, one literal: curl_setopt_array($ch, [CURLOPT_URL
+        # => ..., CURLOPT_POSTFIELDS => ...]). The URL comes from the array,
+        # and the same method gate applies — an array that configures a GET is
+        # not a send and must not be reported.
+        url_spans = curl_option_array_value_spans(
+            lexed, args[1], suffix, "CURLOPT_URL"
+        )[-1:]
+        if not url_spans:
+            return []
+        handle = lexed.code[args[0][0]:args[0][1]].strip()
+        method = php_curl_handle_method(lexed, handle, call.start, suffix)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return []
+        return url_spans
+    if callee_lower in {"post", "postasync"} and not named_url:
+        # Request-style config object: post({url: ..., json: {...}}), with or
+        # without a trailing callback — request.post(options, cb) is the
+        # library's classic form. The URL lives in a member rather than a
+        # named argument, so named_url stays empty and the fallback below
+        # evaluated the whole object, meaning a number-pool send missing
+        # messaging_profile_id was never seen as a required call at all.
+        #
+        # Resolved from the FIRST argument only, never from any argument
+        # carrying a url-ish key: in post(url, {callback_url: ...}) the
+        # endpoint is the positional string and a url-shaped key inside the
+        # body must not displace it. A base-URL client passing only a body
+        # object has no URL member and keeps its existing treatment.
+        object_url = config_object_url_spans(
+            lexed, args[0], call.start, suffix
+        )
+        if object_url:
+            return object_url[-1:]
+    if callee_lower == "request" and named_method and named_url:
+        method = static_method_value(
+            lexed, named_method[-1], call.start, suffix
+        )
+        return (
+            []
+            if method is not None and method not in MUTATING_HTTP_METHODS
+            else named_url[-1:]
+        )
+    if callee_lower == "request":
+        first_config = resolved_config_object_span(
+            lexed, args[0], call.start, suffix
+        )
+        if first_config is not None:
+            members = config_object_url_spans(
+                lexed, args[0], call.start, suffix
+            )
+            if members:
+                return members[-1:]
+            path_members = named_object_member_spans(
+                lexed, first_config, ("path",)
+            )
+            host_members = named_object_member_spans(
+                lexed, first_config, ("hostname", "host")
+            )
+            return path_members[-1:] if path_members and host_members else []
+        if len(args) > 1 and resolved_config_object_span(
+            lexed, args[1], call.start, suffix
+        ) is not None:
+            # request(url, options[, callback]) is URL-first. Method gating
+            # is binding-aware in SourceEndpointResolver.
+            return args[:1]
+    if callee_lower == "request" and len(args) > 1:
+        method = static_method_value(lexed, args[0], call.start, suffix)
+        return (
+            []
+            if method is not None and method not in MUTATING_HTTP_METHODS
+            else args[1:2]
+        )
+    if callee_lower == "request" and len(args) == 1:
+        members = config_object_url_spans(lexed, args[0], call.start, suffix)
+        if members:
+            return members[-1:]
+        # Node core http(s).request splits the endpoint into hostname + path.
+        # The path alone identifies the required endpoint (the normalizer
+        # accepts relative "/v2/messages/number_pool"), so a host member plus
+        # a path member is enough to place the call.
+        path_members = named_object_member_spans(lexed, args[0], ("path",))
+        host_members = named_object_member_spans(
+            lexed, args[0], ("hostname", "host")
+        )
+        if path_members and host_members:
+            return path_members[-1:]
+        return []
+    return args[:1]
+
+
+def selected_members_after_container(
+    lexed: LexedSource, closing: int, end: int
+) -> EndpointReference | None:
+    """Return a static selection chain, or None for a dynamic selector."""
+
+    members: list[str] = []
+    strings = {token.start: token for token in lexed.strings}
+    cursor = closing + 1
+    while cursor < end:
+        while cursor < end and (
+            lexed.code[cursor].isspace() or lexed.code[cursor] == ")"
+        ):
+            cursor += 1
+        bracket = False
+        if lexed.code.startswith("?.", cursor):
+            cursor += 2
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            bracket = cursor < end and lexed.code[cursor] == "["
+        elif cursor < end and lexed.code[cursor] == ".":
+            cursor += 1
+        elif lexed.code.startswith("->", cursor):
+            cursor += 2
+        elif cursor < end and lexed.code[cursor] == "[":
+            bracket = True
+        else:
+            break
+
+        if bracket:
+            cursor += 1
+            while (
+                cursor < end
+                and cursor not in strings
+                and lexed.code[cursor].isspace()
+            ):
+                cursor += 1
+            token = strings.get(cursor)
+            if token is not None:
+                key = token.contents
+                cursor = token.end
+            else:
+                numeric = re.match(r"\d+", lexed.code[cursor:end])
+                symbol = re.match(
+                    r":\s*([A-Za-z_]\w*)", lexed.code[cursor:end]
+                )
+                if numeric is not None:
+                    key = numeric.group(0)
+                    cursor += len(numeric.group(0))
+                elif symbol is not None:
+                    key = symbol.group(1)
+                    cursor += len(symbol.group(0))
+                else:
+                    return None
+            while cursor < end and lexed.code[cursor].isspace():
+                cursor += 1
+            if cursor >= end or lexed.code[cursor] != "]":
+                return None
+            members.append(key)
+            cursor += 1
+            continue
+
+        while cursor < end and lexed.code[cursor].isspace():
+            cursor += 1
+        member = re.match(r"[A-Za-z_]\w*", lexed.code[cursor:end])
+        if member is None:
+            return None
+        member_name = member.group(0)
+        cursor += len(member_name)
+        lookup_cursor = cursor
+        while lookup_cursor < end and lexed.code[lookup_cursor].isspace():
+            lookup_cursor += 1
+        if (
+            member_name in {"fetch", "get", "Get"}
+            and lookup_cursor < end
+            and lexed.code[lookup_cursor] == "("
+        ):
+            lookup_closing = matching_delimiter(
+                lexed.code, lookup_cursor, "(", ")"
+            )
+            if lookup_closing is None or lookup_closing >= end:
+                return None
+            key = static_lookup_key(
+                lexed, lookup_cursor + 1, lookup_closing
+            )
+            if key is None:
+                return None
+            members.append(key)
+            cursor = lookup_closing + 1
+        else:
+            members.append(member_name)
+    return tuple(members)
+
+
+STATIC_REFERENCE_EXPRESSION_RE = re.compile(
+    r"\s*\$?[A-Za-z_]\w*"
+    r"(?:\s*(?:"
+    r"(?:\?\.|\.|->)\s*[A-Za-z_]\w*"
+    r"|(?:\?\.)?\s*\[\s*(?:\"[^\"]*\"|'[^']*'|`[^`]*`|"
+    r":\s*[A-Za-z_]\w*|\d+)\s*\]"
+    r"|(?:\.|->)\s*(?:get|Get|fetch)\s*\(\s*"
+    r"(?:\"[^\"]*\"|'[^']*'|`[^`]*`|:\s*[A-Za-z_]\w*|\d+)"
+    r"\s*\)"
+    r"))*\s*"
+)
+
+
+def strip_expression_parentheses(
+    lexed: LexedSource, start: int, end: int
+) -> tuple[int, int]:
+    while True:
+        while start < end and lexed.original[start].isspace():
+            start += 1
+        while end > start and lexed.original[end - 1].isspace():
+            end -= 1
+        if start >= end or lexed.code[start] != "(":
+            return start, end
+        closing = matching_delimiter(lexed.code, start, "(", ")")
+        if closing != end - 1:
+            return start, end
+        start += 1
+        end -= 1
+
+
+def static_reference_expression(
+    lexed: LexedSource, start: int, end: int
+) -> EndpointReference | None:
+    start, end = strip_expression_parentheses(lexed, start, end)
+    if not STATIC_REFERENCE_EXPRESSION_RE.fullmatch(
+        lexed.original[start:end]
+    ):
+        return None
+    references = static_references(lexed, start, end)
+    return references[0] if references else None
+
+
+def root_literal_container(
+    lexed: LexedSource, start: int, end: int, suffix: str
+) -> tuple[str, int, int] | None:
+    """Return a literal container rooted in one bounded expression."""
+
+    start, end = strip_expression_parentheses(lexed, start, end)
+    call_forms: tuple[tuple[str, str], ...] = ()
+    if suffix == ".java":
+        call_forms = (
+            (r"\bMap\s*\.\s*of\s*\(", "pairs"),
+            (r"\b(?:List\s*\.\s*of|Arrays\s*\.\s*asList)\s*\(", "array"),
+        )
+    elif suffix == ".php":
+        call_forms = ((r"\barray\s*\(", "members"),)
+    for pattern, kind in call_forms:
+        match = re.search(pattern, lexed.code[start:end])
+        if match is None:
+            continue
+        absolute_end = start + match.end()
+        opening = lexed.code.rfind("(", start, absolute_end)
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is not None and closing < end:
+            return kind, opening, closing
+
+    delimiters = "{" if suffix in {".cs", ".go", ".java"} else "[{"
+    candidates: list[int] = []
+    for index in range(start, end):
+        if lexed.code[index] not in delimiters:
+            continue
+        prefix = lexed.code[start:index].strip()
+        prefix = prefix.strip("() \t\r\n")
+        if not prefix or (
+            suffix in {".cs", ".go", ".java"}
+            and re.fullmatch(
+                r"(?:new\s+)?(?:[A-Za-z_]\w*(?:\s*<[^{}]+>)?"
+                r"(?:\s*\[[^{}]*\])?|map\s*\[[^{}]*\]\s*[A-Za-z_]\w*"
+                r"|\[[^{}]*\]\s*[A-Za-z_]\w*)",
+                prefix,
+            )
+        ):
+            candidates.append(index)
+    if not candidates:
+        return None
+    opening = candidates[0]
+    left = lexed.code[opening]
+    right = "}" if left == "{" else "]"
+    closing = matching_delimiter(lexed.code, opening, left, right)
+    return (
+        ("members", opening, closing)
+        if closing is not None and closing < end
+        else None
+    )
+
+
+def literal_value_span(
+    lexed: LexedSource,
+    start: int,
+    end: int,
+    path: EndpointReference,
+    suffix: str,
+) -> tuple[int, int] | None:
+    """Project a static key/index through nested bounded literals."""
+
+    current_start, current_end = start, end
+    for selected_key in path:
+        container = root_literal_container(
+            lexed, current_start, current_end, suffix
+        )
+        if container is None:
+            return None
+        kind, opening, closing = container
+        members = split_arguments(lexed.code, opening + 1, closing)
+        candidates: list[tuple[str, tuple[int, int]]] = []
+        if kind == "pairs":
+            for index in range(1, len(members), 2):
+                key = static_object_key(lexed, *members[index - 1])
+                if key is not None:
+                    candidates.append((key, members[index]))
+        else:
+            separators = [
+                (
+                    (colon, colon + 1)
+                    if (colon := top_level_colon(
+                        lexed.code, member_start, member_end
+                    )) is not None
+                    else top_level_assignment_separator(
+                        lexed.code, member_start, member_end
+                    )
+                )
+                for member_start, member_end in members
+            ]
+            keyed = any(
+                separator is not None for separator in separators
+            )
+            for index, ((member_start, member_end), separator) in enumerate(
+                zip(members, separators)
+            ):
+                if keyed:
+                    if separator is None:
+                        key = static_object_key(
+                            lexed, member_start, member_end
+                        )
+                        if key is not None:
+                            candidates.append(
+                                (key, (member_start, member_end))
+                            )
+                        continue
+                    separator_start, value_start = separator
+                    key = static_object_key(
+                        lexed, member_start, separator_start
+                    )
+                    if key is not None:
+                        candidates.append(
+                            (key, (value_start, member_end))
+                        )
+                else:
+                    candidates.append(
+                        (str(index), (member_start, member_end))
+                    )
+        # Object/hash duplicate keys use their last value.
+        selected = next(
+            (
+                span
+                for key, span in reversed(candidates)
+                if key == selected_key
+            ),
+            None,
+        )
+        if selected is None:
+            return None
+        current_start, current_end = selected
+    return strip_expression_parentheses(lexed, current_start, current_end)
+
+
+def class_field_regions(
+    lexed: LexedSource, suffix: str
+) -> list[tuple[int, int]]:
+    """Top-level regions of JS/TS class BODIES - where fields are declared.
+
+    A class field (`class S { payload = {…} }`) declares a MEMBER, not a
+    reassignment of a same-named outer variable, but the assignment pattern
+    cannot tell them apart. The field's value overwrote an outer `payload`
+    that already carried messaging_profile_id, and the send that used the outer
+    one was reported as missing the profile. Method bodies sit at depth > 0 and
+    are deliberately excluded, so real locals inside them still bind.
+    """
+
+    if suffix not in JS_TS_SUFFIXES:
+        return []
+    code = lexed.code
+    regions: list[tuple[int, int]] = []
+    for match in re.finditer(r"\bclass\b[^{};()]*\{", code):
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is None:
+            continue
+        depth = 0
+        span_start = opening + 1
+        for index in range(opening + 1, closing):
+            character = code[index]
+            if character in "([{":
+                if depth == 0:
+                    regions.append((span_start, index))
+                depth += 1
+            elif character in ")]}" and depth:
+                depth -= 1
+                if depth == 0:
+                    span_start = index + 1
+        regions.append((span_start, closing))
+    return regions
+
+
+def c_function_headers(
+    lexed: LexedSource, suffix: str
+) -> dict[int, tuple[int, int]]:
+    """Index common C-family function/method/closure braces and parameters."""
+
+    supported = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
+    if suffix not in supported:
+        return {}
+    headers: dict[int, tuple[int, int]] = {}
+    controls = {
+        "catch", "checked", "fixed", "for", "foreach", "if", "lock",
+        "switch", "synchronized", "try", "unchecked", "using", "while",
+        "with",
+    }
+    for opening in (index for index, char in enumerate(lexed.code) if char == "{"):
+        statement_start = max(
+            lexed.code.rfind(";", 0, opening),
+            lexed.code.rfind("{", 0, opening),
+            lexed.code.rfind("}", 0, opening),
+            lexed.code.rfind("\n", 0, opening),
+        ) + 1
+        statement_start = max(statement_start, opening - 512)
+        header = lexed.code[statement_start:opening]
+        trimmed = header.rstrip()
+
+        arrow_token = None
+        if suffix in JS_TS_SUFFIXES | {".cs"}:
+            arrow_token = "=>"
+        elif suffix == ".java":
+            arrow_token = "->"
+        if arrow_token and trimmed.endswith(arrow_token):
+            arrow_start = statement_start + len(trimmed) - 2
+            cursor = arrow_start - 1
+            while cursor >= statement_start and lexed.code[cursor].isspace():
+                cursor -= 1
+            if cursor >= statement_start and lexed.code[cursor] == ")":
+                params_open = matching_opening(
+                    lexed.code, cursor, "(", ")"
+                )
+                if params_open is not None and params_open >= statement_start:
+                    headers[opening] = (params_open + 1, cursor)
+                continue
+            parameter = re.search(
+                r"(?:^|[^\w$])([$A-Za-z_]\w*)\s*$",
+                lexed.code[statement_start:arrow_start],
+            )
+            if parameter is not None:
+                headers[opening] = (
+                    statement_start + parameter.start(1),
+                    statement_start + parameter.end(1),
+                )
+            continue
+
+        pairs: list[tuple[int, int]] = []
+        depth = 0
+        params_open = -1
+        for index in range(statement_start, opening):
+            if lexed.code[index] == "(":
+                if depth == 0:
+                    params_open = index
+                depth += 1
+            elif lexed.code[index] == ")" and depth:
+                depth -= 1
+                if depth == 0:
+                    pairs.append((params_open, index))
+        if not pairs:
+            continue
+
+        keyword = re.search(r"\b(function|func)\b", header)
+        if keyword is not None:
+            keyword_end = statement_start + keyword.end()
+            candidates = [pair for pair in pairs if pair[0] >= keyword_end]
+            if not candidates:
+                continue
+            selected = candidates[0]
+            if suffix == ".go" and len(candidates) > 1:
+                before_first = lexed.code[keyword_end:selected[0]].strip()
+                between = lexed.code[selected[1] + 1:candidates[1][0]].strip()
+                if not before_first and re.fullmatch(
+                    r"[A-Za-z_]\w*", between
+                ):
+                    selected = candidates[1]
+            headers[opening] = (selected[0] + 1, selected[1])
+            continue
+        if suffix in {".go", ".php"}:
+            continue
+
+        for candidate_open, candidate_close in pairs:
+            prefix = lexed.code[statement_start:candidate_open]
+            name_match = re.search(r"([A-Za-z_]\w*)\s*$", prefix)
+            if name_match is None:
+                continue
+            name = name_match.group(1)
+            if name in controls:
+                continue
+            before_name = prefix[:name_match.start(1)]
+            if re.search(
+                rf"\b(?:{'|'.join(sorted(controls))})\b[^{{}};]*$",
+                before_name,
+            ):
+                continue
+            if re.search(r"(?:\.|->|::)\s*$", before_name):
+                continue
+            if re.search(
+                r"\b(?:new|return|throw)\b[^{};]*$", before_name
+            ) or re.search(r"\bclass\b[^{};]*\bextends\b", before_name):
+                continue
+            tail = lexed.code[candidate_close + 1:opening].strip()
+            if suffix == ".java" and tail and not tail.startswith("throws"):
+                continue
+            if suffix == ".cs" and tail and not re.fullmatch(
+                r":\s*(?:base|this)\s*\([\s\S]*\)", tail
+            ):
+                continue
+            if suffix in JS_TS_SUFFIXES and tail:
+                if not tail.startswith(":"):
+                    continue
+            if suffix == ".sh":
+                if lexed.code[candidate_open + 1:candidate_close].strip():
+                    continue
+                shell_prefix = prefix.strip()
+                if not re.fullmatch(
+                    rf"(?:function\s+)?{re.escape(name)}\s*", shell_prefix
+                ):
+                    continue
+            headers[opening] = (candidate_open + 1, candidate_close)
+            break
+    return headers
+
+
+def conditional_curly_scopes(code: str) -> set[int]:
+    # The prefix runs back to the previous brace, not a fixed 160 characters:
+    # `[^{}]*` already bounds the search there, and a LONG condition pushed its
+    # `if` outside the window, so the block opened no scope at all and a
+    # block-scoped `const payload` inside it leaked into the enclosing scope -
+    # shadowing the outer payload the send actually uses.
+    guarded: set[int] = set()
+    head = re.compile(
+        r"(?:\b(?:if|else|for|foreach|while|switch|case|catch|try)\b[^{}]*)$"
+    )
+    boundary = 0
+    for index, character in enumerate(code):
+        if character not in "{}":
+            continue
+        if character == "{" and head.search(code[boundary:index]):
+            guarded.add(index)
+        boundary = index + 1
+    return guarded
+
+
+def required_endpoint(value: str) -> bool:
+    # urlsplit RAISES on a malformed authority (an unclosed IPv6 bracket, an
+    # invalid port), and this runs on every endpoint-shaped literal in the tree
+    # - including ones inside test fixtures and documentation. An exception here
+    # aborted the whole FILE, so one unparsable string turned every send in it
+    # into "could not verify". Fall back to plain string handling instead.
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        parsed = None
+    path = (
+        (parsed.path if parsed is not None else "")
+        or value.split("?", 1)[0].split("#", 1)[0]
+    )
+    # Clients configured with a base URL (axios baseURL, requests Session
+    # mounts) pass RELATIVE paths such as "messages/number_pool"; a trailing-
+    # slash base joined with a relative path also leaves INTERIOR "." / ".."
+    # segments, because axios combineURLs does no normalization (baseURL
+    # ".../v2/messages/" + "./number_pool" -> ".../v2/messages/./number_pool",
+    # and ".../v2/messages/foo/" + "../number_pool" -> "...foo/../number_pool").
+    # Resolve all dot segments the way the HTTP layer does before comparing, so
+    # neither the base-URL form nor an interior dot segment is silently missed.
+    if not path.startswith("/"):
+        path = "/" + path
+    path = posixpath.normpath(path)
+    # posixpath.normpath PRESERVES a leading "//" (POSIX reserves it), so
+    # "https://api.telnyx.com//v2/messages/number_pool" kept a "//v2/..." path
+    # and matched nothing. Interior runs are already collapsed by normpath;
+    # collapse the leading run the same way an HTTP router does.
+    path = "/" + path.lstrip("/")
+    if path.startswith("/v2/") or path == "/v2":
+        path = path[3:] or "/"
+    return path.rstrip("/") in {
+        "/messages/number_pool",
+        "/messages/alphanumeric_sender_id",
+    }
+
+
+def required_endpoint_literal_signal(value: str) -> bool:
+    """Whether a URL-expression literal proves a required endpoint suffix.
+
+    Format strings often carry an unknown host prefix (`%s/v2/...`) that is
+    not itself a valid URL/path, but their static suffix is still definitive.
+    Keep this separate from `required_endpoint`, whose exact-path contract is
+    intentionally stricter for fully resolved URLs.
+    """
+    clean = value.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+    return bool(
+        re.search(
+            r"(?:^|/)messages/(?:number_pool|alphanumeric_sender_id)$",
+            clean,
+        )
+    )
+
+
+def endpoint_literal_value(value: str) -> EndpointValue:
+    return EndpointValue(REQUIRED if required_endpoint(value) else SAFE, value)
+
+
+def _default_endpoint_value(
+    values: tuple[EndpointValue, ...]
+) -> EndpointValue:
+    """Combine a `primary, fallback` pair (`get(k, d)`, `{a = d} = o`).
+
+    Only a MISSING primary selects the fallback - that is the one case where the
+    default is provably taken. EVERY other primary, UNRESOLVABLE included, is
+    returned as-is, so a dynamic lookup does NOT promote a REQUIRED literal
+    default. See the comment below for why that stays out of scope here.
+    """
+    primary, fallback = values[0], values[1]
+    if primary.kind == MISSING:
+        return fallback
+    # An UNRESOLVABLE primary deliberately does NOT promote a REQUIRED default.
+    # Treating it as required was tried and reverted: the documented contract
+    # (test_endpoint_resolver_common_static_syntax_corpus, fixture
+    # runtime-primary-default.js) places fail-closed dynamic lookups OUTSIDE
+    # this non-parser's finite grammar, so `const {pool: e = REQUIRED} = r`
+    # with a dynamic `r` is not provably a required send. Changing that is a
+    # behaviour change that needs its own justification, not a side effect.
+    return primary
+
+
+def join_endpoint_values(values: Iterable[EndpointValue]) -> EndpointValue:
+    values = tuple(values)
+    if not values:
+        return UNKNOWN_VALUE
+    kinds = {value.kind for value in values}
+    exacts = {value.exact for value in values}
+    # A JOIN is over branches that may ALL execute (a conditional reassignment,
+    # a guarded arm). If ANY branch reaches the required endpoint the send can
+    # reach it at runtime, so the join must stay REQUIRED. Collapsing the mixed
+    # case to UNKNOWN silently dropped conditionally-assigned number_pool sends:
+    # the surrounding call was still recognised, so the fail-safe backstop had
+    # nothing left to report either.
+    if REQUIRED in kinds:
+        return EndpointValue(
+            REQUIRED, exacts.pop() if len(exacts) == 1 else None
+        )
+    if len(kinds) != 1 or UNKNOWN in kinds:
+        return UNKNOWN_VALUE
+    return EndpointValue(
+        values[0].kind, exacts.pop() if len(exacts) == 1 else None
+    )
+
+
+class EndpointGraph:
+    """Iterative abstract interpreter over pre-indexed endpoint definitions."""
+
+    def __init__(self, source_length: int, state_budget: int = 10_000) -> None:
+        self.scopes: dict[int, IndexedScope] = {
+            0: IndexedScope(0, None, 0, source_length, "module")
+        }
+        self.bindings: dict[int, IndexedBinding] = {}
+        self.bindings_by_name: dict[str, list[int]] = {}
+        self.definitions: dict[int, list[IndexedDefinition]] = {}
+        self.definition_offsets: dict[int, list[int]] = {}
+        self._next_scope = 1
+        self._next_binding = 1
+        self.state_budget = state_budget
+        self._memo: dict[EndpointState, EndpointValue] = {}
+
+    def add_scope(
+        self, parent: int, start: int, end: int, kind: str
+    ) -> int:
+        scope_id = self._next_scope
+        self._next_scope += 1
+        self.scopes[scope_id] = IndexedScope(
+            scope_id, parent, start, end, kind
+        )
+        return scope_id
+
+    def ancestors(self, scope_id: int) -> tuple[int, ...]:
+        result: list[int] = []
+        current: int | None = scope_id
+        while current is not None:
+            result.append(current)
+            current = self.scopes[current].parent
+        return tuple(result)
+
+    def execution_scope(self, scope_id: int) -> int:
+        for candidate in self.ancestors(scope_id):
+            if self.scopes[candidate].kind in {"function", "module"}:
+                return candidate
+        return 0
+
+    def visible_binding(
+        self, name: str, use_scope: int, before: int
+    ) -> int | None:
+        ancestry = self.ancestors(use_scope)
+        depth = {scope_id: index for index, scope_id in enumerate(ancestry)}
+        candidates = [
+            self.bindings[binding_id]
+            for binding_id in self.bindings_by_name.get(name, ())
+            if self.bindings[binding_id].scope_id in depth
+            and self.bindings[binding_id].visibility_start <= before
+        ]
+        if not candidates:
+            return None
+        candidates.sort(
+            key=lambda binding: (
+                depth[binding.scope_id],
+                -binding.declaration_start,
+            )
+        )
+        return candidates[0].id
+
+    def add_binding(
+        self,
+        name: str,
+        scope_id: int,
+        declaration_start: int,
+        visibility_start: int,
+        kind: str,
+    ) -> int:
+        binding_id = self._next_binding
+        self._next_binding += 1
+        binding = IndexedBinding(
+            binding_id,
+            name,
+            scope_id,
+            declaration_start,
+            visibility_start,
+            kind,
+        )
+        self.bindings[binding_id] = binding
+        self.bindings_by_name.setdefault(name, []).append(binding_id)
+        return binding_id
+
+    def add_definition(
+        self,
+        binding_id: int,
+        path: EndpointReference,
+        expression: EndpointExpression,
+        offset: int,
+        scope_id: int,
+        kind: str,
+        guarded: bool = False,
+    ) -> None:
+        self._memo.clear()
+        definition = IndexedDefinition(
+            binding_id,
+            path,
+            offset,
+            expression,
+            scope_id,
+            self.execution_scope(scope_id),
+            kind,
+            guarded,
+        )
+        offsets = self.definition_offsets.setdefault(binding_id, [])
+        definitions = self.definitions.setdefault(binding_id, [])
+        index = bisect.bisect_right(offsets, offset)
+        offsets.insert(index, offset)
+        definitions.insert(index, definition)
+
+    def _definition_reaches(
+        self, definition: IndexedDefinition, state: EndpointAccessState
+    ) -> bool:
+        if definition.kind in {"declaration", "parameter"}:
+            return definition.scope_id in self.ancestors(state.use_scope)
+        return definition.execution_scope == self.execution_scope(
+            state.use_scope
+        )
+
+    def _matching_definitions(
+        self, state: EndpointAccessState
+    ) -> list[IndexedDefinition]:
+        offsets = self.definition_offsets.get(state.binding_id, ())
+        stop = bisect.bisect_left(offsets, state.before)
+        return [
+            definition
+            for definition in self.definitions.get(state.binding_id, ())[:stop]
+            if state.path[: len(definition.member_path)]
+            == definition.member_path
+            and self._definition_reaches(definition, state)
+        ]
+
+    @staticmethod
+    def _concat(values: tuple[EndpointValue, ...]) -> EndpointValue:
+        if not values:
+            return UNKNOWN_VALUE
+        if all(value.exact is not None for value in values):
+            return endpoint_literal_value(
+                "".join(value.exact or "" for value in values)
+            )
+        suffix_parts: list[str] = []
+        for value in reversed(values):
+            if value.exact is None:
+                break
+            suffix_parts.append(value.exact)
+        suffix = "".join(reversed(suffix_parts))
+        if required_endpoint(suffix):
+            return EndpointValue(REQUIRED)
+        # A dynamic QUERY STRING (".../messages/number_pool?ref=" + id) leaves
+        # no exact trailing run at all, so the suffix scan above saw nothing and
+        # the send was silently classified as safe. Once the exact PREFIX has
+        # reached a "?" or "#" the path is already closed: whatever follows is
+        # query or fragment and cannot change the endpoint.
+        prefix_parts: list[str] = []
+        for value in values:
+            if value.exact is None:
+                break
+            prefix_parts.append(value.exact)
+        prefix = "".join(prefix_parts)
+        if ("?" in prefix or "#" in prefix) and required_endpoint(prefix):
+            return EndpointValue(REQUIRED)
+        return UNKNOWN_VALUE
+
+    def _definition_dependency(
+        self,
+        definition: IndexedDefinition,
+        state: EndpointAccessState,
+    ) -> EndpointExpressionState:
+        remainder = state.path[len(definition.member_path):]
+        live_container_alias = (
+            bool(remainder)
+            and isinstance(definition.expression, EndpointRef)
+            and not definition.expression.members
+        )
+        return EndpointExpressionState(
+            definition.expression,
+            remainder,
+            state.before if live_container_alias else definition.start,
+            state.use_scope if live_container_alias else definition.scope_id,
+        )
+
+    def _expand_access(
+        self, state: EndpointAccessState
+    ) -> EndpointExpansion:
+        definitions = self._matching_definitions(state)
+        if not definitions:
+            return EndpointExpansion(immediate=UNKNOWN_VALUE)
+        last_unguarded = -1
+        use_ancestry = set(self.ancestors(state.use_scope))
+        for index, definition in enumerate(definitions):
+            if not definition.guarded or definition.scope_id in use_ancestry:
+                last_unguarded = index
+        if last_unguarded < 0:
+            selected = definitions
+            baseline = (UNKNOWN_VALUE,)
+        else:
+            selected = [definitions[last_unguarded]] + [
+                definition
+                for definition in definitions[last_unguarded + 1:]
+                if definition.guarded
+                and definition.scope_id not in use_ancestry
+            ]
+            baseline = ()
+        dependencies = tuple(
+            self._definition_dependency(definition, state)
+            for definition in selected
+        )
+        return EndpointExpansion(
+            dependencies,
+            lambda values: join_endpoint_values(baseline + values),
+        )
+
+    def _expand_expression(
+        self, state: EndpointExpressionState
+    ) -> EndpointExpansion:
+        expression = state.expression
+        if isinstance(expression, EndpointUnknown):
+            return EndpointExpansion(immediate=UNKNOWN_VALUE)
+        if isinstance(expression, EndpointLiteral):
+            return EndpointExpansion(
+                immediate=(
+                    UNKNOWN_VALUE
+                    if state.projection
+                    else endpoint_literal_value(expression.value)
+                )
+            )
+        if isinstance(expression, EndpointRef):
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointAccessState(
+                        expression.binding_id,
+                        expression.members + state.projection,
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointObject):
+            if not state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            key, remainder = state.projection[0], state.projection[1:]
+            candidates = [
+                value for entry_key, value in expression.entries
+                if entry_key == key
+            ]
+            if not candidates:
+                return EndpointExpansion(immediate=MISSING_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        candidates[-1], remainder, state.before, state.use_scope
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointArray):
+            if not state.projection or not state.projection[0].isdigit():
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            index = int(state.projection[0])
+            if index >= len(expression.items):
+                return EndpointExpansion(immediate=MISSING_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.items[index],
+                        state.projection[1:],
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        if isinstance(expression, EndpointDefault):
+            if state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.primary, (), state.before, state.use_scope
+                    ),
+                    EndpointExpressionState(
+                        expression.fallback, (), state.before, state.use_scope
+                    ),
+                ),
+                combine=_default_endpoint_value,
+            )
+        if isinstance(expression, EndpointConcat):
+            if state.projection:
+                return EndpointExpansion(immediate=UNKNOWN_VALUE)
+            return EndpointExpansion(
+                dependencies=tuple(
+                    EndpointExpressionState(
+                        part, (), state.before, state.use_scope
+                    )
+                    for part in expression.parts
+                ),
+                combine=self._concat,
+            )
+        if isinstance(expression, EndpointProjected):
+            return EndpointExpansion(
+                dependencies=(
+                    EndpointExpressionState(
+                        expression.expression,
+                        expression.members + state.projection,
+                        state.before,
+                        state.use_scope,
+                    ),
+                ),
+                combine=lambda values: values[0],
+            )
+        return EndpointExpansion(immediate=UNKNOWN_VALUE)
+
+    def _expand(self, state: EndpointState) -> EndpointExpansion:
+        return (
+            self._expand_access(state)
+            if isinstance(state, EndpointAccessState)
+            else self._expand_expression(state)
+        )
+
+    def evaluate(self, state: EndpointState) -> EndpointValue:
+        memo: dict[EndpointState, EndpointValue] = dict(self._memo)
+        visiting: set[EndpointState] = set()
+        stack = [EndpointFrame(state)]
+        expanded_states = 0
+        while stack:
+            frame = stack[-1]
+            if frame.state in memo:
+                value = memo[frame.state]
+                stack.pop()
+                if stack:
+                    stack[-1].values.append(value)
+                    stack[-1].next_dependency += 1
+                continue
+            if frame.expansion is None:
+                expanded_states += 1
+                if expanded_states > self.state_budget:
+                    return UNKNOWN_VALUE
+                frame.expansion = self._expand(frame.state)
+                if frame.expansion.immediate is not None:
+                    memo[frame.state] = frame.expansion.immediate
+                    continue
+                visiting.add(frame.state)
+            dependencies = frame.expansion.dependencies
+            if frame.next_dependency < len(dependencies):
+                dependency = dependencies[frame.next_dependency]
+                if dependency in visiting:
+                    frame.values.append(UNKNOWN_VALUE)
+                    frame.next_dependency += 1
+                elif dependency in memo:
+                    frame.values.append(memo[dependency])
+                    frame.next_dependency += 1
+                else:
+                    stack.append(EndpointFrame(dependency))
+                continue
+            visiting.discard(frame.state)
+            assert frame.expansion.combine is not None
+            memo[frame.state] = frame.expansion.combine(tuple(frame.values))
+        self._memo.update(memo)
+        return memo[state]
+
+
+class SourceEndpointResolver:
+    """Compile one source file into a call-centric endpoint value graph."""
+
+    JAVASCRIPT_SUFFIXES = JS_TS_SUFFIXES
+    C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
+
+    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+        self.lexed = lexed
+        self.suffix = suffix
+        self.graph = EndpointGraph(len(lexed.code))
+        self.c_headers = c_function_headers(lexed, suffix)
+        self.class_fields = class_field_regions(lexed, suffix)
+        self.conditional_openings = conditional_curly_scopes(lexed.code)
+        self.scope_ranges: list[tuple[int, int, int]] = []
+        self.scope_by_opening: dict[int, int] = {}
+        self.expression_parameters: list[tuple[int, int, int, int]] = []
+        self.assignment_bindings: dict[int, int] = {}
+        self.destructuring: list[
+            tuple[int, int, int, int, list[tuple[str, EndpointReference, tuple[int, int] | None]]]
+        ] = []
+        self.destructure_mutations: set[int] = set()
+        self._build_scopes()
+        self._find_destructuring()
+        self.root_assignments = [
+            match
+            for match in VARIABLE_ASSIGNMENT_RE.finditer(lexed.code)
+            if not self._inside_destructuring_lhs(match.start())
+            and not self._inside_parameter_list(match.start())
+            and not self._inside_class_field(match.start())
+        ]
+        self._build_bindings()
+        self._index_node_path_join_bindings()
+        self._build_definitions()
+
+    def _index_node_path_join_bindings(self) -> None:
+        """Index only live bindings that originate from Node's path.join.
+
+        The builder parser must distinguish a real destructured/imported
+        ``path.join`` from an unrelated local function with the same name.
+        Binding IDs make parameter/block shadowing explicit; origin offsets
+        let later assignments invalidate a mutable CommonJS alias.
+        """
+
+        self.node_path_join_origins: dict[int, int] = {}
+        self.node_path_join_imports: dict[str, int] = {}
+        self.node_path_module_origins: dict[int, int] = {}
+        self.node_path_module_imports: dict[str, int] = {}
+        source = self.lexed.without_comments
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?(?!\s*\.)",
+            source,
+        ):
+            name = match.group(1)
+            binding_id = self.graph.visible_binding(
+                name, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_module_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+
+        for match in re.finditer(
+            r"\bimport\s+(?:\*\s+as\s+)?([A-Za-z_$]\w*)\s+from\s*"
+            r"['\"](?:node:)?path['\"]",
+            source,
+        ):
+            self.node_path_module_imports[match.group(1)] = match.start()
+
+        commonjs = re.compile(
+            r"\b(?:const|let|var)\s*\{([^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?"
+        )
+        for match in commonjs.finditer(source):
+            opening = source.find("{", match.start(), match.end())
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*join\s*(?::\s*([A-Za-z_$]\w*))?\s*", member
+                )
+                if parsed is None:
+                    continue
+                name = parsed.group(1) or "join"
+                binding_id = self.destructure_bindings.get((opening, name))
+                if binding_id is not None:
+                    self.node_path_join_origins[binding_id] = opening
+
+        for match in re.finditer(
+            r"\bimport\s*\{([^{}]*)\}\s*from\s*"
+            r"['\"](?:node:)?path['\"]",
+            source,
+        ):
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*join\s*(?:as\s+([A-Za-z_$]\w*))?\s*", member
+                )
+                if parsed is not None:
+                    self.node_path_join_imports[parsed.group(1) or "join"] = (
+                        match.start()
+                    )
+
+        # Destructuring or copying `.join` from a previously bound path
+        # module is equivalent to destructuring it directly from require().
+        for opening, _, rhs_start, rhs_end, leaves in self.destructuring:
+            rhs = source[rhs_start:rhs_end].strip()
+            module = re.fullmatch(r"([A-Za-z_$]\w*)", rhs)
+            if module is None or not self._is_node_path_module_alias(
+                module.group(1), self.scope_at(opening), opening
+            ):
+                continue
+            for name, members, _ in leaves:
+                if members == ("join",):
+                    binding_id = self.destructure_bindings.get((opening, name))
+                    if binding_id is not None:
+                        self.node_path_join_origins[binding_id] = opening
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"([A-Za-z_$]\w*)\s*\.\s*join\b",
+            source,
+        ):
+            alias, module = match.groups()
+            if not self._is_node_path_module_alias(
+                module, self.scope_at(match.start()), match.start()
+            ):
+                continue
+            binding_id = self.graph.visible_binding(
+                alias, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_join_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*['\"](?:node:)?path['\"]\s*\)"
+            r"(?:\s*\.\s*posix)?\s*\.\s*join\b",
+            source,
+        ):
+            name = match.group(1)
+            binding_id = self.graph.visible_binding(
+                name, self.scope_at(match.start()), match.end()
+            )
+            if binding_id is not None:
+                self.node_path_join_origins[binding_id] = (
+                    self.graph.bindings[binding_id].declaration_start
+                )
+            else:
+                self.node_path_join_imports[name] = match.start()
+
+    def _is_node_path_module_alias(
+        self, name: str, scope_id: int, before: int
+    ) -> bool:
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        if binding_id is None:
+            return self.node_path_module_imports.get(name, before + 1) < before
+        origin = self.node_path_module_origins.get(binding_id)
+        if origin is None:
+            return False
+        return not any(
+            origin < offset < before and assigned == binding_id
+            for offset, assigned in self.assignment_bindings.items()
+        )
+
+    def _is_node_path_join_alias(
+        self, name: str, scope_id: int, before: int
+    ) -> bool:
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        if binding_id is None:
+            return self.node_path_join_imports.get(name, before + 1) < before
+        origin = self.node_path_join_origins.get(binding_id)
+        if origin is None:
+            return False
+        # A mutable alias stops identifying path.join after any later plain
+        # or destructuring assignment that reaches the same binding.
+        if any(
+            origin < offset < before and assigned == binding_id
+            for offset, assigned in self.assignment_bindings.items()
+        ):
+            return False
+        if any(
+            origin < opening < before
+            and self.destructure_bindings.get((opening, name)) == binding_id
+            for opening in self.destructure_mutations
+        ):
+            return False
+        return True
+
+    def _build_scopes(self) -> None:
+        if self.suffix in self.C_SUFFIXES:
+            stack: list[tuple[int, int, int]] = []
+            for opening, character in enumerate(self.lexed.code):
+                if character != "{":
+                    continue
+                statement_start = max(
+                    self.lexed.code.rfind(";", 0, opening),
+                    self.lexed.code.rfind("\n", 0, opening),
+                    self.lexed.code.rfind("}", 0, opening),
+                ) + 1
+                prefix = self.lexed.code[statement_start:opening].strip()
+                code_block = (
+                    opening in self.c_headers
+                    or opening in self.conditional_openings
+                    or not prefix
+                    or bool(
+                        re.search(
+                            r"\b(?:else|try|finally|do|class|namespace|"
+                            r"interface|struct|enum|synchronized|using|lock|"
+                            r"fixed|checked|unchecked)\b[^{}]*$",
+                            prefix,
+                        )
+                    )
+                )
+                if not code_block:
+                    continue
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "{", "}"
+                )
+                if closing is None:
+                    continue
+                while stack and opening > stack[-1][1]:
+                    stack.pop()
+                parent = stack[-1][2] if stack else 0
+                kind = (
+                    "function"
+                    if opening in self.c_headers
+                    else "conditional"
+                    if opening in self.conditional_openings
+                    else "block"
+                )
+                scope_id = self.graph.add_scope(
+                    parent, opening, closing + 1, kind
+                )
+                self.scope_by_opening[opening] = scope_id
+                self.scope_ranges.append((opening, closing + 1, scope_id))
+                stack.append((opening, closing, scope_id))
+            self._build_expression_lambda_scopes()
+            return
+        if self.suffix == ".py":
+            self._build_python_scopes()
+            return
+        if self.suffix == ".rb":
+            self._build_ruby_scopes()
+
+    def _build_expression_lambda_scopes(self) -> None:
+        token = "->" if self.suffix == ".java" else "=>"
+        if self.suffix not in JS_TS_SUFFIXES | {".cs", ".java"}:
+            return
+        for arrow in re.finditer(re.escape(token), self.lexed.code):
+            body_start = arrow.end()
+            while (
+                body_start < len(self.lexed.code)
+                and self.lexed.code[body_start].isspace()
+            ):
+                body_start += 1
+            if (
+                body_start >= len(self.lexed.code)
+                or self.lexed.code[body_start] == "{"
+            ):
+                continue
+            cursor = arrow.start() - 1
+            while cursor >= 0 and self.lexed.code[cursor].isspace():
+                cursor -= 1
+            if cursor >= 0 and self.lexed.code[cursor] == ")":
+                params_open = matching_opening(
+                    self.lexed.code, cursor, "(", ")"
+                )
+                if params_open is None:
+                    continue
+                params_start, params_end = params_open + 1, cursor
+            else:
+                parameter = re.search(
+                    r"([$A-Za-z_]\w*)\s*$",
+                    self.lexed.code[:arrow.start()],
+                )
+                if parameter is None:
+                    continue
+                params_start, params_end = parameter.span(1)
+
+            round_depth = square_depth = curly_depth = 0
+            body_end = len(self.lexed.code)
+            for index in range(body_start, len(self.lexed.code)):
+                character = self.lexed.code[index]
+                if character == "(":
+                    round_depth += 1
+                elif character == "[":
+                    square_depth += 1
+                elif character == "{":
+                    curly_depth += 1
+                elif character == ")":
+                    if not round_depth:
+                        body_end = index
+                        break
+                    round_depth -= 1
+                elif character == "]":
+                    if not square_depth:
+                        body_end = index
+                        break
+                    square_depth -= 1
+                elif character == "}":
+                    if not curly_depth:
+                        body_end = index
+                        break
+                    curly_depth -= 1
+                elif (
+                    character in {";", "\n", ","}
+                    and not (round_depth or square_depth or curly_depth)
+                ):
+                    body_end = index
+                    break
+            parent = self.scope_at(arrow.start())
+            scope_id = self.graph.add_scope(
+                parent, body_start, body_end, "function"
+            )
+            self.scope_ranges.append((body_start, body_end, scope_id))
+            self.expression_parameters.append(
+                (scope_id, params_start, params_end, arrow.start())
+            )
+
+    def _build_python_scopes(self) -> None:
+        lines = self.lexed.code.splitlines(keepends=True)
+        stack: list[tuple[int, str, int, int]] = []
+        records: list[list[int | str]] = []
+        cursor = 0
+        row = 0
+        while row < len(lines):
+            line = lines[row]
+            consumed = 1
+            stripped = line.lstrip(" \t")
+            if stripped.strip():
+                indent = len(line) - len(stripped)
+                while stack and indent <= stack[-1][0]:
+                    _, _, record_index, _ = stack.pop()
+                    records[record_index][2] = cursor
+                match = None
+                if re.match(r"(?:async\s+)?(?:def|class)\b", stripped):
+                    # A def/class signature may WRAP across lines, leaving its
+                    # ':' on a continuation row. Only a one-line header was
+                    # recognised, so the function opened no scope at all and a
+                    # local `payload` reassignment inside it read as a
+                    # module-level one - hiding a send that never got the
+                    # profile. Join continuation rows until the brackets close.
+                    joined = stripped
+                    while (
+                        re.search(r":\s*$", joined) is None
+                        and row + consumed < len(lines)
+                        and sum(joined.count(character) for character in "([{")
+                        > sum(joined.count(character) for character in ")]}")
+                    ):
+                        joined += lines[row + consumed]
+                        consumed += 1
+                    match = re.fullmatch(
+                        r"(?:async\s+)?(def|class)\b[\s\S]*:\s*", joined
+                    )
+                if match is not None:
+                    kind = "function" if match.group(1) == "def" else "class"
+                    parent = stack[-1][3] if stack else 0
+                    if kind == "function" and stack and stack[-1][1] == "class":
+                        parent = 0
+                    records.append([cursor, kind, len(self.lexed.code), parent])
+                    record_index = len(records) - 1
+                    # The graph id is filled after ranges are known; retain a
+                    # temporary negative record id in the stack.
+                    stack.append((indent, kind, record_index, -(record_index + 1)))
+            cursor += sum(
+                len(lines[row + offset]) for offset in range(consumed)
+            )
+            row += consumed
+        while stack:
+            _, _, record_index, _ = stack.pop()
+            records[record_index][2] = len(self.lexed.code)
+
+        id_by_record: dict[int, int] = {}
+        for index, (start, kind, end, parent_token) in enumerate(records):
+            parent = (
+                id_by_record[-int(parent_token) - 1]
+                if int(parent_token) < 0
+                else int(parent_token)
+            )
+            scope_id = self.graph.add_scope(
+                parent, int(start), int(end), str(kind)
+            )
+            id_by_record[index] = scope_id
+            self.scope_ranges.append((int(start), int(end), scope_id))
+
+    def _build_ruby_scopes(self) -> None:
+        stack: list[tuple[str, int | None, int]] = []
+        records: list[list[int | str]] = []
+        cursor = 0
+        for line in self.lexed.code.splitlines(keepends=True):
+            stripped = line.strip()
+            if re.match(r"end\b", stripped) and stack:
+                _, record_index, _ = stack.pop()
+                if record_index is not None:
+                    records[record_index][2] = cursor + len(line)
+            else:
+                match = re.match(r"(def|class|module)\b", stripped)
+                if match is not None:
+                    kind = "function" if match.group(1) == "def" else "class"
+                    parent_token = stack[-1][2] if stack else 0
+                    if kind == "function" and stack:
+                        parent_token = 0
+                    records.append(
+                        [cursor, kind, len(self.lexed.code), parent_token]
+                    )
+                    record_index = len(records) - 1
+                    stack.append((kind, record_index, -(record_index + 1)))
+                elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
+                    parent_token = stack[-1][2] if stack else 0
+                    records.append(
+                        [cursor, "block", len(self.lexed.code), parent_token]
+                    )
+                    record_index = len(records) - 1
+                    stack.append(("block", record_index, -(record_index + 1)))
+                elif re.match(
+                    r"(?:if|unless|case|begin|for|while|until)\b", stripped
+                ):
+                    parent_token = stack[-1][2] if stack else 0
+                    stack.append(("control", None, parent_token))
+            cursor += len(line)
+        id_by_record: dict[int, int] = {}
+        for index, (start, kind, end, parent_token) in enumerate(records):
+            parent = (
+                id_by_record[-int(parent_token) - 1]
+                if int(parent_token) < 0
+                else int(parent_token)
+            )
+            scope_id = self.graph.add_scope(
+                parent, int(start), int(end), str(kind)
+            )
+            id_by_record[index] = scope_id
+            self.scope_ranges.append((int(start), int(end), scope_id))
+
+    def scope_at(self, offset: int) -> int:
+        candidates = [
+            (end - start, scope_id)
+            for start, end, scope_id in self.scope_ranges
+            if start <= offset < end
+        ]
+        return min(candidates)[1] if candidates else 0
+
+    def _inside_parameter_list(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end in self.c_headers.values())
+
+    def _inside_class_field(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end in self.class_fields)
+
+    def _inside_destructuring_lhs(self, offset: int) -> bool:
+        return any(start <= offset < end for start, end, _, _, _ in self.destructuring)
+
+    def _destructure_leaves(
+        self,
+        start: int,
+        end: int,
+        prefix: EndpointReference = (),
+    ) -> list[tuple[str, EndpointReference, tuple[int, int] | None]]:
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end or self.lexed.code.startswith("...", start):
+            return []
+        if self.lexed.code[start] not in "[{":
+            default = top_level_assignment_separator(
+                self.lexed.code, start, end
+            )
+            leaf_end = default[0] if default is not None else end
+            leaf = self.lexed.code[start:leaf_end].strip()
+            match = re.fullmatch(r"\$?([A-Za-z_]\w*)", leaf)
+            return (
+                [(match.group(1), prefix, (default[1], end) if default else None)]
+                if match is not None
+                else []
+            )
+        left = self.lexed.code[start]
+        right = "}" if left == "{" else "]"
+        closing = matching_delimiter(self.lexed.code, start, left, right)
+        if closing is None:
+            return []
+        leaves: list[
+            tuple[str, EndpointReference, tuple[int, int] | None]
+        ] = []
+        for index, (member_start, member_end) in enumerate(
+            split_arguments(self.lexed.code, start + 1, closing)
+        ):
+            if not self.lexed.code[member_start:member_end].strip():
+                continue
+            if left == "[":
+                leaves.extend(
+                    self._destructure_leaves(
+                        member_start,
+                        member_end,
+                        prefix + (str(index),),
+                    )
+                )
+                continue
+            colon = top_level_colon(
+                self.lexed.code, member_start, member_end
+            )
+            if colon is not None:
+                key = static_object_key(
+                    self.lexed, member_start, colon
+                )
+                if key is not None:
+                    leaves.extend(
+                        self._destructure_leaves(
+                            colon + 1,
+                            member_end,
+                            prefix + (key,),
+                        )
+                    )
+                continue
+            default = top_level_assignment_separator(
+                self.lexed.code, member_start, member_end
+            )
+            key_end = default[0] if default is not None else member_end
+            key = static_object_key(
+                self.lexed, member_start, key_end
+            )
+            if key is not None:
+                leaves.append(
+                    (
+                        key,
+                        prefix + (key,),
+                        (default[1], member_end) if default else None,
+                    )
+                )
+        return leaves
+
+    def _find_destructuring(self) -> None:
+        if self.suffix not in self.JAVASCRIPT_SUFFIXES:
+            return
+        code = self.lexed.code
+        for opening, character in enumerate(code):
+            if character not in "[{":
+                continue
+            boundary = max(
+                code.rfind(";", 0, opening),
+                code.rfind("\n", 0, opening),
+            ) + 1
+            prefix = code[boundary:opening]
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            assignment = declaration is None and re.fullmatch(
+                r"\s*\(*\s*", prefix
+            )
+            if declaration is None and not assignment:
+                continue
+            right = "}" if character == "{" else "]"
+            closing = matching_delimiter(code, opening, character, right)
+            if closing is None:
+                continue
+            round_depth = square_depth = curly_depth = 0
+            equals = None
+            for cursor in range(closing + 1, len(code)):
+                current = code[cursor]
+                if current == "(":
+                    round_depth += 1
+                elif current == ")" and round_depth:
+                    round_depth -= 1
+                elif current == "[":
+                    square_depth += 1
+                elif current == "]" and square_depth:
+                    square_depth -= 1
+                elif current == "{":
+                    curly_depth += 1
+                elif current == "}" and curly_depth:
+                    curly_depth -= 1
+                elif not (round_depth or square_depth or curly_depth):
+                    if current in ";\n":
+                        break
+                    if (
+                        current == "="
+                        and not code.startswith(("==", "=>"), cursor)
+                        and (cursor == 0 or code[cursor - 1] not in "!<>=")
+                    ):
+                        equals = cursor
+                        break
+            if equals is None:
+                continue
+            residual = code[closing + 1:equals]
+            if residual.strip() and not re.fullmatch(
+                r"\s*:\s*[^=;\n]+\s*", residual
+            ):
+                continue
+            leaves = self._destructure_leaves(opening, closing + 1)
+            if not leaves:
+                continue
+            rhs_start = equals + 1
+            rhs_end = assignment_end(self.lexed, rhs_start, self.suffix)
+            if assignment:
+                wrapper = opening - 1
+                while wrapper >= boundary and code[wrapper].isspace():
+                    wrapper -= 1
+                if wrapper >= boundary and code[wrapper] == "(":
+                    wrapper_closing = matching_delimiter(
+                        code, wrapper, "(", ")"
+                    )
+                    if wrapper_closing is not None:
+                        rhs_end = min(rhs_end, wrapper_closing)
+                self.destructure_mutations.add(opening)
+            self.destructuring.append(
+                (opening, equals, rhs_start, rhs_end, leaves)
+            )
+
+    def _parameter_names(
+        self, start: int, end: int
+    ) -> list[str]:
+        names: list[str] = []
+        for span_start, span_end in split_arguments(
+            self.lexed.code, start, end
+        ):
+            source = self.lexed.code[span_start:span_end]
+            if not source.strip() or source.lstrip().startswith(("{", "[")):
+                continue
+            identifiers = re.findall(r"\$?([A-Za-z_]\w*)", source)
+            if not identifiers:
+                continue
+            if self.suffix == ".go":
+                name = identifiers[0]
+            elif self.suffix in self.JAVASCRIPT_SUFFIXES or self.suffix == ".php":
+                name = identifiers[0]
+            else:
+                name = identifiers[-1]
+            if name not in {"self", "this"}:
+                names.append(name)
+        return names
+
+    def _add_parameter_binding(
+        self, name: str, scope_id: int, offset: int
+    ) -> int:
+        existing = [
+            binding
+            for binding in self.graph.bindings.values()
+            if binding.name == name
+            and binding.scope_id == scope_id
+            and binding.kind == "parameter"
+        ]
+        if existing:
+            return existing[0].id
+        scope_start = self.graph.scopes[scope_id].start
+        binding_id = self.graph.add_binding(
+            name, scope_id, offset, scope_start, "parameter"
+        )
+        self.graph.add_definition(
+            binding_id,
+            (),
+            EndpointUnknown("parameter"),
+            scope_start,
+            scope_id,
+            "parameter",
+        )
+        return binding_id
+
+    def _build_parameter_bindings(self) -> None:
+        for opening, (start, end) in self.c_headers.items():
+            scope_id = self.scope_by_opening.get(opening)
+            if scope_id is None:
+                continue
+            for name in self._parameter_names(start, end):
+                self._add_parameter_binding(name, scope_id, opening)
+        for scope_id, start, end, offset in self.expression_parameters:
+            for name in self._parameter_names(start, end):
+                self._add_parameter_binding(name, scope_id, offset)
+        if self.suffix in self.C_SUFFIXES:
+            for match in re.finditer(
+                r"\b(catch|for|foreach)\s*\(", self.lexed.code
+            ):
+                params_open = self.lexed.code.rfind(
+                    "(", match.start(), match.end()
+                )
+                params_close = matching_delimiter(
+                    self.lexed.code, params_open, "(", ")"
+                )
+                if params_close is None:
+                    continue
+                brace = self.lexed.code.find("{", params_close)
+                if brace < 0 or self.lexed.code[params_close + 1:brace].strip():
+                    continue
+                scope_id = self.scope_by_opening.get(brace)
+                if scope_id is None:
+                    continue
+                source = self.lexed.code[params_open + 1:params_close]
+                if match.group(1) == "catch":
+                    identifiers = re.findall(r"\$?([A-Za-z_]\w*)", source)
+                    names = identifiers[-1:] if identifiers else []
+                else:
+                    declaration = re.search(
+                        r"\b(?:const|let|var|final|String|string|var)\s+"
+                        r"\$?([A-Za-z_]\w*)",
+                        source,
+                    )
+                    names = [declaration.group(1)] if declaration else []
+                for name in names:
+                    self._add_parameter_binding(name, scope_id, match.start())
+        if self.suffix == ".py":
+            pattern = re.compile(r"(?:async\s+)?def\s+\w+\s*\(")
+            for match in pattern.finditer(self.lexed.code):
+                opening = self.lexed.code.rfind("(", match.start(), match.end())
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                if closing is None:
+                    continue
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(opening + 1, closing):
+                    self._add_parameter_binding(name, scope_id, match.start())
+        if self.suffix == ".rb":
+            for match in re.finditer(
+                r"\bdef\s+\w+\s*(?:\(([^)]*)\)|([^\n]*))",
+                self.lexed.code,
+            ):
+                start, end = (
+                    match.span(1) if match.group(1) is not None else match.span(2)
+                )
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(start, end):
+                    self._add_parameter_binding(name, scope_id, match.start())
+            for match in re.finditer(
+                r"\bdo\s*\|([^|]*)\|", self.lexed.code
+            ):
+                scope_id = self.scope_at(match.start())
+                for name in self._parameter_names(*match.span(1)):
+                    self._add_parameter_binding(name, scope_id, match.start())
+
+    def _declaration_spec(
+        self, assignment: re.Match[str]
+    ) -> tuple[int, int, str, tuple[object, ...]] | None:
+        name = assignment.group(1).lstrip("$")
+        scope_id = self.scope_at(assignment.start())
+        execution = self.graph.execution_scope(scope_id)
+        line_start = max(
+            self.lexed.code.rfind("\n", 0, assignment.start()),
+            self.lexed.code.rfind(";", 0, assignment.start()),
+            self.lexed.code.rfind("{", 0, assignment.start()),
+        ) + 1
+        prefix = self.lexed.code[line_start:assignment.start()]
+        assignment_text = self.lexed.code[
+            assignment.start():assignment.end()
+        ]
+        if self.suffix in self.JAVASCRIPT_SUFFIXES:
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            if declaration is None:
+                return None
+            keyword = declaration.group(1)
+            owner = execution if keyword == "var" else scope_id
+            visibility = (
+                self.graph.scopes[owner].start
+                if keyword == "var"
+                else assignment.start()
+            )
+            key = ("js-var", owner, name) if keyword == "var" else (
+                "js-block", assignment.start()
+            )
+            return owner, visibility, "declaration", key
+        if self.suffix == ".go":
+            declared = ":=" in assignment_text or re.search(r"\bvar\s*$", prefix)
+            if not declared:
+                return None
+            return scope_id, assignment.start(), "declaration", (
+                "go", assignment.start()
+            )
+        if self.suffix in {".java", ".cs"}:
+            declared = re.search(
+                r"(?:^|[;{}])\s*(?:(?:public|private|protected|static|final|"
+                r"readonly|volatile)\s+)*(?:var|string|String|Uri|URI|URL|"
+                r"[A-Za-z_]\w*(?:\s*<[^;=]+>)?(?:\[\])?)\s*$",
+                prefix,
+            )
+            if declared is None:
+                return None
+            return scope_id, assignment.start(), "declaration", (
+                "c-block", assignment.start()
+            )
+        if self.suffix == ".py":
+            kind = self.graph.scopes[scope_id].kind
+            owner = scope_id if kind in {"function", "class"} else execution
+            visibility = (
+                self.graph.scopes[owner].start
+                if self.graph.scopes[owner].kind == "function"
+                else assignment.start()
+            )
+            return owner, visibility, "declaration", ("py", owner, name)
+        if self.suffix == ".rb":
+            owner = execution
+            return (
+                owner,
+                self.graph.scopes[owner].start,
+                "declaration",
+                ("rb", owner, name),
+            )
+        if self.suffix == ".php":
+            return (
+                execution,
+                self.graph.scopes[execution].start,
+                "declaration",
+                ("php", execution, name),
+            )
+        if self.suffix == ".sh":
+            return (
+                execution,
+                self.graph.scopes[execution].start,
+                "declaration",
+                ("sh", execution, name),
+            )
+        return None
+
+    def _build_bindings(self) -> None:
+        self._build_parameter_bindings()
+        grouped: dict[tuple[object, ...], int] = {}
+        for assignment in self.root_assignments:
+            name = assignment.group(1).lstrip("$")
+            spec = self._declaration_spec(assignment)
+            if spec is None:
+                continue
+            scope_id, visibility, kind, key = spec
+            binding_id = grouped.get(key)
+            if binding_id is None:
+                binding_id = self.graph.add_binding(
+                    name,
+                    scope_id,
+                    assignment.start(),
+                    visibility,
+                    kind,
+                )
+                grouped[key] = binding_id
+            self.assignment_bindings[assignment.start()] = binding_id
+
+        self.destructure_bindings: dict[tuple[int, str], int] = {}
+        for opening, _, _, _, leaves in self.destructuring:
+            prefix = self.lexed.code[
+                max(0, self.lexed.code.rfind("\n", 0, opening) + 1):opening
+            ]
+            declaration = re.search(r"\b(const|let|var)\s*$", prefix)
+            scope_id = self.scope_at(opening)
+            if declaration is None:
+                for name, _, _ in leaves:
+                    binding_id = self.graph.visible_binding(
+                        name, scope_id, opening
+                    )
+                    if binding_id is None:
+                        candidates = list(
+                            re.compile(
+                                rf"\b(let|var|const)\s+{re.escape(name)}\b"
+                            ).finditer(self.lexed.code, 0, opening)
+                        )
+                        if candidates:
+                            candidate = candidates[-1]
+                            candidate_scope = self.scope_at(candidate.start())
+                            keyword = candidate.group(1)
+                            owner = (
+                                self.graph.execution_scope(candidate_scope)
+                                if keyword == "var"
+                                else candidate_scope
+                            )
+                            binding_id = self.graph.add_binding(
+                                name,
+                                owner,
+                                candidate.start(),
+                                (
+                                    self.graph.scopes[owner].start
+                                    if keyword == "var"
+                                    else candidate.start()
+                                ),
+                                "declaration",
+                            )
+                    if binding_id is not None:
+                        self.destructure_bindings[(opening, name)] = binding_id
+                continue
+            keyword = declaration.group(1)
+            owner = (
+                self.graph.execution_scope(scope_id)
+                if keyword == "var"
+                else scope_id
+            )
+            for name, _, _ in leaves:
+                key = (
+                    ("js-var", owner, name)
+                    if keyword == "var"
+                    else ("destructure", opening, name)
+                )
+                binding_id = grouped.get(key)
+                if binding_id is None:
+                    binding_id = self.graph.add_binding(
+                        name,
+                        owner,
+                        opening,
+                        (
+                            self.graph.scopes[owner].start
+                            if keyword == "var"
+                            else opening
+                        ),
+                        "declaration",
+                    )
+                    grouped[key] = binding_id
+                self.destructure_bindings[(opening, name)] = binding_id
+
+        # Plain assignments with no visible declaration create one bounded
+        # implicit binding in their execution scope.
+        for assignment in self.root_assignments:
+            if assignment.start() in self.assignment_bindings:
+                continue
+            name = assignment.group(1).lstrip("$")
+            scope_id = self.scope_at(assignment.start())
+            binding_id = self.graph.visible_binding(
+                name, scope_id, assignment.start()
+            )
+            if binding_id is None:
+                owner = self.graph.execution_scope(scope_id)
+                key = ("implicit", owner, name)
+                binding_id = grouped.get(key)
+                if binding_id is None:
+                    binding_id = self.graph.add_binding(
+                        name,
+                        owner,
+                        assignment.start(),
+                        self.graph.scopes[owner].start,
+                        "implicit",
+                    )
+                    grouped[key] = binding_id
+            self.assignment_bindings[assignment.start()] = binding_id
+
+    def _top_level_plus_spans(
+        self, start: int, end: int
+    ) -> list[tuple[int, int]]:
+        spans: list[tuple[int, int]] = []
+        segment = start
+        round_depth = square_depth = curly_depth = 0
+        for index in range(start, end):
+            character = self.lexed.code[index]
+            if character == "(":
+                round_depth += 1
+            elif character == ")" and round_depth:
+                round_depth -= 1
+            elif character == "[":
+                square_depth += 1
+            elif character == "]" and square_depth:
+                square_depth -= 1
+            elif character == "{":
+                curly_depth += 1
+            elif character == "}" and curly_depth:
+                curly_depth -= 1
+            elif (
+                character == "+"
+                or (
+                    # PHP concatenates with '.', and member access there is
+                    # '->' / '::', so a top-level dot is unambiguous. Guard
+                    # against decimals in a numeric literal.
+                    character == "."
+                    and self.suffix == ".php"
+                    and not (
+                        index > start
+                        and self.lexed.code[index - 1].isdigit()
+                        and index + 1 < end
+                        and self.lexed.code[index + 1].isdigit()
+                    )
+                )
+            ) and not (
+                round_depth or square_depth or curly_depth
+            ):
+                spans.append((segment, index))
+                segment = index + 1
+        if spans:
+            spans.append((segment, end))
+        return spans
+
+    def _typescript_assertion_start(
+        self, start: int, end: int
+    ) -> int | None:
+        if self.suffix not in TYPESCRIPT_SUFFIXES:
+            return None
+        round_depth = square_depth = curly_depth = 0
+        for match in re.finditer(r"\b(?:as|satisfies)\b", self.lexed.code[start:end]):
+            offset = start + match.start()
+            for character in self.lexed.code[start:offset]:
+                if character == "(":
+                    round_depth += 1
+                elif character == ")" and round_depth:
+                    round_depth -= 1
+                elif character == "[":
+                    square_depth += 1
+                elif character == "]" and square_depth:
+                    square_depth -= 1
+                elif character == "{":
+                    curly_depth += 1
+                elif character == "}" and curly_depth:
+                    curly_depth -= 1
+            if round_depth or square_depth or curly_depth:
+                round_depth = square_depth = curly_depth = 0
+                continue
+            tail = self.lexed.original[start + match.end():end].strip()
+            if tail and re.fullmatch(
+                r"(?:const|readonly\s+)?[A-Za-z_$][\w$<>.,\[\]\s|&?:]*",
+                tail,
+            ):
+                return offset
+            round_depth = square_depth = curly_depth = 0
+        return None
+
+    @staticmethod
+    def _project_expression(
+        expression: EndpointExpression, members: EndpointReference
+    ) -> EndpointExpression:
+        if not members:
+            return expression
+        if isinstance(expression, EndpointRef):
+            return EndpointRef(
+                expression.binding_id, expression.members + members
+            )
+        if isinstance(expression, EndpointProjected):
+            return EndpointProjected(
+                expression.expression, expression.members + members
+            )
+        return EndpointProjected(expression, members)
+
+    def _static_key_from_span(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> str | None:
+        literal = static_lookup_key(self.lexed, start, end)
+        if literal is not None:
+            return literal
+        source = self.lexed.original[start:end].strip()
+        if not source or re.fullmatch(r"-\d+", source):
+            return None
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is None or len(reference) != 1:
+            return None
+        binding_id = self.graph.visible_binding(
+            reference[0].lstrip("$"), scope_id, before
+        )
+        if binding_id is None:
+            return None
+        value = self.graph.evaluate(
+            EndpointAccessState(binding_id, (), before, scope_id)
+        )
+        return value.exact
+
+    def _parse_access_expression(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression | None:
+        cursor = start
+        if self.lexed.code[cursor] == "(":
+            closing = matching_delimiter(
+                self.lexed.code, cursor, "(", ")"
+            )
+            if closing is None or closing >= end:
+                return None
+            expression = self._parse_expression(
+                cursor + 1, closing, scope_id, before
+            )
+            cursor = closing + 1
+        else:
+            root = re.match(r"\$?[A-Za-z_]\w*", self.lexed.code[cursor:end])
+            if root is None:
+                return None
+            name = root.group(0).lstrip("$")
+            binding_id = self.graph.visible_binding(name, scope_id, before)
+            expression = (
+                EndpointRef(binding_id)
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{name}")
+            )
+            cursor += len(root.group(0))
+
+        default_methods = {
+            ".py": {"get"},
+            ".rb": {"fetch"},
+            ".java": {"getOrDefault"},
+            ".cs": {"GetValueOrDefault"},
+        }
+        lookup_methods = {"get", "Get", "fetch"}
+        while True:
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            if (
+                self.suffix in TYPESCRIPT_SUFFIXES
+                and cursor < end
+                and self.lexed.code[cursor] == "!"
+            ):
+                cursor += 1
+                continue
+            if cursor >= end:
+                return expression
+
+            if self.lexed.code.startswith("?.", cursor):
+                cursor += 2
+                while cursor < end and self.lexed.code[cursor].isspace():
+                    cursor += 1
+                if cursor < end and self.lexed.code[cursor] == "[":
+                    closing = matching_delimiter(
+                        self.lexed.code, cursor, "[", "]"
+                    )
+                    if closing is None or closing >= end:
+                        return EndpointUnknown("dynamic selector")
+                    key = self._static_key_from_span(
+                        cursor + 1, closing, scope_id, before
+                    )
+                    if key is None:
+                        return EndpointUnknown("dynamic selector")
+                    expression = self._project_expression(expression, (key,))
+                    cursor = closing + 1
+                    continue
+            elif self.lexed.code.startswith("->", cursor):
+                cursor += 2
+            elif self.lexed.code[cursor] == ".":
+                cursor += 1
+            elif self.lexed.code[cursor] == "[":
+                closing = matching_delimiter(
+                    self.lexed.code, cursor, "[", "]"
+                )
+                if closing is None or closing >= end:
+                    return EndpointUnknown("dynamic selector")
+                key = self._static_key_from_span(
+                    cursor + 1, closing, scope_id, before
+                )
+                if key is None:
+                    return EndpointUnknown("dynamic selector")
+                expression = self._project_expression(expression, (key,))
+                cursor = closing + 1
+                continue
+            else:
+                return None
+
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            member = re.match(r"[A-Za-z_]\w*", self.lexed.code[cursor:end])
+            if member is None:
+                return EndpointUnknown("dynamic member")
+            member_name = member.group(0)
+            cursor += len(member_name)
+            while cursor < end and self.lexed.code[cursor].isspace():
+                cursor += 1
+            if cursor >= end or self.lexed.code[cursor] != "(":
+                expression = self._project_expression(
+                    expression, (member_name,)
+                )
+                continue
+
+            closing = matching_delimiter(
+                self.lexed.code, cursor, "(", ")"
+            )
+            if closing is None or closing >= end:
+                return EndpointUnknown("invalid lookup")
+            arguments = split_arguments(
+                self.lexed.code, cursor + 1, closing
+            )
+            if self.suffix == ".rb" and member_name == "dig":
+                keys = [
+                    self._static_key_from_span(
+                        argument_start,
+                        argument_end,
+                        scope_id,
+                        before,
+                    )
+                    for argument_start, argument_end in arguments
+                ]
+                if not keys or any(key is None for key in keys):
+                    return EndpointUnknown("dynamic dig")
+                expression = self._project_expression(
+                    expression, tuple(key for key in keys if key is not None)
+                )
+                cursor = closing + 1
+                continue
+            supported_defaults = default_methods.get(self.suffix, set())
+            if member_name not in lookup_methods | supported_defaults:
+                return EndpointUnknown("unsupported call")
+            if not arguments or len(arguments) > 2:
+                return EndpointUnknown("invalid lookup")
+            key = self._static_key_from_span(
+                arguments[0][0], arguments[0][1], scope_id, before
+            )
+            if key is None:
+                return EndpointUnknown("dynamic lookup")
+            primary = self._project_expression(expression, (key,))
+            expression = (
+                EndpointDefault(
+                    primary,
+                    self._parse_expression(
+                        arguments[1][0],
+                        arguments[1][1],
+                        scope_id,
+                        before,
+                    ),
+                )
+                if len(arguments) == 2 and member_name in supported_defaults
+                else primary
+            )
+            cursor = closing + 1
+
+    def _parse_reference_text(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        temporary = lex_source(source, self.suffix)
+        reference = static_reference_expression(
+            temporary, 0, len(temporary.code)
+        )
+        if reference is None:
+            return EndpointUnknown("dynamic interpolation")
+        name = reference[0].lstrip("$")
+        binding_id = self.graph.visible_binding(name, scope_id, before)
+        return (
+            EndpointRef(binding_id, reference[1:])
+            if binding_id is not None
+            else EndpointUnknown(f"unbound:{name}")
+        )
+
+    def _shell_text_expression(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        parts: list[EndpointExpression] = []
+        cursor = 0
+        for match in SHELL_STATIC_REFERENCE_RE.finditer(source):
+            key: str | None = None
+            if match.group(2):
+                selector = match.group(2).strip()
+                if selector.startswith("$"):
+                    temporary = lex_source(selector, ".sh")
+                    reference = static_reference_expression(
+                        temporary, 0, len(temporary.code)
+                    )
+                    if reference is None or len(reference) != 1:
+                        return EndpointUnknown("dynamic shell selector")
+                    key_binding = self.graph.visible_binding(
+                        reference[0].lstrip("$"), scope_id, before
+                    )
+                    if key_binding is None:
+                        return EndpointUnknown("dynamic shell selector")
+                    key = self.graph.evaluate(
+                        EndpointAccessState(
+                            key_binding, (), before, scope_id
+                        )
+                    ).exact
+                elif re.fullmatch(r"(?:[A-Za-z_]\w*|\d+)", selector) or (
+                    len(selector) >= 2
+                    and selector[0] == selector[-1]
+                    and selector[0] in {"'", '"'}
+                ):
+                    key = shell_static_key(selector)
+                if key is None:
+                    return EndpointUnknown("dynamic shell selector")
+            if match.start() > cursor:
+                parts.append(EndpointLiteral(source[cursor:match.start()]))
+            root = match.group(1) or match.group(3)
+            binding_id = self.graph.visible_binding(root, scope_id, before)
+            parts.append(
+                EndpointRef(binding_id, (key,) if key is not None else ())
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{root}")
+            )
+            cursor = match.end()
+        if cursor < len(source):
+            parts.append(EndpointLiteral(source[cursor:]))
+        return EndpointConcat(tuple(parts)) if parts else EndpointLiteral(source)
+
+    def _parse_shell_array(
+        self, source: str, scope_id: int, before: int
+    ) -> EndpointExpression:
+        try:
+            tokens = shlex.split(source[1:-1], comments=True, posix=True)
+        except ValueError:
+            return EndpointUnknown("invalid shell array")
+        keyed = bool(tokens) and all(
+            re.match(r"^\[[^]]+\]=", token) for token in tokens
+        )
+        if keyed:
+            entries: list[tuple[str, EndpointExpression]] = []
+            for token in tokens:
+                match = re.match(r"^\[([^]]+)\]=(.*)$", token, re.S)
+                if match is None:
+                    return EndpointUnknown("invalid shell member")
+                key = shell_static_key(match.group(1))
+                if key is None:
+                    return EndpointUnknown("dynamic shell key")
+                entries.append(
+                    (
+                        key,
+                        self._shell_text_expression(
+                            match.group(2), scope_id, before
+                        ),
+                    )
+                )
+            return EndpointObject(tuple(entries))
+        return EndpointArray(
+            tuple(
+                self._shell_text_expression(token, scope_id, before)
+                for token in tokens
+            )
+        )
+
+    def _parse_template(
+        self,
+        token: StringToken,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        contents = token.contents
+        patterns = (
+            r"\$\{([^{}]+)\}"
+            if self.suffix in self.JAVASCRIPT_SUFFIXES
+            else r"#\{([^{}]+)\}"
+            if self.suffix == ".rb"
+            else r"\{\s*(\$[A-Za-z_]\w*)\s*\}"
+            if self.suffix == ".php"
+            else r"\{([^{}]+)\}"
+        )
+        parts: list[EndpointExpression] = []
+        cursor = 0
+        for match in re.finditer(patterns, contents):
+            if match.start() > cursor:
+                parts.append(EndpointLiteral(contents[cursor:match.start()]))
+            parts.append(
+                self._parse_reference_text(
+                    match.group(1).strip(), scope_id, before
+                )
+            )
+            cursor = match.end()
+        if cursor < len(contents):
+            parts.append(EndpointLiteral(contents[cursor:]))
+        return (
+            EndpointConcat(tuple(parts))
+            if parts
+            else EndpointLiteral(contents)
+        )
+
+    def _parse_container(
+        self,
+        kind: str,
+        opening: int,
+        closing: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        members = split_arguments(self.lexed.code, opening + 1, closing)
+        if kind == "pairs":
+            entries: list[tuple[str, EndpointExpression]] = []
+            for index in range(1, len(members), 2):
+                key = static_object_key(self.lexed, *members[index - 1])
+                if key is not None:
+                    entries.append(
+                        (
+                            key,
+                            self._parse_expression(
+                                *members[index], scope_id, before
+                            ),
+                        )
+                    )
+            return EndpointObject(tuple(entries))
+        separators = [
+            (
+                (colon, colon + 1)
+                if (colon := top_level_colon(
+                    self.lexed.code, member_start, member_end
+                )) is not None
+                else top_level_assignment_separator(
+                    self.lexed.code, member_start, member_end
+                )
+            )
+            for member_start, member_end in members
+        ]
+        declared_map = bool(
+            re.search(
+                r"(?:\bDictionary\b|\bMap\b|\bmap\s*\[)",
+                self.lexed.code[max(0, opening - 160):opening],
+            )
+        )
+        keyed = any(separator is not None for separator in separators) or (
+            self.lexed.code[opening] == "{"
+            and (
+                self.suffix not in {".cs", ".go", ".java"}
+                or declared_map
+            )
+        )
+        if not keyed:
+            return EndpointArray(
+                tuple(
+                    self._parse_expression(
+                        member_start, member_end, scope_id, before
+                    )
+                    for member_start, member_end in members
+                    if self.lexed.original[member_start:member_end].strip()
+                )
+            )
+        entries = []
+        for (member_start, member_end), separator in zip(members, separators):
+            if separator is None:
+                key = static_object_key(
+                    self.lexed, member_start, member_end
+                )
+                if key is not None:
+                    entries.append(
+                        (
+                            key,
+                            self._parse_expression(
+                                member_start, member_end, scope_id, before
+                            ),
+                        )
+                    )
+                continue
+            separator_start, value_start = separator
+            key = static_object_key(
+                self.lexed, member_start, separator_start
+            )
+            if key is not None:
+                entries.append(
+                    (
+                        key,
+                        self._parse_expression(
+                            value_start, member_end, scope_id, before
+                        ),
+                    )
+                )
+        return EndpointObject(tuple(entries))
+
+    def _parse_expression(
+        self,
+        start: int,
+        end: int,
+        scope_id: int,
+        before: int,
+    ) -> EndpointExpression:
+        raw_start, raw_end = start, end
+        while raw_start < raw_end and self.lexed.original[raw_start].isspace():
+            raw_start += 1
+        while raw_end > raw_start and self.lexed.original[raw_end - 1].isspace():
+            raw_end -= 1
+        if self.suffix == ".sh":
+            raw_source = self.lexed.original[raw_start:raw_end]
+            if raw_source.startswith("(") and raw_source.endswith(")"):
+                return self._parse_shell_array(
+                    raw_source, scope_id, before
+                )
+            if (
+                len(raw_source) >= 2
+                and raw_source[0] == raw_source[-1]
+                and raw_source[0] in {"'", '"'}
+            ):
+                if raw_source[0] == "'":
+                    return EndpointLiteral(raw_source[1:-1])
+                return self._shell_text_expression(
+                    raw_source[1:-1], scope_id, before
+                )
+            if re.fullmatch(r"[A-Za-z_]\w*", raw_source):
+                return EndpointLiteral(raw_source)
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end:
+            return EndpointUnknown("empty")
+        # `new URL(...)` is routinely stringified before use - `u.toString()`,
+        # `u.href`, `String(u)`. Those wrappers are not part of the endpoint, so
+        # peel them before resolving or the binding reads as an unknown
+        # expression and the send disappears.
+        # A TERNARY selecting the endpoint - `flag ? POOL_URL : OTHER` - was not
+        # modelled at all, so the whole expression read as unknown and the send
+        # vanished: not counted, so the fail-safe could not fire either. The
+        # byte-equivalent if/else form was caught. Resolve BOTH arms and treat a
+        # required endpoint in EITHER as required, which is the safe direction:
+        # the send may take that branch at runtime.
+        ternary = _top_level_ternary(self.lexed.code, start, end)
+        if ternary is not None:
+            for arm_start, arm_end in ternary:
+                arm = self._parse_expression(arm_start, arm_end, scope_id, before)
+                if isinstance(arm, EndpointLiteral) and required_endpoint(arm.value):
+                    return arm
+
+        text_for_peel = self.lexed.code[start:end]
+        # SUFFIX forms: u.toString() / u.href / u.toJSON()
+        stringified = re.match(
+            r"^\s*(.+?)\s*(?:\.\s*(?:toString\s*\(\s*\)|href|toJSON\s*\(\s*\)))\s*$",
+            text_for_peel, re.S,
+        )
+        if stringified is not None and stringified.start(1) != stringified.end(1):
+            inner_end = start + stringified.end(1)
+            if inner_end > start and (start, inner_end) != (start, end):
+                return self._parse_expression(start, inner_end, scope_id, before)
+        # PREFIX and TEMPLATE forms: String(u) and `${u}`. An earlier comment
+        # claimed String(u) was covered while the pattern only matched suffix
+        # member access, so `fetch(String(u), ...)` resolved to UNKNOWN - and
+        # because an unknown endpoint is not counted as a send at all, the
+        # fail-safe could not fire either and the linter reported CLEAN.
+        prefix_peel = re.match(
+            r"^\s*(?:String|globalThis\s*\.\s*String)\s*\(\s*(.+?)\s*\)\s*$",
+            text_for_peel, re.S,
+        ) or re.match(r"^\s*`\s*\$\{\s*(.+?)\s*\}\s*`\s*$", text_for_peel, re.S)
+        if prefix_peel is not None:
+            inner_start = start + prefix_peel.start(1)
+            inner_end = start + prefix_peel.end(1)
+            if inner_end > inner_start and (inner_start, inner_end) != (start, end):
+                return self._parse_expression(inner_start, inner_end, scope_id, before)
+
+        # A BOUND two-argument `new URL(path, base)` must be combined here, the
+        # same way the inline spelling is combined at the call site. Leaving it
+        # unresolved was deliberate, but the consequence was a SILENT PASS, not
+        # a caveat: neither `number_pool` nor the base is a required endpoint on
+        # its own, so the fail-safe backstop never fires either and
+        # `const u = new URL('number_pool', BASE); fetch(u, ...)` certified
+        # clean while the byte-identical inline form was correctly flagged.
+        constructor_base = url_constructor_base(self.lexed, (start, end), self.suffix)
+        if constructor_base is not None:
+            constructed = unwrap_url_constructor(self.lexed, (start, end))
+            if constructed != (start, end):
+                inner = self._parse_expression(
+                    constructed[0], constructed[1], scope_id, before
+                )
+                if isinstance(inner, EndpointLiteral):
+                    return EndpointLiteral(urljoin(constructor_base, inner.value))
+
+        constructed = unwrap_bound_url_constructor(self.lexed, (start, end))
+        if constructed != (start, end):
+            return self._parse_expression(
+                constructed[0], constructed[1], scope_id, before
+            )
+        assertion = self._typescript_assertion_start(start, end)
+        if assertion is not None:
+            return self._parse_expression(start, assertion, scope_id, before)
+        plus_spans = self._top_level_plus_spans(start, end)
+        if plus_spans:
+            return EndpointConcat(
+                tuple(
+                    self._parse_expression(
+                        part_start, part_end, scope_id, before
+                    )
+                    for part_start, part_end in plus_spans
+                )
+            )
+
+        # Common URL/string builders. Restrict literal-suffix rescue to these
+        # named producers; applying it to every unsupported expression makes
+        # an unrelated object member or callback URL displace the real request
+        # URL and creates false positives.
+        builder_source = self.lexed.original[start:end]
+        python_percent_format = (
+            self.suffix == ".py"
+            and re.search(r"%(?:\s*\([^)]*\))?[#0 +\-]?[0-9.*]*[a-zA-Z]", builder_source)
+            is not None
+            and re.search(r"%", self.lexed.code[start:end]) is not None
+        )
+        local_builder = re.match(
+            r"\s*([A-Za-z_$]\w*)\s*\(", self.lexed.code[start:end]
+        )
+        node_join_alias = (
+            self.suffix in JS_TS_SUFFIXES
+            and local_builder is not None
+            and self._is_node_path_join_alias(
+                local_builder.group(1), scope_id, start
+            )
+        )
+        if python_percent_format or node_join_alias or re.search(
+            r"(?:\bfmt\s*\.\s*Sprintf\s*\(|\.\s*format\s*\("
+            r"|\burljoin\s*\(|\bencodeURI(?:Component)?\s*\("
+            r"|\.\s*(?:concat|join)\s*\()",
+            builder_source,
+        ):
+            builder_tokens = [
+                token.contents
+                for token in self.lexed.strings
+                if start <= token.start and token.end <= end
+            ]
+            builder_candidates = builder_tokens + [
+                "".join(builder_tokens),
+                "/".join(builder_tokens),
+            ]
+            # A FORMAT builder substitutes later arguments INTO the first
+            # token, so concatenating tokens in source order yields garbage
+            # ("%snumber_pool" + base). Substitute instead, which is what the
+            # runtime does: "%snumber_pool" % base -> ".../messages/number_pool".
+            if len(builder_tokens) >= 2:
+                remaining = list(builder_tokens[1:])
+                substituted = re.sub(
+                    r"%(?:\([^)]*\))?[#0 +\-]?[0-9.*]*[a-zA-Z]|\{\d*\}",
+                    lambda _match: remaining.pop(0) if remaining else "",
+                    builder_tokens[0],
+                )
+                builder_candidates.append(substituted)
+            required = next(
+                (
+                    candidate
+                    for candidate in builder_candidates
+                    if required_endpoint(candidate)
+                    or required_endpoint_literal_signal(candidate)
+                ),
+                None,
+            )
+            if required is not None:
+                suffix_match = re.search(
+                    r"/messages/(?:number_pool|alphanumeric_sender_id)/?$",
+                    required.split("?", 1)[0].split("#", 1)[0],
+                )
+                return EndpointLiteral(
+                    suffix_match.group(0) if suffix_match else required
+                )
+
+        if self.suffix == ".py":
+            python_tokens = [
+                token
+                for token in self.lexed.strings
+                if start <= token.start and token.end <= end
+            ]
+            if len(python_tokens) == 1:
+                token = python_tokens[0]
+                prefix = self.lexed.original[start:token.start].strip().lower()
+                suffix_text = self.lexed.original[token.end:end].strip()
+                if "f" in prefix and not suffix_text and "{" in token.contents:
+                    return self._parse_template(token, scope_id, before)
+
+        container = root_literal_container(
+            self.lexed, start, end, self.suffix
+        )
+        if container is not None:
+            kind, opening, closing = container
+            selected = selected_members_after_container(
+                self.lexed, closing, end
+            )
+            trailing = self.lexed.code[closing + 1:end].strip(" )\t\r\n")
+            if trailing:
+                if selected is None or not selected:
+                    return EndpointUnknown("dynamic container selector")
+                value_span = literal_value_span(
+                    self.lexed, start, end, selected, self.suffix
+                )
+                return (
+                    self._parse_expression(
+                        value_span[0], value_span[1], scope_id, before
+                    )
+                    if value_span is not None
+                    else EndpointUnknown("missing container member")
+                )
+            return self._parse_container(
+                kind, opening, closing, scope_id, before
+            )
+
+        access = self._parse_access_expression(
+            start, end, scope_id, before
+        )
+        if access is not None:
+            return access
+
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is not None:
+            name = reference[0].lstrip("$")
+            binding_id = self.graph.visible_binding(
+                name, scope_id, before
+            )
+            return (
+                EndpointRef(binding_id, reference[1:])
+                if binding_id is not None
+                else EndpointUnknown(f"unbound:{name}")
+            )
+
+        if self.suffix == ".rb":
+            symbol = re.fullmatch(
+                r"\s*:\s*([A-Za-z_]\w*)\s*",
+                self.lexed.original[start:end],
+            )
+            if symbol is not None:
+                return EndpointLiteral(symbol.group(1))
+
+        tokens = [
+            token
+            for token in self.lexed.strings
+            if start <= token.start and token.end <= end
+        ]
+        if len(tokens) == 1:
+            token = tokens[0]
+            residual = (
+                self.lexed.code[start:token.start]
+                + self.lexed.code[token.end:end]
+            ).strip()
+            if self.suffix == ".py":
+                format_match = re.fullmatch(
+                    r"\s*\.\s*format\s*\((.*)\)\s*",
+                    self.lexed.original[token.end:end],
+                    re.S,
+                )
+                if format_match is not None:
+                    opening = self.lexed.code.find("(", token.end, end)
+                    closing = matching_delimiter(
+                        self.lexed.code, opening, "(", ")"
+                    )
+                    arguments = (
+                        split_arguments(
+                            self.lexed.code, opening + 1, closing
+                        )
+                        if closing is not None
+                        else []
+                    )
+                    pieces = token.contents.split("{}")
+                    if len(pieces) == len(arguments) + 1:
+                        parts: list[EndpointExpression] = []
+                        for index, piece in enumerate(pieces):
+                            if piece:
+                                parts.append(EndpointLiteral(piece))
+                            if index < len(arguments):
+                                parts.append(
+                                    self._parse_expression(
+                                        arguments[index][0],
+                                        arguments[index][1],
+                                        scope_id,
+                                        before,
+                                    )
+                                )
+                        return EndpointConcat(tuple(parts))
+            is_template = (
+                self.lexed.original[token.start] == "`"
+                or (self.suffix == ".rb" and "#{" in token.contents)
+                or (self.suffix == ".php" and "{$" in token.contents)
+                or (
+                    self.suffix == ".cs"
+                    and "$" in residual
+                    and "{" in token.contents
+                )
+                or (
+                    self.suffix == ".py"
+                    and "f" in residual.lower()
+                    and "{" in token.contents
+                )
+            )
+            if is_template:
+                return self._parse_template(token, scope_id, before)
+            if (
+                self.suffix == ".sh"
+                and self.lexed.original[token.start] == '"'
+                and "$" in token.contents
+            ):
+                return self._shell_text_expression(
+                    token.contents, scope_id, before
+                )
+            if residual.lower() in {"", "f", "r", "u", "b", "fr", "rf"}:
+                return EndpointLiteral(token.contents)
+        return EndpointUnknown("unsupported expression")
+
+    def _guard_scope(self, scope_id: int) -> int | None:
+        for candidate in self.graph.ancestors(scope_id):
+            if self.graph.scopes[candidate].kind == "conditional":
+                return candidate
+            if self.graph.scopes[candidate].kind in {"function", "module"}:
+                break
+        return None
+
+    def _definition_scope(self, scope_id: int) -> tuple[int, bool]:
+        guard = self._guard_scope(scope_id)
+        return (guard, True) if guard is not None else (scope_id, False)
+
+    def _container_origin_binding(
+        self, binding_id: int, before: int
+    ) -> int:
+        seen: set[int] = set()
+        current = binding_id
+        cutoff = before
+        while current not in seen:
+            seen.add(current)
+            definitions = [
+                definition
+                for definition in self.graph.definitions.get(current, ())
+                if definition.start < cutoff and not definition.member_path
+            ]
+            if not definitions:
+                return current
+            latest = definitions[-1]
+            if not (
+                isinstance(latest.expression, EndpointRef)
+                and not latest.expression.members
+            ):
+                return current
+            current = latest.expression.binding_id
+            cutoff = latest.start
+        return binding_id
+
+    def _add_member_definition(
+        self,
+        binding_id: int,
+        path: EndpointReference,
+        expression: EndpointExpression,
+        offset: int,
+        scope_id: int,
+        guarded: bool,
+    ) -> None:
+        targets = {binding_id, self._container_origin_binding(binding_id, offset)}
+        for target in targets:
+            self.graph.add_definition(
+                target,
+                path,
+                expression,
+                offset,
+                scope_id,
+                "mutation",
+                guarded,
+            )
+
+    def _build_definitions(self) -> None:
+        for assignment in self.root_assignments:
+            binding_id = self.assignment_bindings[assignment.start()]
+            scope_id = self.scope_at(assignment.start())
+            rhs_end = assignment_end(
+                self.lexed, assignment.end(), self.suffix
+            )
+            expression = self._parse_expression(
+                assignment.end(), rhs_end, scope_id, assignment.start()
+            )
+            binding = self.graph.bindings[binding_id]
+            kind = (
+                "declaration"
+                if binding.declaration_start == assignment.start()
+                else "mutation"
+            )
+            definition_scope, guarded = self._definition_scope(scope_id)
+            self.graph.add_definition(
+                binding_id,
+                (),
+                expression,
+                assignment.start(),
+                definition_scope,
+                kind,
+                guarded,
+            )
+
+        for reference, start, rhs_start, rhs_end in direct_member_assignments(
+            self.lexed, len(self.lexed.code), self.suffix
+        ):
+            root = reference[0].lstrip("$")
+            scope_id = self.scope_at(start)
+            binding_id = self.graph.visible_binding(root, scope_id, start)
+            if binding_id is None:
+                continue
+            definition_scope, guarded = self._definition_scope(scope_id)
+            self._add_member_definition(
+                binding_id,
+                reference[1:],
+                self._parse_expression(
+                    rhs_start, rhs_end, scope_id, start
+                ),
+                start,
+                definition_scope,
+                guarded,
+            )
+
+        if self.suffix == ".java":
+            put_pattern = re.compile(
+                r"(?<![\w$.])([A-Za-z_]\w*)\s*\.\s*put\s*\("
+            )
+            for put in put_pattern.finditer(self.lexed.code):
+                opening = self.lexed.code.rfind(
+                    "(", put.start(), put.end()
+                )
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                if closing is None:
+                    continue
+                arguments = split_arguments(
+                    self.lexed.code, opening + 1, closing
+                )
+                if len(arguments) != 2:
+                    continue
+                key = static_lookup_key(self.lexed, *arguments[0])
+                scope_id = self.scope_at(put.start())
+                binding_id = self.graph.visible_binding(
+                    put.group(1), scope_id, put.start()
+                )
+                if key is None or binding_id is None:
+                    continue
+                definition_scope, guarded = self._definition_scope(scope_id)
+                self._add_member_definition(
+                    binding_id,
+                    (key,),
+                    self._parse_expression(
+                        arguments[1][0], arguments[1][1], scope_id, put.start()
+                    ),
+                    put.start(),
+                    definition_scope,
+                    guarded,
+                )
+
+        if self.suffix == ".sh":
+            for reference, start, rhs_start, rhs_end in shell_member_assignments(
+                self.lexed, len(self.lexed.code), self.suffix
+            ):
+                scope_id = self.scope_at(start)
+                binding_id = self.graph.visible_binding(
+                    reference[0], scope_id, start
+                )
+                if binding_id is None:
+                    continue
+                self._add_member_definition(
+                    binding_id,
+                    reference[1:],
+                    self._parse_expression(
+                        rhs_start, rhs_end, scope_id, start
+                    ),
+                    start,
+                    scope_id,
+                    False,
+                )
+
+        for opening, _, rhs_start, rhs_end, leaves in self.destructuring:
+            scope_id = self.scope_at(opening)
+            mutation = opening in self.destructure_mutations
+            definition_scope, guarded = (
+                self._definition_scope(scope_id)
+                if mutation
+                else (scope_id, False)
+            )
+            source = self._parse_expression(
+                rhs_start, rhs_end, scope_id, opening
+            )
+            for name, projection, fallback in leaves:
+                binding_id = self.destructure_bindings.get((opening, name))
+                if binding_id is None:
+                    continue
+                expression: EndpointExpression = EndpointProjected(
+                    source, projection
+                )
+                if fallback is not None:
+                    expression = EndpointDefault(
+                        expression,
+                        self._parse_expression(
+                            fallback[0], fallback[1], scope_id, opening
+                        ),
+                    )
+                self.graph.add_definition(
+                    binding_id,
+                    (),
+                    expression,
+                    opening,
+                    definition_scope,
+                    "mutation" if mutation else "declaration",
+                    guarded,
+                )
+
+        delete_pattern = re.compile(r"\bdelete\s+([^;\n]+)")
+        for deletion in delete_pattern.finditer(self.lexed.code):
+            reference = static_reference_expression(
+                self.lexed, deletion.start(1), deletion.end(1)
+            )
+            if reference is None or len(reference) < 2:
+                continue
+            scope_id = self.scope_at(deletion.start())
+            binding_id = self.graph.visible_binding(
+                reference[0].lstrip("$"), scope_id, deletion.start()
+            )
+            if binding_id is not None:
+                definition_scope, guarded = self._definition_scope(scope_id)
+                self._add_member_definition(
+                    binding_id,
+                    reference[1:],
+                    EndpointUnknown("delete"),
+                    deletion.start(),
+                    definition_scope,
+                    guarded,
+                )
+
+    def resolve_expression(
+        self,
+        start: int,
+        end: int,
+        before: int,
+        projection: EndpointReference = (),
+    ) -> EndpointValue:
+        scope_id = self.scope_at(before)
+        expression = self._parse_expression(
+            start, end, scope_id, before
+        )
+        return self.graph.evaluate(
+            EndpointExpressionState(
+                expression, projection, before, scope_id
+            )
+        )
+
+    def config_method_may_mutate(
+        self, span: tuple[int, int], before: int
+    ) -> bool:
+        """Return whether a request config can use POST, PUT, or PATCH.
+
+        A proven config without a method defaults to GET. Static methods use
+        the shared mutating-method contract, while unresolved dynamic configs
+        remain in scope so analysis fails safely.
+        """
+
+        value = self.resolve_expression(
+            span[0], span[1], before, ("method",)
+        )
+        if value.exact is not None:
+            return value.exact.upper() in MUTATING_HTTP_METHODS
+        method_spans = config_object_member_spans(
+            self.lexed, span, before, self.suffix, ("method",)
+        )
+        if method_spans:
+            method_source = self.lexed.code[slice(*method_spans[-1])].strip()
+            if method_source in {"null", "undefined"}:
+                return False
+            method = static_method_value(
+                self.lexed,
+                method_spans[-1],
+                before,
+                self.suffix,
+            )
+            return method is None or method in MUTATING_HTTP_METHODS
+        if resolved_config_object_span(
+            self.lexed, span, before, self.suffix
+        ) is not None:
+            return False
+        return self.lexed.code[slice(*span)].strip() not in {
+            "null", "undefined"
+        }
+
+    def request_is_required(self, call: Call) -> bool:
+        args = split_arguments(
+            self.lexed.code, call.open_paren + 1, call.end - 1
+        )
+        callee = re.sub(
+            r"\s+", "", self.lexed.code[call.start:call.open_paren]
+        ).lower()
+        if callee == "fetch":
+            # Fetch defaults to GET.  Only known mutating methods, or an
+            # unresolved dynamic method that may be mutating, are sends.
+            if len(args) < 2:
+                return False
+            if not self.config_method_may_mutate(args[1], call.start):
+                return False
+        receiver = call_receiver(self.lexed, call)
+        config_span: tuple[int, int] | None = None
+        if callee in {"axios", "axios.request"} or (
+            callee == "request" and receiver == "axios"
+        ):
+            config_span = args[0] if args else None
+        elif callee == "request" and args:
+            if resolved_config_object_span(
+                self.lexed, args[0], call.start, self.suffix
+            ) is not None:
+                config_span = args[0]
+            elif len(args) > 1 and resolved_config_object_span(
+                self.lexed, args[1], call.start, self.suffix
+            ) is not None:
+                config_span = args[1]
+        if config_span is not None and not self.config_method_may_mutate(
+            config_span, call.start
+        ):
+            return False
+        if callee == "curl_setopt" and len(args) >= 3:
+            option = self.lexed.code[slice(*args[1])].strip()
+            if option == "CURLOPT_URL":
+                handle = self.lexed.code[slice(*args[0])].strip()
+                method = php_curl_handle_method(
+                    self.lexed, handle, call.start, self.suffix
+                )
+                if method is not None and method not in MUTATING_HTTP_METHODS:
+                    return False
+        original_spans = _request_url_spans(self.lexed, call, self.suffix)
+        resolved = []
+        for span in original_spans:
+            unwrapped = unwrap_url_constructor(self.lexed, span)
+            value = self.resolve_expression(
+                unwrapped[0], unwrapped[1], call.start
+            )
+            resolved.append(value)
+            # new URL(path, base) resolves the path relative to the base per
+            # RFC 3986 — a base without a trailing slash drops its last
+            # segment — so use urljoin rather than naive concatenation.
+            constructor_base = url_constructor_base(self.lexed, span, self.suffix)
+            if (
+                constructor_base is not None
+                and value.exact is not None
+                and required_endpoint(urljoin(constructor_base, value.exact))
+            ):
+                return True
+        if any(value.kind == REQUIRED for value in resolved):
+            return True
+        # A client base URL makes the request path relative, so combine the
+        # base with the resolved path before classifying:
+        # axios.create({baseURL: '.../messages'}).post('/number_pool').
+        base = client_base_url(self.lexed, call, self.suffix)
+        if base is not None and any(
+            value.exact is not None
+            and required_endpoint(join_base_and_path(base, value.exact))
+            for value in resolved
+        ):
+            return True
+        # Guzzle, Faraday, and HttpClient also allow the base to be declared
+        # in a nearby client configuration form that is not a root assignment
+        # the binding index can recover. Keep this fallback narrow: only the
+        # three base-client languages, only a relative required suffix, and
+        # only a prior static URL whose path is the messages collection.
+        if self.suffix in {".php", ".rb", ".cs"} and any(
+            value.exact is not None
+            and re.search(r"(?:^|/)(?:number_pool|alphanumeric_sender_id)/?$", value.exact)
+            for value in resolved
+        ):
+            prior_bases = [
+                token.contents
+                for token in self.lexed.strings
+                if token.end <= call.start
+                and re.search(r"/messages/?$", urlsplit(token.contents).path)
+            ]
+            if prior_bases and any(
+                value.exact is not None
+                and required_endpoint(join_base_and_path(prior_bases[-1], value.exact))
+                for value in resolved
+            ):
+                return True
+        if not args:
+            return False
+        return bool(
+            config_span is not None
+            and self.resolve_expression(
+                config_span[0], config_span[1], call.start, ("url",)
+            ).kind
+            == REQUIRED
+        )
+
+    def shell_curl_is_required(self, call: Call) -> bool:
+        method = shell_curl_http_method(self.lexed, call)
+        if method is not None and method not in MUTATING_HTTP_METHODS:
+            return False
+        scope_id = self.scope_at(call.start)
+        allowed_references = shell_curl_url_references(self.lexed, call)
+        for argument in shell_curl_url_arguments(self.lexed, call):
+            if required_endpoint(argument.strip("'\"")):
+                return True
+            references = shell_static_references(argument)
+            if references and any(
+                reference not in allowed_references
+                for reference in references
+            ):
+                continue
+            expression = self._shell_text_expression(
+                argument, scope_id, call.start
+            )
+            if self.graph.evaluate(
+                EndpointExpressionState(
+                    expression, (), call.start, scope_id
+                )
+            ).kind == REQUIRED:
+                return True
+        return False
+
+
+ABSENT, MAYBE, PRESENT = "absent", "maybe", "present"
+NO_WRITE, WRITE_ABSENT, WRITE_MAYBE, WRITE_PRESENT = range(4)
+
+
+@dataclass(frozen=True)
+class Presence:
+    state: str
+    evidence: bool = False
+
+
+ABSENT_VALUE = Presence(ABSENT)
+MAYBE_VALUE = Presence(MAYBE)
+PRESENT_VALUE = Presence(PRESENT, True)
+
+
+def join_presence(values: Iterable[Presence]) -> Presence:
+    values = tuple(values)
+    states = {value.state for value in values}
+    return Presence(
+        next(iter(states)) if len(states) == 1 else MAYBE,
+        any(value.evidence for value in values),
+    ) if values else MAYBE_VALUE
+
+
+def apply_field_effect(value: Presence, effect: int) -> Presence:
+    if effect == NO_WRITE:
+        return value
+    if effect == WRITE_PRESENT:
+        return PRESENT_VALUE
+    if effect == WRITE_ABSENT:
+        return Presence(ABSENT, True)
+    return Presence(MAYBE, True)
+
+
+def overlay_effect(value: Presence) -> int:
+    if value.state == PRESENT:
+        return WRITE_PRESENT
+    if value.state == MAYBE:
+        return WRITE_MAYBE
+    return WRITE_ABSENT if value.evidence else NO_WRITE
+
+
+@dataclass(frozen=True)
+class ObjectTargets:
+    must: frozenset[tuple[int, int]] = frozenset()
+    may: frozenset[tuple[int, int]] = frozenset()
+    unknown: bool = False
+
+    @property
+    def all(self) -> frozenset[tuple[int, int]]:
+        return self.must | self.may
+
+
+def join_targets(values: Iterable[ObjectTargets]) -> ObjectTargets:
+    values = tuple(values)
+    if not values:
+        return ObjectTargets(unknown=True)
+    possible = frozenset().union(*(value.all for value in values))
+    must = set(values[0].must)
+    for value in values[1:]:
+        must.intersection_update(value.must)
+    if any(value.unknown for value in values):
+        must.clear()
+    required = frozenset(must)
+    return ObjectTargets(required, possible - required, any(v.unknown for v in values))
+
+
+@dataclass(frozen=True)
+class ControlArm:
+    group: int
+    branch: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class RootFieldEvent:
+    binding: int
+    start: int
+    rhs: tuple[int, int]
+    scope: int
+    execution: int
+    kind: str
+    path: tuple[tuple[int, int], ...]
+    aliases: tuple[int, ...] | None
+    alias_unknown: bool = False
+
+    @property
+    def object_id(self) -> tuple[int, int]:
+        return self.binding, self.start
+
+
+@dataclass(frozen=True)
+class FieldEvent:
+    binding: int
+    start: int
+    scope: int
+    execution: int
+    path: tuple[tuple[int, int], ...]
+    effect: int
+    overlay: tuple[int, int] | None = None
+
+
+class ControlIndex:
+    """Finite branch index; callable boundaries remain in the binding graph."""
+
+    C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php"}
+
+    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+        self.lexed, self.suffix = lexed, suffix
+        self.arms: list[ControlArm] = []
+        self.exhaustive: set[int] = set()
+        if suffix in self.C_SUFFIXES:
+            self._curly()
+            # Expression-level guards are not a JavaScript peculiarity: PHP,
+            # Ruby and Python all write `cond && payload[...] = x`, `cond and
+            # payload.update(...)` and the ternary forms, and a field written
+            # that way is CONDITIONAL. Indexing them only for JS/TS meant the
+            # same guarded write read as unconditional in every other language -
+            # a silent pass on a profile that may never be set.
+            if suffix in JS_TS_SUFFIXES or suffix == ".php":
+                self._expression_guards()
+        elif suffix in {".py", ".rb", ".sh"}:
+            self._lines()
+            if suffix in {".py", ".rb"}:
+                self._expression_guards()
+
+    def _unbraced_body_end(self, start: int) -> int | None:
+        """End of a single-statement `if (cond) stmt;` body after the ')'.
+
+        The lexer masks string interiors, so scanning the masked code for a
+        top-level ';' or line break is safe. Returns None if no statement
+        follows (e.g. a stray brace).
+        """
+        code = self.lexed.code
+        index = start
+        while index < len(code) and code[index].isspace():
+            index += 1
+        if index >= len(code) or code[index] in "{};":
+            return None
+        depth = 0
+        while index < len(code):
+            character = code[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif depth == 0 and character == ";":
+                return index + 1
+            elif depth == 0 and character == "\n":
+                return index
+            index += 1
+        return None
+
+    def _expression_guards(self) -> None:
+        """Index short-circuit and ternary expression arms in JS/TS.
+
+        A field write after `&&`/`||`, in either side of `?:`, or through a
+        logical assignment (`&&=`/`||=`) is conditional even though no block
+        exists. Scope only the containing statement so adjacent unconditional
+        writes retain an empty control path.
+        """
+        code = self.lexed.code
+        # A WRAPPED guard is still one statement. Breaking on every raw newline
+        # put `usePool &&` and `(payload.messaging_profile_id = p)` into
+        # different segments, so neither held both the operator and the write
+        # and the conditional write read as unconditional. Only a newline that
+        # neither follows nor precedes a logical/ternary operator ends a
+        # statement; nothing else is joined, so unrelated lines cannot merge
+        # into a spurious arm.
+        # Ruby, PHP and Python spell the same operators as WORDS as well.
+        word_ops = self.suffix in {".php", ".rb", ".py"}
+        logical_re = (
+            r"&&=?|\|\|=?|(?<![\w])(?:and|or)(?![\w])" if word_ops
+            else r"&&=?|\|\|=?"
+        )
+        dangling = re.compile(
+            r"(?:&&|\|\||\?|(?<![\w])(?:and|or))\s*$" if word_ops
+            else r"(?:&&|\|\||\?)\s*$"
+        )
+        continuing = re.compile(
+            r"[ \t]*(?:&&|\|\||\?|:|(?<![\w])(?:and|or)(?![\w]))" if word_ops
+            else r"[ \t]*(?:&&|\|\||\?|:)"
+        )
+        statement_start = 0
+        for match in re.finditer(r"[;\n]|$", code):
+            statement_end = match.start()
+            segment = code[statement_start:statement_end]
+            if match.group(0) == "\n" and (
+                dangling.search(segment)
+                or continuing.match(code, match.end())
+            ):
+                continue
+            # Search the ORIGINAL text, not the masked code: a Python/PHP/Ruby
+            # payload spells the key as a STRING ("messaging_profile_id"), and
+            # string interiors are blanked in lexed.code - so the guard was only
+            # ever found in JS, where object keys are usually bare identifiers.
+            # Offsets are preserved by the lexer, so the spans stay valid.
+            profile = PROFILE_IDENTIFIER_RE.search(
+                self.lexed.original[statement_start:statement_end]
+            )
+            if profile is not None:
+                absolute_profile = statement_start + profile.start()
+                logical = list(re.finditer(logical_re, segment))
+                for operator in logical:
+                    operator_end = statement_start + operator.end()
+                    if operator_end <= absolute_profile:
+                        self.arms.append(
+                            ControlArm(statement_start, 0, operator_end, statement_end)
+                        )
+                question = segment.find("?")
+                colon = segment.find(":", question + 1) if question >= 0 else -1
+                if question >= 0 and colon >= 0 and absolute_profile > statement_start + question:
+                    self.arms.append(
+                        ControlArm(
+                            statement_start,
+                            0 if absolute_profile < statement_start + colon else 1,
+                            statement_start + question + 1,
+                            statement_end,
+                        )
+                    )
+            statement_start = match.end()
+
+    def _body_arm(self, group: int, branch: int, after: int) -> int | None:
+        """Index one control body — a braced block OR an unbraced single
+        statement — starting at/after `after`. Appends a ControlArm and
+        returns the position after the body, or None if there is no body.
+
+        Every C-family control construct routes through here so that braced
+        and unbraced bodies are treated identically: a field write inside any
+        of them is conditional. Handling only braced bodies let unbraced if /
+        else / for / while writes look unconditional and pass a send that can
+        run without the profile.
+        """
+        code = self.lexed.code
+        cursor = after
+        while cursor < len(code) and code[cursor].isspace():
+            cursor += 1
+        if self.suffix == ".php" and cursor < len(code) and code[cursor] == ":":
+            # PHP alternative syntax (`if (…): … endif;`). The body runs to its
+            # end-keyword, not to the first ';', so _php_alt spans it. Treating
+            # the ':' as a one-statement body would guard only the first
+            # statement and leave a later profile write looking unconditional.
+            return None
+        if cursor < len(code) and code[cursor] == "{":
+            closing = matching_delimiter(code, cursor, "{", "}")
+            if closing is None:
+                return None
+            self.arms.append(ControlArm(group, branch, cursor, closing + 1))
+            return closing + 1
+        body_end = self._unbraced_body_end(after)
+        if body_end is None:
+            return None
+        self.arms.append(ControlArm(group, branch, after, body_end))
+        return body_end
+
+    def _curly(self) -> None:
+        code = self.lexed.code
+        # PHP spells a chained branch as one word, `elseif`, so `\bif` never
+        # matches inside it: neither the elseif body nor the `else` that closes
+        # the chain was indexed and a profile written there looked
+        # unconditional. Treat it exactly like the C-family `else if` - its own
+        # group, closed by its own `else`.
+        opener = r"\b(?:else)?if\s*\(" if self.suffix == ".php" else r"\bif\s*\("
+        # An `else if` used to open a group of its own, which was then marked
+        # exhaustive by its trailing `else` INDEPENDENTLY of the outer `if` -
+        # so `if (a) {} else if (b) {mp} else {mp}` looked like it always set
+        # the profile even though the `a` path sets nothing. The whole
+        # if/else-if/else chain is one group with one branch per arm, and only
+        # a final bare `else` makes it exhaustive (as Ruby/shell/PHP-alt
+        # chains already do).
+        chained = (
+            r"\s*(?:else\s*if|elseif|else)\b"
+            if self.suffix == ".php"
+            else r"\s*(?:else\s*if|else)\b"
+        )
+        handled: set[int] = set()
+        for match in re.finditer(opener, code):
+            if match.start() in handled:
+                continue
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            if close is None:
+                continue
+            group = match.start()
+            branch = 0
+            after = self._body_arm(group, branch, close + 1)
+            if after is None:
+                continue
+            while True:
+                tail = re.match(chained, code[after:])
+                if tail is None:
+                    break
+                head = after + tail.end()
+                if tail.group(0).strip() == "else":
+                    branch += 1
+                    if self._body_arm(group, branch, head) is not None:
+                        self.exhaustive.add(group)
+                    break
+                token = re.search(r"(?:\belseif|\bif)\s*$", code[after:head])
+                paren = head
+                while paren < len(code) and code[paren].isspace():
+                    paren += 1
+                if token is None or paren >= len(code) or code[paren] != "(":
+                    break
+                closing = matching_delimiter(code, paren, "(", ")")
+                if closing is None:
+                    break
+                handled.add(after + token.start())
+                branch += 1
+                nxt = self._body_arm(group, branch, closing + 1)
+                if nxt is None:
+                    break
+                after = nxt
+        if self.suffix == ".go":
+            # Go conditions and range clauses conventionally omit the
+            # parentheses required by the C-family forms above.
+            for match in re.finditer(r"\bif\b(?!\s*\()[^{}\n]*\{", code):
+                opening = code.rfind("{", match.start(), match.end())
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is None:
+                    continue
+                group = match.start()
+                self.arms.append(ControlArm(group, 0, opening, closing + 1))
+                tail = re.match(r"\s*else\s*", code[closing + 1:])
+                if tail is None:
+                    continue
+                cursor = closing + 1 + tail.end()
+                else_open = code.find("{", cursor)
+                if else_open >= 0 and not code[cursor:else_open].strip():
+                    else_close = matching_delimiter(code, else_open, "{", "}")
+                    if else_close is not None:
+                        self.arms.append(
+                            ControlArm(group, 1, else_open, else_close + 1)
+                        )
+                        self.exhaustive.add(group)
+            for match in re.finditer(r"\bfor\b(?!\s*\()[^{}\n]*\{", code):
+                opening = code.rfind("{", match.start(), match.end())
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is not None:
+                    self.arms.append(
+                        ControlArm(match.start(), 0, opening, closing + 1)
+                    )
+        # for / while / foreach / catch bodies, braced or unbraced. A loop may
+        # execute zero times, so a profile write in its body is conditional —
+        # `while (cond) payload.messaging_profile_id = p; send()` can send
+        # without the profile. A do-while `} while (cond);` has no following
+        # body (the next token is `;`), so _body_arm yields nothing for it,
+        # which is correct: a do body always runs at least once.
+        for match in re.finditer(r"\b(?:for|foreach|while|catch)\s*\(", code):
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            if close is None:
+                continue
+            self._body_arm(match.start(), 0, close + 1)
+        # `try { … }` takes no condition, so the parenthesised sweep above (which
+        # already covers `catch (…)`) never saw it. A try body is NOT
+        # unconditional: when a sibling catch swallows the error, execution
+        # continues past the statement with the write skipped. Treated as an arm,
+        # a send INSIDE the body shares it and stays unguarded, while a send
+        # after the statement is correctly guarded. Same rule as Python's `try`.
+        for match in re.finditer(r"\btry\s*\{", code):
+            opening = code.find("{", match.start())
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is None:
+                continue
+            # ONLY a try whose handler SWALLOWS is a guard. `try { } finally { }`
+            # with no handler propagates, and so does `catch (e) { throw e; }`:
+            # a later send is never reached and the write is not conditional
+            # relative to it - treating either as an arm reported compliant
+            # code as missing the profile.
+            if not self._swallowing_catch(closing + 1):
+                continue
+            self.arms.append(
+                ControlArm(match.start(), 0, opening, closing + 1)
+            )
+        # Go writes `switch mode {`, `switch x := f(); x {` and the bare
+        # `switch {` with NO parentheses, so the paren-anchored scan below never
+        # saw them: every case arm read as unconditional code, and a profile
+        # set in a single arm certified the whole send. Indexed here with the
+        # same per-arm modelling, so an exhaustive switch (one with `default:`)
+        # still counts as covering every path.
+        if self.suffix == ".go":
+            # The body brace is found by a BALANCED SCAN, not a lookahead. Two
+            # successive lookahead patterns were tried and both failed, because
+            # a Go switch header is not lexically simple: it may contain
+            # parentheses (`switch v := i.(type) {`), a semicolon and an init
+            # statement (`switch x := f(); x {`), a newline when it wraps, and
+            # a COMPOSITE LITERAL whose own brace (`switch cfg{A: 1}.mode {`)
+            # is not the body. Each failure indexed no arms at all, so a profile
+            # set in one arm read as unconditional - a silent pass every time.
+            # Scanning for the first brace that opens a BLOCK handles all four
+            # without another round of pattern guessing.
+            for match in re.finditer(r"(?<![\w.])switch(?![\w])", code):
+                opening = _go_block_brace(code, match.end())
+                if opening < 0:
+                    continue
+                closing = matching_delimiter(code, opening, "{", "}")
+                if closing is None:
+                    continue
+                split = self._switch_arms(opening, closing)
+                if split is None:
+                    self.arms.append(
+                        ControlArm(match.start(), 0, opening, closing + 1)
+                    )
+                    continue
+                spans, has_default = split
+                for branch, (arm_start, arm_end) in enumerate(spans):
+                    self.arms.append(
+                        ControlArm(match.start(), branch, arm_start, arm_end)
+                    )
+                if has_default:
+                    self.exhaustive.add(match.start())
+
+        # switch bodies are always braced.
+        for match in re.finditer(r"\bswitch\s*\(", code):
+            condition = code.rfind("(", match.start(), match.end())
+            close = matching_delimiter(code, condition, "(", ")")
+            opening = code.find("{", close + 1) if close is not None else -1
+            if opening < 0 or code[close + 1:opening].strip():
+                continue
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is None:
+                continue
+            # One arm for the whole body could never be exhaustive, so a switch
+            # in which EVERY arm (including `default:`) sets the profile was
+            # still reported as missing it. Index one arm per case label and
+            # mark the group exhaustive when a `default:` covers the rest.
+            split = self._switch_arms(opening, closing)
+            if split is None:
+                self.arms.append(ControlArm(match.start(), 0, opening, closing + 1))
+                continue
+            spans, has_default = split
+            for branch, (arm_start, arm_end) in enumerate(spans):
+                self.arms.append(
+                    ControlArm(match.start(), branch, arm_start, arm_end)
+                )
+            if has_default:
+                self.exhaustive.add(match.start())
+        if self.suffix == ".php":
+            self._php_alt()
+
+    def _swallowing_catch(self, cursor: int) -> bool:
+        """True when a `catch` clause at `cursor` can SWALLOW the error.
+
+        Only a swallowing handler makes the try body conditional. A handler
+        that re-raises (`catch (e) { log(e); throw e; }` — the standard
+        log-and-rethrow idiom) never lets execution continue past the
+        statement, so a write in the try body is unconditional relative to a
+        later send. Every handler must re-raise for the body to lose its arm;
+        a handler we cannot parse counts as swallowing, which keeps the
+        cautious FLAG.
+        """
+        code = self.lexed.code
+        while True:
+            head = re.match(r"\s*catch\b", code[cursor:cursor + 40])
+            if head is None:
+                return False
+            index = cursor + head.end()
+            while index < len(code) and code[index].isspace():
+                index += 1
+            if index < len(code) and code[index] == "(":
+                shut = matching_delimiter(code, index, "(", ")")
+                if shut is None:
+                    return True
+                index = shut + 1
+                while index < len(code) and code[index].isspace():
+                    index += 1
+            if index >= len(code) or code[index] != "{":
+                return True
+            shut = matching_delimiter(code, index, "{", "}")
+            if shut is None:
+                return True
+            if not self._braced_tail_throws(code[index + 1:shut]):
+                return True
+            cursor = shut + 1
+
+    @staticmethod
+    def _braced_tail_throws(body: str) -> bool:
+        """True when the LAST statement of a braced handler body re-raises.
+
+        Deliberately conservative: only a trailing top-level `throw` counts, so
+        a nested or conditional `if (fatal) { throw e; }` still reads as
+        swallowing and the body keeps its arm.
+        """
+        text = body.rstrip().rstrip(";").rstrip()
+        depth = 0
+        start = 0
+        for index in range(len(text) - 1, -1, -1):
+            character = text[index]
+            if character in ")]}":
+                depth += 1
+            elif character in "([{":
+                depth -= 1
+                if depth < 0:
+                    start = index + 1
+                    break
+            elif depth == 0 and character == ";":
+                start = index + 1
+                break
+        return re.match(r"\s*(?:throw|rethrow)\b", text[start:]) is not None
+
+    @staticmethod
+    def _label_colon(text: str, start: int) -> int | None:
+        """Offset of the ':' ending a `case …:` label, or None.
+
+        Skips bracketed spans, the `::` scope operator (`Status::SENT`) and the
+        ':' of a ternary so a computed case expression still finds its label.
+        """
+        depth = 0
+        pending = 0
+        index = start
+        while index < len(text):
+            character = text[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+            elif character in ";\n" and depth == 0 and pending == 0:
+                return None
+            elif depth == 0 and character == "?":
+                pending += 1
+            elif depth == 0 and character == ":":
+                if text[index + 1:index + 2] == ":":
+                    index += 2
+                    continue
+                if pending:
+                    pending -= 1
+                else:
+                    return index
+            index += 1
+        return None
+
+    def _switch_arms(
+        self, opening: int, closing: int
+    ) -> tuple[list[tuple[int, int]], bool] | None:
+        """Per-case arm spans for a switch body, plus whether it has a default.
+
+        Returns None when the shape cannot be modelled safely - no labels, an
+        unparsable label, or an IMPLICIT FALL-THROUGH (a non-empty case body
+        with no break/return before the next label). In those cases the caller
+        keeps the single whole-body arm, which over-guards rather than
+        under-guards. Consecutive labels with nothing between them share one
+        arm, which is exactly how `case 'a': case 'b': …` behaves.
+        """
+        code = self.lexed.code
+        body = code[opening + 1:closing]
+        depths: list[int] = []
+        depth = 0
+        for character in body:
+            depths.append(depth)
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+        labels: list[tuple[int, int, bool]] = []
+        for match in re.finditer(r"\b(case|default)\b", body):
+            if depths[match.start()] != 0:
+                continue
+            if match.group(1) == "default":
+                tail = re.match(r"\s*:", body[match.end():])
+                if tail is None:
+                    continue
+                colon = match.end() + tail.end() - 1
+            else:
+                found = self._label_colon(body, match.end())
+                if found is None:
+                    return None
+                colon = found
+            labels.append(
+                (
+                    opening + 1 + match.start(),
+                    opening + 2 + colon,
+                    match.group(1) == "default",
+                )
+            )
+        if not labels:
+            return None
+        terminator = re.compile(r"\b(?:break|return|continue|throw|goto|exit|die)\b")
+        spans: list[tuple[int, int]] = []
+        arm_start: int | None = None
+        for position, (label_start, body_start, _) in enumerate(labels):
+            if arm_start is None:
+                arm_start = label_start
+            body_end = (
+                labels[position + 1][0]
+                if position + 1 < len(labels)
+                else closing
+            )
+            segment = code[body_start:body_end]
+            if not segment.strip():
+                # Consecutive labels share one arm (`case 'a': case 'b': …`) in
+                # the C family, where an empty body falls through. Go does NOT
+                # fall through, so an empty `case "a":` is a real arm that runs
+                # and sets nothing - merging it into the following `default:`
+                # let that default certify a path which writes no profile.
+                if self.suffix == ".go":
+                    spans.append((arm_start, body_end))
+                    arm_start = None
+                continue
+            # Go breaks IMPLICITLY - falling through needs an explicit
+            # `fallthrough` keyword - so a Go arm without `break` is the normal
+            # case, not an unmodellable fall-through. Requiring a terminator
+            # there made every Go switch fall back to one whole-body arm, so an
+            # exhaustive switch whose every arm (including `default:`) sets the
+            # profile was still reported as missing it.
+            if self.suffix == ".go":
+                if re.search(r"\bfallthrough\b", segment):
+                    return None
+            elif position + 1 < len(labels) and terminator.search(segment) is None:
+                return None
+            spans.append((arm_start, body_end))
+            arm_start = None
+        if arm_start is not None:
+            spans.append((arm_start, closing))
+        return spans, any(is_default for _, _, is_default in labels)
+
+    def _php_alt(self) -> None:
+        """Index PHP alternative-syntax bodies (`if (…): … endif;`).
+
+        The colon-delimited forms have no braces, so _body_arm cannot span
+        them; without this a profile write between the ':' and the closing
+        `endif` / `else` / `elseif` looks unconditional. A stack pairs each
+        opener with its terminator so the if/elseif/else chain shares one group
+        (a trailing `else` marks it exhaustive) and the loop/switch forms get a
+        single conditional arm.
+        """
+        code = self.lexed.code
+        openers = {"if", "elseif", "else", "for", "foreach", "while", "switch"}
+        terminators = {
+            "endif": "if",
+            "endforeach": "foreach",
+            "endfor": "for",
+            "endwhile": "while",
+            "endswitch": "switch",
+        }
+        token = re.compile(
+            r"\b(if|elseif|else|for|foreach|while|switch)\b"
+            r"|\b(endif|endforeach|endfor|endwhile|endswitch)\b"
+        )
+        stack: list[list[int | str]] = []
+        for match in token.finditer(code):
+            keyword = match.group(1)
+            if keyword is not None:
+                if keyword == "else":
+                    head_end = match.end()
+                else:
+                    paren = match.end()
+                    while paren < len(code) and code[paren].isspace():
+                        paren += 1
+                    if paren >= len(code) or code[paren] != "(":
+                        continue
+                    close = matching_delimiter(code, paren, "(", ")")
+                    if close is None:
+                        continue
+                    head_end = close + 1
+                probe = head_end
+                while probe < len(code) and code[probe].isspace():
+                    probe += 1
+                if probe >= len(code) or code[probe] != ":":
+                    # Brace syntax or a non-alternative use — leave it to the
+                    # C-family handler.
+                    continue
+                body_start = probe + 1
+                if keyword in {"elseif", "else"}:
+                    if not stack or stack[-1][0] != "if":
+                        continue
+                    entry = stack[-1]
+                    self.arms.append(
+                        ControlArm(entry[1], entry[2], entry[3], match.start())
+                    )
+                    entry[2] += 1
+                    entry[3] = body_start
+                    if keyword == "else":
+                        self.exhaustive.add(entry[1])
+                elif keyword in openers:
+                    kind = "if" if keyword == "if" else keyword
+                    stack.append([kind, match.start(), 0, body_start])
+            else:
+                want = terminators[match.group(2)]
+                if stack and stack[-1][0] == want:
+                    entry = stack.pop()
+                    self.arms.append(
+                        ControlArm(entry[1], entry[2], entry[3], match.start())
+                    )
+
+    def _py_header_colon(self, start: int, end: int) -> int | None:
+        """Offset of the ':' that ends a Python compound-statement header.
+
+        Scans the masked line (strings/comments already blanked) for the first
+        top-level ':' — skipping brackets (slices, dicts, call args) and the
+        walrus ':=' — so a compact `if cond: stmt` header is found even when its
+        condition contains colons.
+        """
+        code = self.lexed.code
+        depth = 0
+        index = start
+        while index < end:
+            character = code[index]
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+            elif character == ":" and depth == 0:
+                if index + 1 < len(code) and code[index + 1] == "=":
+                    index += 2
+                    continue
+                return index
+            index += 1
+        return None
+
+    def _py_logical_row(
+        self, lines: list[tuple[int, int, int, str]], index: int
+    ) -> int:
+        """Index of the last physical row of the logical line starting at `index`.
+
+        A compound header may WRAP: `if (use_pool\n        and enabled):` keeps
+        its ':' on a continuation row, so scanning only the first physical line
+        found no colon at all and the guard was never indexed - a profile
+        written in its body read as unconditional.
+        """
+        code = self.lexed.code
+        depth = 0
+        row = index
+        while True:
+            for position in range(lines[row][0], lines[row][1]):
+                character = code[position]
+                if character in "([{":
+                    depth += 1
+                elif character in ")]}":
+                    depth -= 1
+            if depth <= 0 or row + 1 >= len(lines):
+                return row
+            row += 1
+
+    def _swallowing_except(
+        self, lines: list[tuple[int, int, int, str]], index: int, indent: int
+    ) -> bool:
+        """True when an `except` handler of the `try` at `index` can SWALLOW.
+
+        Python mirror of `_swallowing_catch`: a handler whose last statement is
+        `raise` propagates, so execution never continues past the statement
+        with the write skipped. Every handler must re-raise for the try body to
+        lose its arm; anything unparseable counts as swallowing.
+        """
+        row = index + 1
+        while row < len(lines):
+            _, _, row_indent, text = lines[row]
+            if not text or row_indent > indent:
+                row += 1
+                continue
+            if row_indent < indent:
+                return False
+            if re.match(r"(?:else|finally)\b", text):
+                row += 1
+                continue
+            if re.match(r"except\b", text) is None:
+                return False
+            if not self._py_handler_reraises(lines, row, indent):
+                return True
+            row += 1
+        return False
+
+    def _py_handler_reraises(
+        self, lines: list[tuple[int, int, int, str]], row: int, indent: int
+    ) -> bool:
+        """True when the `except` handler at `row` ends in a bare-level `raise`.
+
+        Deliberately conservative: a `raise` nested deeper than the handler's
+        own body indent is conditional, so it reads as swallowing and the try
+        body keeps its arm.
+        """
+        code = self.lexed.code
+        last = self._py_logical_row(lines, row)
+        header_end = lines[last][1]
+        colon = self._py_header_colon(lines[row][0], header_end)
+        if colon is None:
+            return False
+        inline = code[colon + 1:header_end]
+        if inline.strip():
+            return self._tail_statement_raises(inline)
+        body = []
+        for entry in lines[last + 1:]:
+            if not entry[3]:
+                continue
+            if entry[2] <= indent:
+                break
+            body.append(entry)
+        if not body or body[-1][2] != body[0][2]:
+            return False
+        return self._tail_statement_raises(body[-1][3])
+
+    @staticmethod
+    def _tail_statement_raises(text: str) -> bool:
+        """True when the last `;`-separated statement of `text` is a `raise`."""
+        statements = [part for part in text.split(";") if part.strip()]
+        return bool(statements) and re.match(r"\s*raise\b", statements[-1]) is not None
+
+    def _python(self, lines: list[tuple[int, int, int, str]]) -> None:
+        """Index Python control arms, block and compact one-line forms alike.
+
+        A guard writes a profile only on some path — an `if`/`elif`/`else`
+        branch, a loop body that may not run, an `except` handler, or one
+        `case` arm — whether the body sits on its own indented lines or inline
+        after the header colon (`if cond: payload[...] = p`, or a `;`-separated
+        suite). Block `if`/`else` chains and `match`/`case` groups are tracked
+        so a fully-covering `else` / wildcard `case _` stays exhaustive and a
+        genuinely unconditional write is never guarded.
+        """
+        code = self.lexed.code
+        # A `try` body is NOT unconditional: when a sibling handler swallows the
+        # error, execution continues past the statement with the write skipped.
+        # It is an arm like any other — a send INSIDE the same body shares the
+        # arm and stays unguarded, while a send after the statement is guarded.
+        conditional = {"if", "elif", "else", "for", "while", "except", "case", "try"}
+        if_pending: dict[int, int] = {}
+        case_pending: dict[int, int] = {}
+        for index, (start, line_end, indent, text) in enumerate(lines):
+            header = re.match(
+                r"(if|elif|else|for|while|try|except|finally|with|match|case)\b",
+                text,
+            )
+            if header is None:
+                continue
+            word = header.group(1)
+            if word == "match":
+                # `match` only dispatches; its `case` arms carry the guard.
+                # Start a fresh case chain for any deeper indent.
+                for level in [key for key in case_pending if key > indent]:
+                    del case_pending[level]
+                continue
+            if word not in conditional:
+                # with / finally bodies always execute — not guards.
+                continue
+            if word == "try":
+                # ONLY a try whose handler SWALLOWS is a guard. `try: / finally:`
+                # with no handler propagates, and so does an `except:` whose
+                # body ends in `raise`: a later send is never reached and the
+                # write is not conditional relative to it - treating either as
+                # an arm reported compliant code as missing the profile.
+                if not self._swallowing_except(lines, index, indent):
+                    continue
+            last = self._py_logical_row(lines, index)
+            header_end = lines[last][1]
+            colon = self._py_header_colon(start, header_end)
+            if colon is None:
+                continue
+            if code[colon + 1:header_end].strip():
+                end = header_end  # compact inline body — guard only this line
+            else:
+                end = next(
+                    (row[0] for row in lines[last + 1:] if row[3] and row[2] <= indent),
+                    len(code),
+                )
+            orphan = False
+            if word in {"elif", "else"}:
+                orphan = indent not in if_pending
+                group = if_pending.get(indent, start)
+                if_pending[indent] = group
+            elif word == "case":
+                group = case_pending.get(indent, start)
+                case_pending[indent] = group
+            else:
+                group = start
+                if word in {"if", "for", "while"}:
+                    if_pending[indent] = group
+            self.arms.append(
+                ControlArm(
+                    group,
+                    sum(arm.group == group for arm in self.arms),
+                    start,
+                    end,
+                )
+            )
+            if word == "else" and not orphan:
+                # An `else` with NO recorded opener at this indent is not the
+                # tail of an if/for/while chain - it is `try/except/else`, whose
+                # body runs only when no exception was raised. Marking it
+                # exhaustive made a one-branch group that is always taken, so a
+                # profile written there read as unconditional.
+                self.exhaustive.add(group)
+            elif word == "case":
+                pattern = code[start + indent + len(word):colon].strip()
+                if re.fullmatch(r"_|[a-z]\w*", pattern):
+                    self.exhaustive.add(group)
+
+    def _lines(self) -> None:
+        lines: list[tuple[int, int, int, str]] = []
+        cursor = 0
+        for line in self.lexed.code.splitlines(keepends=True):
+            stripped = line.lstrip(" \t")
+            lines.append((cursor, cursor + len(line), len(line) - len(stripped), stripped.strip()))
+            cursor += len(line)
+        if self.suffix == ".py":
+            self._python(lines)
+            return
+        stack: list[tuple[str, int, int, int]] = []
+        for start, end, indent, text in lines:
+            if self.suffix == ".rb":
+                if re.match(r"(?:if|unless|case|for|while|until|begin)\b", text) or re.match(
+                    r".+\.(?:each|each_pair|each_with_index|times|map|select)\b.*\bdo(?:\s*\|[^|]*\|)?\s*$",
+                    text,
+                ):
+                    stack.append(("end", start, start, 0))
+                elif re.match(r"(?:elsif|when|rescue)\b", text) and stack:
+                    # A MIDDLE branch closes the previous one and opens the
+                    # next, but does NOT make the group exhaustive - only a
+                    # final `else` does. Without this, an `elsif`/`when` body
+                    # folded into branch 0 and a profile written only there
+                    # read as unconditional.
+                    token, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, start))
+                    stack.append((token, group, start, branch + 1))
+                elif text == "else" and stack:
+                    token, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, start))
+                    self.exhaustive.add(group)
+                    stack.append((token, group, start, branch + 1))
+                elif re.match(r"end\b", text) and stack:
+                    _, group, branch_start, branch = stack.pop()
+                    self.arms.append(ControlArm(group, branch, branch_start, end))
+                elif re.search(
+                    r"\S\s+\b(?:if|unless|while|until)\b\s+\S", text
+                ) and not re.search(r"\b(?:then|do)\b\s*(?:\|[^|]*\|)?\s*$", text):
+                    # Trailing modifier: `stmt if cond` / `stmt unless cond`
+                    # runs the statement only conditionally. It is not a block
+                    # opener (those start with the keyword) so it has no `end`.
+                    self.arms.append(ControlArm(start, 0, start, end))
+            else:
+                one_line_if = re.match(r"if\b.*;\s*then\b.*\bfi\b", text)
+                if one_line_if:
+                    # Self-contained `if …; then …; fi` — the body is guarded
+                    # but there is no separate `fi` line to close it.
+                    self.arms.append(ControlArm(start, 0, start, end))
+                else:
+                    opener = re.match(r"(if|for|while|until|case)\b", text)
+                    if opener:
+                        close = "fi" if opener.group(1) == "if" else "esac" if opener.group(1) == "case" else "done"
+                        stack.append((close, start, start, 0))
+                    elif (
+                        re.match(r"elif\b", text)
+                        and stack
+                        and stack[-1][0] == "fi"
+                    ):
+                        # Same as Ruby's elsif: closes the previous branch,
+                        # opens the next, does not make the group exhaustive.
+                        token, group, branch_start, branch = stack.pop()
+                        self.arms.append(
+                            ControlArm(group, branch, branch_start, start)
+                        )
+                        stack.append((token, group, start, branch + 1))
+                    elif text == "else" and stack and stack[-1][0] == "fi":
+                        token, group, branch_start, branch = stack.pop()
+                        self.arms.append(ControlArm(group, branch, branch_start, start))
+                        self.exhaustive.add(group)
+                        stack.append((token, group, start, branch + 1))
+                    elif stack and re.match(rf"{stack[-1][0]}\b", text):
+                        _, group, branch_start, branch = stack.pop()
+                        self.arms.append(ControlArm(group, branch, branch_start, end))
+                guard = re.search(r"&&|\|\|", text)
+                if guard is not None and not re.match(
+                    r"(?:if|elif|else|fi|for|while|until|case|esac|done|then|do)\b",
+                    text,
+                ):
+                    # `cond && assign` / `cond || assign` runs the right side
+                    # only conditionally; guard from the operator onward so a
+                    # left-hand assignment that always runs stays unguarded.
+                    self.arms.append(
+                        ControlArm(start, 0, start + indent + guard.end(), end)
+                    )
+
+    def path(self, offset: int) -> tuple[tuple[int, int], ...]:
+        arms = [arm for arm in self.arms if arm.start <= offset < arm.end]
+        arms.sort(key=lambda arm: (-(arm.end - arm.start), arm.start))
+        return tuple((arm.group, arm.branch) for arm in arms)
+
+    def environments(self, paths: Iterable[tuple[tuple[int, int], ...]], call_path: tuple[tuple[int, int], ...]) -> list[dict[int, int | None]]:
+        fixed = dict(call_path)
+        groups: dict[int, set[int]] = {}
+        for path in paths:
+            for group, branch in path:
+                if group not in fixed:
+                    groups.setdefault(group, set()).add(branch)
+        environments: list[dict[int, int | None]] = [fixed]
+        for group, branches in groups.items():
+            if group in self.exhaustive:
+                # An exhaustive if/else covers all paths, but a branch that
+                # writes nothing never appears in the write paths above. Pull
+                # in every branch of the group so the path through a
+                # profile-less branch is considered — otherwise
+                # `if (skip) {...} else payload.messaging_profile_id = p;` was
+                # read as always setting the profile.
+                branches = branches | {
+                    arm.branch for arm in self.arms if arm.group == group
+                }
+            choices: list[int | None] = sorted(branches)
+            if group not in self.exhaustive:
+                choices.append(None)
+            expanded: list[dict[int, int | None]] = []
+            for environment in environments:
+                for choice in choices:
+                    candidate = dict(environment)
+                    candidate[group] = choice
+                    expanded.append(candidate)
+            environments = expanded
+            if len(environments) > 64:
+                return []
+        return environments
+
+    @staticmethod
+    def active(path: tuple[tuple[int, int], ...], environment: dict[int, int | None]) -> bool:
+        return all(environment.get(group) == branch for group, branch in path)
+
+
+class PayloadStateResolver:
+    """Indexed abstract interpreter for payload field/object state."""
+
+    JS_SUFFIXES = JS_TS_SUFFIXES
+
+    def __init__(
+        self,
+        lexed: LexedSource,
+        suffix: str,
+        fields: Iterable[str],
+        *,
+        require_value: bool,
+        source: SourceEndpointResolver | None = None,
+    ) -> None:
+        self.lexed, self.suffix = lexed, suffix
+        self.fields, self.require_value = frozenset(fields), require_value
+        self.source = source or SourceEndpointResolver(lexed, suffix)
+        self.control = ControlIndex(lexed, suffix)
+        self.roots: dict[int, list[RootFieldEvent]] = {}
+        self.root_offsets: dict[int, list[int]] = {}
+        self.objects: dict[tuple[int, int], RootFieldEvent] = {}
+        self.events: list[FieldEvent] = []
+        self.event_offsets: list[int] = []
+        self._targets_memo: dict[tuple[int, int, int], ObjectTargets] = {}
+        self._presence_memo: dict[tuple[tuple[int, int], int, int], Presence] = {}
+        self._index_roots()
+        self._index_field_events()
+
+    def _binding(self, start: int, end: int, scope: int, before: int) -> int | None:
+        reference = static_reference_expression(self.lexed, start, end)
+        if reference is not None and len(reference) == 1:
+            name = reference[0].lstrip("$")
+        else:
+            text = re.sub(r"^(?:\.\.\.|\*\*|[&*])\s*", "", self.lexed.code[start:end].strip())
+            match = re.fullmatch(r"\$?([A-Za-z_]\w*)", text)
+            if match is None:
+                return None
+            name = match.group(1)
+        return self.source.graph.visible_binding(name, scope, before)
+
+    def _index_roots(self) -> None:
+        for assignment in self.source.root_assignments:
+            binding = self.source.assignment_bindings[assignment.start()]
+            scope = self.source.scope_at(assignment.start())
+            end = assignment_end(self.lexed, assignment.end(), self.suffix)
+            owner = self.source.graph.bindings[binding]
+            direct_alias = self._binding(
+                assignment.end(), end, scope, assignment.start()
+            )
+            conditional = self._conditional(assignment.end(), end)
+            aliases: tuple[int, ...] | None = (
+                (direct_alias,) if direct_alias is not None else None
+            )
+            alias_unknown = False
+            if conditional is not None:
+                choices = tuple(
+                    self._binding(*span, scope, assignment.start())
+                    for span in conditional
+                )
+                aliases = tuple(
+                    dict.fromkeys(choice for choice in choices if choice is not None)
+                )
+                alias_unknown = any(choice is None for choice in choices)
+            event = RootFieldEvent(
+                binding,
+                assignment.start(),
+                (assignment.end(), end),
+                scope,
+                self.source.graph.execution_scope(scope),
+                "declaration" if owner.declaration_start == assignment.start() else "mutation",
+                self.control.path(assignment.start()),
+                aliases,
+                alias_unknown,
+            )
+            self.roots.setdefault(binding, []).append(event)
+            self.root_offsets.setdefault(binding, []).append(event.start)
+            if event.aliases is None:
+                self.objects[event.object_id] = event
+
+    def _add_event(self, binding: int, start: int, effect: int, overlay: tuple[int, int] | None = None) -> None:
+        scope = self.source.scope_at(start)
+        self.events.append(FieldEvent(
+            binding,
+            start,
+            scope,
+            self.source.graph.execution_scope(scope),
+            self.control.path(start),
+            effect,
+            overlay,
+        ))
+
+    def _value_effect(
+        self, start: int, end: int, seen: frozenset[int] = frozenset()
+    ) -> int:
+        if not self.require_value:
+            return WRITE_PRESENT
+        conditional = self._conditional(start, end)
+        if conditional is not None:
+            effects = {
+                self._value_effect(span[0], span[1], seen) for span in conditional
+            }
+            return effects.pop() if len(effects) == 1 else WRITE_MAYBE
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        code = self.lexed.code[start:end].strip()
+        if re.fullmatch(r"(?:null|nil|none|undefined|Optional\s*\.\s*empty\s*\(\s*\))", code, re.I):
+            return WRITE_ABSENT
+        # A messaging_profile_id must be a non-empty identifier. A statically
+        # falsy or empty literal — false/true, 0, [], {}, and empty collection
+        # constructors — is present in shape but unusable, so the Messages API
+        # receives an invalid profile. Treat those as absent (shape vs value).
+        if re.fullmatch(
+            r"(?:false|true"
+            r"|[+-]?0(?:\.0+)?"
+            r"|\[\s*\]|\{\s*\}|\(\s*\)"
+            r"|(?:dict|list|tuple|set|array|Array|Map|Set|Object|String)\s*\(\s*\)"
+            r"|new\s+(?:Array|Map|Set|Object)\s*\(\s*\))",
+            code,
+            re.I,
+        ):
+            return WRITE_ABSENT
+        tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
+        if len(tokens) == 1:
+            residual = (self.lexed.code[start:tokens[0].start] + self.lexed.code[tokens[0].end:end]).strip().lower()
+            if residual in {"", "f", "r", "u", "b", "fr", "rf"}:
+                return (
+                    WRITE_PRESENT
+                    if tokens[0].contents.strip()
+                    else WRITE_ABSENT
+                )
+        # A value with an empty fallback is not guaranteed usable. Treat both
+        # nullish and logical-OR fallbacks consistently; a concrete non-empty
+        # fallback is handled by the conditional resolver above.
+        if re.search(r"(?:\?\?|\|\||\boptional\b|\bmaybe\b)", code, re.I):
+            return WRITE_MAYBE
+        if self.suffix == ".py":
+            env_getter = re.search(
+                r"(?:os\.environ\.get|os\.getenv)\s*\(",
+                self.lexed.code[start:end],
+            )
+            if env_getter is not None:
+                opening = start + env_getter.end() - 1
+                closing = matching_delimiter(
+                    self.lexed.code, opening, "(", ")"
+                )
+                arguments = (
+                    split_arguments(self.lexed.code, opening + 1, closing)
+                    if closing is not None and closing <= end
+                    else []
+                )
+                if len(arguments) < 2:
+                    return WRITE_MAYBE
+        if tokens and all(not token.contents.strip() for token in tokens):
+            # Empty literal concatenations/coercions (`'' + ''`,
+            # `String('   ')`, `.concat('')`, `.join('')`) are statically
+            # unusable even though their source text is non-empty.
+            residual = self.lexed.code[start:end]
+            if not re.search(r"[A-Za-z_$]\w*(?!\s*\()", residual):
+                return WRITE_ABSENT
+        alias = self._alias_absence(start, code, seen)
+        if alias is not None:
+            return alias
+        return WRITE_PRESENT if code else WRITE_ABSENT
+
+    def _assignment_entries(self) -> list[tuple[str, int, int, int]]:
+        cached = getattr(self, "_assignment_entries_cache", None)
+        if cached is None:
+            cached = assignment_index(self.lexed, self.suffix)
+            self._assignment_entries_cache = cached
+        return cached
+
+    def _alias_absence(
+        self, start: int, code: str, seen: frozenset[int]
+    ) -> int | None:
+        """Resolve a bare-identifier value to its nearest static literal.
+
+        A direct empty/falsy literal is already treated as absent above, but a
+        value assigned through a local constant — ``const mp = ''; {..: mp}`` —
+        would otherwise pass as present because the identifier text is non-empty.
+        Resolve the nearest binding-matched assignment and recurse, so every
+        empty/falsy form and any alias chain is caught. This ONLY returns a
+        proven absence: a present/maybe value keeps the existing behaviour, so
+        the resolution can flag more, never fewer (no new false positives on a
+        genuinely populated alias).
+        """
+        match = re.fullmatch(r"\$?([A-Za-z_]\w*)", code)
+        if match is None:
+            return None
+        name = match.group(1)
+        # DECLARED but never assigned - `let mp;` / `var mp;`. Such a name has
+        # no assignment entry at all, so it also has no binding, and the lookup
+        # below returns None before any absence can be proven. The serialized
+        # payload is byte-identical to the explicitly-empty `let mp = ""` case
+        # that IS flagged, so treat a bare declaration as proven absence.
+        # Checked BEFORE the binding lookup for exactly that reason.
+        if not any(
+            entry_name.lstrip("$") == name
+            for entry_name, _, _, _ in self._assignment_entries()
+        ) and re.search(
+            rf"(?:^|[;{{}}\n])[ \t]*(?:let|var|my|our)[ \t]+\$?{re.escape(name)}[ \t]*(?=[;\n])",
+            self.lexed.code[:start],
+        ):
+            return WRITE_ABSENT
+        binding = self.source.graph.visible_binding(
+            name, self.source.scope_at(start), start
+        )
+        if binding is None or binding in seen:
+            return None
+        assignments: list[tuple[int, int, int]] = []
+        for entry_name, entry_start, rhs_start, rhs_end in self._assignment_entries():
+            if entry_name.lstrip("$") != name:
+                continue
+            entry_binding = self.source.graph.visible_binding(
+                name, self.source.scope_at(entry_start), entry_start
+            )
+            if entry_binding == binding:
+                assignments.append((entry_start, rhs_start, rhs_end))
+        # Only a SINGLE static assignment is a constant alias. A reassigned or
+        # conditionally-assigned binding may hold a different value at the use
+        # site, so leave it to the existing present/maybe handling — stay
+        # conservative and never manufacture a false absence.
+        if len(assignments) != 1:
+            return None
+        entry_start, rhs_start, rhs_end = assignments[0]
+        if entry_start >= start:
+            return None
+        resolved = self._value_effect(rhs_start, rhs_end, seen | {binding})
+        return WRITE_ABSENT if resolved == WRITE_ABSENT else None
+
+    def _index_field_events(self) -> None:
+        seen: set[tuple[int, int, int, tuple[int, int] | None]] = set()
+
+        def add(binding: int | None, start: int, effect: int, overlay: tuple[int, int] | None = None) -> None:
+            if binding is None or (binding, start, effect, overlay) in seen:
+                return
+            seen.add((binding, start, effect, overlay))
+            self._add_event(binding, start, effect, overlay)
+
+        for reference, start, rhs_start, rhs_end in direct_member_assignments(self.lexed, len(self.lexed.code), self.suffix):
+            if len(reference) != 2 or reference[1] not in self.fields:
+                continue
+            scope = self.source.scope_at(start)
+            add(self.source.graph.visible_binding(reference[0].lstrip("$"), scope, start), start, self._value_effect(rhs_start, rhs_end))
+        if self.suffix == ".sh":
+            for reference, start, rhs_start, rhs_end in shell_member_assignments(self.lexed, len(self.lexed.code), self.suffix):
+                if len(reference) == 2 and reference[1] in self.fields:
+                    scope = self.source.scope_at(start)
+                    add(self.source.graph.visible_binding(reference[0], scope, start), start, self._value_effect(rhs_start, rhs_end))
+
+        names = "|".join(map(re.escape, sorted(self.fields)))
+        root_spans = [event.rhs for events in self.roots.values() for event in events]
+        setter = re.compile(rf"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:set)?(?:{names})\s*\(")
+        for match in setter.finditer(self.lexed.code):
+            if any(start <= match.start() < end for start, end in root_spans):
+                continue
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            scope = self.source.scope_at(match.start())
+            if closing is not None:
+                add(self.source.graph.visible_binding(match.group(1), scope, match.start()), match.start(), self._value_effect(opening + 1, closing))
+
+        # `.Add(key, value)` (C# Dictionary), `.TryAdd(...)`, `.set(...)` (JS
+        # Map) and `.putIfAbsent(...)` are the same two-argument key/value write
+        # as Java's `.put(...)`. Modelling only `put` meant a C# payload built
+        # with Dictionary.Add was seen as never receiving the profile, so a
+        # COMPLIANT send was reported as missing it.
+        put = re.compile(
+            r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*"
+            r"(?:put|putIfAbsent|Add|TryAdd|set)\s*\("
+        )
+        for match in put.finditer(self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if len(arguments) == 2 and static_lookup_key(self.lexed, *arguments[0]) in self.fields:
+                scope = self.source.scope_at(match.start())
+                add(self.source.graph.visible_binding(match.group(1), scope, match.start()), match.start(), self._value_effect(*arguments[1]))
+
+        # Snapshot overlays and in-place merge/update adapters.
+        merge = re.compile(r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:update|merge!|putAll)\s*\(")
+        for match in merge.finditer(self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            if closing is not None:
+                scope = self.source.scope_at(match.start())
+                binding = self.source.graph.visible_binding(match.group(1), scope, match.start())
+                for span in split_arguments(self.lexed.code, opening + 1, closing):
+                    add(binding, match.start() + span[0] - opening, NO_WRITE, span)
+        for match in re.finditer(r"\bObject\s*\.\s*assign\s*\(", self.lexed.code):
+            opening = self.lexed.code.rfind("(", match.start(), match.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if len(arguments) < 2:
+                continue
+            scope = self.source.scope_at(match.start())
+            binding = self._binding(*arguments[0], scope, match.start())
+            for span in arguments[1:]:
+                add(binding, span[0], NO_WRITE, span)
+
+        deletion_patterns = (
+            re.compile(r"\b(?:delete|del)\s+([^;\n]+)"),
+            re.compile(r"(?<![\w$.])([A-Za-z_]\w*)\s*(?:\.|->)\s*(?:delete|remove|Remove)\s*\(([^)]*)\)"),
+            re.compile(r"\bdelete\s*\(\s*([A-Za-z_]\w*)\s*,([^)]*)\)"),
+            re.compile(r"\bunset\s*\(\s*([^)]*)\)"),
+        )
+        for index, pattern in enumerate(deletion_patterns):
+            for match in pattern.finditer(self.lexed.code):
+                reference = static_reference_expression(self.lexed, match.start(1), match.end(1)) if index in {0, 3} else None
+                if index in {1, 2} and static_lookup_key(self.lexed, *match.span(2)) in self.fields:
+                    reference = (match.group(1), next(iter(self.fields)))
+                if reference is None or len(reference) != 2 or reference[1] not in self.fields:
+                    continue
+                scope = self.source.scope_at(match.start())
+                add(self.source.graph.visible_binding(reference[0].lstrip("$"), scope, match.start()), match.start(), WRITE_ABSENT)
+        self.events.sort(key=lambda event: event.start)
+        self.event_offsets = [event.start for event in self.events]
+
+    def _conditional(self, start: int, end: int) -> tuple[tuple[int, int], tuple[int, int]] | None:
+        round_depth = square_depth = curly_depth = nested = 0
+        question: int | None = None
+        for index in range(start, end):
+            character = self.lexed.code[index]
+            if character == "(": round_depth += 1
+            elif character == ")" and round_depth: round_depth -= 1
+            elif character == "[": square_depth += 1
+            elif character == "]" and square_depth: square_depth -= 1
+            elif character == "{": curly_depth += 1
+            elif character == "}" and curly_depth: curly_depth -= 1
+            elif not (round_depth or square_depth or curly_depth):
+                if character == "?" and not self.lexed.code.startswith(("?.", "??"), index):
+                    if question is None: question = index
+                    else: nested += 1
+                elif character == ":" and question is not None:
+                    if nested: nested -= 1
+                    else: return (question + 1, index), (index + 1, end)
+        # Python's `a if cond else b`. The `if`/`else` must be at the TOP LEVEL
+        # of the span: a plain `build(a if flag else b)` was split by a naive
+        # fullmatch into the bogus alias branches "build(a" and "b)", and the
+        # payload it really assigns became unresolvable - compliant code was
+        # reported as missing the profile.
+        depth = 0
+        word_if: int | None = None
+        for token in re.finditer(
+            r"[()\[\]{}]|\bif\b|\belse\b", self.lexed.code[start:end]
+        ):
+            text = token.group(0)
+            if text in "([{":
+                depth += 1
+            elif text in ")]}":
+                depth -= 1
+            elif depth:
+                continue
+            elif text == "if":
+                if word_if is None and token.start() > 0:
+                    word_if = token.start()
+            elif word_if is not None:
+                return (
+                    (start, start + word_if),
+                    (start + token.end(), end),
+                )
+        return None
+
+    def _root_reaches(self, event: RootFieldEvent, use_scope: int) -> bool:
+        if event.kind == "declaration":
+            return self.source.graph.bindings[event.binding].scope_id in self.source.graph.ancestors(use_scope)
+        return event.execution == self.source.graph.execution_scope(use_scope)
+
+    def targets(self, binding: int, before: int, use_scope: int, visiting: frozenset[tuple[int, int, int]] = frozenset()) -> ObjectTargets:
+        key = (binding, before, use_scope)
+        if key in self._targets_memo:
+            return self._targets_memo[key]
+        if key in visiting:
+            return ObjectTargets(unknown=True)
+        stop = bisect.bisect_left(self.root_offsets.get(binding, ()), before)
+        events = [event for event in self.roots.get(binding, ())[:stop] if self._root_reaches(event, use_scope)]
+        call_path = self.control.path(before)
+        environments = self.control.environments((event.path for event in events), call_path)
+        if not environments:
+            return ObjectTargets(unknown=True)
+        results: list[ObjectTargets] = []
+        for environment in environments:
+            current = ObjectTargets(unknown=True)
+            for event in events:
+                if not self.control.active(event.path, environment):
+                    continue
+                current = (
+                    ObjectTargets(frozenset((event.object_id,)))
+                    if event.aliases is None
+                    else join_targets(
+                        [
+                            self.targets(
+                                alias,
+                                event.start,
+                                event.scope,
+                                visiting | {key},
+                            )
+                            for alias in event.aliases
+                        ]
+                        + (
+                            [ObjectTargets(unknown=True)]
+                            if event.alias_unknown
+                            else []
+                        )
+                    )
+                )
+            results.append(current)
+        value = join_targets(results)
+        self._targets_memo[key] = value
+        return value
+
+    def _effect_from_presence(self, value: Presence) -> int:
+        return overlay_effect(value)
+
+    def _object_presence(self, object_id: tuple[int, int], before: int, use_scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]] = frozenset()) -> Presence:
+        key = (object_id, before, use_scope)
+        if key in self._presence_memo:
+            return self._presence_memo[key]
+        if key in visiting or object_id not in self.objects:
+            return MAYBE_VALUE
+        root = self.objects[object_id]
+        initial = self._span_presence(*root.rhs, root.start, root.scope, visiting | {key})
+        stop = bisect.bisect_left(self.event_offsets, before)
+        # A field write in an ENCLOSING function reaches a send written inside
+        # a callback: the object is captured by the closure and the write has
+        # already run at the point the send is written. Requiring an exact
+        # execution-scope match dropped every such write, so
+        # `payload.messaging_profile_id = mp; items.forEach(i => fetch(...))`
+        # was reported as missing the profile it plainly sets. The reverse
+        # direction stays blocked - a write INSIDE a callback still cannot
+        # prove anything about a send outside it, because the callback may
+        # never run.
+        enclosing = self.source.graph.ancestors(use_scope)
+        events = [event for event in self.events[:stop] if event.execution in enclosing]
+        environments = self.control.environments((event.path for event in events), self.control.path(before))
+        if not environments:
+            return Presence(MAYBE, initial.evidence or bool(events))
+        outcomes: list[Presence] = []
+        for environment in environments:
+            value = initial
+            for event in events:
+                if not self.control.active(event.path, environment):
+                    continue
+                targets = self.targets(event.binding, event.start, event.scope)
+                definite = object_id in targets.must
+                possible = definite or object_id in targets.may or targets.unknown
+                if not possible:
+                    continue
+                effect = event.effect
+                if event.overlay is not None:
+                    effect = self._effect_from_presence(self._span_presence(*event.overlay, event.start, event.scope, visiting | {key}))
+                changed = apply_field_effect(value, effect)
+                value = changed if definite else join_presence((value, changed))
+            outcomes.append(value)
+        result = join_presence(outcomes)
+        self._presence_memo[key] = result
+        return result
+
+    def presence_for_binding(self, binding: int, before: int, use_scope: int) -> Presence:
+        targets = self.targets(binding, before, use_scope)
+        values = [self._object_presence(object_id, before, use_scope) for object_id in targets.all]
+        if targets.unknown:
+            values.append(MAYBE_VALUE)
+        return join_presence(values)
+
+    def presence_for_name(self, name: str, before: int) -> Presence:
+        scope = self.source.scope_at(before)
+        binding = self.source.graph.visible_binding(name.lstrip("$"), scope, before)
+        return self.presence_for_binding(binding, before, scope) if binding is not None else MAYBE_VALUE
+
+    def _serialized(self, value: str) -> Presence | None:
+        candidates = [value]
+        try:
+            decoded = json.loads(f'"{value}"')
+            if decoded != value: candidates.append(decoded)
+        except (TypeError, ValueError):
+            pass
+        for candidate in candidates:
+            try: payload = json.loads(candidate)
+            except (TypeError, ValueError): continue
+            if not isinstance(payload, dict):
+                return ABSENT_VALUE
+            selected = next((payload[name] for name in reversed(tuple(payload)) if name in self.fields), ...)
+            if selected is ...:
+                return ABSENT_VALUE
+            if not self.require_value:
+                return PRESENT_VALUE
+            return Presence(
+                PRESENT
+                if selected not in (None, "", [], {}, False)
+                else ABSENT,
+                True,
+            )
+        return None
+
+    def text_presence(self, value: str) -> Presence:
+        return self._serialized(value) or MAYBE_VALUE
+
+    def _members(self, kind: str, opening: int, closing: int, before: int, scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]]) -> Presence:
+        members = split_arguments(self.lexed.code, opening + 1, closing)
+        value = ABSENT_VALUE
+        if kind == "pairs":
+            for key_span, value_span in zip(members[::2], members[1::2]):
+                key = static_object_key(self.lexed, *key_span)
+                if key in self.fields: value = apply_field_effect(value, self._value_effect(*value_span))
+                elif key is None: value = join_presence((value, MAYBE_VALUE))
+            return value
+        for member_start, member_end in members:
+            text = self.lexed.code[member_start:member_end].strip()
+            if not text: continue
+            # Match on raw source offsets: `text` is stripped, so any offset
+            # derived from it is short by the member's leading whitespace and
+            # `{ a, ...base }` resolved to `.base` instead of `base`.
+            spread = SPREAD_MEMBER_RE.match(self.lexed.code, member_start, member_end)
+            if spread:
+                value = apply_field_effect(value, overlay_effect(self._span_presence(spread.end(), member_end, before, scope, visiting)))
+                continue
+            colon = top_level_colon(self.lexed.code, member_start, member_end)
+            separator = (colon, colon + 1) if colon is not None else top_level_assignment_separator(self.lexed.code, member_start, member_end)
+            if separator is None:
+                key = static_object_key(self.lexed, member_start, member_end)
+                # A separator-less member is either a string key or a JS/TS
+                # shorthand. Shorthand means the VARIABLE's value, so the value
+                # still has to be analysed - hard-coding WRITE_PRESENT
+                # certified `const messaging_profile_id = ''; {..., messaging_profile_id}`.
+                # For a string-literal key the span is its own non-empty
+                # literal, so _value_effect keeps the previous verdict.
+                if key in self.fields: value = apply_field_effect(value, self._value_effect(member_start, member_end))
+                elif key is None and text.startswith("["): value = join_presence((value, MAYBE_VALUE))
+                continue
+            separator_start, value_start = separator
+            key = static_object_key(self.lexed, member_start, separator_start)
+            if key in self.fields: value = apply_field_effect(value, self._value_effect(value_start, member_end))
+            elif key is None: value = join_presence((value, MAYBE_VALUE))
+        return value
+
+    def _builder(self, start: int, end: int) -> Presence | None:
+        names = "|".join(map(re.escape, sorted(self.fields)))
+        matches = list(
+            re.compile(
+                rf"(?:\.|->)\s*(?:set)?(?:{names})\s*\("
+            ).finditer(self.lexed.code, start, end)
+        )
+        matches = [
+            match
+            for match in matches
+            if structural_depth(self.lexed.code, start, match.start())
+            == (0, 0, 0)
+        ]
+        if not matches: return None
+        opening = self.lexed.code.rfind("(", matches[-1].start(), matches[-1].end())
+        closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+        return Presence(MAYBE, True) if closing is None or closing > end else apply_field_effect(ABSENT_VALUE, self._value_effect(opening + 1, closing))
+
+    def _arguments(self, start: int, end: int) -> Presence | None:
+        value, found = ABSENT_VALUE, False
+        for member_start, member_end in split_arguments(self.lexed.code, start, end):
+            colon = top_level_colon(self.lexed.code, member_start, member_end)
+            separator = (colon, colon + 1) if colon is not None else top_level_assignment_separator(self.lexed.code, member_start, member_end)
+            if separator is None: continue
+            key = static_object_key(self.lexed, member_start, separator[0])
+            if key in self.fields:
+                value, found = apply_field_effect(value, self._value_effect(separator[1], member_end)), True
+        return value if found else None
+
+    def _span_presence(self, start: int, end: int, before: int, scope: int, visiting: frozenset[tuple[tuple[int, int], int, int]] = frozenset()) -> Presence:
+        start, end = strip_expression_parentheses(self.lexed, start, end)
+        if start >= end: return ABSENT_VALUE
+        conditional = self._conditional(start, end)
+        if conditional is not None:
+            return join_presence(self._span_presence(*span, before, scope, visiting) for span in conditional)
+        wrapper = re.match(r"\s*(?:JSON\s*\.\s*stringify|json\s*\.\s*dumps)\s*\(", self.lexed.code[start:end])
+        if wrapper:
+            opening = self.lexed.code.find("(", start, start + wrapper.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            arguments = split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []
+            if arguments: return self._span_presence(*arguments[0], before, scope, visiting)
+        # Ruby's serializer is a suffix, not a call wrapper: `payload.to_json`
+        # is the idiomatic Net::HTTP/Faraday body. Only the inline-literal form
+        # `{..}.to_json` resolved, so a compliant send through a variable was
+        # reported as missing the profile.
+        to_json = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*to_json\s*(?:\(\s*\))?\s*",
+            self.lexed.code[start:end],
+        )
+        if to_json is not None:
+            return self._span_presence(
+                start + to_json.start(1), start + to_json.end(1), before, scope, visiting
+            )
+        assign = re.match(r"\s*Object\s*\.\s*assign\s*\(", self.lexed.code[start:end])
+        if assign:
+            opening = self.lexed.code.find("(", start, start + assign.end())
+            closing = matching_delimiter(self.lexed.code, opening, "(", ")")
+            value = ABSENT_VALUE
+            for span in split_arguments(self.lexed.code, opening + 1, closing) if closing is not None else []:
+                value = apply_field_effect(value, overlay_effect(self._span_presence(*span, before, scope, visiting)))
+            return value
+        copy_call = re.fullmatch(
+            r"\s*(?:new\s+)?(?:dict|HashMap|Dictionary)"
+            r"(?:\s*<[^>]*>)?\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if copy_call is not None:
+            copy_start = start + copy_call.start(1)
+            return self._span_presence(
+                copy_start,
+                start + copy_call.end(1),
+                before,
+                scope,
+                visiting,
+            )
+        copy_method = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*"
+            r"(?:copy|dup|clone)\s*(?:\(\s*\))?\s*",
+            self.lexed.code[start:end],
+        )
+        if copy_method is not None:
+            name_start = start + copy_method.start(1)
+            binding = self._binding(
+                name_start, start + copy_method.end(1), scope, before
+            )
+            if binding is not None:
+                return self.presence_for_binding(binding, before, scope)
+        clone_call = re.fullmatch(
+            r"\s*maps\s*\.\s*Clone\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if clone_call is not None:
+            clone_start = start + clone_call.start(1)
+            return self._span_presence(
+                clone_start,
+                start + clone_call.end(1),
+                before,
+                scope,
+                visiting,
+            )
+        merge_copy = re.fullmatch(
+            r"\s*(\$?[A-Za-z_]\w*)\s*(?:\.|->)\s*merge\s*\((.*)\)\s*",
+            self.lexed.code[start:end],
+            re.DOTALL,
+        )
+        if merge_copy is not None:
+            receiver_start = start + merge_copy.start(1)
+            value = self._span_presence(
+                receiver_start,
+                start + merge_copy.end(1),
+                before,
+                scope,
+                visiting,
+            )
+            argument_start = start + merge_copy.start(2)
+            for span in split_arguments(
+                self.lexed.code,
+                argument_start,
+                start + merge_copy.end(2),
+            ):
+                value = apply_field_effect(
+                    value,
+                    overlay_effect(
+                        self._span_presence(*span, before, scope, visiting)
+                    ),
+                )
+            return value
+        container = root_literal_container(self.lexed, start, end, self.suffix)
+        if container is not None: return self._members(*container, before, scope, visiting)
+        builder = self._builder(start, end)
+        if builder is not None: return builder
+        arguments = self._arguments(start, end)
+        if arguments is not None: return arguments
+        binding = self._binding(start, end, scope, before)
+        if binding is not None: return self.presence_for_binding(binding, before, scope)
+        tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
+        if len(tokens) == 1:
+            serialized = self._serialized(tokens[0].contents)
+            if serialized is not None: return serialized
+        if (
+            self.require_value
+            and self.suffix == ".sh"
+            and shell_jq_assignment_has_profile(self.lexed, start, end)
+        ):
+            return PRESENT_VALUE
+        old = region_has_profile(self.lexed, start, end, serialized_assignment=True, allow_js_shorthand=self.suffix in self.JS_SUFFIXES) if self.require_value else region_has_message_body(self.lexed, start, end, self.suffix)
+        return PRESENT_VALUE if old else MAYBE_VALUE
+
+    def span_presence(self, start: int, end: int, before: int) -> Presence:
+        return self._span_presence(start, end, before, self.source.scope_at(before))
+
+
+def shell_static_key(source: str) -> str | None:
+    key = source.strip()
+    if len(key) >= 2 and key[0] == key[-1] and key[0] in {"'", '"'}:
+        key = key[1:-1]
+    return key if re.fullmatch(r"(?:[A-Za-z_]\w*|\d+)", key) else None
+
+
+def shell_static_references(
+    source: str,
+) -> list[EndpointReference]:
+    references: list[EndpointReference] = []
+    for match in SHELL_STATIC_REFERENCE_RE.finditer(source):
+        root = match.group(1) or match.group(3)
+        key = shell_static_key(match.group(2)) if match.group(2) else None
+        if match.group(2) and key is None:
+            continue
+        references.append((root, key) if key is not None else (root,))
+    return references
+
+
+def shell_member_assignments(
+    lexed: LexedSource, before: int, suffix: str
+) -> list[tuple[EndpointReference, int, int, int]]:
+    pattern = re.compile(
+        r"(?<![\w$])([A-Za-z_]\w*)\[\s*([^\]]+)\s*\]\s*=(?!=)"
+    )
+    assignments: list[tuple[EndpointReference, int, int, int]] = []
+    for match in pattern.finditer(lexed.without_comments, 0, before):
+        key = shell_static_key(match.group(2))
+        if key is None:
+            continue
+        assignments.append(
+            (
+                (match.group(1), key),
+                match.start(),
+                match.end(),
+                assignment_end(lexed, match.end(), suffix),
+            )
+        )
+    return assignments
+
+
+def shell_separator(lexed: LexedSource, offset: int) -> bool:
+    character = lexed.code[offset]
+    if character not in {"\n", ";", "&", "|"}:
+        return False
+    backslashes = 0
+    cursor = offset - 1
+    while cursor >= 0 and lexed.original[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 0
+
+
+def shell_command_span(lexed: LexedSource, offset: int) -> tuple[int, int]:
+    """Bound one shell command without merging adjacent curl payloads."""
+
+    start = 0
+    for index in range(offset - 1, -1, -1):
+        if shell_separator(lexed, index):
+            start = index + 1
+            break
+    end = len(lexed.original)
+    for index in range(offset, len(lexed.code)):
+        if shell_separator(lexed, index):
+            end = index
+            break
+    return start, end
+
+
+def shell_curl_is_command(
+    lexed: LexedSource, command_start: int, curl_start: int
+) -> bool:
+    """Exclude prose/arguments containing the word curl without executing it."""
+
+    prefix = lexed.original[command_start:curl_start].strip()
+    if not prefix or prefix.endswith("$("):
+        return True
+    try:
+        tokens = shlex.split(prefix, comments=True, posix=True)
+    except ValueError:
+        return False
+    allowed = {
+        "!", "command", "do", "elif", "env", "if", "then", "until", "while"
+    }
+    return all(
+        token in allowed or SHELL_ASSIGNMENT_TOKEN_RE.fullmatch(token)
+        for token in tokens
+    )
+
+
+def shell_curl_calls(lexed: LexedSource) -> list[Call]:
+    calls: list[Call] = []
+    seen: set[tuple[int, int]] = set()
+    for match in SHELL_CURL_RE.finditer(lexed.code):
+        start, end = shell_command_span(lexed, match.start(1))
+        if not shell_curl_is_command(lexed, start, match.start(1)):
+            continue
+        if (start, end) not in seen:
+            seen.add((start, end))
+            calls.append(Call(start, start, end, parenthesized=False))
+    return calls
+
+
+def shell_curl_url_arguments(lexed: LexedSource, call: Call) -> list[str]:
+    """Return curl URL arguments while excluding option values and payloads."""
+
+    source = lexed.original[call.start:call.end]
+    try:
+        tokens = shlex.split(source, comments=True, posix=True)
+    except ValueError:
+        return []
+    curl_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if re.search(r"(?:^|[/$(])curl$", token)
+        ),
+        None,
+    )
+    if curl_index is None:
+        return []
+
+    candidates: list[str] = []
+    index = curl_index + 1
+    while index < len(tokens):
+        token = tokens[index]
+        option, separator, attached = token.partition("=")
+        if separator and option in SHELL_CURL_VALUE_OPTIONS:
+            if option in SHELL_CURL_URL_OPTIONS:
+                candidates.append(attached)
+            index += 1
+            continue
+        if token in SHELL_CURL_VALUE_OPTIONS:
+            if index + 1 < len(tokens) and token in SHELL_CURL_URL_OPTIONS:
+                candidates.append(tokens[index + 1])
+            index += 2
+            continue
+        if any(
+            token.startswith(short) and len(token) > len(short)
+            for short in ("-A", "-d", "-H", "-o", "-u", "-w", "-X")
+        ):
+            index += 1
+            continue
+        if not token.startswith("-"):
+            candidates.append(token)
+        index += 1
+    return candidates
+
+
+def shell_curl_url_references(
+    lexed: LexedSource, call: Call
+) -> set[EndpointReference]:
+    expanded: set[EndpointReference] = set()
+    for match in SHELL_STATIC_REFERENCE_RE.finditer(
+        lexed.original, call.start, call.end
+    ):
+        token = next(
+            (
+                candidate
+                for candidate in lexed.strings
+                if candidate.start <= match.start() < candidate.end
+            ),
+            None,
+        )
+        if token is not None and lexed.original[token.start] == "'":
+            continue
+        root = match.group(1) or match.group(3)
+        key = shell_static_key(match.group(2)) if match.group(2) else None
+        expanded.add((root, key) if key is not None else (root,))
+    return {
+        reference
+        for candidate in shell_curl_url_arguments(lexed, call)
+        for reference in shell_static_references(candidate)
+        if reference in expanded
+    }
+
+
+def iter_source_files(project_root: Path):
+    for directory, child_dirs, filenames in os.walk(project_root):
+        child_dirs[:] = sorted(name for name in child_dirs if name not in EXCLUDED_DIRS)
+        for filename in sorted(filenames):
+            # Generated bundles are build OUTPUT, not source. The scanner and
+            # both shell validators already exclude *.bundle.js / *.chunk.js /
+            # *.min.css alongside *.min.js; skipping only *.min.js here meant a
+            # stale webpack bundle carrying an old number-pool POST kept failing
+            # `lint-telnyx-correctness.sh --product messaging` long after the
+            # source was fixed, with no file the user could correct.
+            if filename in EXCLUDED_FILES or filename.endswith(
+                (".min.js", ".min.css", ".bundle.js", ".chunk.js")
+            ):
+                continue
+            path = Path(directory, filename)
+            suffix = path.suffix.lower()
+            if suffix in INCLUDED_SUFFIXES:
+                yield path
+            elif not suffix and shebang_suffix(path) is not None:
+                yield path
+
+
+
+
+# --- member-clearance net (proof-based; see member_net_contexts) ---
+
+ASSIGNMENT_TARGET_RE = re.compile(
+    r"(?<![\w$.>])(\$?[A-Za-z_]\w*)(?!\w)(?:\s*:[^=;\n]+)?\s*(?::=|=(?!=|>))"
+)
+
+
+MEMBER_ACCESS_AFTER_RE = re.compile(r"\s*(?:\?\.|\.)\s*([A-Za-z_]\w*)")
+
+
+SUBSCRIPT_AFTER_RE = re.compile(r"\s*\[([^\[\]\n]*)\]")
+
+
+CALL_AFTER_RE = re.compile(r"\s*\(")
+
+
+IDENTIFIER_TOKEN_RE = re.compile(r"\$?[A-Za-z_]\w*")
+
+
+RESERVED_TARGETS = frozenset(
+    {"export", "default", "module", "exports", "return", "yield", "await",
+     "typeof", "delete", "void", "new", "in", "of", "import", "case"}
+)
+
+
+def quoted_key_before(lexed: LexedSource, position: int) -> str | None:
+    """Read back a masked quoted key ending immediately before `position`."""
+
+    for token in reversed(lexed.strings):
+        if token.end > position:
+            continue
+        if lexed.code[token.end : position].strip():
+            return None
+        key = token.contents
+        return key if re.fullmatch(r"[A-Za-z_]\w*", key) else None
+    return None
+
+
+def literal_subscript_key(lexed: LexedSource, start: int, end: int) -> str | None:
+    """Key of `obj[...]` when the subscript is a literal; None when dynamic."""
+
+    region = lexed.code[start:end]
+    numeric = re.fullmatch(r"\s*(\d+)\s*", region)
+    if numeric is not None:
+        # Normalize so sloppy-mode `[01]` compares equal to position 1.
+        return str(int(numeric.group(1)))
+    symbol = re.fullmatch(r"\s*:\s*([A-Za-z_]\w*)\s*", region)
+    if symbol is not None:
+        return symbol.group(1)
+    if region.strip():
+        return None
+    tokens = [t for t in lexed.strings if start <= t.start and t.end <= end]
+    if len(tokens) != 1:
+        return None
+    key = tokens[0].contents
+    return key if re.fullmatch(r"[A-Za-z_]\w*", key) else None
+
+
+def stored_member_key(lexed: LexedSource, token_start: int) -> str | None:
+    """Mapping key a literal is stored under: `pool:`, `'pool':`, `=>` forms."""
+
+    code = lexed.code
+    end = token_start
+    while end > 0 and code[end - 1].isspace():
+        end -= 1
+    # End-anchored searches only need a small window, not the whole prefix.
+    window_start = max(0, end - 160)
+    window = code[window_start:end]
+    if window.endswith("=>"):
+        symbol = re.search(r":([A-Za-z_]\w*)\s*$", window[:-2])
+        if symbol is not None:
+            return symbol.group(1)
+        return quoted_key_before(lexed, end - 2)
+    if window.endswith(":"):
+        # Not a key when the colon belongs to a ternary (`cond ? x : "..."`).
+        if re.search(r"\?[^:{,\n]*:$", window):
+            return None
+        identifier = re.search(r"(?<![\w$]):?([A-Za-z_]\w*)\s*:$", window)
+        if identifier is not None:
+            return identifier.group(1)
+        return quoted_key_before(lexed, end - 1)
+    return None
+
+
+def container_is_file_private(
+    lexed: LexedSource, assign_start: int, name: str, suffix: str, operator: str
+) -> bool:
+    """Whether the container provably cannot be referenced from another file.
+
+    Clearing is only sound when every use is visible to this analysis, and
+    this analysis reads one file. JS/TS module locals qualify unless exported.
+    Go's `:=` declares a function local; anything else is package-visible
+    across files. Python, Ruby and PHP top-level names are importable or
+    global, so only indented (function-scoped) definitions qualify; Ruby
+    constants (uppercase) never do.
+    """
+
+    line_start, _ = line_bounds(lexed.original, assign_start)
+    line_prefix = lexed.code[line_start:assign_start]
+    if suffix in JS_TS_SUFFIXES:
+        return re.search(r"\bexport\b", line_prefix) is None
+    if suffix == ".go":
+        return operator == ":="
+    if suffix in {".py", ".rb", ".php"}:
+        if suffix == ".rb" and name[:1].isupper():
+            return False
+        # Indented (whitespace-only prefix) AND enclosed by a `def`, not a
+        # `class` body — class attributes are reachable from other files.
+        if line_prefix == "" or line_prefix.strip() != "":
+            return False
+        indent = len(line_prefix)
+        position = line_bounds(lexed.original, assign_start)[0]
+        while position > 0:
+            position = lexed.original.rfind("\n", 0, position - 1) + 1
+            line_end = lexed.original.find("\n", position)
+            line = lexed.original[position : line_end if line_end >= 0 else None]
+            stripped = line.strip()
+            if not stripped or len(line) - len(line.lstrip()) >= indent:
+                if position == 0:
+                    break
+                continue
+            if suffix == ".php":
+                return "function" in stripped
+            return bool(re.match(r"(?:async\s+)?def\s", stripped))
+        return False
+    if suffix in {".cs", ".java"}:
+        return (
+            re.search(r"\b(?:public|protected|internal)\b", line_prefix)
+            is None
+        )
+    return False
+
+
+def assignment_index(
+    lexed: LexedSource, suffix: str
+) -> list[tuple[str, int, int, int]]:
+    """Every assignment as (name, start, rhs_start, rhs_end), computed once.
+
+    Per-token rescans of the file are what made an earlier attempt at this
+    analysis quadratic; everything below reads this index instead.
+    """
+
+    entries = []
+    for assignment in ASSIGNMENT_TARGET_RE.finditer(lexed.code):
+        rhs_start = assignment.end()
+        entries.append(
+            (
+                assignment.group(1),
+                assignment.start(),
+                rhs_start,
+                assignment_end(lexed, rhs_start, suffix),
+            )
+        )
+    return entries
+
+
+def container_for_token(
+    lexed: LexedSource,
+    token: StringToken,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    walkers: dict[int, list],
+) -> tuple[str, list[str], tuple[int, int], str] | None:
+    """(name, required key chain, definition span, operator) for `token`."""
+
+    for name, start, rhs_start, rhs_end in reversed(assignments):
+        if start >= token.start:
+            continue
+        if not (rhs_start <= token.start < rhs_end):
+            continue
+        # Incremental stack walker per RHS: path tokens arrive in ascending
+        # order, so each RHS is walked once in total, not once per token —
+        # a per-token walk made large single-container literals quadratic.
+        walker = walkers.get(rhs_start)
+        if walker is None:
+            walker = [rhs_start, []]
+            walkers[rhs_start] = walker
+        position, stack = walker
+        while position < token.start:
+            character = lexed.code[position]
+            if character in "([{":
+                stack.append([character, position, 0])
+            elif character in ")]}" and stack:
+                stack.pop()
+            elif character == "," and stack:
+                stack[-1][2] += 1
+            position += 1
+        walker[0] = position
+        if not stack:
+            return None
+        # Resolve the FULL key chain, outermost to innermost. Comparing only
+        # the innermost key let a reference to an ancestor member count as
+        # proof while handing out the object that contains the required path.
+        chain: list[str] = []
+        for level, (opener, opener_at, commas) in enumerate(stack):
+            boundary = (
+                stack[level + 1][1]
+                if level + 1 < len(stack)
+                else token.start
+            )
+            if opener == "{":
+                key = stored_member_key(lexed, boundary)
+            elif opener == "[":
+                # PHP spells associative arrays with `[` — a `=>` key wins
+                # over position.
+                key = stored_member_key(lexed, boundary)
+                if key is None:
+                    key = str(commas)
+            else:
+                # A call such as Map.of(...) — not a literal this rule models.
+                return None
+            if key is None:
+                return None
+            chain.append(key)
+        operator = lexed.code[max(0, rhs_start - 2) : rhs_start].strip()
+        return name, chain, (start, rhs_end), operator
+    return None
+
+
+def access_chain_after(
+    lexed: LexedSource, position: int
+) -> tuple[list[str], bool, bool]:
+    """Static keys accessed after an occurrence: (keys, resolvable, is_call)."""
+
+    keys: list[str] = []
+    code = lexed.code
+    while True:
+        member = MEMBER_ACCESS_AFTER_RE.match(code, position)
+        if member is not None:
+            keys.append(member.group(1))
+            position = member.end()
+            continue
+        subscript = SUBSCRIPT_AFTER_RE.match(code, position)
+        if subscript is not None:
+            key = literal_subscript_key(
+                lexed, subscript.start(1), subscript.end(1)
+            )
+            if key is None:
+                return keys, False, False
+            keys.append(key)
+            position = subscript.end()
+            continue
+        break
+    return keys, True, CALL_AFTER_RE.match(code, position) is not None
+
+
+def identifier_occurrences(lexed: LexedSource) -> dict[str, list[int]]:
+    """Map identifier -> end offsets of its standalone occurrences in code.
+
+    One pass per file; per-token lookups replace whole-file rescans (the
+    quadratic trap an earlier attempt fell into).
+    """
+
+    positions: dict[str, list[int]] = {}
+    dotted: dict[str, list[int]] = {}
+    for match in IDENTIFIER_TOKEN_RE.finditer(lexed.code):
+        before = lexed.code[match.start() - 1] if match.start() else " "
+        if before == ".":
+            # Reached through a property path (`globalThis.x`, `Config.x`,
+            # `...x` spread) — a use this rule cannot align, NOT an ignorable
+            # one. Skipping these silently is how a container escaped once.
+            dotted.setdefault(match.group(0), []).append(match.start())
+            continue
+        if before == "$" or before.isalnum() or before == "_":
+            continue
+        positions.setdefault(match.group(0), []).append(match.start())
+    return positions, dotted
+
+
+def masked_identifier_names(lexed: LexedSource) -> dict[str, list[int]]:
+    """Identifiers inside strings or comments (unreadable uses), by position."""
+
+    names: dict[str, list[int]] = {}
+    for match in IDENTIFIER_TOKEN_RE.finditer(lexed.original):
+        if lexed.code[match.start()] != lexed.original[match.start()]:
+            names.setdefault(match.group(0), []).append(match.start())
+    return names
+
+
+def member_accesses_prove_unused(
+    lexed: LexedSource,
+    offset: int,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    occurrences: dict[str, list[int]],
+    masked_names: set[str],
+    dotted_names: set[str],
+    walkers: dict[int, list],
+    reference_cache: dict[str, tuple[bool, bool, list[list[str]]]],
+) -> bool:
+    token = next(
+        (t for t in lexed.strings if t.start <= offset < t.end), None
+    )
+    if token is None:
+        return False
+    resolved = container_for_token(lexed, token, suffix, assignments, walkers)
+    if resolved is None:
+        return False
+    name, required_chain, definition, operator = resolved
+    if not container_is_file_private(
+        lexed, definition[0], name, suffix, operator
+    ):
+        return False
+
+    summary = reference_cache.get(name)
+    if summary is None:
+        names = {name}
+        skip_spans = [definition]
+        for alias, start, rhs_start, rhs_end in assignments:
+            alias_of = lexed.code[rhs_start:rhs_end].strip()
+            if (
+                alias_of == name
+                and alias != name
+                and alias.lstrip("$") not in RESERVED_TARGETS
+            ):
+                names.add(alias)
+                skip_spans.append((start, rhs_end))
+        # Unreadable uses — via a property path, or mentioned inside a string
+        # or comment (template literals, exports lists) — forbid proof.
+        readable = not any(
+            n in dotted_names or n in masked_names for n in names
+        )
+        chains: list[list[str]] = []
+        proved = False
+        if readable:
+            for n in sorted(names):
+                for start in occurrences.get(n, ()):
+                    if any(s <= start < e for s, e in skip_spans):
+                        continue
+                    keys, resolvable, is_call = access_chain_after(
+                        lexed, start + len(n)
+                    )
+                    if not resolvable or not keys or is_call:
+                        readable = False
+                        break
+                    chains.append(keys)
+                    proved = True
+                if not readable:
+                    break
+        summary = (readable, proved, chains)
+        reference_cache[name] = summary
+
+    readable, proved, chains = summary
+    if not readable or not proved:
+        return False
+    for chain in chains:
+        # A reference conflicts when it agrees with the required chain for
+        # its whole shared prefix: it reaches the required member or an
+        # ancestor holding it. Only a divergent chain is proof of non-use.
+        shared = min(len(chain), len(required_chain))
+        if chain[:shared] == required_chain[:shared]:
+            return False
+    return True
+
+
+
+DESTRUCTURE_LHS_RE = re.compile(r"[}\]]\s*$")
+
+
+
+def safe_literal_span(
+    lexed: LexedSource,
+    rhs_from: int,
+    rhs_to: int,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+) -> bool:
+    """Whether an assignment RHS is provably free of required paths.
+
+    Accepts a single string literal, or a bare variable whose own latest
+    assignment is such a literal (one indirection, no recursion)."""
+
+    tokens = [
+        t for t in lexed.strings
+        if rhs_from <= t.start and t.end <= rhs_to
+    ]
+    remainder = lexed.code[rhs_from:rhs_to].strip()
+    if len(tokens) == 1 and not remainder:
+        return not MEMBER_NET_PATH_RE.search(tokens[0].contents)
+    if tokens:
+        return False
+    variable = re.fullmatch(r"\$?[A-Za-z_]\w*", remainder.rstrip(";").strip())
+    if variable is None:
+        return False
+    latest = None
+    for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+        if a_name == variable.group(0) and a_rhs_start < rhs_from:
+            latest = (a_rhs_start, a_rhs_end)
+    if latest is None:
+        return False
+    inner = [
+        t for t in lexed.strings
+        if latest[0] <= t.start and t.end <= latest[1]
+    ]
+    if len(inner) != 1 or lexed.code[latest[0]:latest[1]].strip():
+        return False
+    return not MEMBER_NET_PATH_RE.search(inner[0].contents)
+
+
+def build_binding_index(
+    lexed: LexedSource,
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+) -> dict:
+    """Once-per-file maps the per-container summary builder reads: binding
+    positions per name (pattern keys excluded) and bare-name RHS aliases."""
+
+    own: dict[str, list[int]] = {}
+    bare_rhs: dict[str, list[tuple[str, int, int]]] = {}
+    for alias, start, rhs_start, rhs_end in assignments:
+        before = start
+        while before > 0 and lexed.code[before - 1] in " \t":
+            before -= 1
+        if (
+            before > 0
+            and lexed.code[before - 1] in "{,("
+            and ":" in lexed.code[start:rhs_start]
+        ):
+            continue
+        own.setdefault(alias, []).append(start)
+        alias_of = lexed.code[rhs_start:rhs_end].strip()
+        if re.fullmatch(r"\$?[A-Za-z_]\w*;?", alias_of):
+            bare_rhs.setdefault(alias_of.rstrip(";"), []).append(
+                (alias, start, rhs_end)
+            )
+    return {"own": own, "bare_rhs": bare_rhs}
+
+def build_container_summary(
+    lexed: LexedSource,
+    name: str,
+    definition: tuple[int, int],
+    suffix: str,
+    assignments: list[tuple[str, int, int, int]],
+    binding_index: dict,
+    occurrences: dict[str, list[int]],
+    masked_names: set[str],
+    dotted_names: set[str],
+    evaluated_spans: list[tuple[int, int]],
+    flagged_spans: list[tuple[int, int]],
+) -> dict:
+    """Chain-independent reference summary for one container, built once.
+
+    Per-token work then reduces to prefix checks against an index keyed by
+    each reference chain's first element — the per-token full rescans of an
+    earlier version were quadratic on large containers."""
+
+    names = {name}
+    skip_spans = [definition]
+    own_assignments = binding_index["own"]
+    for alias, start, rhs_end in binding_index["bare_rhs"].get(name, ()):
+        if alias != name and alias.lstrip("$") not in RESERVED_TARGETS:
+            names.add(alias)
+            skip_spans.append((start, rhs_end))
+
+    summary = {
+        "ok": True,
+        "had_skipped": False,
+        "proved_any": False,
+        "by_first": {},
+        "destructured": [],
+        "kills": [],
+    }
+
+    def flagged_has(word: str) -> bool:
+        ref = re.compile(rf"(?<![\w$.]){re.escape(word)}(?!\w)")
+        return any(ref.search(lexed.code, fs, fe) for fs, fe in flagged_spans)
+
+    def evaluated_has(word: str) -> bool:
+        ref = re.compile(rf"(?<![\w$.]){re.escape(word)}(?!\w)")
+        return any(
+            ref.search(lexed.code, es, ee) for es, ee in evaluated_spans
+        )
+
+    unreadable = [n for n in names if n in dotted_names or n in masked_names]
+    for n in unreadable:
+        spots = list(masked_names.get(n, ())) + list(dotted_names.get(n, ()))
+        for spot in spots:
+            if any(ds <= spot < de for ds, de in skip_spans):
+                continue
+            covering = None
+            for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+                if a_rhs_start <= spot < a_rhs_end:
+                    covering = a_name
+                    break
+            if covering is None or not flagged_has(covering):
+                summary["ok"] = False
+                return summary
+        summary["had_skipped"] = True
+
+    for n in sorted(names):
+        for start in occurrences.get(n, ()):
+            if any(ds <= start < de for ds, de in skip_spans):
+                continue
+            nearest = None
+            for a_start in own_assignments.get(n, ()):
+                if a_start <= start:
+                    nearest = a_start if nearest is None else max(
+                        nearest, a_start
+                    )
+            if nearest is not None and all(
+                nearest != ds for ds, _de in skip_spans
+            ):
+                summary["had_skipped"] = True
+                continue
+            end = start + len(n)
+            keys, resolvable, is_call = access_chain_after(lexed, end)
+            in_evaluated = any(
+                es <= start < ee for es, ee in evaluated_spans
+            )
+            if not resolvable:
+                if in_evaluated:
+                    # Dynamic keys inside evaluated calls are the resolver's
+                    # corpus-pinned domain.
+                    summary["had_skipped"] = True
+                    continue
+                # A dynamic key handed to code the resolver never judged can
+                # reach the required member — no proof.
+                summary["ok"] = False
+                return summary
+            if not keys:
+                prefix_end = start
+                while prefix_end > 0 and lexed.code[prefix_end - 1] in " \t":
+                    prefix_end -= 1
+                if lexed.code[max(0, prefix_end - 1):prefix_end] == "=":
+                    lhs_close = prefix_end - 1
+                    while lhs_close > 0 and lexed.code[lhs_close - 1] in " \t":
+                        lhs_close -= 1
+                    if lexed.code[lhs_close - 1:lhs_close] in "}]":
+                        opener = {"}": "{", "]": "["}[
+                            lexed.code[lhs_close - 1]
+                        ]
+                        depth = 0
+                        lhs_open = -1
+                        for pos in range(lhs_close - 1, -1, -1):
+                            ch = lexed.code[pos]
+                            if ch in ")]}":
+                                depth += 1
+                            elif ch in "([{":
+                                depth -= 1
+                                if depth == 0 and ch == opener:
+                                    lhs_open = pos
+                                    break
+                        if lhs_open >= 0:
+                            pattern = lexed.code[lhs_open:lhs_close]
+                            source_pattern = lexed.original[
+                                lhs_open:lhs_close
+                            ]
+                            if "..." in pattern or "**" in pattern:
+                                # Rest elements can bind the required
+                                # member invisibly.
+                                summary["ok"] = False
+                                return summary
+                            if opener == "[":
+                                # Array patterns bind by position — the
+                                # resolver's corpus tracks them end to end.
+                                summary["had_skipped"] = True
+                                continue
+                            if "[" in pattern[1:]:
+                                # Computed property names in an object
+                                # pattern can bind the required member
+                                # invisibly.
+                                summary["ok"] = False
+                                return summary
+                            words = set(
+                                re.findall(
+                                    r"[A-Za-z_]\w*", source_pattern
+                                )
+                            )
+                            covered = any(
+                                flagged_has(w) for w in words
+                            )
+                            summary["destructured"].append(
+                                (frozenset(words), covered)
+                            )
+                            summary["proved_any"] = True
+                            continue
+                depth = 0
+                callee = None
+                for pos in range(start - 1, -1, -1):
+                    ch = lexed.code[pos]
+                    if ch in ")]}":
+                        depth += 1
+                    elif ch in "([{":
+                        if depth == 0:
+                            if ch == "(":
+                                callee = re.search(
+                                    r"([A-Za-z_$][\w$]*)\s*$",
+                                    lexed.code[max(0, pos - 60):pos],
+                                )
+                            break
+                        depth -= 1
+                if callee is not None and callee.group(1) in {
+                    "axios", "fetch", "request", "post",
+                }:
+                    summary["had_skipped"] = True
+                    continue
+                summary["ok"] = False
+                return summary
+            if is_call:
+                summary["ok"] = False
+                return summary
+            entry = {
+                "start": start,
+                "keys": keys,
+                "in_evaluated": in_evaluated,
+                "flag_covered": any(
+                    fs <= start < fe for fs, fe in flagged_spans
+                ),
+                "alias_covered": False,
+                "alias_evaluated": False,
+                "kill": None,
+            }
+            enclosing_alias = None
+            for a_name, a_start, a_rhs_start, a_rhs_end in assignments:
+                if a_rhs_start <= start < a_rhs_end:
+                    enclosing_alias = a_name
+                    break
+            if enclosing_alias is not None:
+                entry["alias_covered"] = flagged_has(enclosing_alias)
+                entry["alias_evaluated"] = evaluated_has(enclosing_alias)
+            m = re.match(
+                r"(?:\s*(?:\?\.|\.)\s*[A-Za-z_]\w*|"
+                r"\s*\[[^\[\]\n]*\])*",
+                lexed.code[end:],
+            )
+            chain_end = end + (m.end() if m else 0)
+            write = re.match(r"\s*=(?!=)", lexed.code[chain_end:])
+            if write is not None:
+                rhs_from = chain_end + write.end()
+                rhs_to = assignment_end(lexed, rhs_from, suffix)
+                open_braces: list[int] = []
+                for position in range(definition[1], start):
+                    character = lexed.code[position]
+                    if character in "([{":
+                        open_braces.append(position)
+                    elif character in ")]}" and open_braces:
+                        open_braces.pop()
+                # A bare statement block always executes, so a kill inside it
+                # dominates; a block belonging to if/else/loop/switch/catch is
+                # conditional and proves nothing about the send's path.
+                conditional = False
+                for brace_at in open_braces:
+                    if lexed.code[brace_at] != "{":
+                        conditional = True
+                        break
+                    before = brace_at
+                    while before > 0 and lexed.code[before - 1].isspace():
+                        before -= 1
+                    if lexed.code[before - 1 : before] == ")":
+                        conditional = True
+                        break
+                    word = re.search(
+                        r"([A-Za-z_]\w*)\s*$", lexed.code[:before]
+                    )
+                    if word is not None and word.group(1) in {
+                        "else", "do", "case", "default", "finally",
+                    }:
+                        conditional = True
+                        break
+                if not conditional and safe_literal_span(
+                    lexed, rhs_from, rhs_to, suffix, assignments
+                ):
+                    entry["kill"] = chain_end
+            summary["by_first"].setdefault(keys[0], []).append(entry)
+    return summary
+
+
+def member_net_proves_unused(
+    lexed: LexedSource,
+    resolved: tuple,
+    suffix: str,
+    summary: dict,
+) -> bool:
+    name, required_chain, definition, operator = resolved
+    if not summary["ok"]:
+        return False
+    private = container_is_file_private(
+        lexed, definition[0], name, suffix, operator
+    )
+    required_key = required_chain[-1] if required_chain else None
+    for words, covered in summary["destructured"]:
+        if required_key in words and not covered:
+            return False
+    had_skipped = summary["had_skipped"] or bool(summary["destructured"])
+    proved = summary["proved_any"]
+    kill_at = None
+    conflicts = []
+    for entry in summary["by_first"].get(required_chain[0], []):
+        keys = entry["keys"]
+        shared = min(len(keys), len(required_chain))
+        if keys[:shared] != required_chain[:shared]:
+            proved = True
+            continue
+        if entry["in_evaluated"] and entry["start"] >= definition[1]:
+            had_skipped = True
+            continue
+        if (
+            entry["kill"] is not None
+            and len(keys) == len(required_chain)
+        ):
+            kill_at = entry["kill"]
+            proved = True
+            continue
+        if entry["flag_covered"] or entry["alias_covered"]:
+            had_skipped = True
+            continue
+        conflicts.append(entry["start"])
+    for first, entries in summary["by_first"].items():
+        if first == required_chain[0]:
+            continue
+        for entry in entries:
+            if entry["in_evaluated"] and entry["start"] >= definition[1]:
+                had_skipped = True
+            elif entry["alias_evaluated"]:
+                had_skipped = True
+            else:
+                proved = True
+    if conflicts:
+        if kill_at is None:
+            return False
+        if any(c < kill_at for c in conflicts):
+            return False
+    if proved:
+        return private
+    return True if had_skipped else private
+
+MEMBER_NET_PATH_RE = re.compile(
+    # A leading slash, or a relative path at the very start of a string
+    # literal (base-URL clients pass "messages/number_pool").
+    r"(?:/|(?<=['\"`]))(?:v2/)?messages/"
+    r"(?:number_pool|alphanumeric_sender_id)\b"
+)
+
+
+def member_net_contexts(
+    lexed: LexedSource,
+    suffix: str,
+    evaluated_spans: list[tuple[int, int]],
+    flagged_spans: list[tuple[int, int]],
+) -> list[Call]:
+    """Literal-driven safety net over the call-centric analysis.
+
+    The resolver only judges recognized calls, so a required path that never
+    flows into one (helper parameters, exports, spreads, dynamic keys,
+    cross-file definitions) would otherwise vanish. Every required-path
+    literal held in a CONTAINER MEMBER outside the evaluated call spans is
+    flagged at its definition unless member-access analysis PROVES the member
+    is unused in this file, or the resolver already flagged a call that
+    references the container (reporting the definition too would be noise).
+    """
+
+    contexts: list[Call] = []
+    assignments = None
+    occurrences: dict[str, list[int]] = {}
+    dotted: set[str] = set()
+    masked: set[str] = set()
+    walkers: dict[int, list] = {}
+    cache: dict[str, tuple[bool, bool, list[list[str]]]] = {}
+    for match in MEMBER_NET_PATH_RE.finditer(lexed.without_comments):
+        if any(s <= match.start() < e for s, e in evaluated_spans):
+            continue
+        if assignments is None:
+            assignments = assignment_index(lexed, suffix)
+            binding_index = build_binding_index(lexed, suffix, assignments)
+            occurrences, dotted = identifier_occurrences(lexed)
+            masked = masked_identifier_names(lexed)
+        token = next(
+            (t for t in lexed.strings if t.start <= match.start() < t.end),
+            None,
+        )
+        if token is None:
+            continue
+        tail = token.contents.rstrip("/")
+        if not (
+            required_endpoint(token.contents)
+            or tail.endswith("messages/number_pool")
+            or tail.endswith("messages/alphanumeric_sender_id")
+            # A URL builder splits the path, so the literal may be only a
+            # fragment ("%snumber_pool"). Accept the distinctive segment, but
+            # ONLY for a URL-shaped token - prose that merely mentions the path
+            # contains whitespace and must not be treated as an endpoint.
+            or (
+                not re.search(r"\s", tail)
+                and re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
+            )
+        ):
+            # The literal merely MENTIONS a required path (prose, docs);
+            # it is not itself an endpoint value.
+            continue
+        resolved = container_for_token(
+            lexed, token, suffix, assignments, walkers
+        )
+        if resolved is None:
+            # Plain variables and direct arguments are the resolver's tested
+            # domain; the net only covers container members, which the
+            # call-centric analysis never evaluates.
+            continue
+        name = resolved[0]
+        summary = cache.get(name)
+        if summary is None:
+            summary = build_container_summary(
+                lexed, name, resolved[2], suffix, assignments,
+                binding_index, occurrences, masked, dotted,
+                evaluated_spans, flagged_spans,
+            )
+            cache[name] = summary
+        if member_net_proves_unused(lexed, resolved, suffix, summary):
+            continue
+        if suffix == ".sh":
+            start, end = shell_command_span(lexed, match.start())
+        else:
+            start, end = resolved[2]
+        contexts.append(Call(start, start, end, parenthesized=False))
+    return contexts
+
+
+# A send is only exempt from the profile requirement when it is provably NOT a
+# mutating request. These are the spellings that prove it.
+def required_path_tokens(lexed: LexedSource) -> list[StringToken]:
+    """Return every string literal that IS a required endpoint value.
+
+    Prose that merely mentions the path is excluded: an endpoint literal has no
+    whitespace and either resolves as a required endpoint or ends with the
+    required path segment.
+    """
+    found: list[StringToken] = []
+    for match in MEMBER_NET_PATH_RE.finditer(lexed.without_comments):
+        token = next(
+            (t for t in lexed.strings if t.start <= match.start() < t.end), None
+        )
+        if token is None or any(t.start == token.start for t in found):
+            continue
+        tail = token.contents.rstrip("/")
+        if re.search(r"\s", tail):
+            continue
+        if (
+            required_endpoint(token.contents)
+            or tail.endswith("messages/number_pool")
+            or tail.endswith("messages/alphanumeric_sender_id")
+            or re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
+        ):
+            found.append(token)
+    return found
+
+
+def _tokens_in_span(
+    lexed: LexedSource, span: tuple[int, int]
+) -> set[tuple[int, int]]:
+    return {
+        (t.start, t.end)
+        for t in lexed.strings
+        if span[0] <= t.start and t.end <= span[1]
+    }
+
+
+def consumed_endpoint_tokens(
+    lexed: LexedSource, call: Call, suffix: str
+) -> set[tuple[int, int]]:
+    """Return the endpoint literals this call's URL resolution actually USED.
+
+    PROVENANCE, not proximity. A literal counts as accounted-for only when the
+    analyzer consumed it while resolving THIS call's endpoint - directly as the
+    URL expression, or indirectly through the binding the URL expression names.
+    Two sends in one file therefore consume their own literals independently,
+    and a recognised send can never account for a different, unrecognised one.
+    """
+    consumed: set[tuple[int, int]] = set()
+    if suffix == ".sh":
+        # Shell curl resolves URLs from word-split tokens rather than spans, so
+        # the call's own text plus any variable it dereferences is the region.
+        consumed |= _tokens_in_span(lexed, (call.start, call.end))
+        for name in set(re.findall(r"\$\{?([A-Za-z_]\w*)", lexed.original[call.start:call.end])):
+            for form in (f"${name}", name):
+                for match in assignment_matches(lexed.code, form, call.end):
+                    rhs = match.end()
+                    consumed |= _tokens_in_span(
+                        lexed, (rhs, assignment_end(lexed, rhs, suffix))
+                    )
+        return consumed
+
+    # An ANALYSED call consumes the endpoint literals of its own statement even
+    # when it is ultimately dismissed (a GET, or a request object that is never
+    # executed). The analyzer examined those literals and reached a verdict, so
+    # they are accounted for - "analysed and rejected" is not "never analysed",
+    # and only the latter is unresolved.
+    # Consumption is therefore per ENCLOSING STATEMENT, not per call span: a
+    # builder chain puts the URL literal outside the span of the call that was
+    # analysed (HttpRequest.newBuilder().uri(URI.create(URL)).POST(...)), so a
+    # span-only check re-reported a send the analyser had already resolved.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        chain_newline_boundary(lexed.code, call.start),
+        lexed.code.rfind("{", 0, call.start),
+    ) + 1
+    statement_end = call.end
+    for terminator in (";", "\n"):
+        found = lexed.code.find(terminator, call.end)
+        if found > 0:
+            # Forward mirror of `chain_newline_boundary`: a wrapped chain's
+            # remaining links belong to the same statement, so a newline the
+            # chain continues across is not the end of it.
+            while (
+                terminator == "\n"
+                and found > 0
+                and newline_continues_chain(lexed.code, found)
+            ):
+                nxt = lexed.code.find("\n", found + 1)
+                if nxt < 0:
+                    found = len(lexed.code)
+                    break
+                found = nxt
+            statement_end = max(statement_end, found)
+            break
+    consumed |= _tokens_in_span(lexed, (statement_start, statement_end))
+
+    for span in request_url_spans(lexed, call, suffix):
+        consumed |= _tokens_in_span(lexed, span)
+        # Follow the alias chain the resolver itself walked. The endpoint is
+        # often held one or more hops away - `url = routes.get("pool")` where
+        # `routes` is a Map.of/dict/array literal - so stopping at the first hop
+        # left the real literal looking unconsumed and reported it as
+        # unresolved. Bounded to keep this linear and cycle-free.
+        pending = [lexed.code[span[0]:span[1]].strip()]
+        seen: set[str] = set()
+        for _ in range(4):
+            names: list[str] = []
+            for text in pending:
+                for name in re.findall(r"\$?[A-Za-z_]\w*", text):
+                    if name not in seen:
+                        seen.add(name)
+                        names.append(name)
+            if not names:
+                break
+            pending = []
+            for name in names:
+                for form in {name, name.lstrip("$")}:
+                    for match in assignment_matches(lexed.code, form, call.end):
+                        rhs = match.end()
+                        end = assignment_end(lexed, rhs, suffix)
+                        consumed |= _tokens_in_span(lexed, (rhs, end))
+                        pending.append(lexed.code[rhs:end])
+    return consumed
+
+
+def unresolved_endpoint_tokens(
+    lexed: LexedSource,
+    suffix: str,
+    analysed_calls: list[Call],
+) -> list[StringToken]:
+    """Return required endpoints that NO analysed send accounted for.
+
+    These are reported as "could not verify" - a distinct outcome from "missing
+    profile". The analyzer recognised a required endpoint in the source but was
+    unable to attribute it to a send it understands, so it must not certify the
+    file either way.
+    """
+    consumed: set[tuple[int, int]] = set()
+    unexplained_calls = 0
+    for call in analysed_calls:
+        tokens = consumed_endpoint_tokens(lexed, call, suffix)
+        if tokens:
+            consumed |= tokens
+        else:
+            # The analyzer resolved this call's endpoint through a path this
+            # consumption model does not mirror - a destructuring default, an
+            # interprocedural alias, a computed member. It still ACCOUNTED for
+            # one endpoint, so it explains one otherwise-unconsumed literal.
+            # Budgeting them this way keeps two independent sends independent:
+            # a file with two endpoint literals and one resolved call still
+            # reports the second.
+            unexplained_calls += 1
+    candidates = [
+        token
+        for token in required_path_tokens(lexed)
+        if (token.start, token.end) not in consumed
+        and _looks_like_a_send_target(lexed, token, suffix)
+    ]
+    return candidates[unexplained_calls:] if unexplained_calls else candidates
+
+
+# A required path can appear WITHOUT being a request target: as a curl -d body,
+# in a header value, or in prose (`echo curl "$url"`). Those are not sends and
+# reporting them blocks valid code, so an unconsumed literal is only actionable
+# when it is used somewhere that looks like a request.
+_SEND_SITE_RE = re.compile(
+    # NOT preceded by a word character - the same guard the read-verb regex
+    # below already carries. Without it `isOpen ` matches the `open`
+    # alternative and `recall ` matches `call `, so an ordinary declaration
+    # looks like a send. `do` is restricted to `do(` (Go's `client.Do(req)`)
+    # because bare `do ` matches the English word in a trailing comment.
+    r"(?<![A-Za-z0-9_])"
+    r"(?:(?:post|put|patch|send|transmit|request|fetch|execute|dispatch|submit"
+    r"|invoke|call|open|urlopen|curl)\s*(?:\(|\s)"
+    r"|do\s*\()",
+    re.I,
+)
+_ENDPOINT_KEY_RE = re.compile(
+    r"(?:url|uri|endpoint|href|target|address)\s*[:=]\s*$", re.I
+)
+
+
+# A literal sitting under a NON-URL key is payload, headers or metadata - not an
+# endpoint - even when the enclosing line is a real send to a DIFFERENT endpoint.
+_NON_URL_KEY_RE = re.compile(
+    r"(?:data|body|json|header|headers|metadata|meta|audit|params|query|form"
+    r"|note|comment|description|payload|options|context|extra|tags)"
+    r"\s*[:=]\s*$",
+    re.I,
+)
+
+
+_ANY_KEY_RE = re.compile(
+    r"""(?:['"`]?)(\w+)(?:['"`]?)\s*(?::|=>)\s*$"""
+)
+
+
+def _under_non_url_key(prefix: str) -> bool:
+    """Return whether the literal sits under a key that is not an endpoint.
+
+    Inverted deliberately: if the literal has ANY immediately-preceding object
+    key, that key must be URL-like. A decoy under `audit:`, a route table under
+    `pool:`, or a payload under `data:` are all non-endpoints, and enumerating
+    only the bad names would leave every unlisted key looking like a send.
+    A POSITIONAL literal (no key) keeps its normal treatment.
+    """
+    stripped = prefix.rstrip()[-80:]
+    if _ENDPOINT_KEY_RE.search(stripped):
+        return False
+    return _ANY_KEY_RE.search(stripped) is not None
+
+
+# The verb of the call that ENCLOSES the literal, split off its receiver. The
+# line-anchored `echo|printf|print|console.log` test only sees a display command
+# that starts the line, so `console.error(...)`, `logger.info(...)`,
+# `fmt.Printf(...)`, `var_dump(...)` and a mid-line `echo` all read as sends.
+_DISPLAY_VERB_RE = re.compile(
+    r"^(?:echo|puts|write_?line|[sf]?print(?:f|ln|_r)?|printStackTrace"
+    r"|var_dump|var_export|dump|inspect"
+    r"|log|logf|logln|debug|info|warn|warnf|warning|error|errorf|fatal|fatalf"
+    r"|trace|critical|exception)$",
+    re.I,
+)
+# A string INSPECTION is not a transport. `url.endswith(URL)` reaches the
+# fluent-client catch-all otherwise, because the literal is an argument of a
+# call like any other.
+_INSPECTION_VERB_RE = re.compile(
+    r"^(?:ends?_?with|starts?_?with|includes|contains|str_?contains"
+    r"|index_?of|last_?index_?of|strpos|strcmp"
+    r"|match|matches|search|test|replace|replace_?all|split"
+    r"|equals|equals_?ignore_?case|compare|compare_?to"
+    r"|substr|substring|slice|trim)$",
+    re.I,
+)
+# `if (url === URL)` is a comparison, not a call - but the catch-all only asks
+# whether a `(` precedes the literal and a `,` or `)` follows it.
+_NOT_A_CALL_VERB_RE = re.compile(
+    r"^(?:if|elif|elsif|while|switch|for|foreach|when|unless|until|case"
+    r"|catch|except|with|return|and|or|not|in|is)$",
+    re.I,
+)
+# A display STATEMENT has no parentheses to enclose the literal: `<?php echo
+# "$url"`, `then echo "$url"`.
+_DISPLAY_STATEMENT_RE = re.compile(
+    # The tail must not cross a call or a command separator: `echo start; curl
+    # -X POST "$URL"` is a SEND, and letting `echo` reach across the `;` would
+    # excuse it.
+    r"(?:^|[;&|`>{}\s])(?:echo|print|print_r|var_dump|var_export|puts|printf)"
+    r"\s+[^()\n;&|]*$",
+    re.I,
+)
+
+_CALLEE_SPLIT_RE = re.compile(r"\s*(?:->|::|\?\.|\.)\s*")
+_CALLEE_TAIL_RE = re.compile(
+    r"[A-Za-z_$][\w$]*(?:\s*(?:->|::|\?\.|\.)\s*[A-Za-z_$][\w$]*)*$"
+)
+
+
+def _enclosing_call_verb(lexed: LexedSource, position: int) -> str:
+    """Return the verb of the innermost unclosed CALL enclosing `position`.
+
+    Scans the blanked source backwards so brackets inside strings and comments
+    cannot unbalance the walk. Returns "" when the innermost enclosure is an
+    object/array literal rather than a call, or when there is no enclosure.
+    """
+    window_start = max(0, position - 600)
+    prefix = lexed.code[window_start:position]
+    depth = 0
+    for index in range(len(prefix) - 1, -1, -1):
+        char = prefix[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth:
+                depth -= 1
+                continue
+            if char != "(":
+                return ""
+            head = lexed.original[window_start:window_start + index].rstrip()
+            match = _CALLEE_TAIL_RE.search(head)
+            if match is None:
+                return ""
+            return _CALLEE_SPLIT_RE.split(match.group(0))[-1]
+    return ""
+
+
+def _is_display_or_inspection(lexed: LexedSource, position: int, prefix: str) -> bool:
+    """Return whether the literal is shown, compared or inspected, not sent."""
+    verb = _enclosing_call_verb(lexed, position)
+    if verb and (
+        _DISPLAY_VERB_RE.match(verb)
+        or _INSPECTION_VERB_RE.match(verb)
+        or _NOT_A_CALL_VERB_RE.match(verb)
+    ):
+        return True
+    return _DISPLAY_STATEMENT_RE.search(prefix) is not None
+
+
+def _is_standalone_binding(lexed: LexedSource, token: StringToken) -> bool:
+    """Return whether the literal is a statement-level `NAME = "..."` binding.
+
+    A binding stands alone when nothing on its line opens a call, an object or
+    an array around it - `export const POOL_URL = "..."`, `POOL_URL="..."`,
+    `const NumberPoolURL = "..."`. A MEMBER (`{endpoint: "..."}`, `url="..."`
+    inside a call) always sits within an opener, on its line or an earlier one,
+    and a member separator is `:`/`=>`, never a bare `=`.
+    """
+    line_start = lexed.code.rfind("\n", 0, token.start) + 1
+    declaration = lexed.code[line_start:token.start]
+    if any(bracket in declaration for bracket in "([{,"):
+        return False
+    return re.search(r"(?<![=!<>])=\s*$", declaration) is not None
+
+
+def _looks_like_a_send_target(
+    lexed: LexedSource, token: StringToken, suffix: str
+) -> bool:
+    """Return whether an unconsumed endpoint literal is plausibly a request."""
+    # A ROUTE TABLE is data, not a send. `Map.of("pool", URL)`, `{pool: URL}`,
+    # `["...URL"]` assigned to a name are declarations; the send happens where
+    # the table is READ, and that site is judged on its own. Reporting the
+    # declaration duplicates the real send and contradicts the documented scope
+    # boundary for computed/interprocedural lookups.
+    line_start_decl = lexed.code.rfind("\n", 0, token.start) + 1
+    declaration = lexed.original[line_start_decl:token.start]
+    if re.search(
+        r"(?:=|:=)\s*(?:new\s+\w+[^=]*)?(?:Map\s*\.\s*of|List\s*\.\s*of"
+        r"|Arrays\s*\.\s*asList|array|dict|\{|\[|\()",
+        declaration,
+    ) and not _SEND_SITE_RE.search(declaration):
+        return False
+
+    prefix = lexed.original[max(0, token.start - 120):token.start]
+    if _under_non_url_key(prefix):
+        return False
+    key = _ENDPOINT_KEY_RE.search(prefix.rstrip()[-60:])
+    if key is not None:
+        name = re.search(r"([A-Za-z_]\w*)\s*[:=]\s*$", prefix.rstrip())
+        if name is None:
+            return True
+        # An endpoint-named MEMBER (`endpoint: "..."`) sits inside the call that
+        # would send it. An endpoint-named VARIABLE does not - it must still be
+        # used somewhere that looks like a request, or it is just a constant
+        # that happens to be printed or documented.
+        references = [
+            match
+            for match in re.finditer(
+                rf"(?<![\w$])\$?\{{?{re.escape(name.group(1))}(?![\w])",
+                lexed.original,
+            )
+            if match.start() > token.end
+        ]
+        if not references:
+            # NO use of the binding in this file. A MEMBER is still a send: the
+            # call that would send it is the one it sits inside. A standalone
+            # BINDING is not - an endpoint constants module exports the URL and
+            # the request lives in another file, where it is judged on its own.
+            # Reporting the declaration instead blocks the most common correct
+            # layout in a migrated project.
+            return not _is_standalone_binding(lexed, token)
+        for match in references:
+            start = lexed.original.rfind("\n", 0, match.start()) + 1
+            stop = lexed.original.find("\n", match.end())
+            line = lexed.original[start:stop if stop > 0 else len(lexed.original)]
+            if re.match(
+                r"\s*(?:echo|printf|print|console\s*\.\s*log|#|//)\b", line
+            ) or _is_display_or_inspection(
+                lexed, match.start(), lexed.original[start:match.start()]
+            ):
+                continue
+            if _under_non_url_key(lexed.original[:match.start()]):
+                # `fetch(other, {metadata: endpoint})` - the variable reaches a
+                # send, but not as its URL.
+                continue
+            if _SEND_SITE_RE.search(line):
+                return True
+        return False
+    # Otherwise require a request-like call on the same logical line, and NOT a
+    # display command, which is how prose mentions reach the source.
+    line_start = lexed.code.rfind("\n", 0, token.start) + 1
+    line_end = lexed.code.find("\n", token.end)
+    line = lexed.original[line_start:line_end if line_end > 0 else len(lexed.original)]
+    if re.match(r"\s*(?:echo|printf|print|console\s*\.\s*log|#|//)\b", line):
+        return False
+    # The line-anchored test above only catches a display command that STARTS
+    # the line. `console.error(..., URL)`, `logger.info(..., URL)`,
+    # `fmt.Printf(..., URL)`, `var_dump(URL)`, a mid-line `echo`, a string
+    # inspection (`url.endsWith(URL)`) and a comparison (`if (url === URL)`)
+    # all reach the fluent-client catch-all below otherwise.
+    if _is_display_or_inspection(
+        lexed, token.start, lexed.original[line_start:token.start]
+    ):
+        return False
+    # A TEST ASSERTION is not a send. `expect(x).toBe(URL)`, `assertEqual(...)`,
+    # `x.should.equal(URL)` all mention the endpoint to compare against it.
+    if re.search(
+        r"(?<![\w])(?:expect|assert\w*|should|toBe|toEqual|toHaveBeenCalledWith"
+        r"|assertEqual|assertIn|is_expected)\s*[.(]",
+        line,
+        re.I,
+    ):
+        return False
+    # A READ verb is not a send. Without this, `requests.get(url)` - which the
+    # analyzer deliberately does not treat as a required send - was reported as
+    # unverifiable purely because no send consumed its endpoint.
+    if re.search(
+        # NOT preceded by a word character - otherwise the `get` inside
+        # `target(` matches and a fluent send is silently excused. `.get(` is
+        # fine because `.` is not a word character. Async suffixes included for
+        # C# (`GetAsync(`).
+        r"(?<![A-Za-z0-9_])"
+        r"(?:get|head|options|read|download|list|find|query)(?:Async)?\s*\(",
+        line,
+        re.I,
+    ) and not _SEND_SITE_RE.search(line):
+        return False
+    if _SEND_SITE_RE.search(line) is not None:
+        return True
+    # A fluent client can spell its verbs anything (`zoom.target(url).fire()`),
+    # so relying on a known-verb list makes the gate brittle in the dangerous
+    # direction. Any CALL that takes the endpoint as an argument counts, with
+    # display/logging commands excluded above.
+    tail = lexed.original[token.end:token.end + 4]
+    return bool(re.match(r"\s*[,)]", tail)) and "(" in line[: line.find(
+        token.contents[:20]
+    ) if token.contents[:20] in line else len(line)]
+
+
+
+def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
+    source = path.read_text(encoding="utf-8", errors="replace")
+    suffix = canonical_suffix(path)
+    lexed = lex_source(source, suffix)
+    sdk_calls = calls_matching(lexed, SDK_CALL_RE)
+    fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
+    shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
+    required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
+    source_resolver = SourceEndpointResolver(lexed, suffix)
+    profile_resolver = PayloadStateResolver(
+        lexed,
+        suffix,
+        PROFILE_NAMES,
+        require_value=True,
+        source=source_resolver,
+    )
+
+    seen_rest_contexts: set[tuple[int, int]] = set()
+    endpoint_calls = shell_curls if suffix == ".sh" else fetch_calls
+    if endpoint_calls:
+        for context in endpoint_calls:
+            is_required = (
+                source_resolver.shell_curl_is_required(context)
+                if suffix == ".sh"
+                else source_resolver.request_is_required(context)
+            )
+            if is_required:
+                seen_rest_contexts.add((context.start, context.end))
+                required_calls.append((context, False))
+
+    # Literal-driven safety net: required container-member paths the
+    # call-centric resolver never evaluated stay reported unless provably
+    # unused (see member_net_contexts). A miss is worse than an extra report.
+    evaluated_spans = [(c.start, c.end) for c in endpoint_calls]
+    flagged_spans = [
+        (c.start, c.end) for c, sdk in required_calls if not sdk
+    ]
+    for context in member_net_contexts(
+        lexed, suffix, evaluated_spans, flagged_spans
+    ):
+        key = (context.start, context.end)
+        if key not in seen_rest_contexts:
+            seen_rest_contexts.add(key)
+            required_calls.append((context, False))
+
+    required_calls.sort(key=lambda item: (item[0].start, item[0].end))
+    missing = [
+        call_detail(path, lexed, call)
+        for call, sdk_call in required_calls
+        if not call_has_profile(
+            lexed,
+            call,
+            suffix,
+            path,
+            project_root,
+            sdk_call=sdk_call,
+            resolver=profile_resolver,
+        )
+    ]
+
+    # Fail-safe backstop: a required endpoint the analysis never accounted for
+    # is reported for manual verification rather than passed silently.
+    # BLOCKING, provenance-based. A required endpoint that NO analysed send
+    # consumed is reported as "could not verify" - a distinct outcome from
+    # "missing profile". Attribution is by CONSUMPTION, so each send accounts
+    # only for the literals it actually resolved: multiple sends in one file are
+    # independent, and a recognised send never suppresses an unrecognised one.
+    analysed = list(endpoint_calls) + [call for call, _ in required_calls]
+    unresolved = unresolved_endpoint_tokens(lexed, suffix, analysed)
+    for token in unresolved:
+        bounds = line_bounds(source, token.start)
+        missing.append(
+            finding_row(
+                path,
+                line_number(source, token.start),
+                f"{source[bounds[0]:bounds[1]].strip()}"
+                "  [could not verify this send - the endpoint was found but no "
+                "recognized request consumed it; verify messaging_profile_id manually]",
+            )
+        )
+    # An unresolved endpoint is a CANDIDATE send, so it counts toward the total.
+    # Reporting it while excluding it from the count produced total=0 with
+    # missing=1, breaking the missing <= total contract every caller assumes.
+    return len(required_calls) + len(unresolved), missing
+
+
+def at_object_member_start(
+    code: str, start: int, end: int, offset: int
+) -> bool:
+    """Return true when offset starts a direct object-literal member."""
+
+    root_depth = payload_root_depth(code, start, end)
+    if root_depth[2] == 0 or structural_depth(code, start, offset) != root_depth:
+        return False
+    cursor = offset - 1
+    while cursor >= start and code[cursor].isspace():
+        cursor -= 1
+    return cursor >= start and code[cursor] in {"{", ","}
+
+
+def region_has_message_body(
+    lexed: LexedSource, start: int, end: int, suffix: str
+) -> bool:
+    """Recognize a real top-level message body field in one payload region."""
+
+    body_identifier = re.compile(r"(?<![\w$])body(?!\w)")
+    for match in body_identifier.finditer(lexed.code, start, end):
+        if not at_payload_root(lexed.code, start, end, match.start()):
+            continue
+        after = lexed.code[match.end() : end]
+        if re.match(r"\s*(?::|=(?!=))", after):
+            return True
+        if (
+            suffix in JS_TS_SUFFIXES
+            and at_object_member_start(
+                lexed.code, start, end, match.start()
+            )
+            and re.match(r"\s*(?=[,}])", after)
+        ):
+            return True
+
+    for token in lexed.strings:
+        if token.contents != "body" or token.start < start or token.end > end:
+            continue
+        after = lexed.without_comments[token.end : end]
+        if (
+            at_payload_root(lexed.code, start, end, token.start)
+            and re.match(r"\s*(?::|=>|=(?!=))", after)
+        ):
+            return True
+        if suffix not in JS_TS_SUFFIXES:
+            continue
+        prefix = lexed.code[start : token.start]
+        computed = re.search(r"\[\s*$", prefix)
+        if computed is None or not re.match(r"\s*\]\s*:", after):
+            continue
+        opening = start + computed.start()
+        if at_object_member_start(lexed.code, start, end, opening):
+            return True
+    return False
+
+
+def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
+    """Return real top-level body fields from selected messaging calls."""
+
+    source = path.read_text(encoding="utf-8", errors="replace")
+    suffix = canonical_suffix(path)
+    lexed = lex_source(source, suffix)
+    source_resolver = SourceEndpointResolver(lexed, suffix)
+    resolver = PayloadStateResolver(
+        lexed,
+        suffix,
+        ("body", "Body"),
+        require_value=False,
+        source=source_resolver,
+    )
+    matches: list[str] = []
+    for call in calls_matching(lexed, pattern):
+        states = [
+            resolver.span_presence(start, end, call.start)
+            for start, end in payload_spans(
+                lexed, call, suffix, "body"
+            )
+        ]
+        if any(
+            state.state == PRESENT
+            or (state.state == MAYBE and state.evidence)
+            for state in states
+        ):
+            matches.append(call_detail(path, lexed, call))
+    return matches
+
+
+def main(argv: list[str]) -> int:
+    source_modes = {
+        "--twilio-body-fields": TWILIO_MESSAGE_CREATE_RE,
+        "--message-body-fields": MESSAGE_BODY_CALL_RE,
+    }
+    if len(argv) == 3 and argv[1] in source_modes:
+        project_root = Path(argv[2]).resolve()
+        if not project_root.is_dir():
+            print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
+            return 2
+        findings = [
+            finding
+            for path in iter_source_files(project_root)
+            for finding in message_body_fields(path, source_modes[argv[1]])
+        ]
+        print("\n".join(findings))
+        return 0
+    if len(argv) != 2:
+        print(
+            f"Usage: {Path(argv[0]).name} "
+            "[--twilio-body-fields|--message-body-fields] <project-root>",
+            file=sys.stderr,
+        )
+        return 2
+    project_root = Path(argv[1]).resolve()
+    if not project_root.is_dir():
+        print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
+        return 2
+
+    total = 0
+    missing: list[str] = []
+    for path in iter_source_files(project_root):
+        try:
+            file_total, file_missing = analyze_file(path, project_root)
+        except Exception as error:  # noqa: BLE001 - one file must not abort the scan
+            # A pathological file previously took the WHOLE run down, so every
+            # other file went unanalysed and the project was reported clean.
+            # Fail safe instead: keep scanning and surface the file for manual
+            # review rather than silently dropping it.
+            total += 1
+            missing.append(
+                finding_row(
+                    path,
+                    1,
+                    f"  [could not analyze this file "
+                    f"({type(error).__name__}) - verify messaging_profile_id manually]",
+                )
+            )
+            continue
+        total += file_total
+        missing.extend(file_missing)
+
+    print(total)
+    print("\n".join(missing))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -682,8 +682,27 @@ SDK_CALL_RE = re.compile(
     rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
     r"\s*(?:\?\.)?\s*\("
 )
+CSHARP_HTTP_CONTENT_METHODS = ("PostAsync", "PutAsync", "PatchAsync")
+CSHARP_JSON_MUTATING_METHOD_NAMES = (
+    "PostAsJsonAsync",
+    "PutAsJsonAsync",
+    "PatchAsJsonAsync",
+)
+CSHARP_HTTP_CONTENT_METHOD_PATTERN = "|".join(CSHARP_HTTP_CONTENT_METHODS)
+CSHARP_JSON_MUTATING_METHOD_PATTERN = "|".join(
+    CSHARP_JSON_MUTATING_METHOD_NAMES
+)
+CSHARP_JSON_MUTATING_METHODS = frozenset(
+    name.lower() for name in CSHARP_JSON_MUTATING_METHOD_NAMES
+)
+CSHARP_ONLY_FETCH_METHODS = frozenset(
+    {"PutAsync", "PatchAsync", *CSHARP_JSON_MUTATING_METHOD_NAMES}
+)
 FETCH_CALL_RE = re.compile(
-    r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
+    rf"(?<![\w$])(?:fetch|request|post_form|postAsync|"
+    rf"(?:{CSHARP_HTTP_CONTENT_METHOD_PATTERN})|"
+    rf"(?:{CSHARP_JSON_MUTATING_METHOD_PATTERN})(?:\s*<[^()]{{0,512}}>)?|"
+    r"post|Post|POST|"
     # curl_init($url) is the documented one-liner that sets CURLOPT_URL
     # directly. Listing only the setopt spellings made that whole shape
     # invisible: no endpoint resolved, so the send was never counted and the
@@ -1922,7 +1941,14 @@ def rest_payload_spans(
             if projected is not None:
                 return [projected]
 
-    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    callee = normalized_call_callee(lexed, call)
+    callee_lower = callee.lower()
+    if suffix == ".cs" and callee_lower in CSHARP_JSON_MUTATING_METHODS:
+        named_value = named_argument_spans(lexed, arguments, "value")
+        if named_value:
+            return named_value[-1:]
+        offset = csharp_json_extension_argument_offset(lexed, call)
+        return arguments[offset + 1 : offset + 2]
     if suffix == ".php" and callee == "file_get_contents":
         region = php_stream_context_region(lexed, call, suffix)
         if region is None:
@@ -3045,6 +3071,44 @@ def call_receiver(lexed: LexedSource, call: Call) -> str | None:
     return match.group(1).lstrip("$") if match is not None else None
 
 
+def normalized_call_callee(lexed: LexedSource, call: Call) -> str:
+    """Return a call name without whitespace or C# generic type arguments."""
+
+    callee = re.sub(r"\s+", "", lexed.code[call.start:call.open_paren])
+    return re.sub(r"<[^()]{0,512}>$", "", callee)
+
+
+def csharp_json_extension_argument_offset(
+    lexed: LexedSource, call: Call
+) -> int:
+    """Return the URL offset for instance versus static extension calls.
+
+    ``client.PostAsJsonAsync(url, value)`` starts at URL argument zero, while
+    ``HttpClientJsonExtensions.PostAsJsonAsync(client, url, value)`` and a
+    ``using static`` call start at argument one.  A type alias for the official
+    extension class is the same static form.  Expression receivers such as
+    ``GetClient().PostAsJsonAsync(...)`` remain instance calls even though they
+    do not have a simple identifier receiver.
+    """
+
+    receiver = call_receiver(lexed, call)
+    explicit_receiver = bool(
+        re.search(r"(?:\?|!)?\s*\.\s*$", lexed.code[:call.start])
+    )
+    if receiver is None:
+        return 0 if explicit_receiver else 1
+    if receiver == "HttpClientJsonExtensions":
+        return 1
+    if re.search(
+        rf"(?m)^\s*(?:global\s+)?using\s+{re.escape(receiver)}\s*=\s*"
+        r"(?:global\s*::\s*)?System\s*\.\s*Net\s*\.\s*Http\s*\.\s*Json"
+        r"\s*\.\s*HttpClientJsonExtensions\s*;",
+        lexed.original,
+    ):
+        return 1
+    return 0
+
+
 # Factory methods that build an HTTP client which then sends. A `.post()` on
 # such a factory (requests.Session().post, httpx.Client().post,
 # axios.create(...).post) is a real send; a `.post()` on a mock/assertion
@@ -4114,7 +4178,10 @@ def request_write_payload_spans(
 
 
 URL_CONSTRUCTOR_RE = re.compile(
-    r"^\s*(?:new\s+)?(?:URI|URL)(?:\s*\.\s*(?:create|parse|join))?\s*\("
+    # Java/Ruby use URI/URL; .NET's official overload uses System.Uri.  The
+    # case-sensitive type spelling matters because strings are already masked
+    # and this runs on arbitrary expressions, not on a C# AST.
+    r"^\s*(?:new\s+)?(?:URI|URL|Uri)(?:\s*\.\s*(?:create|parse|join))?\s*\("
 )
 
 
@@ -4424,9 +4491,7 @@ def _request_url_spans(
     args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
     if not args:
         return []
-    callee = re.sub(
-        r"\s+", "", lexed.code[call.start:call.open_paren]
-    )
+    callee = normalized_call_callee(lexed, call)
     callee_lower = callee.lower()
     receiver = call_receiver(lexed, call)
     explicit_receiver = bool(
@@ -4484,6 +4549,11 @@ def _request_url_spans(
         for name in URL_MEMBER_NAMES
         for span in named_argument_spans(lexed, args, name)
     ]
+    if suffix == ".cs" and callee_lower in CSHARP_JSON_MUTATING_METHODS:
+        if named_url:
+            return named_url[-1:]
+        offset = csharp_json_extension_argument_offset(lexed, call)
+        return args[offset : offset + 1]
     if callee_lower in {"post", "postasync"} and named_url:
         return named_url[-1:]
     if suffix == ".php" and callee == "file_get_contents" and args:
@@ -11413,6 +11483,16 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     lexed = lex_source(source, suffix)
     sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
+    if suffix != ".cs":
+        # These PascalCase names are official .NET HttpClient methods. Keeping
+        # their discovery C#-only avoids turning an unrelated Java/JavaScript
+        # method with the same name into a recognised transport call.
+        fetch_calls = [
+            call
+            for call in fetch_calls
+            if normalized_call_callee(lexed, call)
+            not in CSHARP_ONLY_FETCH_METHODS
+        ]
     shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
     required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
     source_resolver = SourceEndpointResolver(

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -56,6 +56,7 @@ SUFFIX_LANGUAGE_ALIASES = {
     ".pyw": ".py",
     ".rake": ".rb",
     ".cshtml": ".cs",
+    ".razor": ".cs",
     ".scala": ".java",
     # Kotlin shares Java's grammar for everything this linter models - the
     # OkHttp/java.net.http builder chains, the braced control-flow arms, the
@@ -224,6 +225,200 @@ def _balanced_parenthesis_ranges(
     return ranges
 
 
+def _balanced_delimiter_end(source: str, opening: int) -> int | None:
+    """Return the index after a quote-aware (), [], or {} expression."""
+
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    opening_character = source[opening] if opening < len(source) else ""
+    if opening_character not in pairs:
+        return None
+    stack = [pairs[opening_character]]
+    quote = ""
+    escaped = False
+    for index in range(opening + 1, len(source)):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif character in pairs:
+            stack.append(pairs[character])
+        elif character == stack[-1]:
+            stack.pop()
+            if not stack:
+                return index + 1
+    return None
+
+
+def _razor_implicit_expression_ranges(source: str) -> list[tuple[int, int]]:
+    """Return executable C# spans introduced by Razor's implicit ``@`` form.
+
+    Razor permits member, invocation, indexer, null-conditional, and ``await``
+    expressions without the explicit ``@(...)`` wrapper.  Parse those access
+    chains instead of preserving a handful of examples; markup and email-like
+    text remain excluded by requiring a non-word boundary before ``@``.
+    """
+
+    ranges: list[tuple[int, int]] = []
+    start_pattern = re.compile(
+        r"(?<![\w@])@(?!@)(?P<expression>await\s+|[A-Za-z_][\w]*)",
+        re.IGNORECASE,
+    )
+    for match in start_pattern.finditer(source):
+        start = match.start("expression")
+        cursor = match.end("expression")
+        if source[start:cursor].lower().startswith("await"):
+            identifier = re.match(r"[A-Za-z_][\w]*", source[cursor:])
+            if not identifier:
+                continue
+            cursor += identifier.end()
+
+        # Directives and control blocks are handled by the dedicated ranges
+        # below.  Treating their keyword as an expression adds no coverage and
+        # can retain adjacent markup as though it were C#.
+        first_identifier = re.match(r"[A-Za-z_][\w]*", source[start:])
+        if first_identifier and first_identifier.group(0).lower() in {
+            "addtaghelper", "attribute", "case", "catch", "class", "code",
+            "default", "do", "else", "finally", "for", "foreach", "functions",
+            "helper", "if", "implements", "inherits", "inject", "lock", "model",
+            "namespace", "page", "removetaghelper", "section", "switch",
+            "taghelperprefix", "try", "using", "while",
+        }:
+            continue
+
+        while cursor < len(source):
+            chain = re.match(r"(?:\?\.|\.)[A-Za-z_][\w]*", source[cursor:])
+            if chain:
+                cursor += chain.end()
+                continue
+            if source[cursor] in "([{":
+                end = _balanced_delimiter_end(source, cursor)
+                if end is None:
+                    break
+                cursor = end
+                continue
+            if source[cursor] in "!?":
+                cursor += 1
+                continue
+            break
+        ranges.append((start, cursor))
+    return ranges
+
+
+def _razor_continuation_block_ranges(
+    source: str, initial_ranges: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Return ``else``/``catch``/``finally`` blocks chained to Razor C#."""
+
+    continuations: list[tuple[int, int]] = []
+    pending = list(initial_ranges)
+    while pending:
+        _, closing = pending.pop()
+        tail = source[closing + 1 :]
+        match = re.match(
+            r"\s*@?(?:else(?:\s+if\b[^{}]*)?|catch\b[^{}]*|finally\b)\s*\{",
+            tail,
+            flags=re.IGNORECASE,
+        )
+        if not match:
+            continue
+        opening = closing + 1 + match.end() - 1
+        balanced = _balanced_brace_ranges(source, [opening])
+        if balanced:
+            continuations.extend(balanced)
+            pending.extend(balanced)
+    return continuations
+
+
+def _vue_directive_expression_ranges(source: str) -> list[tuple[int, int]]:
+    """Return value and dynamic-argument expressions for every Vue directive."""
+
+    directive = (
+        r"(?<!\S)(?:v-[\w-]+(?::(?:[\w:-]+|\[[^\]\r\n]+\]))?"
+        r"|[@:#.](?:[\w:-]+|\[[^\]\r\n]+\]))"
+        r"(?:\.[\w-]+)*"
+    )
+    ranges: list[tuple[int, int]] = []
+
+    # Restrict directive discovery to opening tags.  A documentation snippet
+    # rendered as text (``<pre>v-if="..."</pre>``) is not executable Vue and
+    # must not become a false positive merely because it resembles an
+    # attribute.  Scan tag endings quote-aware so ``>`` inside an expression
+    # does not truncate the attribute list.
+    tag_ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        if opening + 1 >= len(source) or not re.match(
+            r"[A-Za-z]", source[opening + 1]
+        ):
+            cursor = opening + 1
+            continue
+        quote = ""
+        for index in range(opening + 1, len(source)):
+            character = source[index]
+            if quote:
+                if character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+            elif character == ">":
+                tag_ranges.append((opening, index + 1))
+                cursor = index + 1
+                break
+        else:
+            break
+
+    for tag_start, tag_end in tag_ranges:
+        tag = source[tag_start:tag_end]
+        outside_attribute_value: list[bool] = []
+        quote = ""
+        for character in tag:
+            outside_attribute_value.append(not quote)
+            if quote:
+                if character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+
+        value_pattern = re.compile(
+            directive
+            + r"\s*=\s*(?:(?P<quote>['\"])(?P<quoted>.*?)(?P=quote)"
+            + r"|(?P<unquoted>[^\s>]+))",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        for candidate in re.finditer(directive, tag, flags=re.IGNORECASE):
+            if not outside_attribute_value[candidate.start()]:
+                continue
+            match = value_pattern.match(tag, candidate.start())
+            if not match:
+                continue
+            group = "quoted" if match.group("quoted") is not None else "unquoted"
+            start, end = match.span(group)
+            ranges.append((tag_start + start, tag_start + end))
+
+        # A dynamic directive argument is JavaScript independently of its
+        # value: ``:[selectEndpoint()]="payload"`` executes both expressions.
+        for match in re.finditer(
+            r"(?<!\S)(?:v-[\w-]+:|[@:#])\[(?P<argument>[^\]\r\n]+)\]",
+            tag,
+            flags=re.IGNORECASE,
+        ):
+            if not outside_attribute_value[match.start()]:
+                continue
+            start, end = match.span("argument")
+            ranges.append((tag_start + start, tag_start + end))
+    return ranges
+
+
 def _javascript_template_expression_ranges(
     source: str, start: int, end: int
 ) -> list[tuple[int, int]]:
@@ -283,15 +478,7 @@ def executable_source(path: Path, source: str) -> str:
             if frontmatter:
                 ranges.append(frontmatter.span(1))
         if suffix == ".vue":
-            ranges.extend(
-                match.span("expression")
-                for match in re.finditer(
-                    r"(?:v-on:[\w:-]+|@[\w:-]+)(?:\.[\w-]+)*\s*=\s*"
-                    r"(?P<quote>['\"])(?P<expression>.*?)(?P=quote)",
-                    template_source,
-                    re.DOTALL,
-                )
-            )
+            ranges.extend(_vue_directive_expression_ranges(template_source))
             # Vue interpolations may contain nested object literals. A
             # non-greedy regex leaves such calls unterminated; balance the
             # entire double-brace region and retain its inner expression.
@@ -320,37 +507,66 @@ def executable_source(path: Path, source: str) -> str:
                 for match in re.finditer(r"\{", expression_source)
             ]
             ranges.extend(_balanced_brace_ranges(expression_source, openings))
-    elif suffix == ".cshtml":
+    elif suffix in {".cshtml", ".razor"}:
         # Razor is a mixed HTML/C# template. Retain explicit expressions,
         # statement/code blocks, and single-line directives while blanking page
         # markup so text such as `<p>VoiceResponse()</p>` is not treated as C#.
+        razor_source = re.sub(
+            r"@\*.*?\*@",
+            lambda match: "".join(
+                char if char in "\r\n" else " " for char in match.group(0)
+            ),
+            source,
+            flags=re.DOTALL,
+        )
         brace_openings = [
             match.end() - 1
             for match in re.finditer(
                 r"(?<!@)@(?:\s*|(?:code|functions)\s*)\{",
-                source,
+                razor_source,
                 flags=re.IGNORECASE,
             )
         ]
-        brace_openings.extend(
+        control_openings = [
             match.end() - 1
             for match in re.finditer(
-                r"(?<!@)@(?:if|for|foreach|while|switch|try|catch|finally|using|lock)\b[^{}]*\{",
-                source,
+                r"(?<!@)@(?:if|for|foreach|while|do|switch|try|catch|finally|using|lock)\b[^{}]*\{",
+                razor_source,
                 flags=re.IGNORECASE,
             )
+        ]
+        ordinary_brace_ranges = _balanced_brace_ranges(
+            razor_source, brace_openings
         )
-        ranges.extend(_balanced_brace_ranges(source, brace_openings))
+        control_ranges = _balanced_brace_ranges(razor_source, control_openings)
+        ranges.extend(ordinary_brace_ranges)
+        ranges.extend(control_ranges)
+        ranges.extend(_razor_continuation_block_ranges(razor_source, control_ranges))
+
+        # The condition after a Razor do/while body is executable C# too.
+        for opening in control_openings:
+            prefix = razor_source[max(0, opening - 16) : opening]
+            if not re.search(r"@do\s*$", prefix, re.IGNORECASE):
+                continue
+            body = _balanced_brace_ranges(razor_source, [opening])
+            if not body:
+                continue
+            tail = razor_source[body[0][1] + 1 :]
+            while_match = re.match(r"\s*while\s*\(", tail, re.IGNORECASE)
+            if while_match:
+                paren = body[0][1] + 1 + while_match.end() - 1
+                ranges.extend(_balanced_parenthesis_ranges(razor_source, [paren]))
         paren_openings = [
             match.end() - 1
-            for match in re.finditer(r"(?<!@)@\s*\(", source)
+            for match in re.finditer(r"(?<!@)@\s*\(", razor_source)
         ]
-        ranges.extend(_balanced_parenthesis_ranges(source, paren_openings))
+        ranges.extend(_balanced_parenthesis_ranges(razor_source, paren_openings))
+        ranges.extend(_razor_implicit_expression_ranges(razor_source))
         ranges.extend(
             match.span()
             for match in re.finditer(
                 r"(?m)^\s*@(?:using|inject|model|inherits|implements|namespace|addTagHelper|removeTagHelper|tagHelperPrefix)\b[^\r\n]*",
-                source,
+                razor_source,
             )
         )
     elif suffix == ".phtml":
@@ -358,9 +574,13 @@ def executable_source(path: Path, source: str) -> str:
         # Feeding its markup to the PHP lexer lets an apostrophe in page text
         # open a string that masks a later request inside <?php ... ?>.
         ranges.extend(
-            match.span(1)
+            match.span("code")
             for match in re.finditer(
-                r"<\?(?:php\b|=)(.*?)(?:\?>|\Z)",
+                # Plain ``<?`` is executable when short_open_tag is enabled.
+                # Keep XML declarations out: with short tags disabled they are
+                # markup, and with short tags enabled they make the PHP file
+                # invalid rather than forming a customer request.
+                r"<\?(?:php\b|=|(?!(?:xml)\b))(?P<code>.*?)(?:\?>|\Z)",
                 source,
                 flags=re.IGNORECASE | re.DOTALL,
             )

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -11,6 +11,7 @@ their nearest real assignment in the same file.
 from __future__ import annotations
 
 import bisect
+import html
 import json
 import os
 import posixpath
@@ -150,7 +151,7 @@ def canonical_suffix(path: Path) -> str:
         if re.search(
             r"<script\b[^>]*\blang\s*=\s*(?:(['\"])(?:ts|typescript)\1|(?:ts|typescript)(?=\s|>))",
             source,
-            re.I,
+            re.I | re.ASCII,
         ):
             return ".ts"
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
@@ -1268,6 +1269,298 @@ def _mask_jsx_markup(source: str, suffix: str) -> str:
     return "".join(output)
 
 
+_JAVASCRIPT_MIME_ESSENCES = {
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "text/ecmascript",
+    "text/javascript",
+    "text/javascript1.0",
+    "text/javascript1.1",
+    "text/javascript1.2",
+    "text/javascript1.3",
+    "text/javascript1.4",
+    "text/javascript1.5",
+    "text/jscript",
+    "text/livescript",
+    "text/x-ecmascript",
+    "text/x-javascript",
+}
+
+
+def _html_attributes(attributes: str) -> list[tuple[str, str]]:
+    """Parse static HTML attributes without matching inside quoted values."""
+
+    parsed: list[tuple[str, str]] = []
+    index = 0
+    while index < len(attributes):
+        while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+            index += 1
+        if index >= len(attributes) or attributes[index] in {">", "/"}:
+            break
+        name_start = index
+        while (
+            index < len(attributes)
+            and attributes[index] not in "\t\n\f\r "
+            and attributes[index] not in {'=', '>', '/'}
+        ):
+            index += 1
+        name = attributes[name_start:index].lower()
+        if not name:
+            index += 1
+            continue
+        while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+            index += 1
+        value = ""
+        if index < len(attributes) and attributes[index] == "=":
+            index += 1
+            while index < len(attributes) and attributes[index] in "\t\n\f\r ":
+                index += 1
+            if index < len(attributes) and attributes[index] in {'"', "'"}:
+                quote = attributes[index]
+                index += 1
+                value_start = index
+                closing = attributes.find(quote, index)
+                if closing < 0:
+                    value = attributes[value_start:]
+                    index = len(attributes)
+                else:
+                    value = attributes[value_start:closing]
+                    index = closing + 1
+            else:
+                value_start = index
+                while (
+                    index < len(attributes)
+                    and attributes[index] not in "\t\n\f\r "
+                    and attributes[index] != ">"
+                ):
+                    index += 1
+                value = attributes[value_start:index]
+        parsed.append((name, html.unescape(value)))
+    return parsed
+
+
+def _script_attributes_execute_javascript(attributes: str) -> bool:
+    """Return whether a browser treats a static script tag as JavaScript."""
+
+    attribute_values: dict[str, str] = {}
+    for name, value in _html_attributes(attributes):
+        # HTML keeps the first duplicate attribute and ignores later ones.
+        attribute_values.setdefault(name, value)
+
+    if "type" in attribute_values:
+        value = attribute_values["type"].strip("\t\n\f\r ")
+        # A server-generated type cannot be classified statically. Retaining
+        # its body prevents a dynamic JavaScript block from silently escaping.
+        if "<%" in value:
+            return True
+        if not value:
+            return True
+        lowered = value.lower()
+        if lowered == "module":
+            return True
+        # HTML's JavaScript MIME *essence match* is an exact comparison against
+        # these legacy strings, not MIME parsing.  In particular the standard
+        # says `text/javascript; charset=utf-8` is a data block and is not run.
+        return lowered in _JAVASCRIPT_MIME_ESSENCES
+
+    language = attribute_values.get("language", "").strip("\t\n\f\r ")
+    if not language or "<%" in language:
+        return True
+    essence = language.lower()
+    if "/" not in essence:
+        essence = f"text/{essence}"
+    return essence in _JAVASCRIPT_MIME_ESSENCES
+
+
+_HTML_TAG_RE = re.compile(r"<(?P<closing>/)?(?P<name>[^\t\n\f\r />]+)")
+_HTML_INERT_RAW_TEXT_ELEMENTS = {
+    "iframe",
+    "noembed",
+    "noframes",
+    "noscript",
+    "plaintext",
+    "style",
+    "template",
+    "textarea",
+    "title",
+    "xmp",
+}
+
+
+def _html_tag_end(source: str, start: int) -> int | None:
+    """Return the first tag-closing angle bracket outside quoted attributes."""
+
+    quote = ""
+    index = start
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if character == quote:
+                quote = ""
+        elif character in {'"', "'"}:
+            quote = character
+        elif character == ">":
+            return index
+        index += 1
+    return None
+
+
+def _html_raw_text_end(
+    source: str, start: int, name: str
+) -> tuple[int, int] | None:
+    """Return the start/end of a raw-text element's next matching end tag."""
+
+    closer = re.compile(
+        rf"</{re.escape(name)}(?=[\t\n\f\r />])", re.I | re.ASCII
+    ).search(source, start)
+    if closer is None:
+        return None
+    end = _html_tag_end(source, closer.end())
+    return closer.start(), len(source) if end is None else end + 1
+
+
+def _html_template_end(source: str, start: int) -> int | None:
+    """Return the end of a template element, including nested templates."""
+
+    depth = 1
+    cursor = start
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            return None
+        tag = _HTML_TAG_RE.match(source, opening)
+        if tag is None:
+            cursor = opening + 1
+            continue
+        tag_end = _html_tag_end(source, tag.end())
+        if tag_end is None:
+            return None
+        name = tag.group("name").lower()
+        if tag.group("closing"):
+            if name == "template":
+                depth -= 1
+                if depth == 0:
+                    return tag_end + 1
+            cursor = tag_end + 1
+            continue
+        if name == "plaintext":
+            cursor = len(source)
+            continue
+        if name == "template":
+            depth += 1
+            cursor = tag_end + 1
+            continue
+        if name == "script" or name in (_HTML_INERT_RAW_TEXT_ELEMENTS - {"template"}):
+            closer = _html_raw_text_end(source, tag_end + 1, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return None
+
+
+def _script_element_body_ranges(source: str) -> list[tuple[int, int]]:
+    """Return executable JavaScript bodies from quote-aware HTML script tags."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        opener = _HTML_TAG_RE.match(source, opening)
+        if opener is None:
+            cursor = opening + 1
+            continue
+        boundary = opener.end()
+        tag_end = _html_tag_end(source, boundary)
+        if tag_end is None:
+            break
+        name = opener.group("name").lower()
+        if opener.group("closing"):
+            cursor = tag_end + 1
+            continue
+
+        body_start = tag_end + 1
+        if name == "script":
+            closer = _html_raw_text_end(source, body_start, name)
+            body_end = len(source) if closer is None else closer[0]
+            if _script_attributes_execute_javascript(source[boundary:tag_end]):
+                ranges.append((body_start, body_end))
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        if name == "template":
+            closing_end = _html_template_end(source, body_start)
+            cursor = len(source) if closing_end is None else closing_end
+            continue
+        if name in _HTML_INERT_RAW_TEXT_ELEMENTS:
+            closer = _html_raw_text_end(source, body_start, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return ranges
+
+
+def _html_comment_end(source: str, opening: int) -> int:
+    """Return the offset after an HTML comment, or EOF when unterminated."""
+
+    content_start = opening + 4
+    abrupt = (
+        content_start + 1
+        if source.startswith(">", content_start)
+        else content_start + 2
+        if source.startswith("->", content_start)
+        else -1
+    )
+    normal = source.find("-->", content_start)
+    bang = source.find("--!>", content_start)
+    closers = [position for position in (abrupt, normal, bang) if position >= 0]
+    closing = min(closers) if closers else -1
+    if closing < 0:
+        return len(source)
+    if closing == abrupt:
+        return abrupt
+    if closing == bang:
+        return bang + 4
+    return normal + 3
+
+
+def _without_html_comments(source: str) -> str:
+    """Blank HTML comments in markup state while preserving source offsets."""
+
+    output = list(source)
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        if source.startswith("<!--", opening):
+            end = _html_comment_end(source, opening)
+            _blank(output, opening, end)
+            cursor = end
+            continue
+        tag = _HTML_TAG_RE.match(source, opening)
+        if tag is None:
+            cursor = opening + 1
+            continue
+        tag_end = _html_tag_end(source, tag.end())
+        if tag_end is None:
+            break
+        name = tag.group("name").lower()
+        if tag.group("closing"):
+            cursor = tag_end + 1
+            continue
+        if name == "plaintext":
+            break
+        if name == "script" or name in (_HTML_INERT_RAW_TEXT_ELEMENTS - {"template"}):
+            closer = _html_raw_text_end(source, tag_end + 1, name)
+            cursor = len(source) if closer is None else closer[1]
+            continue
+        cursor = tag_end + 1
+    return "".join(output)
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
@@ -1275,32 +1568,28 @@ def executable_source(path: Path, source: str) -> str:
     if suffix in JSX_CAPABLE_SUFFIXES:
         return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
-        # Comments may contain complete, syntactically valid examples. Preserve
-        # their offsets/newlines but remove their contents before discovering
-        # script blocks, handlers, interpolations, or balanced expressions.
-        template_source = re.sub(
-            r"<!--.*?-->",
-            lambda match: "".join(
-                char if char in "\r\n" else " " for char in match.group(0)
-            ),
-            source,
-            flags=re.DOTALL,
-        )
-        ranges.extend(
-            match.span(1)
-            for match in re.finditer(
-                r"<script\b[^>]*>(.*?)</script\b[^>]*>", template_source,
-                flags=re.IGNORECASE | re.DOTALL,
-            )
-        )
+        frontmatter = None
+        markup_source = source
         if suffix == ".astro":
+            # Astro frontmatter is JavaScript/TypeScript, not HTML markup. A
+            # string such as `"<!--"` must therefore not open an HTML comment
+            # that erases the remaining executable frontmatter.
             frontmatter = re.match(
                 r"\A\s*---\s*\r?\n(.*?)\r?\n---(?:\s*\r?\n|\Z)",
-                template_source,
+                source,
                 re.DOTALL,
             )
             if frontmatter:
-                ranges.append(frontmatter.span(1))
+                markup = list(source)
+                _blank(markup, *frontmatter.span(1))
+                markup_source = "".join(markup)
+        # Comments may contain complete, syntactically valid examples. Preserve
+        # their offsets/newlines but remove their contents before discovering
+        # script blocks, handlers, interpolations, or balanced expressions.
+        template_source = _without_html_comments(markup_source)
+        ranges.extend(_script_element_body_ranges(template_source))
+        if frontmatter:
+            ranges.append(frontmatter.span(1))
         if suffix == ".vue":
             ranges.extend(_vue_directive_expression_ranges(template_source))
             # Vue interpolations may contain nested object literals. A
@@ -1418,11 +1707,7 @@ def executable_source(path: Path, source: str) -> str:
             # blocks execute in the generated browser page. Both can contain
             # migration-sensitive JavaScript and must remain visible.
             ranges.extend(
-                match.span(1)
-                for match in re.finditer(
-                    r"<script\b[^>]*>(.*?)</script\b[^>]*>", source,
-                    flags=re.IGNORECASE | re.DOTALL,
-                )
+                _script_element_body_ranges(_without_html_comments(source))
             )
         for match in re.finditer(
             r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL
@@ -1539,8 +1824,11 @@ FETCH_CALL_RE = re.compile(
     r"axios\s*\.\s*post|axios)\s*\("
 )
 TWILIO_MESSAGE_CREATE_RE = re.compile(
+    r"(?:"
     r"(?:\?\.|\.|->)\s*messages\s*(?:\?\.|\.|->)\s*"
     r"create\s*(?:\?\.)?\s*\("
+    r"|(?<![\w$])MessageResource\s*\.\s*Create\s*\("
+    r")"
 )
 MESSAGE_BODY_CALL_RE = re.compile(
     r"(?:"
@@ -1550,6 +1838,7 @@ MESSAGE_BODY_CALL_RE = re.compile(
     r"Send\s*\("
     r"|(?:\?\.|\.|->)\s*messages\s*\(\s*\)\s*"
     r"(?:\?\.|\.|->)\s*send\s*\("
+    r"|(?<![\w$])MessageResource\s*\.\s*Create\s*\("
     r")"
 )
 SIMPLE_VARIABLE_RE = re.compile(r"(?:\.\.\.|\*\*|[&*])?\s*(\$?[A-Za-z_]\w*)\s*$")
@@ -1815,13 +2104,89 @@ def _line_comment_end(source: str, start: int, suffix: str) -> int:
 _HEREDOC_OPENER_RE = re.compile(
     r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)(?!\w)"
 )
+_RUBY_HEREDOC_OPENER_RE = re.compile(
+    r"<<(?P<indent>[-~]?)(?:"
+    r"'(?P<single>[^'\r\n]*)'|"
+    r'"(?P<double>[^"\r\n]*)"|'
+    r"`(?P<command>[^`\r\n]*)`|"
+    r"(?P<tag>(?!\d)\w+)"
+    r")"
+)
 # Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
 # singleton-class syntax `class <<self` also puts a bare word straight after
 # `<<` at end of line, so it parsed as a heredoc opening a body that never
 # closed - blanking the rest of the file and silently passing every send below
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
-_NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+def _ruby_heredoc_tag(match: "re.Match[str]") -> str:
+    """Return the delimiter spelling from a Ruby heredoc opener match."""
+
+    for name in ("single", "double", "command", "tag"):
+        value = match.group(name)
+        if value is not None:
+            return value
+    return ""
+
+
+def _ruby_heredoc_quote(match: "re.Match[str]") -> str:
+    """Return the quote mode used by one Ruby heredoc opener."""
+
+    if match.group("single") is not None:
+        return "'"
+    if match.group("double") is not None:
+        return '"'
+    if match.group("command") is not None:
+        return "`"
+    return ""
+
+
+def _ruby_heredoc_has_shift_left_context(source: str, index: int) -> bool:
+    """Return whether Ruby lexes this compact ``<<TAG`` as left shift."""
+
+    cursor = index - 1
+    adjacent = cursor >= 0 and source[cursor] not in " \t\r\n"
+    while cursor >= 0 and source[cursor] in " \t":
+        cursor -= 1
+    if cursor < 0 or source[cursor] in "\r\n":
+        return False
+    # Ruby's lexical ambiguity treats command/local/constant receivers followed
+    # by whitespace and <<TAG as heredocs, but literals, completed expressions,
+    # and instance/global variables remain shift operands.  These are the
+    # contexts Ripper emits as on_op rather than on_heredoc_beg.
+    if source[cursor].isdigit() or source[cursor] in "'\"`)]}/":
+        return True
+    if not (source[cursor].isalnum() or source[cursor] == "_"):
+        return False
+    end = cursor + 1
+    while cursor >= 0 and (source[cursor].isalnum() or source[cursor] == "_"):
+        cursor -= 1
+    word = source[cursor + 1:end]
+    return (
+        adjacent
+        or word
+        in {
+            "nil",
+            "true",
+            "false",
+            "self",
+            "__FILE__",
+            "__LINE__",
+            "__ENCODING__",
+        }
+        or (cursor >= 0 and source[cursor] in {"@", "$", ":"})
+    )
+
+
+def _ruby_heredoc_has_class_left_context(source: str, index: int) -> bool:
+    """Return whether the token before ``<<`` is Ruby's ``class`` keyword."""
+
+    cursor = index - 1
+    while cursor >= 0 and source[cursor] in " \t":
+        cursor -= 1
+    end = cursor + 1
+    while cursor >= 0 and (source[cursor].isalnum() or source[cursor] == "_"):
+        cursor -= 1
+    return source[cursor + 1:end] == "class"
 
 
 def _heredoc_opener_at(
@@ -1833,7 +2198,18 @@ def _heredoc_opener_at(
     applying the rejection there would disable heredoc masking on any opener
     line that merely ENDS with the word `class` (`echo class <<EOT`).
     """
-    match = _HEREDOC_OPENER_RE.match(source, index)
+    opener_pattern = _HEREDOC_OPENER_RE
+    if suffix == ".rb":
+        match = _RUBY_HEREDOC_OPENER_RE.match(source, index)
+        if match is None:
+            return None
+        if (
+            _ruby_heredoc_has_class_left_context(source, index)
+            or _ruby_heredoc_has_shift_left_context(source, index)
+        ):
+            return None
+        return match
+    match = opener_pattern.match(source, index)
     if match is None:
         return None
     # In shell, three opening angle brackets introduce an inline here-string,
@@ -1850,10 +2226,68 @@ def _heredoc_opener_at(
         line_end = len(source)
     if suffix != ".sh" and source[match.end():line_end].strip():
         return None
-    if suffix == ".rb":
-        if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
-            return None
     return match
+
+
+def _ruby_heredoc_openers_at(
+    source: str, index: int
+) -> list["re.Match[str]"]:
+    """Return ordered Ruby heredoc openers declared by one expression.
+
+    Ruby consumes multiple heredoc bodies after the declaration line, in the
+    same order as their openers. The ordinary single-opener validator requires
+    an opener to end its line, so this also accepts comma-separated openers on
+    the declaration line without lending one opener's mode to another body.
+    """
+
+    first = _heredoc_opener_at(source, index, ".rb")
+    if first is None:
+        return []
+    line_end = source.find("\n", first.end())
+    if line_end < 0:
+        line_end = len(source)
+
+    openers = [first]
+    cursor = first.end()
+    quote = ""
+    escaped = False
+    while cursor < line_end:
+        character = source[cursor]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            cursor += 1
+            continue
+        if character == "#":
+            break
+        if character in {"'", '"', "`"}:
+            quote = character
+            cursor += 1
+            continue
+        if character == "/":
+            regexp = _ruby_slash_regex(source, cursor, allow_newlines=False)
+            if regexp is not None and regexp[0] <= line_end:
+                cursor = regexp[0]
+                continue
+        if character == "%":
+            percent = _ruby_percent_literal(source, cursor)
+            if percent is not None and percent[0] <= line_end:
+                cursor = percent[0]
+                continue
+        if source.startswith("<<", cursor):
+            candidate = _heredoc_opener_at(source, cursor, ".rb")
+            if candidate is not None:
+                openers.append(candidate)
+                cursor = candidate.end()
+                continue
+            cursor += 2
+            continue
+        cursor += 1
+    return openers
 
 
 def _heredoc_langs(suffix: str) -> bool:
@@ -2283,7 +2717,244 @@ def _ruby_command_regex_has_valid_tail(source: str, regexp_end: int) -> bool:
     return re.match(r"(?:[+-]\s*)?(?:[$@A-Za-z_\d]|[('\"\[{])", tail) is None
 
 
-def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
+def _ruby_bound_shift_offsets(source: str, code: str) -> frozenset[int]:
+    """Return ambiguous ``<<TAG`` offsets whose receiver is a local binding.
+
+    Ruby lexes ``puts <<DOC`` as a heredoc, but lexes ``value <<BITS`` as an
+    operator once ``value`` has been introduced as a local in the same lexical
+    method/top-level scope.  A first masking pass gives us comment/string-safe
+    code and method boundaries; this binding pass then prevents the second pass
+    from swallowing the rest of the file as a nonexistent heredoc body.
+    """
+
+    spans = sorted(_ruby_function_spans(code))
+    span_starts = [start for start, _ in spans]
+    parents: list[int] = []
+    stack: list[int] = []
+    for span_index, (start, end) in enumerate(spans):
+        while stack and spans[stack[-1]][1] <= start:
+            stack.pop()
+        parents.append(stack[-1] if stack else -1)
+        stack.append(span_index)
+
+    def owner(offset: int) -> tuple[int, int] | None:
+        # Intervals are nested or disjoint. Start with the latest possible
+        # owner and follow its precomputed parent chain instead of scanning all
+        # method spans for every binding/candidate (quadratic on large files).
+        span_index = bisect.bisect_right(span_starts, offset) - 1
+        while span_index >= 0:
+            start, end = spans[span_index]
+            if start <= offset < end:
+                return start, end
+            span_index = parents[span_index]
+        return None
+
+    def parameter_names(parameters: str) -> set[str]:
+        """Return declaration names, excluding identifiers in defaults."""
+
+        names: set[str] = set()
+        start = 0
+        depth = 0
+        for index, character in enumerate(parameters + ","):
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth = max(0, depth - 1)
+            elif character in {",", ";"} and depth == 0:
+                piece = parameters[start:index].strip()
+                start = index + 1
+                while (
+                    len(piece) >= 2
+                    and piece[0] == "("
+                    and matching_delimiter(piece, 0, "(", ")")
+                    == len(piece) - 1
+                ):
+                    piece = piece[1:-1].strip()
+                if "," in piece:
+                    names.update(parameter_names(piece))
+                    continue
+                declared = re.match(
+                    r"(?:\*\*?|&)?\s*(?P<name>[a-z_]\w*)\b", piece
+                )
+                if declared is not None:
+                    names.add(declared.group("name"))
+        return names
+
+    def do_block_end(opening_end: int) -> int:
+        """Match a Ruby ``do`` with its structurally corresponding ``end``."""
+
+        depth = 1
+        boundaries = list(re.finditer(r"[;\r\n]", code[opening_end:]))
+        start = opening_end
+        pieces: list[tuple[int, int]] = []
+        for boundary in boundaries:
+            end = opening_end + boundary.start()
+            pieces.append((start, end))
+            start = opening_end + boundary.end()
+        pieces.append((start, len(code)))
+        for statement_start, statement_end in pieces:
+            stripped = code[statement_start:statement_end].strip()
+            if not stripped:
+                continue
+            if re.match(r"end\b", stripped):
+                depth -= 1
+                if depth == 0:
+                    return statement_end
+                continue
+            if (
+                re.match(
+                    r"(?:def|class|module|if|unless|case|begin|for|while|until)\b",
+                    stripped,
+                )
+                or re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped)
+            ):
+                depth += 1
+        return len(code)
+
+    # Identify block parameter lists before ordinary assignments: a default
+    # such as `|item = fallback|` binds only `item` inside the block and must
+    # not invent either name as an outer local.
+    pipe_spans = [
+        (match.start(), match.end(), parameter_names(match.group("params")))
+        for match in re.finditer(r"\|(?P<params>[^|\r\n]*)\|", code)
+    ]
+    block_bindings: list[tuple[int, int, set[str], tuple[int, int] | None]] = []
+    for pipe_start, pipe_end, names in pipe_spans:
+        if not names:
+            continue
+        prefix_start = max(0, pipe_start - 120)
+        prefix = code[prefix_start:pipe_start]
+        brace = prefix.rfind("{")
+        if brace >= 0:
+            opening = prefix_start + brace
+            closing = matching_delimiter(code, opening, "{", "}")
+            if closing is not None:
+                block_bindings.append((pipe_end, closing, names, owner(pipe_start)))
+                continue
+        do_match = re.search(r"\bdo\s*$", prefix)
+        if do_match is not None:
+            opening_end = prefix_start + do_match.end()
+            closing = do_block_end(opening_end)
+            block_bindings.append((pipe_end, closing, names, owner(pipe_start)))
+
+    bindings: dict[tuple[tuple[int, int] | None, str], list[int]] = {}
+
+    def bind(name: str, offset: int) -> None:
+        if not re.fullmatch(r"[a-z_]\w*", name):
+            return
+        bindings.setdefault((owner(offset), name), []).append(offset)
+
+    # Simple and compound assignments establish a Ruby local from that point
+    # onward.  Strings/comments/heredoc bodies are blank in ``code``, so text
+    # that merely resembles an assignment cannot leak a binding into code.
+    assignment = re.compile(
+        r"(?<![\w@$.])([a-z_]\w*)\s*"
+        r"(?:\|\|=|&&=|<<=|>>=|\*\*=|[+\-*/%&|^]=|=(?!=|>))"
+    )
+    for match in assignment.finditer(code):
+        if any(start <= match.start() < end for start, end, _ in pipe_spans):
+            continue
+        if any(
+            start <= match.start() < end and match.group(1) in names
+            for start, end, names, _ in block_bindings
+        ):
+            continue
+        bind(match.group(1), match.start(1))
+
+    # Multiple assignment binds every bare local on its left side, not just
+    # the identifier adjacent to ``=``.
+    for match in re.finditer(
+        r"(?:^|[;\r\n])\s*"
+        r"(?P<lhs>[a-z_]\w*(?:\s*,\s*[a-z_]\w*)+)\s*=(?!=|>)",
+        code,
+        re.M,
+    ):
+        for name in re.findall(r"[a-z_]\w*", match.group("lhs")):
+            if any(
+                start <= match.start("lhs") < end
+                for start, end, _ in pipe_spans
+            ):
+                continue
+            if any(
+                start <= match.start("lhs") < end and name in names
+                for start, end, names, _ in block_bindings
+            ):
+                continue
+            bind(name, match.start("lhs"))
+
+    # Method parameters are local for the whole method body.  Their binding
+    # position is the method opener so a shift in an endless method expression
+    # is covered too.
+    for start, end in spans:
+        method = re.match(
+            r"\s*(?:(?:private|protected|public)\s+)?def\s+"
+            r"(?:self\s*\.\s*)?(?:\[\]=?|[A-Za-z_]\w*[!?=]?)",
+            code[start:end],
+        )
+        if method is None:
+            continue
+        params_start = start + method.end()
+        while params_start < end and code[params_start] in " \t":
+            params_start += 1
+        if params_start < end and code[params_start] == "(":
+            params_end = matching_delimiter(code, params_start, "(", ")")
+            if params_end is None:
+                continue
+            parameters = code[params_start + 1:params_end]
+        else:
+            ends = [
+                position
+                for position in (
+                    code.find("\n", params_start, end),
+                    code.find(";", params_start, end),
+                )
+                if position >= 0
+            ]
+            params_end = min(ends) if ends else end
+            parameters = code[params_start:params_end]
+        for name in parameter_names(parameters):
+            bind(name, start)
+
+    for positions in bindings.values():
+        positions.sort()
+
+    shifts: set[int] = set()
+    for candidate in re.finditer(r"<<", code):
+        index = candidate.start()
+        opener = _RUBY_HEREDOC_OPENER_RE.match(source, index)
+        if opener is None:
+            continue
+        cursor = index - 1
+        if cursor < 0 or code[cursor] not in " \t":
+            continue
+        while cursor >= 0 and code[cursor] in " \t":
+            cursor -= 1
+        word_end = cursor + 1
+        while cursor >= 0 and (code[cursor].isalnum() or code[cursor] == "_"):
+            cursor -= 1
+        name = code[cursor + 1:word_end]
+        if re.fullmatch(r"[a-z_]\w*", name) is None:
+            continue
+        scope = owner(index)
+        positions = bindings.get((scope, name), [])
+        insertion = bisect.bisect_left(positions, index)
+        if insertion and positions[insertion - 1] < index:
+            shifts.add(index)
+            continue
+        if any(
+            start <= index < end and block_owner == scope and name in names
+            for start, end, names, block_owner in block_bindings
+        ):
+            shifts.add(index)
+    return frozenset(shifts)
+
+
+def _lex_source_once(
+    source: str,
+    suffix: str,
+    dialect: str = "",
+    ruby_shift_offsets: frozenset[int] = frozenset(),
+) -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
     code = list(source)
@@ -2472,17 +3143,31 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         # Heredoc bodies are DATA, not code. They were lexed as code, so an
         # apostrophe inside one ("Don't edit by hand") paired with a later quote
         # and masked the send that followed.
-        heredoc = _heredoc_opener_at(source, index, suffix) if _heredoc_langs(suffix) else None
-        if heredoc is not None:
-            body_start = source.find("\n", heredoc.end())
+        openers: list["re.Match[str]"] = []
+        if suffix == ".rb":
+            if index not in ruby_shift_offsets:
+                openers = _ruby_heredoc_openers_at(source, index)
+        elif _heredoc_langs(suffix):
+            heredoc = _heredoc_opener_at(source, index, suffix)
+            if heredoc is not None:
+                openers = [heredoc]
+        if openers:
+            body_start = source.find("\n", openers[0].end())
             if body_start < 0:
-                index = heredoc.end()
+                index = openers[-1].end()
                 continue
             body_start += 1
-            openers = [heredoc]
             for opener in openers:
-                tag = opener.group("tag")
-                terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
+                if suffix == ".rb":
+                    tag = _ruby_heredoc_tag(opener)
+                    indentation = opener.group("indent")
+                    line_prefix = r"^[ \t]*" if indentation in {"-", "~"} else "^"
+                    terminator_pattern = (
+                        rf"{line_prefix}{re.escape(tag)}(?=\r?$)"
+                    )
+                else:
+                    tag = opener.group("tag")
+                    terminator_pattern = rf"^[ \t]*{re.escape(tag)}\b"
                 terminator = re.compile(terminator_pattern, re.M).search(
                     source, body_start
                 )
@@ -2491,7 +3176,7 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 )
                 _blank(code, body_start, body_end)
                 _blank(without_comments, body_start, body_end)
-                if suffix == ".rb" and opener.group("q") != "'":
+                if suffix == ".rb" and _ruby_heredoc_quote(opener) != "'":
                     for expression_start, expression_end in _ruby_interpolation_ranges(
                         source, body_start, body_end
                     ):
@@ -2775,6 +3460,24 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
             last_js_opaque_end = index
 
     return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
+
+
+def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
+    """Mask comments/strings, resolving Ruby's binding-sensitive ``<<``."""
+
+    if suffix != ".rb":
+        return _lex_source_once(source, suffix, dialect)
+
+    ruby_shift_offsets: frozenset[int] = frozenset()
+    while True:
+        lexed = _lex_source_once(
+            source, suffix, dialect, ruby_shift_offsets
+        )
+        discovered = _ruby_bound_shift_offsets(source, lexed.code)
+        combined = ruby_shift_offsets | discovered
+        if combined == ruby_shift_offsets:
+            return lexed
+        ruby_shift_offsets = combined
 
 
 def matching_delimiter(code: str, opening: int, left: str, right: str) -> int | None:
@@ -4089,6 +4792,10 @@ def payload_spans(
             # the argument list this region covers.
             spans.append(arguments[-1])
         return spans
+    if suffix == ".cs" and mode == "body":
+        # Twilio's MessageResource.Create uses independent named arguments;
+        # `body:` is commonly the third argument, not an object in argument 0.
+        return [(start, end)]
     return arguments[:1]
 
 
@@ -4876,6 +5583,13 @@ def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
                 r"(?:if|unless|case|begin|for|while|until)\b", stripped
             ):
                 stack.append(("control", None))
+    # A provisional heredoc pass can mask the `end` belonging to a method whose
+    # body contains a binding-sensitive shift. Retain such open named scopes to
+    # EOF so the repair pass can still associate parameters and assignments
+    # with the correct method rather than dropping the scope entirely.
+    for kind, opener_start in stack:
+        if kind in {"def", "class", "module"} and opener_start is not None:
+            spans.append((opener_start, len(code)))
     return spans
 
 
@@ -13827,6 +14541,92 @@ def call_belongs_to_kept_product(
     )
 
 
+def csharp_twilio_message_calls(
+    lexed: LexedSource, source: SourceEndpointResolver | None = None
+) -> list[Call]:
+    return csharp_twilio_resource_calls(
+        lexed, "Twilio.Rest.Api.V2010.Account.MessageResource", ("Create",), source
+    )
+
+
+def csharp_twilio_resource_calls(
+    lexed: LexedSource, target: str, methods: tuple[str, ...],
+    source: SourceEndpointResolver | None = None,
+) -> list[Call]:
+    """Resolve the SDK resource's C# using/alias forms before checking its body.
+
+    Generic class names are not sufficient ownership evidence. Keep imports
+    scoped to their namespace and let local types shadow namespace imports.
+    """
+    code = lexed.code
+    namespaces = _csharp_namespace_spans(code)
+    types = _csharp_type_spans(code)
+    source = source or SourceEndpointResolver(lexed, ".cs")
+
+    def namespace_at(offset: int) -> tuple[int, int, str] | None:
+        return max((span for span in namespaces if span[0] < offset < span[1]),
+                   key=lambda span: span[0], default=None)
+
+    imports = []
+    for match in re.finditer(
+        r"\b(?:global\s+)?using\s+(?:(?P<static>static)\s+)?"
+        r"(?:(?P<alias>\w+)\s*=\s*)?(?:global\s*::\s*)?"
+        r"(?P<target>\w+(?:\s*\.\s*\w+)*)\s*;", code
+    ):
+        imports.append((match, re.sub(r"\s+", "", match.group("target")),
+                        namespace_at(match.start())))
+    candidates = calls_matching(lexed, re.compile(
+        r"(?<![\w$.])(?:global\s*::\s*)?(?:\w+\s*\.\s*)*(?:"
+        + "|".join(re.escape(method) for method in methods) + r")\s*\("
+    ))
+    result = []
+    for call in candidates:
+        head = re.sub(r"\s+", "", code[call.start:call.open_paren])
+        receiver = head.rsplit(".", 1)[0] if "." in head else ""
+        if receiver.startswith("global::"):
+            if receiver.removeprefix("global::") == target:
+                result.append(call)
+            continue
+        visible = [(match, name) for match, name, scope in imports
+                   if scope is None or scope[0] < call.start < scope[1]]
+        aliases = {match.group("alias"): name for match, name in visible
+                   if match.group("alias")}
+        first, dot, rest = receiver.partition(".")
+        binding_id = source.graph.visible_binding(
+            first, source.scope_at(call.start), call.start
+        ) if first else None
+        if binding_id is not None:
+            declaration = source.graph.bindings[binding_id].declaration_start
+            if (scope_contains(code, declaration, call.start)
+                    and not any(match.start() <= declaration < match.end()
+                                for match, _, _ in imports)):
+                # Local variables, parameters and fields beat a using alias.
+                # Reuse the normal scope index so an unrelated method/block
+                # cannot hide the SDK receiver here.
+                continue
+        expanded = aliases.get(first, first) + (dot + rest if dot else "")
+        if expanded == target:
+            result.append(call)
+            continue
+        # A same-namespace or enclosing type declaration takes precedence over
+        # imported namespace members, even when declared after the use.
+        local = any(name == first and (
+            opening < call.start < closing
+            or namespace_at(opening) == namespace_at(call.start)
+        ) for opening, closing, name in types)
+        if local or first in aliases:
+            continue
+        if receiver == target.rsplit(".", 1)[-1] and any(
+            not match.group("alias") and not match.group("static")
+            and name == target.rsplit(".", 1)[0] for match, name in visible
+        ):
+            result.append(call)
+        elif not receiver and any(match.group("static") and name == target
+                                  for match, name in visible):
+            result.append(call)
+    return result
+
+
 def message_body_fields(
     path: Path, pattern: re.Pattern[str], kept_products: set[str] | None = None
 ) -> list[str]:
@@ -13845,7 +14645,15 @@ def message_body_fields(
         source=source_resolver,
     )
     matches: list[str] = []
-    for call in calls_matching(lexed, pattern):
+    # Ownership applies only to the ambiguous C# resource class, not to the
+    # existing generic Messages.Send / messages.create body-check families.
+    calls = [call for call in calls_matching(lexed, pattern)
+             if not re.search(r"\bMessageResource\s*\.\s*Create\s*$",
+                              lexed.code[call.start:call.open_paren])]
+    if suffix == ".cs":
+        calls.extend(csharp_twilio_message_calls(lexed, source_resolver))
+    calls = list({call.open_paren: call for call in calls}.values())
+    for call in calls:
         if call_belongs_to_kept_product(
             lexed, call, kept_products or set(), pattern
         ):

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -6473,6 +6473,12 @@ class SourceEndpointResolver:
         self.suffix = suffix
         self.external_values = external_values or {}
         self.external_names = external_names or set()
+        self.csharp_namespace_spans = (
+            _csharp_namespace_spans(lexed.original) if suffix == ".cs" else []
+        )
+        self.csharp_type_spans = (
+            _csharp_type_spans(lexed.original) if suffix == ".cs" else []
+        )
         self.unverified_external_calls: set[int] = set()
         self.graph = EndpointGraph(len(lexed.code))
         self.c_headers = c_function_headers(lexed, suffix)
@@ -8107,7 +8113,14 @@ class SourceEndpointResolver:
         if access is not None:
             return access
 
-        reference = static_reference_expression(self.lexed, start, end)
+        reference_start = start
+        if self.suffix == ".cs":
+            global_prefix = re.match(
+                r"\s*global\s*::\s*", self.lexed.original[start:end]
+            )
+            if global_prefix is not None:
+                reference_start += global_prefix.end()
+        reference = static_reference_expression(self.lexed, reference_start, end)
         if reference is not None:
             name = reference[0].lstrip("$")
             binding_id = self.graph.visible_binding(
@@ -8432,11 +8445,45 @@ class SourceEndpointResolver:
         # per-file binding graph. Keeping module provenance explicit avoids
         # conflating same-named locals and makes the cross-file boundary the
         # only special case; all endpoint classification remains shared.
-        expression_text = self.lexed.code[start:end].strip()
-        if not projection and re.fullmatch(r"[A-Za-z_$]\w*", expression_text):
-            external = self.external_values.get(expression_text.lstrip("$"))
-            if external is not None:
-                return endpoint_literal_value(external)
+        reference_start = start
+        if self.suffix == ".cs":
+            global_prefix = re.match(
+                r"\s*global\s*::\s*", self.lexed.original[start:end]
+            )
+            if global_prefix is not None:
+                reference_start += global_prefix.end()
+        reference = static_reference_expression(self.lexed, reference_start, end)
+        if not projection and reference is not None:
+            reference_key = ".".join(
+                part.lstrip("$") for part in reference
+            )
+            scope_id = self.scope_at(before)
+            if self.suffix == ".cs" and self.graph.visible_binding(
+                reference[0].lstrip("$"), scope_id, before
+            ) is not None:
+                expression = self._parse_expression(
+                    start, end, scope_id, before
+                )
+                return self.graph.evaluate(
+                    EndpointExpressionState(
+                        expression, projection, before, scope_id
+                    )
+                )
+            candidates = (
+                _csharp_reference_candidates(
+                    before,
+                    reference_key,
+                    self.csharp_namespace_spans,
+                    self.csharp_type_spans,
+                    global_only=global_prefix is not None,
+                )
+                if self.suffix == ".cs"
+                else (reference_key,)
+            )
+            for candidate in candidates:
+                external = self.external_values.get(candidate)
+                if external is not None:
+                    return endpoint_literal_value(external)
         scope_id = self.scope_at(before)
         expression = self._parse_expression(
             start, end, scope_id, before
@@ -11804,7 +11851,9 @@ def _looks_like_a_send_target(
         r"|\b(?:public|private|protected|internal)[ \t]+const"
         r"|\b(?:public|private|protected|internal)?[ \t]*static[ \t]+readonly)"
         r"[ \t]+[A-Za-z_$][\w$<>,.?\[\]]*[ \t]+"
-        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*$",
+        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*"
+        r"(?:new[ \t]*(?:(?:System[ \t]*\.[ \t]*)?Uri[ \t]*)?"
+        r"\([ \t]*)?@?[ \t]*$",
         declaration,
         re.I,
     ) and _SEND_SITE_RE.search(declaration) is None:
@@ -12072,8 +12121,233 @@ def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
     return assignment.group("value") if assignment is not None else None
 
 
+def _python_from_imports(visible: str) -> list[tuple[str, str, str]]:
+    """Return ``(module, exported, local)`` for logical Python imports.
+
+    Python permits a parenthesized member list to span physical lines, and a
+    backslash can continue the unparenthesized form. Parse the bounded logical
+    statement once and share it between exact local-module resolution and the
+    fail-closed external-provenance index so those two contracts cannot drift.
+    """
+
+    imports: list[tuple[str, str, str]] = []
+    header = re.compile(
+        r"(?m)(?:^|;)[ \t]*from[ \t]+"
+        r"(?P<module>\.*(?:[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)?)"
+        r"[ \t]+import[ \t]*"
+    )
+    for match in header.finditer(visible):
+        module = match.group("module")
+        if not module:
+            continue
+        start = match.end()
+        while start < len(visible) and visible[start] in " \t":
+            start += 1
+        if start < len(visible) and visible[start] == "(":
+            closing = matching_delimiter(visible, start, "(", ")")
+            if closing is None:
+                continue
+            members = visible[start + 1 : closing]
+        else:
+            end = start
+            while end < len(visible):
+                line_break = re.search(r"\r\n|\r|\n", visible[end:])
+                if line_break is None:
+                    end = len(visible)
+                    break
+                line_end = end + line_break.start()
+                semicolon = visible.find(";", end, line_end)
+                if semicolon >= 0:
+                    end = semicolon
+                    break
+                if visible[start:line_end].rstrip().endswith("\\"):
+                    end += line_break.end()
+                    continue
+                end = line_end
+                break
+            members = re.sub(r"\\(?:\r\n|\r|\n)", " ", visible[start:end])
+        for member in members.split(","):
+            parsed = re.fullmatch(
+                r"\s*(?P<export>[A-Za-z_]\w*)"
+                r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
+                member,
+            )
+            if parsed is not None:
+                imports.append(
+                    (
+                        module,
+                        parsed.group("export"),
+                        parsed.group("local") or parsed.group("export"),
+                    )
+                )
+    return imports
+
+
+def _csharp_namespace_spans(source: str) -> list[tuple[int, int, str]]:
+    """Return namespace scopes with their fully qualified names."""
+
+    code = lex_source(source, ".cs").code
+    raw: list[tuple[int, int, str]] = []
+    for match in re.finditer(
+        r"\bnamespace\s+(?P<name>[A-Za-z_]\w*"
+        r"(?:\s*\.\s*[A-Za-z_]\w*)*)\s*(?P<kind>;|\{)",
+        code,
+    ):
+        name = re.sub(r"\s+", "", match.group("name"))
+        if match.group("kind") == ";":
+            raw.append((match.end(), len(code), name))
+            continue
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is not None:
+            raw.append((opening, closing, name))
+
+    qualified: list[tuple[int, int, str]] = []
+    for start, end, name in sorted(raw, key=lambda item: (item[0], -item[1])):
+        parents = [
+            span for span in qualified if span[0] < start and end < span[1]
+        ]
+        parent = max(parents, key=lambda span: span[0], default=None)
+        full_name = f"{parent[2]}.{name}" if parent is not None else name
+        qualified.append((start, end, full_name))
+    return qualified
+
+
+def _csharp_static_scalars(source: str) -> dict[str, str]:
+    """Return fully qualified, statically addressable C# scalar members."""
+
+    lexed = lex_source(source, ".cs")
+    code = lexed.code
+    type_spans = _csharp_type_spans(source)
+
+    values: dict[str, str] = {}
+    namespace_spans = _csharp_namespace_spans(source)
+    for token in lexed.strings:
+        enclosing = sorted(
+            (span for span in type_spans if span[0] < token.start < span[1]),
+            key=lambda span: span[0],
+        )
+        if not enclosing:
+            continue
+        innermost = enclosing[-1]
+        # Type fields are at curly depth zero. A static readonly Uri keeps the
+        # string inside its constructor parentheses, so round depth is allowed.
+        if structural_depth(code, innermost[0] + 1, token.start)[2] != 0:
+            continue
+        declaration_start = max(
+            code.rfind(";", innermost[0] + 1, token.start),
+            code.rfind("{", innermost[0] + 1, token.start),
+            code.rfind("}", innermost[0] + 1, token.start),
+        ) + 1
+        prefix = code[declaration_start:token.start]
+        field = re.search(
+            r"(?P<head>.*?)\b(?P<name>[A-Za-z_]\w*)\s*=\s*"
+            r"(?:new\s*(?:(?:System\s*\.\s*)?Uri\s*)?\(\s*)?@?$",
+            prefix,
+            re.DOTALL,
+        )
+        if field is None:
+            continue
+        modifiers = field.group("head")
+        if not (
+            re.search(r"\bconst\b", modifiers)
+            or (
+                re.search(r"\bstatic\b", modifiers)
+                and re.search(r"\breadonly\b", modifiers)
+            )
+        ):
+            continue
+        type_path = ".".join(span[2] for span in enclosing)
+        namespaces = [
+            span for span in namespace_spans if span[0] < token.start < span[1]
+        ]
+        namespace = max(namespaces, key=lambda span: span[0], default=None)
+        prefix = f"{namespace[2]}." if namespace is not None else ""
+        values[f"{prefix}{type_path}.{field.group('name')}"] = token.contents
+    return values
+
+
+def _csharp_type_spans(source: str) -> list[tuple[int, int, str]]:
+    """Return nested C# type scopes as ``(open, close, local_name)``."""
+
+    code = lex_source(source, ".cs").code
+    type_spans: list[tuple[int, int, str]] = []
+    for match in re.finditer(
+        r"\b(?:class|struct|record(?:\s+class|\s+struct)?)\s+"
+        r"(?P<name>[A-Za-z_]\w*)[^;{}]*\{",
+        code,
+    ):
+        opening = code.rfind("{", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "{", "}")
+        if closing is not None:
+            type_spans.append((opening, closing, match.group("name")))
+    return type_spans
+
+
+def _csharp_project_static_index(project_root: Path) -> dict[str, str]:
+    """Build one exact C# static-member index for an analyzer invocation."""
+
+    resolved: dict[str, str] = {}
+    for candidate in project_root.rglob("*.cs"):
+        try:
+            relative = candidate.relative_to(project_root)
+        except ValueError:
+            continue
+        if any(part in EXCLUDED_DIRS for part in relative.parts[:-1]):
+            continue
+        candidate_source = _read_source_text(candidate)
+        resolved.update(_csharp_static_scalars(candidate_source))
+    return resolved
+
+
+def _csharp_reference_candidates(
+    position: int,
+    reference: str,
+    namespace_spans: list[tuple[int, int, str]],
+    type_spans: list[tuple[int, int, str]],
+    *,
+    global_only: bool = False,
+) -> tuple[str, ...]:
+    """Return C# member spellings from nearest lexical scope to global."""
+
+    if global_only:
+        return (reference,)
+    candidates: list[str] = []
+    namespaces = [
+        span
+        for span in namespace_spans
+        if span[0] < position < span[1]
+    ]
+    namespace = max(namespaces, key=lambda span: span[0], default=None)
+    namespace_name = namespace[2] if namespace is not None else ""
+    enclosing_types = sorted(
+        (
+            span
+            for span in type_spans
+            if span[0] < position < span[1]
+        ),
+        key=lambda span: span[0],
+    )
+    for count in range(len(enclosing_types), 0, -1):
+        prefix = ".".join(span[2] for span in enclosing_types[:count])
+        candidates.append(
+            ".".join(part for part in (namespace_name, prefix, reference) if part)
+        )
+    namespace_parts = namespace_name.split(".") if namespace_name else []
+    for count in range(len(namespace_parts), 0, -1):
+        candidates.append(
+            f"{'.'.join(namespace_parts[:count])}.{reference}"
+        )
+    candidates.append(reference)
+    return tuple(dict.fromkeys(candidates))
+
+
 def external_static_values(
-    path: Path, project_root: Path, source: str, suffix: str
+    path: Path,
+    project_root: Path,
+    source: str,
+    suffix: str,
+    csharp_project_values: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Resolve relative named imports to statically exported scalar strings.
 
@@ -12147,28 +12421,26 @@ def external_static_values(
                         )
                     )
     elif suffix == ".py":
-        for match in re.finditer(
-            r"(?m)^\s*from\s+(?P<module>\.*[A-Za-z_][\w.]*)\s+import\s+"
-            r"(?P<members>[^\r\n]+)",
-            visible,
+        for module, exported, local in _python_from_imports(
+            lex_source(source, ".py").code
         ):
-            for member in match.group("members").split(","):
-                parsed = re.fullmatch(
-                    r"\s*(?P<export>[A-Za-z_]\w*)"
-                    r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
-                    member,
+            dots = len(module) - len(module.lstrip("."))
+            module_tail = module[dots:].replace(".", "/")
+            relative = "../" * max(0, dots - 1) + module_tail
+            imports.append(
+                (
+                    "./" + relative if dots else module,
+                    exported,
+                    local,
                 )
-                if parsed is not None:
-                    dots = len(match.group("module")) - len(match.group("module").lstrip("."))
-                    module_tail = match.group("module")[dots:].replace(".", "/")
-                    relative = "../" * max(0, dots - 1) + module_tail
-                    imports.append(
-                        (
-                            "./" + relative if dots else match.group("module"),
-                            parsed.group("export"),
-                            parsed.group("local") or parsed.group("export"),
-                        )
-                    )
+            )
+    elif suffix == ".cs":
+        project_values = (
+            csharp_project_values
+            if csharp_project_values is not None
+            else _csharp_project_static_index(project_root)
+        )
+        return project_values
 
     resolved: dict[str, str] = {}
     for module, exported, local in imports:
@@ -12310,14 +12582,12 @@ def external_reference_names(
                 if parsed is not None:
                     names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
     elif suffix == ".py":
-        for match in re.finditer(r"(?m)^\s*from\s+[\w.]+\s+import\s+([^\r\n]+)", visible):
-            for member in match.group(1).split(","):
-                parsed = re.fullmatch(
-                    r"\s*([A-Za-z_]\w*)(?:\s+as\s+([A-Za-z_]\w*))?\s*",
-                    member,
-                )
-                if parsed is not None:
-                    names.add(parsed.group(2) or parsed.group(1))
+        names.update(
+            local
+            for _, _, local in _python_from_imports(
+                lex_source(source, ".py").code
+            )
+        )
         for match in re.finditer(
             r"(?m)^\s*import\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)"
             r"(?:\s+as\s+([A-Za-z_]\w*))?",
@@ -12353,7 +12623,11 @@ def external_reference_names(
     return names
 
 
-def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
+def analyze_file(
+    path: Path,
+    project_root: Path,
+    csharp_project_values: dict[str, str] | None = None,
+) -> tuple[int, list[str]]:
     # newline="" is required: Path.read_text() performs universal-newline
     # translation, destroying bare-CR and CRLF source boundaries before the
     # lexer and grep-line protocol can agree on them.
@@ -12382,7 +12656,13 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source_resolver = SourceEndpointResolver(
         lexed,
         suffix,
-        external_static_values(path, project_root, source, suffix),
+        external_static_values(
+            path,
+            project_root,
+            source,
+            suffix,
+            csharp_project_values,
+        ),
         external_reference_names(source, suffix, project_root),
     )
     profile_resolver = PayloadStateResolver(
@@ -12651,9 +12931,12 @@ def main(argv: list[str]) -> int:
 
     total = 0
     missing: list[str] = []
+    csharp_project_values = _csharp_project_static_index(project_root)
     for path in iter_source_files(project_root):
         try:
-            file_total, file_missing = analyze_file(path, project_root)
+            file_total, file_missing = analyze_file(
+                path, project_root, csharp_project_values
+            )
         except Exception as error:  # noqa: BLE001 - one file must not abort the scan
             # A pathological file previously took the WHOLE run down, so every
             # other file went unanalysed and the project was reported clean.

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1007,6 +1007,162 @@ def _heredoc_langs(suffix: str) -> bool:
     return suffix in {".sh", ".php", ".rb"}
 
 
+_JS_REGEX_PREFIX_WORDS = {
+    "await",
+    "break",
+    "case",
+    "continue",
+    "debugger",
+    "delete",
+    "do",
+    "else",
+    "in",
+    "instanceof",
+    "new",
+    "of",
+    "return",
+    "throw",
+    "typeof",
+    "void",
+    "yield",
+}
+_JS_CONTROL_PAREN_WORDS = {"catch", "for", "if", "switch", "while", "with"}
+
+
+def _previous_code_index(code: list[str], before: int) -> int | None:
+    for index in range(before - 1, -1, -1):
+        if not code[index].isspace():
+            return index
+    return None
+
+
+def _word_before(code: list[str], before: int) -> str:
+    end = before
+    start = end
+    while start > 0 and (code[start - 1].isalnum() or code[start - 1] in "_$"):
+        start -= 1
+    return "".join(code[start:end])
+
+
+def _javascript_control_paren(code: list[str], closing: int) -> bool:
+    """Whether `closing` ends a control header after which a statement starts."""
+
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == ")":
+            depth += 1
+        elif code[index] == "(":
+            depth -= 1
+            if depth == 0:
+                previous = _previous_code_index(code, index)
+                return (
+                    previous is not None
+                    and _word_before(code, previous + 1).lower()
+                    in _JS_CONTROL_PAREN_WORDS
+                )
+    return False
+
+
+def _javascript_block_brace(code: list[str], closing: int) -> bool:
+    """Conservatively identify a closing statement/class/function block."""
+
+    depth = 0
+    for index in range(closing, -1, -1):
+        if code[index] == "}":
+            depth += 1
+        elif code[index] == "{":
+            depth -= 1
+            if depth != 0:
+                continue
+            previous = _previous_code_index(code, index)
+            if previous is None:
+                return True
+            if code[previous] == ")":
+                return True
+            if code[previous] == ">" and previous > 0 and code[previous - 1] == "=":
+                return True
+            return _word_before(code, previous + 1).lower() in {
+                "class",
+                "do",
+                "else",
+                "finally",
+                "function",
+                "try",
+            }
+    return False
+
+
+def _javascript_regex_can_start(
+    source: str, code: list[str], index: int, last_opaque_end: int
+) -> bool:
+    """Approximate ECMAScript's regexp lexical goal from the preceding token.
+
+    JavaScript uses the same slash for division and regexp literals. The
+    distinction is grammatical: a regexp can begin where an expression is
+    expected, but not after an operand. `code` already has earlier comments and
+    literals blanked, while `last_opaque_end` prevents a preceding string,
+    template, or regexp operand from disappearing from that decision.
+    """
+
+    previous = _previous_code_index(code, index)
+    if last_opaque_end and (previous is None or previous < last_opaque_end):
+        if all(character.isspace() for character in code[last_opaque_end:index]):
+            return False
+    if previous is None:
+        return True
+
+    character = code[previous]
+    if (
+        character == "<"
+        and previous == index - 1
+        and index + 1 < len(source)
+        and (source[index + 1].isalpha() or source[index + 1] in "_$>")
+    ):
+        # JSX closing tags (`</Panel>` and `</>`) are markup delimiters, not a
+        # regexp in the expression position that `<` would otherwise permit.
+        return False
+    if character in "([,;:=!?&|^~<>*%":
+        return True
+    if character in "+-":
+        return previous == 0 or code[previous - 1] != character
+    if character == ")":
+        return _javascript_control_paren(code, previous)
+    if character == "}":
+        return _javascript_block_brace(code, previous)
+    if character.isalnum() or character in "_$":
+        return _word_before(code, previous + 1).lower() in _JS_REGEX_PREFIX_WORDS
+    return False
+
+
+def _javascript_regex_end(source: str, start: int) -> int | None:
+    """Return the end of a valid-looking JS regexp literal, including flags."""
+
+    if source.startswith(("//", "/*"), start):
+        return None
+    index = start + 1
+    in_class = False
+    while index < len(source):
+        character = source[index]
+        if character in {"\r", "\n", "\u2028", "\u2029"}:
+            return None
+        if character == "\\":
+            index += 2
+            continue
+        if character == "[":
+            in_class = True
+        elif character == "]" and in_class:
+            in_class = False
+        elif character == "/" and not in_class:
+            index += 1
+            while index < len(source) and (
+                source[index].isalpha() or source[index] in "_$"
+            ):
+                index += 1
+            return index
+        index += 1
+    return None
+
+
 def lex_source(source: str, suffix: str) -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
@@ -1017,8 +1173,24 @@ def lex_source(source: str, suffix: str) -> LexedSource:
     c_block_comments = c_line_comments
     hash_comments = suffix in {".php", ".py", ".rb", ".sh"}
     index = 0
+    last_js_opaque_end = 0
 
     while index < len(source):
+        if (
+            suffix in JS_TS_SUFFIXES
+            and source[index] == "/"
+            and _javascript_regex_can_start(
+                source, code, index, last_js_opaque_end
+            )
+        ):
+            regex_end = _javascript_regex_end(source, index)
+            if regex_end is not None:
+                _blank(code, index, regex_end)
+                _blank(without_comments, index, regex_end)
+                last_js_opaque_end = regex_end
+                index = regex_end
+                continue
+
         if c_block_comments and source.startswith("/*", index):
             end = source.find("*/", index + 2)
             end = len(source) if end < 0 else end + 2
@@ -1170,6 +1342,8 @@ def lex_source(source: str, suffix: str) -> LexedSource:
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
+        if suffix in JS_TS_SUFFIXES:
+            last_js_opaque_end = index
 
     return LexedSource(source, "".join(code), "".join(without_comments), tuple(strings))
 

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -74,6 +74,8 @@ SUFFIX_LANGUAGE_ALIASES = {
     ".svelte": ".js",
     ".astro": ".js",
     ".erb": ".rb",
+    ".ejs": ".js",
+    ".jsp": ".java",
 }
 INCLUDED_SUFFIXES = {
     ".cs",
@@ -120,8 +122,281 @@ def canonical_suffix(path: Path) -> str:
     """Return the language suffix a file should be analysed as."""
     suffix = path.suffix.lower()
     if not suffix:
+        if path.name.lower() == "rakefile":
+            return ".rb"
         return shebang_suffix(path) or ""
+    # Component files can opt into TypeScript inside their script block. Keep
+    # that grammar mode: treating `as const` as JavaScript can make endpoint
+    # resolution fail while provenance still consumes the literal, silently
+    # certifying a required-profile send.
+    # Astro frontmatter is TypeScript-capable by default; JavaScript remains a
+    # valid subset, so using the TS grammar avoids consuming an endpoint literal
+    # while failing to resolve a legal `as const` alias.
+    if suffix == ".astro":
+        return ".ts"
+    if suffix in {".vue", ".svelte"}:
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            source = ""
+        if re.search(
+            r"<script\b[^>]*\blang\s*=\s*(?:(['\"])(?:ts|typescript)\1|(?:ts|typescript)(?=\s|>))",
+            source,
+            re.I,
+        ):
+            return ".ts"
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
+
+
+def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
+    """Preserve offsets/newlines while retaining only executable ranges."""
+    keep = bytearray(len(source))
+    for start, end in ranges:
+        keep[start:end] = b"\x01" * (end - start)
+    return "".join(
+        char if char in "\r\n" or keep[index] else " "
+        for index, char in enumerate(source)
+    )
+
+
+def _balanced_brace_ranges(source: str, openings: list[int]) -> list[tuple[int, int]]:
+    """Return quote-aware inner spans for balanced template expressions."""
+
+    ranges: list[tuple[int, int]] = []
+    for opening in openings:
+        depth = 0
+        quote = ""
+        escaped = False
+        for index in range(opening, len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+                continue
+            if character in {"'", '"', "`"}:
+                quote = character
+            elif character == "{":
+                depth += 1
+            elif character == "}":
+                depth -= 1
+                if depth == 0:
+                    ranges.append((opening + 1, index))
+                    break
+    return ranges
+
+
+def _balanced_parenthesis_ranges(
+    source: str, openings: list[int]
+) -> list[tuple[int, int]]:
+    """Return quote-aware inner spans for balanced parenthesized expressions."""
+
+    ranges: list[tuple[int, int]] = []
+    for opening in openings:
+        depth = 0
+        quote = ""
+        escaped = False
+        for index in range(opening, len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+                continue
+            if character in {"'", '"', "`"}:
+                quote = character
+            elif character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+                if depth == 0:
+                    ranges.append((opening + 1, index))
+                    break
+    return ranges
+
+
+def _javascript_template_expression_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable `${...}` spans inside one JavaScript template literal."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("${", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        probe = marker - 1
+        while probe >= start and source[probe] == "\\":
+            backslashes += 1
+            probe -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        balanced = _balanced_brace_ranges(source, [marker + 1])
+        if not balanced or balanced[0][1] > end:
+            break
+        ranges.append(balanced[0])
+        cursor = balanced[0][1] + 1
+    return ranges
+
+
+def executable_source(path: Path, source: str) -> str:
+    """Extract executable host-language regions from mixed template files."""
+    suffix = path.suffix.lower()
+    ranges: list[tuple[int, int]] = []
+    if suffix in {".vue", ".svelte", ".astro"}:
+        # Comments may contain complete, syntactically valid examples. Preserve
+        # their offsets/newlines but remove their contents before discovering
+        # script blocks, handlers, interpolations, or balanced expressions.
+        template_source = re.sub(
+            r"<!--.*?-->",
+            lambda match: "".join(
+                char if char in "\r\n" else " " for char in match.group(0)
+            ),
+            source,
+            flags=re.DOTALL,
+        )
+        ranges.extend(
+            match.span(1)
+            for match in re.finditer(
+                r"<script\b[^>]*>(.*?)</script\s*>", template_source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+        )
+        if suffix == ".astro":
+            frontmatter = re.match(
+                r"\A\s*---\s*\r?\n(.*?)\r?\n---(?:\s*\r?\n|\Z)",
+                template_source,
+                re.DOTALL,
+            )
+            if frontmatter:
+                ranges.append(frontmatter.span(1))
+        if suffix == ".vue":
+            ranges.extend(
+                match.span("expression")
+                for match in re.finditer(
+                    r"(?:v-on:[\w:-]+|@[\w:-]+)(?:\.[\w-]+)*\s*=\s*"
+                    r"(?P<quote>['\"])(?P<expression>.*?)(?P=quote)",
+                    template_source,
+                    re.DOTALL,
+                )
+            )
+            # Vue interpolations may contain nested object literals. A
+            # non-greedy regex leaves such calls unterminated; balance the
+            # entire double-brace region and retain its inner expression.
+            for opening in (
+                match.start() for match in re.finditer(r"\{\{", template_source)
+            ):
+                balanced = _balanced_brace_ranges(template_source, [opening])
+                if balanced:
+                    _, closing = balanced[0]
+                    ranges.append((opening + 2, closing - 1))
+        else:
+            # Svelte event handlers / expressions and Astro template
+            # expressions are executable JavaScript outside <script> too.
+            # Preserve their complete balanced spans, including nested payload
+            # objects, rather than stopping at the first closing brace.
+            expression_source = re.sub(
+                r"<style\b[^>]*>.*?</style\s*>",
+                lambda match: "".join(
+                    char if char in "\r\n" else " " for char in match.group(0)
+                ),
+                template_source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            openings = [
+                match.start()
+                for match in re.finditer(r"\{", expression_source)
+            ]
+            ranges.extend(_balanced_brace_ranges(expression_source, openings))
+    elif suffix == ".cshtml":
+        # Razor is a mixed HTML/C# template. Retain explicit expressions,
+        # statement/code blocks, and single-line directives while blanking page
+        # markup so text such as `<p>VoiceResponse()</p>` is not treated as C#.
+        brace_openings = [
+            match.end() - 1
+            for match in re.finditer(
+                r"(?<!@)@(?:\s*|(?:code|functions)\s*)\{",
+                source,
+                flags=re.IGNORECASE,
+            )
+        ]
+        brace_openings.extend(
+            match.end() - 1
+            for match in re.finditer(
+                r"(?<!@)@(?:if|for|foreach|while|switch|try|catch|finally|using|lock)\b[^{}]*\{",
+                source,
+                flags=re.IGNORECASE,
+            )
+        )
+        ranges.extend(_balanced_brace_ranges(source, brace_openings))
+        paren_openings = [
+            match.end() - 1
+            for match in re.finditer(r"(?<!@)@\s*\(", source)
+        ]
+        ranges.extend(_balanced_parenthesis_ranges(source, paren_openings))
+        ranges.extend(
+            match.span()
+            for match in re.finditer(
+                r"(?m)^\s*@(?:using|inject|model|inherits|implements|namespace|addTagHelper|removeTagHelper|tagHelperPrefix)\b[^\r\n]*",
+                source,
+            )
+        )
+    elif suffix == ".phtml":
+        # PHTML is a mixed HTML/PHP template, not a plain PHP source file.
+        # Feeding its markup to the PHP lexer lets an apostrophe in page text
+        # open a string that masks a later request inside <?php ... ?>.
+        ranges.extend(
+            match.span(1)
+            for match in re.finditer(
+                r"<\?(?:php\b|=)(.*?)(?:\?>|\Z)",
+                source,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+        )
+    elif suffix in {".ejs", ".erb", ".jsp"}:
+        if suffix == ".ejs":
+            # EJS scriptlets execute on the server, while ordinary <script>
+            # blocks execute in the generated browser page. Both can contain
+            # migration-sensitive JavaScript and must remain visible.
+            ranges.extend(
+                match.span(1)
+                for match in re.finditer(
+                    r"<script\b[^>]*>(.*?)</script\s*>", source,
+                    flags=re.IGNORECASE | re.DOTALL,
+                )
+            )
+        for match in re.finditer(
+            r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL
+        ):
+            # ERB/EJS <%# ... %> and JSP <%-- ... --%> are template
+            # comments, not executable scriptlets.
+            if source.startswith(("<%#", "<%--"), match.start()):
+                continue
+            ranges.append(match.span(1))
+    else:
+        return source
+    return _blank_outside_ranges(source, ranges)
+
+
+def backend_executable_source(path: Path, source: str) -> str:
+    """Return executable regions that can declare server-side handlers."""
+    if path.suffix.lower() != ".ejs":
+        return executable_source(path, source)
+    ranges: list[tuple[int, int]] = []
+    for match in re.finditer(r"<%(?!%)(?:[=#-])?(.*?)(?:[-]?%>)", source, re.DOTALL):
+        if source.startswith("<%#", match.start()):
+            continue
+        ranges.append(match.span(1))
+    return _blank_outside_ranges(source, ranges)
 # Kept in step with the EXCLUDE_DIRS list in scan-twilio-usage.sh. Generated
 # output belongs here as much as node_modules: a stale compiled bundle under
 # .next carrying a pre-fix number-pool send would fail Phase 4 after the
@@ -612,6 +887,30 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         _blank(code, string_start, index)
+        if delimiter == "`" and suffix in JS_TS_SUFFIXES:
+            # JavaScript template literal text is inert, but every `${...}`
+            # interpolation is executable JavaScript. Recursively lex those
+            # spans and restore their code/comments at the original offsets.
+            # Nested string tokens are recorded before the enclosing template
+            # token so lookups inside an interpolation select the narrow token.
+            for expression_start, expression_end in _javascript_template_expression_ranges(
+                source, contents_start, contents_end
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
@@ -3517,13 +3816,20 @@ def client_base_url(lexed: LexedSource, call: Call, suffix: str) -> str | None:
             return base
 
     if receiver is None:
-        region = _paren_group_span_before_accessor(lexed, call)
-        return _base_url_in_region(lexed, region) if region is not None else None
+        # `axios.post(...)` has no client instance receiver. Use the dotted
+        # callee prefix so `axios.defaults.baseURL = ...` participates in the
+        # same member-assignment resolution as an axios instance.
+        prefix = re.split(r"->|::|\.", callee)[0] if "." in callee else ""
+        if prefix and re.fullmatch(r"[a-z_]\w*", prefix):
+            receiver = prefix
+        else:
+            region = _paren_group_span_before_accessor(lexed, call)
+            return _base_url_in_region(lexed, region) if region is not None else None
 
-    # C# commonly configures HttpClient in a separate member assignment:
-    # `client.BaseAddress = new Uri("..."); client.PostAsync(path, ...)`.
+    # C# and Axios both support assigning a base URL after construction.
     member_base_pattern = re.compile(
-        rf"\b{re.escape(receiver)}\s*\.\s*BaseAddress\s*="
+        rf"\b{re.escape(receiver)}\s*\.\s*"
+        rf"(?:BaseAddress|(?:defaults\s*\.\s*)?base[Uu][Rr][LlIi]?)\s*="
     )
     member_base = list(
         member_base_pattern.finditer(lexed.code, 0, call.start)
@@ -8787,7 +9093,7 @@ def iter_source_files(project_root: Path):
                 continue
             path = Path(directory, filename)
             suffix = path.suffix.lower()
-            if suffix in INCLUDED_SUFFIXES:
+            if suffix in INCLUDED_SUFFIXES or filename.lower() == "rakefile":
                 yield path
             elif not suffix and shebang_suffix(path) is not None:
                 yield path
@@ -9630,12 +9936,13 @@ def required_path_tokens(lexed: LexedSource) -> list[StringToken]:
         tail = token.contents.rstrip("/")
         if re.search(r"\s", tail):
             continue
-        if (
-            required_endpoint(token.contents)
-            or tail.endswith("messages/number_pool")
-            or tail.endswith("messages/alphanumeric_sender_id")
-            or re.search(r"(?:number_pool|alphanumeric_sender_id)\b", tail)
-        ):
+        template_endpoint = re.fullmatch(
+            r"(?:\$\{[^{}\s]+\}|#\{[^{}\s]+\}|\{[^{}\s]+\})"
+            r"(?:/v2)?/messages/(?:number_pool|alphanumeric_sender_id)/?"
+            r"(?:[?#][^\s]*)?",
+            tail,
+        )
+        if required_endpoint(token.contents) or template_endpoint:
             found.append(token)
     return found
 
@@ -9752,27 +10059,19 @@ def unresolved_endpoint_tokens(
     file either way.
     """
     consumed: set[tuple[int, int]] = set()
-    unexplained_calls = 0
     for call in analysed_calls:
         tokens = consumed_endpoint_tokens(lexed, call, suffix)
         if tokens:
             consumed |= tokens
-        else:
-            # The analyzer resolved this call's endpoint through a path this
-            # consumption model does not mirror - a destructuring default, an
-            # interprocedural alias, a computed member. It still ACCOUNTED for
-            # one endpoint, so it explains one otherwise-unconsumed literal.
-            # Budgeting them this way keeps two independent sends independent:
-            # a file with two endpoint literals and one resolved call still
-            # reports the second.
-            unexplained_calls += 1
     candidates = [
         token
         for token in required_path_tokens(lexed)
         if (token.start, token.end) not in consumed
         and _looks_like_a_send_target(lexed, token, suffix)
     ]
-    return candidates[unexplained_calls:] if unexplained_calls else candidates
+    # Never use one call as a positional "budget" for an unrelated literal.
+    # Only provenance from that exact call may consume a candidate endpoint.
+    return candidates
 
 
 # A required path can appear WITHOUT being a request target: as a curl -d body,
@@ -9855,6 +10154,14 @@ _NOT_A_CALL_VERB_RE = re.compile(
     r"|catch|except|with|return|and|or|not|in|is)$",
     re.I,
 )
+_READ_VERB_RE = re.compile(
+    r"^(?:get|head|options|read|download|list|find|query)(?:Async)?$", re.I
+)
+_ASSERTION_VERB_RE = re.compile(
+    r"^(?:expect|assert\w*|should|toBe|toEqual|toHaveBeenCalledWith"
+    r"|assertEqual|assertIn|is_expected)$",
+    re.I,
+)
 # A display STATEMENT has no parentheses to enclose the literal: `<?php echo
 # "$url"`, `then echo "$url"`.
 _DISPLAY_STATEMENT_RE = re.compile(
@@ -9870,6 +10177,30 @@ _CALLEE_SPLIT_RE = re.compile(r"\s*(?:->|::|\?\.|\.)\s*")
 _CALLEE_TAIL_RE = re.compile(
     r"[A-Za-z_$][\w$]*(?:\s*(?:->|::|\?\.|\.)\s*[A-Za-z_$][\w$]*)*$"
 )
+
+
+def _enclosing_call_verbs(lexed: LexedSource, position: int) -> list[str]:
+    """Return innermost-to-outermost unclosed call verbs at `position`."""
+
+    window_start = max(0, position - 600)
+    prefix = lexed.code[window_start:position]
+    depth = 0
+    verbs: list[str] = []
+    for index in range(len(prefix) - 1, -1, -1):
+        char = prefix[index]
+        if char in ")]}":
+            depth += 1
+        elif char in "([{":
+            if depth:
+                depth -= 1
+                continue
+            if char != "(":
+                continue
+            head = lexed.original[window_start:window_start + index].rstrip()
+            match = _CALLEE_TAIL_RE.search(head)
+            if match is not None:
+                verbs.append(_CALLEE_SPLIT_RE.split(match.group(0))[-1])
+    return verbs
 
 
 def _enclosing_call_verb(lexed: LexedSource, position: int) -> str:
@@ -9991,6 +10322,28 @@ def _looks_like_a_send_target(
             if _SEND_SITE_RE.search(line):
                 return True
         return False
+    # Use the lexical call enclosure before falling back to a physical line.
+    # A custom request call commonly wraps its URL onto the next line; limiting
+    # this check to the URL's line silently certified such unknown clients.
+    # The nearest call can be a helper nested inside an OUTER assertion, e.g.
+    # `assertTrue(required_endpoint(URL))`. Consider every enclosing call before
+    # treating the innermost unknown helper as a send.
+    if any(
+        _ASSERTION_VERB_RE.match(verb)
+        for verb in _enclosing_call_verbs(lexed, token.start)
+    ):
+        return False
+    enclosing_verb = _enclosing_call_verb(lexed, token.start)
+    if enclosing_verb:
+        if (
+            _DISPLAY_VERB_RE.match(enclosing_verb)
+            or _INSPECTION_VERB_RE.match(enclosing_verb)
+            or _NOT_A_CALL_VERB_RE.match(enclosing_verb)
+            or _READ_VERB_RE.match(enclosing_verb)
+            or _ASSERTION_VERB_RE.match(enclosing_verb)
+        ):
+            return False
+        return True
     # Otherwise require a request-like call on the same logical line, and NOT a
     # display command, which is how prose mentions reach the source.
     line_start = lexed.code.rfind("\n", 0, token.start) + 1
@@ -10045,6 +10398,7 @@ def _looks_like_a_send_target(
 
 def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = path.read_text(encoding="utf-8", errors="replace")
+    source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
     sdk_calls = calls_matching(lexed, SDK_CALL_RE)
@@ -10185,10 +10539,50 @@ def region_has_message_body(
     return False
 
 
-def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
+def call_belongs_to_kept_product(
+    lexed: LexedSource,
+    call: Call,
+    kept_products: set[str],
+    pattern: re.Pattern[str],
+) -> bool:
+    """Recognize product-qualified calls that intentionally remain on Twilio."""
+
+    call_head = lexed.code[call.start:call.open_paren]
+    # A retained Twilio Messaging client uses messages.create({body: ...}).
+    # Do not waive Telnyx-only messages.send({body: ...}) calls in the same
+    # hybrid file.
+    if pattern is MESSAGE_BODY_CALL_RE and "messaging" in kept_products and re.search(
+        r"\bcreate\s*$", call_head, re.IGNORECASE
+    ):
+        return True
+
+    if "conversations" not in kept_products and "conversation" not in kept_products:
+        return False
+
+    # Bind the waiver to the immediate receiver of `.messages`, not to any
+    # conversation-looking identifier earlier on the line. Preserve newlines
+    # inside a fluent `client.conversations(id)\n  .messages.create(...)` chain.
+    statement_start = max(
+        lexed.code.rfind(";", 0, call.start),
+        lexed.code.rfind("{", 0, call.start),
+        lexed.code.rfind("}", 0, call.start),
+    ) + 1
+    receiver = lexed.code[statement_start:call.start].strip()
+    return bool(
+        re.search(r"(?:^|[^\w$])(?:conversation|channel)\s*$", receiver, re.I)
+        or re.search(
+            r"\.\s*conversations?\s*\([^;{}]*\)\s*$", receiver, re.I
+        )
+    )
+
+
+def message_body_fields(
+    path: Path, pattern: re.Pattern[str], kept_products: set[str] | None = None
+) -> list[str]:
     """Return real top-level body fields from selected messaging calls."""
 
     source = path.read_text(encoding="utf-8", errors="replace")
+    source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
     source_resolver = SourceEndpointResolver(lexed, suffix)
@@ -10201,6 +10595,10 @@ def message_body_fields(path: Path, pattern: re.Pattern[str]) -> list[str]:
     )
     matches: list[str] = []
     for call in calls_matching(lexed, pattern):
+        if call_belongs_to_kept_product(
+            lexed, call, kept_products or set(), pattern
+        ):
+            continue
         states = [
             resolver.span_presence(start, end, call.start)
             for start, end in payload_spans(
@@ -10221,22 +10619,43 @@ def main(argv: list[str]) -> int:
         "--twilio-body-fields": TWILIO_MESSAGE_CREATE_RE,
         "--message-body-fields": MESSAGE_BODY_CALL_RE,
     }
-    if len(argv) == 3 and argv[1] in source_modes:
-        project_root = Path(argv[2]).resolve()
+    if len(argv) in {3, 5} and argv[1] in source_modes:
+        kept_products: set[str] = set()
+        if len(argv) == 5:
+            if argv[2] != "--kept-products":
+                print("Error: expected --kept-products", file=sys.stderr)
+                return 2
+            kept_products = {
+                product.strip().lower()
+                for product in argv[3].split(",")
+                if product.strip()
+            }
+        project_root = Path(argv[-1]).resolve()
         if not project_root.is_dir():
             print(f"Error: '{project_root}' is not a directory", file=sys.stderr)
             return 2
-        findings = [
-            finding
-            for path in iter_source_files(project_root)
-            for finding in message_body_fields(path, source_modes[argv[1]])
-        ]
+        findings: list[str] = []
+        for path in iter_source_files(project_root):
+            try:
+                findings.extend(
+                    message_body_fields(path, source_modes[argv[1]], kept_products)
+                )
+            except Exception as error:  # noqa: BLE001 - fail safe per file
+                findings.append(
+                    finding_row(
+                        path,
+                        1,
+                        f"  [could not analyze this file "
+                        f"({type(error).__name__}) - verify body fields manually]",
+                    )
+                )
         print("\n".join(findings))
         return 0
     if len(argv) != 2:
         print(
             f"Usage: {Path(argv[0]).name} "
-            "[--twilio-body-fields|--message-body-fields] <project-root>",
+            "[--twilio-body-fields|--message-body-fields] "
+            "[--kept-products <csv>] <project-root>",
             file=sys.stderr,
         )
         return 2

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -10898,16 +10898,95 @@ def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
 
     lexed = lex_source(source, suffix)
     visible = lexed.without_comments
-    escaped = re.escape(name)
     if suffix in JS_TS_SUFFIXES:
-        assignment = re.search(
+        def literal(
+            pattern: str, separator: str = r"\s*=\s*"
+        ) -> str | None:
+            match = re.search(
+                pattern
+                + separator
+                + r"(?P<quote>['\"`])(?P<value>.*?)(?P=quote)",
+                visible,
+                re.S,
+            )
+            if match is None:
+                return None
+            value = match.group("value")
+            if match.group("quote") == "`" and "${" in value:
+                return None
+            return value
+
+        def local_literal(local: str) -> str | None:
+            escaped_local = re.escape(local)
+            return literal(
+                rf"\b(?:const|let|var)\s+{escaped_local}"
+            )
+
+        if name == "default":
+            direct = literal(r"\bexport\s+default", r"\s+")
+            if direct is None:
+                direct = literal(
+                    r"(?:\b(?:module\s*\.\s*)?exports\s*\.\s*default|"
+                    r"\bmodule\s*\.\s*exports)"
+                )
+            if direct is not None:
+                return direct
+            alias = re.search(
+                r"(?:\bexport\s+default\s+"
+                r"|\bmodule\s*\.\s*exports\s*=\s*"
+                r"|\b(?:module\s*\.\s*)?exports\s*\.\s*default\s*=\s*)"
+                r"(?P<local>[A-Za-z_$]\w*)\b"
+                r"|\bexport\s*\{\s*(?P<braced>[A-Za-z_$]\w*)"
+                r"\s+as\s+default\s*\}",
+                visible,
+            )
+            if alias is not None:
+                return local_literal(alias.group("local") or alias.group("braced"))
+            for export_list in re.finditer(
+                r"\bexport\s*\{(?P<members>[^{}]*)\}", visible
+            ):
+                for member in export_list.group("members").split(","):
+                    parsed = re.fullmatch(
+                        r"\s*(?P<local>[A-Za-z_$]\w*)\s+as\s+default\s*",
+                        member,
+                    )
+                    if parsed is not None:
+                        return local_literal(parsed.group("local"))
+            return None
+        if name == "<module>":
+            direct = literal(r"\bmodule\s*\.\s*exports")
+            if direct is not None:
+                return direct
+            alias = re.search(
+                r"\bmodule\s*\.\s*exports\s*=\s*"
+                r"(?P<local>[A-Za-z_$]\w*)\b",
+                visible,
+            )
+            return local_literal(alias.group("local")) if alias is not None else None
+
+        escaped = re.escape(name)
+        direct = literal(
             rf"(?:\bexport\s+(?:const|let|var)\s+{escaped}"
             rf"|\b(?:module\s*\.\s*)?exports\s*\.\s*{escaped})"
-            r"\s*=\s*(['\"])(?P<value>.*?)\1",
-            visible,
-            re.S,
         )
+        if direct is not None:
+            return direct
+        for export_list in re.finditer(
+            r"\bexport\s*\{(?P<members>[^{}]*)\}", visible
+        ):
+            for member in export_list.group("members").split(","):
+                parsed = re.fullmatch(
+                    rf"\s*(?P<local>[A-Za-z_$]\w*)"
+                    rf"(?:\s+as\s+{escaped})?\s*",
+                    member,
+                )
+                if parsed is not None and (
+                    " as " in member or parsed.group("local") == name
+                ):
+                    return local_literal(parsed.group("local"))
+        return None
     elif suffix == ".py":
+        escaped = re.escape(name)
         assignment = re.search(
             rf"(?m)^[ \t]*{escaped}\s*=\s*(['\"])(?P<value>.*?)\1",
             visible,
@@ -10931,7 +11010,17 @@ def external_static_values(
     imports: list[tuple[str, str, str]] = []
     if suffix in JS_TS_SUFFIXES:
         for match in re.finditer(
-            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
+            r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
+            r"from\s*(['\"])(?P<module>\.[^'\"]*)\2",
+            visible,
+        ):
+            imports.append(
+                (match.group("module"), "default", match.group("local"))
+            )
+        for match in re.finditer(
+            r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+            r"\{(?P<members>[^{}]*)\}\s*from\s*"
             r"(['\"])(?P<module>\.[^'\"]*)\2",
             visible,
         ):
@@ -10949,6 +11038,19 @@ def external_static_values(
                             parsed.group("local") or parsed.group("export"),
                         )
                     )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+(?P<local>[A-Za-z_$]\w*)\s*=\s*"
+            r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)"
+            r"(?P<default>\s*\.\s*default)?",
+            visible,
+        ):
+            imports.append(
+                (
+                    match.group("module"),
+                    "default" if match.group("default") else "<module>",
+                    match.group("local"),
+                )
+            )
         for match in re.finditer(
             r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
             r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)",
@@ -11022,8 +11124,18 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
     visible = lex_source(source, suffix).without_comments
     names: set[str] = set()
     if suffix in JS_TS_SUFFIXES:
+        names.update(
+            match.group("local")
+            for match in re.finditer(
+                r"\bimport\s+(?P<local>[A-Za-z_$]\w*)\s*"
+                r"(?:,\s*(?:\{[^{}]*\}|\*\s+as\s+[A-Za-z_$]\w*)\s*)?"
+                r"from\s*(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
         for match in re.finditer(
-            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+            r"\{(?P<members>[^{}]*)\}\s*from\s*"
             r"(['\"])\.[^'\"]*\2",
             visible,
         ):
@@ -11037,7 +11149,8 @@ def external_reference_names(source: str, suffix: str) -> set[str]:
         names.update(
             match.group(1)
             for match in re.finditer(
-                r"\bimport\s+\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
+                r"\bimport\s+(?:[A-Za-z_$]\w*\s*,\s*)?"
+                r"\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
                 r"(['\"])\.[^'\"]*\2",
                 visible,
             )

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -2872,21 +2872,59 @@ def ruby_request_body_spans(
     arrives in a later statement as `req.body = ...`, so the constructor's own
     arguments never reveal it.
     """
-    line_start = lexed.code.rfind("\n", 0, call.start) + 1
+    # Ruby permits several statements on one line.  Starting at the physical
+    # line boundary makes `uri = ...; req = Post.new(uri)` bind the request to
+    # `uri`, and reading the body through the next newline absorbs every later
+    # compact statement.  Use logical statement boundaries in both directions.
+    line_start = max(
+        lexed.code.rfind("\n", 0, call.start),
+        lexed.code.rfind(";", 0, call.start),
+    ) + 1
     binding = re.search(
-        r"([A-Za-z_]\w*)\s*=", lexed.code[line_start:call.start]
+        r"(?<![\w@$.])((?:@@|@|\$)?[A-Za-z_]\w*)\s*=",
+        lexed.code[line_start:call.start],
     )
     if binding is None:
         return []
     name = re.escape(binding.group(1))
-    match = re.search(
-        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*", lexed.code[call.end:]
+    local_binding = not binding.group(1).startswith(("@", "$"))
+    ruby_spans = _ruby_function_spans(lexed.code)
+
+    # A later body assignment is relevant only if it reaches the execution of
+    # THIS request in the SAME Ruby method.  Without both bounds, a helper's
+    # body assignment could satisfy a top-level send, or an assignment after
+    # `http.request(req)` could retroactively make the already-issued request
+    # look compliant.
+    execution_pattern = re.compile(
+        rf"\.\s*request\s*(?:\(\s*{name}\b|[ \t]+{name}\b)"
     )
-    if match is None:
+    execution_offset = None
+    for execution in execution_pattern.finditer(lexed.code, call.end):
+        if not local_binding or _same_ruby_function_scope(
+            lexed.code, call.start, execution.start(), ruby_spans
+        ):
+            execution_offset = execution.start()
+            break
+    if execution_offset is None:
         return []
-    start = call.end + match.end()
-    end = lexed.code.find("\n", start)
-    span = (start, end if end > 0 else len(lexed.code))
+
+    body_pattern = re.compile(
+        rf"(?<![\w.]){name}\s*\.\s*body\s*=\s*"
+    )
+    assignments = [
+        match
+        for match in body_pattern.finditer(
+            lexed.code, call.end, execution_offset
+        )
+        if not local_binding
+        or _same_ruby_function_scope(
+            lexed.code, call.start, match.start(), ruby_spans
+        )
+    ]
+    if not assignments:
+        return []
+    start = assignments[-1].end()
+    span = (start, assignment_end(lexed, start, suffix))
     return [resolve_wrapped_payload(lexed, span, span[0], suffix)]
 
 
@@ -4270,35 +4308,166 @@ _EXECUTION_LINK_RE = {
 _INLINE_EXECUTION_RE = re.compile(
     # The constructor may be namespaced inside the execution call, as in
     # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
-    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
+    r"(?:urlopen|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
     r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
 )
 
 
 def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
-    """Return conservative Ruby `def ... end` spans from masked source."""
+    """Return Ruby local-scope spans for methods, classes, and modules."""
 
     stack: list[tuple[str, int | None]] = []
     spans: list[tuple[int, int]] = []
-    cursor = 0
-    for line in code.splitlines(keepends=True):
-        stripped = line.strip()
+    # Newlines and semicolons are equivalent Ruby statement separators.  The
+    # old line-only stack leaked executions from `def f; ...; end` into top
+    # level and ignored endless methods (`def f = expr`) altogether.
+    boundaries = list(re.finditer(r"[;\r\n]", code))
+    pieces: list[tuple[int, int, int]] = []
+    start = 0
+    for boundary in boundaries:
+        pieces.append((start, boundary.start(), boundary.end()))
+        start = boundary.end()
+    pieces.append((start, len(code), len(code)))
+
+    for statement_start, statement_end, terminated_end in pieces:
+        statement = code[statement_start:statement_end]
+        stripped = statement.strip()
+        if not stripped:
+            continue
+        content_start = statement_start + len(statement) - len(statement.lstrip())
         if re.match(r"end\b", stripped) and stack:
-            kind, start = stack.pop()
-            if kind == "def" and start is not None:
-                spans.append((start, cursor + len(line)))
+            kind, opener_start = stack.pop()
+            if kind in {"def", "class", "module"} and opener_start is not None:
+                spans.append((opener_start, terminated_end))
         else:
-            opener = re.match(r"(def|class|module)\b", stripped)
+            opener = re.match(
+                r"(?:(?:private|protected|public)\s+)?(?P<def>def)\b"
+                r"|(?P<container>class|module)\b",
+                stripped,
+            )
             if opener is not None:
-                stack.append((opener.group(1), cursor))
+                kind = "def" if opener.group("def") else opener.group("container")
+                if kind == "def":
+                    separator = top_level_assignment_separator(
+                        stripped, opener.end(), len(stripped)
+                    )
+                    # A setter's name owns its adjacent `=` (`writer=`, `[]=`).
+                    # It is an ordinary `def ... end` unless a SECOND top-level
+                    # `=` follows its parameter list, as in an endless setter.
+                    setter = False
+                    if separator is not None:
+                        left, right = separator
+                        setter = left > 0 and not stripped[left - 1].isspace()
+                        if setter:
+                            later = top_level_assignment_separator(
+                                stripped, right, len(stripped)
+                            )
+                            if later is not None:
+                                separator = later
+                                setter = False
+                    if separator is not None and not setter:
+                        spans.append((content_start, statement_end))
+                        continue
+                stack.append((kind, content_start))
             elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
                 stack.append(("block", None))
             elif re.match(
                 r"(?:if|unless|case|begin|for|while|until)\b", stripped
             ):
                 stack.append(("control", None))
-        cursor += len(line)
     return spans
+
+
+def _enclosing_named_call(
+    code: str, position: int, name: str
+) -> tuple[int, int] | None:
+    """Return `(open, close)` for the innermost named call around position."""
+
+    candidate: tuple[int, int] | None = None
+    pattern = re.compile(rf"\b{re.escape(name)}\s*\(")
+    for match in pattern.finditer(code, 0, position):
+        opening = code.rfind("(", match.start(), match.end())
+        closing = matching_delimiter(code, opening, "(", ")")
+        if closing is not None and opening < position < closing:
+            candidate = (opening, closing)
+    return candidate
+
+
+def _inline_okhttp_is_executed(lexed: LexedSource, call: Call) -> bool:
+    """An inline OkHttp request is live only after execute()/enqueue()."""
+
+    enclosing = _enclosing_named_call(lexed.code, call.start, "newCall")
+    if enclosing is None:
+        return False
+    tail = lexed.code[enclosing[1] + 1 : enclosing[1] + 80]
+    if re.match(
+        r"\s*(?:\?|!!)?\s*\.\s*(?:execute|enqueue)\s*\(", tail
+    ) is not None:
+        return True
+
+    # The Call itself may be stored before execution:
+    #   Call pending = client.newCall(new Request.Builder()...build());
+    #   pending.execute();
+    statement_start = max(
+        lexed.code.rfind(";", 0, enclosing[0]),
+        lexed.code.rfind("\n", 0, enclosing[0]),
+        lexed.code.rfind("{", 0, enclosing[0]),
+    ) + 1
+    prefix = lexed.code[statement_start:enclosing[0]]
+    assignment = re.search(
+        r"(?:(?:final|public|private|protected|static)\s+)*"
+        r"(?:[\w.<>,?\[\]]+\s+)?(?P<alias>[A-Za-z_]\w*)\s*=\s*"
+        r"[^;\n]*\bnewCall\s*$",
+        prefix,
+    )
+    if assignment is None:
+        return False
+    alias = assignment.group("alias")
+    after = enclosing[1] + 1
+    execution = re.search(
+        rf"(?<![\w$]){re.escape(alias)}\s*(?:\?|!!)?\s*\.\s*"
+        rf"(?:execute|enqueue)\s*\(",
+        lexed.code[after:],
+    )
+    if execution is None:
+        return False
+    execution_offset = after + execution.start()
+    return re.search(
+        rf"(?<![\w$]){re.escape(alias)}\s*=(?!=)",
+        lexed.code[after:execution_offset],
+    ) is None
+
+
+def _stored_okhttp_execution_offsets(
+    tail: str, request_name: str
+) -> list[tuple[int, int]]:
+    """`(execution, capture)` offsets for stored OkHttp Call aliases."""
+
+    offsets: list[tuple[int, int]] = []
+    assignment_re = re.compile(
+        rf"(?:^|[;\n{{}}])\s*(?:(?:final|public|private|protected|static)\s+)*"
+        rf"(?:[\w.<>,?\[\]]+\s+)?"
+        rf"(?P<alias>[A-Za-z_]\w*)\s*=\s*[^;\n]*?"
+        rf"\bnewCall\s*\(\s*{re.escape(request_name)}\s*\)"
+    )
+    for assignment in assignment_re.finditer(tail):
+        alias = assignment.group("alias")
+        after = assignment.end()
+        execution = re.search(
+            rf"(?<![\w$]){re.escape(alias)}\s*(?:\?|!!)?\s*\.\s*"
+            rf"(?:execute|enqueue)\s*\(",
+            tail[after:],
+        )
+        if execution is None:
+            continue
+        execution_offset = after + execution.start()
+        rebound = re.search(
+            rf"(?<![\w$]){re.escape(alias)}\s*=(?!=)",
+            tail[after:execution_offset],
+        )
+        if rebound is None:
+            offsets.append((execution_offset, assignment.start()))
+    return offsets
 
 
 def _same_ruby_function_scope(
@@ -4328,7 +4497,13 @@ def request_object_is_executed(
     if pattern is None:
         return True
 
-    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)).
+    # Inline: urlopen(Request(...)) / client.Do(http.NewRequest(...)). OkHttp's
+    # newCall(...) only creates a Call; network I/O begins at execute/enqueue.
+    if canonical == ".java" and _BUILDER_LINK_KIND.get(
+        (id(lexed), call.start)
+    ) == "url":
+        if _inline_okhttp_is_executed(lexed, call):
+            return True
     prefix = lexed.code[max(0, call.start - 160):call.start]
     if _INLINE_EXECUTION_RE.search(prefix):
         return True
@@ -4347,7 +4522,7 @@ def request_object_is_executed(
         # An UNBOUND chain can still be executed inline:
         #   client.send(HttpRequest.newBuilder()...build(), handler)
         return re.search(
-            r"(?:send|sendAsync|newCall|execute|enqueue|urlopen|Do)\s*\(", head
+            r"(?:send|sendAsync|execute|enqueue|urlopen|Do)\s*\(", head
         ) is not None
     # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
     # never the one executed, so every candidate must be tried.
@@ -4372,8 +4547,18 @@ def request_object_is_executed(
         rebound_pattern = re.compile(
             rf"{binding_boundary}{re.escape(name)}\s*=(?!=)"
         )
-        for execution in re.finditer(execution_pattern, tail):
-            execution_offset = call.end + execution.start()
+        execution_events = [
+            (execution.start(), execution.start())
+            for execution in re.finditer(execution_pattern, tail)
+        ]
+        if canonical == ".java":
+            execution_events.extend(
+                _stored_okhttp_execution_offsets(tail, name)
+            )
+        for relative_execution_offset, capture_offset in sorted(
+            set(execution_events)
+        ):
+            execution_offset = call.end + relative_execution_offset
             # Ruby locals belong to one method/top-level scope. Instance,
             # class and global variables retain their identity across methods.
             local_ruby_binding = suffix == ".rb" and not name.startswith(
@@ -4387,7 +4572,9 @@ def request_object_is_executed(
             # every exact-binding assignment before THIS execution; for Ruby
             # locals, assignments in unrelated methods do not rebind it.
             rebound = False
-            for candidate in rebound_pattern.finditer(tail, 0, execution.start()):
+            for candidate in rebound_pattern.finditer(
+                tail, 0, capture_offset
+            ):
                 candidate_offset = call.end + candidate.start()
                 if local_ruby_binding and not _same_ruby_function_scope(
                     lexed.code, call.start, candidate_offset, ruby_spans

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -906,6 +906,68 @@ def _shell_command_substitution_ranges(
     return ranges
 
 
+def _php_closing_tag(source: str, start: int) -> int | None:
+    """Return the next PHP closing tag outside strings/comments/heredocs."""
+
+    index = start
+    quote = ""
+    escaped = False
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if source.startswith("/*", index):
+            closing = source.find("*/", index + 2)
+            index = len(source) if closing < 0 else closing + 2
+            continue
+        heredoc = _heredoc_opener_at(source, index, ".php")
+        if heredoc is not None and source.startswith("<<<", index):
+            body_start = source.find("\n", heredoc.end())
+            if body_start < 0:
+                return None
+            terminator = re.compile(
+                rf"^[ \t]*{re.escape(heredoc.group('tag'))}\b[^\r\n]*",
+                re.MULTILINE,
+            ).search(source, body_start + 1)
+            index = len(source) if terminator is None else terminator.end()
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if source.startswith("?>", index):
+            return index
+        index += 1
+    return None
+
+
+def _php_executable_ranges(source: str) -> list[tuple[int, int]]:
+    """Return PHP code regions with lexical, rather than textual, closers."""
+
+    opener = re.compile(
+        r"<\?(?:php\b|=|(?!(?:xml)\b))",
+        re.IGNORECASE,
+    )
+    ranges: list[tuple[int, int]] = []
+    cursor = 0
+    while match := opener.search(source, cursor):
+        start = match.end()
+        closing = _php_closing_tag(source, start)
+        end = len(source) if closing is None else closing
+        ranges.append((start, end))
+        if closing is None:
+            break
+        cursor = closing + 2
+    return ranges
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
@@ -1037,18 +1099,10 @@ def executable_source(path: Path, source: str) -> str:
         # regions whenever tags are present. Tagless `.php` remains supported
         # because many analyzer fixtures and generated snippets contain raw PHP
         # statements without an opening tag; tagless `.phtml` remains markup.
-        php_ranges = [
-            match.span("code")
-            for match in re.finditer(
-                # Plain ``<?`` is executable when short_open_tag is enabled.
-                # Keep XML declarations out: with short tags disabled they are
-                # markup, and with short tags enabled they make the PHP file
-                # invalid rather than forming a customer request.
-                r"<\?(?:php\b|=|(?!(?:xml)\b))(?P<code>.*?)(?:\?>|\Z)",
-                source,
-                flags=re.IGNORECASE | re.DOTALL,
-            )
-        ]
+        # Plain ``<?`` is executable when short_open_tag is enabled. Keep XML
+        # declarations out, and find closing tags lexically: a textual `?>`
+        # inside a PHP string, block comment, heredoc, or nowdoc is data.
+        php_ranges = _php_executable_ranges(source)
         if (
             suffix == ".php"
             and not php_ranges
@@ -1134,11 +1188,15 @@ PROFILE_IDENTIFIER_RE = re.compile(
     rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
 )
 PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
-SDK_METHOD_PATTERN = (
-    r"sendNumberPool|send_number_pool|SendNumberPool|"
-    r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
-    r"SendWithAlphanumericSender"
+SDK_METHOD_NAMES = (
+    "sendNumberPool",
+    "send_number_pool",
+    "SendNumberPool",
+    "sendWithAlphanumericSender",
+    "send_with_alphanumeric_sender",
+    "SendWithAlphanumericSender",
 )
+SDK_METHOD_PATTERN = "|".join(map(re.escape, SDK_METHOD_NAMES))
 SDK_CALL_RE = re.compile(
     rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
     r"\s*(?:\?\.)?\s*\("
@@ -1601,7 +1659,7 @@ def _javascript_regex_can_start(
         # JSX closing tags (`</Panel>` and `</>`) are markup delimiters, not a
         # regexp in the expression position that `<` would otherwise permit.
         return False
-    if character in "([,;:=!?&|^~<>*%":
+    if character in "([{,;:=!?&|^~<>*%":
         return True
     if character in "+-":
         return previous == 0 or code[previous - 1] != character
@@ -2158,6 +2216,70 @@ def sdk_alias_calls(lexed: LexedSource) -> list[Call]:
             if callable_arg == alias and key not in seen:
                 seen.add(key)
                 calls.append(call)
+    return calls
+
+
+def sdk_computed_calls(lexed: LexedSource, suffix: str) -> list[Call]:
+    """Find JS/TS SDK calls with a statically named bracket member.
+
+    The lexer deliberately blanks string literals, so the direct SDK regex
+    cannot see ``messages['sendNumberPool'](...)``. Recover only exact static
+    method-name tokens that are bracket members on a real receiver. Dynamic
+    lookups and object/array literals remain unresolved rather than being
+    misclassified as SDK sends.
+    """
+
+    if suffix not in JS_TS_SUFFIXES:
+        return []
+
+    code = lexed.code
+    calls: list[Call] = []
+    for token in lexed.strings:
+        if token.contents not in SDK_METHOD_NAMES:
+            continue
+
+        opening_bracket = token.start - 1
+        while opening_bracket >= 0 and code[opening_bracket].isspace():
+            opening_bracket -= 1
+        if opening_bracket < 0 or code[opening_bracket] != "[":
+            continue
+
+        receiver_end = opening_bracket - 1
+        while receiver_end >= 0 and code[receiver_end].isspace():
+            receiver_end -= 1
+        if (
+            receiver_end >= 1
+            and code[receiver_end] == "."
+            and code[receiver_end - 1] == "?"
+        ):
+            receiver_end -= 2
+            while receiver_end >= 0 and code[receiver_end].isspace():
+                receiver_end -= 1
+        if receiver_end < 0 or not (
+            code[receiver_end].isalnum()
+            or code[receiver_end] in {"_", "$", "]", ")"}
+        ):
+            continue
+
+        closing_bracket = token.end
+        while closing_bracket < len(code) and code[closing_bracket].isspace():
+            closing_bracket += 1
+        if closing_bracket >= len(code) or code[closing_bracket] != "]":
+            continue
+
+        opening = closing_bracket + 1
+        while opening < len(code) and code[opening].isspace():
+            opening += 1
+        if code.startswith("?.", opening):
+            opening += 2
+            while opening < len(code) and code[opening].isspace():
+                opening += 1
+        if opening >= len(code) or code[opening] != "(":
+            continue
+
+        closing = matching_delimiter(code, opening, "(", ")")
+        if closing is not None:
+            calls.append(Call(opening_bracket, opening, closing + 1))
     return calls
 
 
@@ -12239,7 +12361,11 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix, source_dialect(path))
-    sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
+    sdk_calls = (
+        calls_matching(lexed, SDK_CALL_RE)
+        + sdk_alias_calls(lexed)
+        + sdk_computed_calls(lexed, suffix)
+    )
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     if suffix != ".cs":
         # These PascalCase names are official .NET HttpClient methods. Keeping

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -136,7 +136,10 @@ def canonical_suffix(path: Path) -> str:
         return ".ts"
     if suffix in {".vue", ".svelte"}:
         try:
-            source = path.read_text(encoding="utf-8", errors="replace")
+            with path.open(
+                "r", encoding="utf-8", errors="replace", newline=""
+            ) as source_file:
+                source = source_file.read()
         except OSError:
             source = ""
         if re.search(
@@ -154,7 +157,7 @@ def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
     for start, end in ranges:
         keep[start:end] = b"\x01" * (end - start)
     return "".join(
-        char if char in "\r\n" or keep[index] else " "
+        char if char in "\r\n\u2028\u2029" or keep[index] else " "
         for index, char in enumerate(source)
     )
 
@@ -440,12 +443,14 @@ PROFILE_IDENTIFIER_RE = re.compile(
     rf"(?<![\w$])(?:{PROFILE_NAME_PATTERN})(?!\w)"
 )
 PROFILE_CLI_RE = re.compile(r"--messaging-profile-id(?:\s|=|$)")
-SDK_CALL_RE = re.compile(
-    r"(?:\?\.|\.|->)\s*(?:"
+SDK_METHOD_PATTERN = (
     r"sendNumberPool|send_number_pool|SendNumberPool|"
     r"sendWithAlphanumericSender|send_with_alphanumeric_sender|"
     r"SendWithAlphanumericSender"
-    r")\s*(?:\?\.)?\s*\("
+)
+SDK_CALL_RE = re.compile(
+    rf"(?:\?\.|\.|->)\s*(?:{SDK_METHOD_PATTERN})"
+    r"\s*(?:\?\.)?\s*\("
 )
 FETCH_CALL_RE = re.compile(
     r"(?<![\w$])(?:fetch|request|post_form|postAsync|PostAsync|post|Post|POST|"
@@ -710,8 +715,24 @@ class EndpointFrame:
 
 def _blank(buffer: list[str], start: int, end: int) -> None:
     for index in range(start, end):
-        if buffer[index] != "\n":
+        # Preserve every source line terminator. JavaScript recognizes U+2028
+        # and U+2029 in addition to CR/LF, and all C-style languages accept a
+        # bare CR as a physical line boundary. Replacing one with a space can
+        # merge the comment with executable code on the following line.
+        if buffer[index] not in {"\r", "\n", "\u2028", "\u2029"}:
             buffer[index] = " "
+
+
+def _line_comment_end(source: str, start: int, suffix: str) -> int:
+    """Return the first language-valid line terminator after ``start``."""
+
+    terminators = {"\r", "\n"}
+    if suffix in JS_TS_SUFFIXES:
+        terminators.update({"\u2028", "\u2029"})
+    for index in range(start, len(source)):
+        if source[index] in terminators:
+            return index
+    return len(source)
 
 
 # Heredoc openers: shell/ruby `<<TAG`, `<<-TAG`, `<<~TAG`, `<<'TAG'`; PHP
@@ -777,8 +798,7 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         if c_line_comments and source.startswith("//", index):
-            end = source.find("\n", index + 2)
-            end = len(source) if end < 0 else end
+            end = _line_comment_end(source, index + 2, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)
             index = end
@@ -786,11 +806,10 @@ def lex_source(source: str, suffix: str) -> LexedSource:
 
         if hash_comments and source[index] == "#":
             if suffix == ".sh" and index == 0 and source.startswith("#!", index):
-                end = source.find("\n", index + 2)
-                index = len(source) if end < 0 else end
+                end = _line_comment_end(source, index + 2, suffix)
+                index = end
                 continue
-            end = source.find("\n", index + 1)
-            end = len(source) if end < 0 else end
+            end = _line_comment_end(source, index + 1, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)
             index = end
@@ -866,7 +885,14 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             if honours_escapes and source[index] == "\\":
                 index = min(len(source), index + 2)
                 continue
-            if source[index] == "\n" and line_bounded:
+            if (
+                line_bounded
+                and source[index] in {"\r", "\n", "\u2028", "\u2029"}
+                and (
+                    source[index] in {"\r", "\n"}
+                    or suffix in JS_TS_SUFFIXES
+                )
+            ):
                 # A single/double-quoted JS/TS or Python literal cannot contain a
                 # raw newline, so hitting one means the quote never opened a
                 # string at all (an apostrophe in JSX text, prose, or a comment).
@@ -940,6 +966,118 @@ def calls_matching(lexed: LexedSource, pattern: re.Pattern[str]) -> list[Call]:
             closing = lexed.code.find("\n", opening)
             closing = len(lexed.code) - 1 if closing < 0 else closing
         calls.append(Call(match.start(), opening, closing + 1))
+    return calls
+
+
+def sdk_alias_calls(lexed: LexedSource) -> list[Call]:
+    """Find calls through local aliases of required-profile SDK methods.
+
+    Method values/delegates are ordinary customer code in Python, JS/TS, Go,
+    Java/Kotlin and C#. The direct-call regex cannot see them once the member
+    name is assigned. Track both assignment/bind forms and JS destructuring,
+    and require the defining assignment to remain the nearest one before each
+    call so a later reassignment does not create a false SDK finding.
+    """
+
+    code = lexed.code
+    definitions: list[tuple[str, int]] = []
+    member = re.compile(
+        rf"(?:\?\.|\.|->|::)\s*(?:{SDK_METHOD_PATTERN})(?!\w)"
+    )
+    for match in member.finditer(code):
+        # A direct invocation is already covered by SDK_CALL_RE.
+        after = code[match.end():]
+        if re.match(r"\s*(?:\?\.)?\s*\(", after):
+            continue
+        line_start = max(code.rfind("\n", 0, match.start()), code.rfind(";", 0, match.start())) + 1
+        prefix = code[line_start:match.start()]
+        assignment = re.search(
+            r"(?P<alias>\$?[A-Za-z_][A-Za-z0-9_]*)\s*(?:=|:=)\s*.*$",
+            prefix,
+        )
+        if assignment is not None:
+            definitions.append((assignment.group("alias").lstrip("$"), match.end()))
+
+    # JavaScript/TypeScript/CommonJS destructuring aliases.
+    for match in re.finditer(r"\{(?P<members>[^{}]*)\}\s*=", code):
+        for item in split_arguments(code, match.start("members"), match.end("members")):
+            text = code[slice(*item)].strip()
+            parsed = re.fullmatch(
+                rf"(?P<method>{SDK_METHOD_PATTERN})(?:\s*:\s*(?P<alias>[A-Za-z_$]\w*))?",
+                text,
+            )
+            if parsed is not None:
+                definitions.append(
+                    ((parsed.group("alias") or parsed.group("method")).lstrip("$"), match.end())
+                )
+
+    # Ruby's bound Method and PHP callable-array/Closure forms store the SDK
+    # method name as a symbol or string, so it is intentionally absent from the
+    # masked code view used above. without_comments retains those values while
+    # still excluding prose and comments.
+    visible = lexed.without_comments
+    for match in re.finditer(
+        rf"(?m)^\s*(?P<alias>[A-Za-z_]\w*)\s*=\s*[^\r\n;]*"
+        rf"\.\s*method\s*\(\s*:\s*(?:{SDK_METHOD_PATTERN})\s*\)",
+        visible,
+    ):
+        definitions.append((match.group("alias"), match.end()))
+    for match in re.finditer(
+        rf"(?m)^\s*\$(?P<alias>[A-Za-z_]\w*)\s*=\s*"
+        rf"(?:Closure\s*::\s*fromCallable\s*\(\s*)?\["
+        rf"[^\]\r\n]*,\s*['\"](?:{SDK_METHOD_PATTERN})['\"]\s*\]",
+        visible,
+    ):
+        definitions.append((match.group("alias"), match.end()))
+
+    calls: list[Call] = []
+    seen: set[tuple[int, int]] = set()
+    for alias, definition_end in definitions:
+        invocation_patterns = (
+            re.compile(rf"(?<![\w$.>])\$?{re.escape(alias)}\s*\("),
+            re.compile(
+                rf"(?<![\w$])\$?{re.escape(alias)}\s*(?:\.|->)\s*"
+                r"(?:call|apply|accept|invoke|Invoke)\s*\("
+            ),
+        )
+        invocations = sorted(
+            (
+                match
+                for pattern in invocation_patterns
+                for match in pattern.finditer(code, definition_end)
+            ),
+            key=lambda match: match.start(),
+        )
+        for match in invocations:
+            # A later assignment/shadowing invalidates the original method
+            # value. Nearest-definition semantics match the rest of the linter.
+            between = code[definition_end:match.start()]
+            if re.search(
+                rf"(?<![\w$])\$?{re.escape(alias)}\s*(?:=|:=)(?!=)",
+                between,
+            ):
+                continue
+            opening = code.find("(", match.start(), match.end())
+            closing = matching_delimiter(code, opening, "(", ")")
+            if closing is None:
+                continue
+            key = (match.start(), closing + 1)
+            if key not in seen:
+                seen.add(key)
+                calls.append(Call(match.start(), opening, closing + 1))
+
+        # PHP also invokes callable arrays via call_user_func(_array).
+        for call in calls_matching(
+            lexed, re.compile(r"(?<!\w)call_user_func(?:_array)?\s*\(")
+        ):
+            args = split_arguments(code, call.open_paren + 1, call.end - 1)
+            if not args:
+                continue
+            callable_arg = code[slice(*args[0])].strip().lstrip("$")
+            key = (call.start, call.end)
+            if callable_arg == alias and key not in seen:
+                seen.add(key)
+                calls.append(call)
     return calls
 
 
@@ -2073,7 +2211,12 @@ def finding_row(path: Path, line: int, detail: str) -> str:
     in one run leaves a consumer unable to group, dedupe or open by file.
     """
 
-    return f"{path}:{line}:{detail}"
+    # The analyzer-to-shell protocol is LF-delimited. POSIX permits CR and LF
+    # in filenames, so emitting a raw path can turn one finding into several
+    # records and inflate both counts and details.files. Escape only the record
+    # delimiters; keep the rest of the path byte-for-byte displayable.
+    display_path = str(path).replace("\r", "\\r").replace("\n", "\\n")
+    return f"{display_path}:{line}:{detail}"
 
 
 def call_detail(path: Path, lexed: LexedSource, call: Call) -> str:
@@ -5060,9 +5203,18 @@ class SourceEndpointResolver:
     JAVASCRIPT_SUFFIXES = JS_TS_SUFFIXES
     C_SUFFIXES = JS_TS_SUFFIXES | {".cs", ".go", ".java", ".php", ".sh"}
 
-    def __init__(self, lexed: LexedSource, suffix: str) -> None:
+    def __init__(
+        self,
+        lexed: LexedSource,
+        suffix: str,
+        external_values: dict[str, str] | None = None,
+        external_names: set[str] | None = None,
+    ) -> None:
         self.lexed = lexed
         self.suffix = suffix
+        self.external_values = external_values or {}
+        self.external_names = external_names or set()
+        self.unverified_external_calls: set[int] = set()
         self.graph = EndpointGraph(len(lexed.code))
         self.c_headers = c_function_headers(lexed, suffix)
         self.class_fields = class_field_regions(lexed, suffix)
@@ -7017,6 +7169,15 @@ class SourceEndpointResolver:
         before: int,
         projection: EndpointReference = (),
     ) -> EndpointValue:
+        # Resolve statically imported scalar endpoints before entering the
+        # per-file binding graph. Keeping module provenance explicit avoids
+        # conflating same-named locals and makes the cross-file boundary the
+        # only special case; all endpoint classification remains shared.
+        expression_text = self.lexed.code[start:end].strip()
+        if not projection and re.fullmatch(r"[A-Za-z_$]\w*", expression_text):
+            external = self.external_values.get(expression_text.lstrip("$"))
+            if external is not None:
+                return endpoint_literal_value(external)
         scope_id = self.scope_at(before)
         expression = self._parse_expression(
             start, end, scope_id, before
@@ -7026,6 +7187,33 @@ class SourceEndpointResolver:
                 expression, projection, before, scope_id
             )
         )
+
+    def _is_external_expression(self, start: int, end: int) -> bool:
+        """Return whether an unresolved URL expression crosses a module boundary."""
+
+        # Shell references commonly live inside double-quoted URL arguments,
+        # which the code view masks as string data. This check is already
+        # bounded to the selected URL/call span, so the original view is the
+        # correct place to recover the imported reference spelling.
+        text = self.lexed.original[start:end].strip()
+        references = re.findall(r"\$?[A-Za-z_][A-Za-z0-9_$]*", text)
+        normalized = [reference.lstrip("$") for reference in references]
+        if any(reference in self.external_names for reference in normalized):
+            return True
+        if "<uppercase>" in self.external_names and any(
+            re.fullmatch(r"[A-Z][A-Z0-9_]*", reference)
+            for reference in normalized
+        ):
+            return True
+        if "<qualified>" in self.external_names and re.search(
+            r"(?:\.|::|->)\s*[A-Za-z_]", text
+        ):
+            return True
+        if "<shell>" in self.external_names and re.search(
+            r"\$(?:\{)?[A-Za-z_]", text
+        ):
+            return True
+        return False
 
     def config_method_may_mutate(
         self, span: tuple[int, int], before: int
@@ -7158,6 +7346,19 @@ class SourceEndpointResolver:
                 for value in resolved
             ):
                 return True
+        # A mutating request whose URL crosses a module boundary must not be
+        # certified merely because this file has no literal. Resolve exact
+        # local exports where possible; otherwise fail closed only for a URL
+        # expression proven to originate from an import/require/source form.
+        # The caller emits a distinct manual-verification finding, rather than
+        # pretending the unknown endpoint is definitely a number-pool route.
+        if any(
+            value.kind in {UNKNOWN, MISSING}
+            and self._is_external_expression(*span)
+            for span, value in zip(original_spans, resolved)
+        ):
+            self.unverified_external_calls.add(call.start)
+            return True
         if not args:
             return False
         return bool(
@@ -7191,6 +7392,20 @@ class SourceEndpointResolver:
                     expression, (), call.start, scope_id
                 )
             ).kind == REQUIRED:
+                return True
+            if (
+                self.graph.evaluate(
+                    EndpointExpressionState(
+                        expression, (), call.start, scope_id
+                    )
+                ).kind
+                in {UNKNOWN, MISSING}
+                and self._is_external_expression(
+                    call.start,
+                    call.end,
+                )
+            ):
+                self.unverified_external_calls.add(call.start)
                 return True
         return False
 
@@ -8329,6 +8544,19 @@ class PayloadStateResolver:
             r"|new\s+(?:Array|Map|Set|Object)\s*\(\s*\))",
             code,
             re.I,
+        ):
+            return WRITE_ABSENT
+        # The public API contract is a UUID string. Reject every statically
+        # numeric literal (not just zero) across the advertised languages;
+        # dynamic expressions remain MAYBE/PRESENT because their runtime type
+        # cannot be proven here.
+        if re.fullmatch(
+            r"[+-]?(?:(?:0[xX][0-9a-fA-F](?:_?[0-9a-fA-F])*)"
+            r"|(?:0[bB][01](?:_?[01])*)|(?:0[oO][0-7](?:_?[0-7])*)"
+            r"|(?:(?:\d(?:_?\d)*)(?:\.(?:\d(?:_?\d)*)?)?"
+            r"|\.(?:\d(?:_?\d)*))(?:[eE][+-]?\d(?:_?\d)*)?)"
+            r"(?:[nNlLfFdDmM])?",
+            code,
         ):
             return WRITE_ABSENT
         tokens = [token for token in self.lexed.strings if start <= token.start and token.end <= end]
@@ -10270,6 +10498,21 @@ def _looks_like_a_send_target(
     # boundary for computed/interprocedural lookups.
     line_start_decl = lexed.code.rfind("\n", 0, token.start) + 1
     declaration = lexed.original[line_start_decl:token.start]
+    # A class/package constant is a declaration, not a send. Braces from the
+    # surrounding class made _is_standalone_binding reject Java/C# fields, so a
+    # compliant cross-file consumer was still accompanied by an unverifiable
+    # finding on the constant definition itself. The imported use site is now
+    # judged (or failed closed) independently.
+    if re.search(
+        r"(?:\bstatic[ \t]+final"
+        r"|\b(?:public|private|protected|internal)[ \t]+const"
+        r"|\b(?:public|private|protected|internal)?[ \t]*static[ \t]+readonly)"
+        r"[ \t]+[A-Za-z_$][\w$<>,.?\[\]]*[ \t]+"
+        r"[A-Za-z_$][\w$]*[ \t]*=[ \t]*$",
+        declaration,
+        re.I,
+    ) and _SEND_SITE_RE.search(declaration) is None:
+        return False
     if re.search(
         r"(?:=|:=)\s*(?:new\s+\w+[^=]*)?(?:Map\s*\.\s*of|List\s*\.\s*of"
         r"|Arrays\s*\.\s*asList|array|dict|\{|\[|\()",
@@ -10396,16 +10639,271 @@ def _looks_like_a_send_target(
 
 
 
+def _read_source_text(path: Path) -> str:
+    """Read source without universal-newline translation."""
+
+    with path.open(
+        "r", encoding="utf-8", errors="replace", newline=""
+    ) as source_file:
+        return source_file.read()
+
+
+def _relative_module_candidates(
+    source_path: Path, module: str, suffix: str, project_root: Path
+) -> list[Path]:
+    """Return bounded local-module candidates for JS/TS and Python imports."""
+
+    if module.startswith("."):
+        base = source_path.parent / module
+    elif suffix == ".py":
+        # Python commonly imports a sibling/top-level project module without a
+        # leading dot. Resolve only beneath the scanned project root; package
+        # dependencies are intentionally outside this static contract.
+        base = project_root / module.replace(".", "/")
+    else:
+        return []
+    candidates = [base]
+    if base.suffix:
+        return candidates
+    if suffix in JS_TS_SUFFIXES:
+        candidates.extend(base.with_suffix(ext) for ext in sorted(JS_TS_SUFFIXES))
+        candidates.extend((base / "index").with_suffix(ext) for ext in sorted(JS_TS_SUFFIXES))
+    elif suffix == ".py":
+        candidates.extend((base.with_suffix(".py"), base / "__init__.py"))
+    return candidates
+
+
+def _exported_scalar(source: str, suffix: str, name: str) -> str | None:
+    """Resolve one exported/top-level name when its value is a string literal."""
+
+    lexed = lex_source(source, suffix)
+    visible = lexed.without_comments
+    escaped = re.escape(name)
+    if suffix in JS_TS_SUFFIXES:
+        assignment = re.search(
+            rf"(?:\bexport\s+(?:const|let|var)\s+{escaped}"
+            rf"|\b(?:module\s*\.\s*)?exports\s*\.\s*{escaped})"
+            r"\s*=\s*(['\"])(?P<value>.*?)\1",
+            visible,
+            re.S,
+        )
+    elif suffix == ".py":
+        assignment = re.search(
+            rf"(?m)^[ \t]*{escaped}\s*=\s*(['\"])(?P<value>.*?)\1",
+            visible,
+        )
+    else:
+        assignment = None
+    return assignment.group("value") if assignment is not None else None
+
+
+def external_static_values(
+    path: Path, project_root: Path, source: str, suffix: str
+) -> dict[str, str]:
+    """Resolve relative named imports to statically exported scalar strings.
+
+    This deliberately follows only explicit relative modules and literal
+    exports. Dynamic/package imports stay unknown instead of being guessed.
+    """
+
+    lexed = lex_source(source, suffix)
+    visible = lexed.without_comments
+    imports: list[tuple[str, str, str]] = []
+    if suffix in JS_TS_SUFFIXES:
+        for match in re.finditer(
+            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"(['\"])(?P<module>\.[^'\"]*)\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_$]\w*)"
+                    r"(?:\s+as\s+(?P<local>[A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    imports.append(
+                        (
+                            match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*(['\"])(?P<module>\.[^'\"]*)\2\s*\)",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_$]\w*)"
+                    r"(?:\s*:\s*(?P<local>[A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    imports.append(
+                        (
+                            match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+    elif suffix == ".py":
+        for match in re.finditer(
+            r"(?m)^\s*from\s+(?P<module>\.*[A-Za-z_][\w.]*)\s+import\s+"
+            r"(?P<members>[^\r\n]+)",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*(?P<export>[A-Za-z_]\w*)"
+                    r"(?:\s+as\s+(?P<local>[A-Za-z_]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    dots = len(match.group("module")) - len(match.group("module").lstrip("."))
+                    module_tail = match.group("module")[dots:].replace(".", "/")
+                    relative = "../" * max(0, dots - 1) + module_tail
+                    imports.append(
+                        (
+                            "./" + relative if dots else match.group("module"),
+                            parsed.group("export"),
+                            parsed.group("local") or parsed.group("export"),
+                        )
+                    )
+
+    resolved: dict[str, str] = {}
+    for module, exported, local in imports:
+        for candidate in _relative_module_candidates(
+            path, module, suffix, project_root
+        ):
+            if not candidate.is_file():
+                continue
+            target_suffix = canonical_suffix(candidate)
+            value = _exported_scalar(
+                _read_source_text(candidate), target_suffix, exported
+            )
+            if value is not None:
+                resolved[local] = value
+            break
+    return resolved
+
+
+def external_reference_names(source: str, suffix: str) -> set[str]:
+    """Return local names whose values originate outside the current file.
+
+    Exact static exports are resolved separately. This index covers the wider
+    language-level import boundary so an unresolved mutating request fails
+    closed instead of silently passing. Sentinels are intentionally narrow:
+    uppercase constants after require/include, qualified package/class members,
+    and shell variables only when a source command is present.
+    """
+
+    visible = lex_source(source, suffix).without_comments
+    names: set[str] = set()
+    if suffix in JS_TS_SUFFIXES:
+        for match in re.finditer(
+            r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*"
+            r"(['\"])\.[^'\"]*\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_$]\w*)(?:\s+as\s+([A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"\bimport\s+\*\s+as\s+([A-Za-z_$]\w*)\s+from\s*"
+                r"(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"\b(?:const|let|var)\s+([A-Za-z_$]\w*)\s*=\s*"
+                r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+                visible,
+            )
+        )
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*"
+            r"require\s*\(\s*(['\"])\.[^'\"]*\2",
+            visible,
+        ):
+            for member in match.group("members").split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_$]\w*)(?:\s*:\s*([A-Za-z_$]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add((parsed.group(2) or parsed.group(1)).lstrip("$"))
+    elif suffix == ".py":
+        for match in re.finditer(r"(?m)^\s*from\s+[\w.]+\s+import\s+([^\r\n]+)", visible):
+            for member in match.group(1).split(","):
+                parsed = re.fullmatch(
+                    r"\s*([A-Za-z_]\w*)(?:\s+as\s+([A-Za-z_]\w*))?\s*",
+                    member,
+                )
+                if parsed is not None:
+                    names.add(parsed.group(2) or parsed.group(1))
+        for match in re.finditer(
+            r"(?m)^\s*import\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)"
+            r"(?:\s+as\s+([A-Za-z_]\w*))?",
+            visible,
+        ):
+            names.add(match.group(2) or match.group(1).split(".")[0])
+    elif suffix == ".rb" and re.search(r"(?m)^\s*require(?:_relative)?\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".php" and re.search(r"\b(?:require|require_once|include|include_once)\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".go" and re.search(r"(?m)^\s*import\b", visible):
+        names.add("<qualified>")
+        for match in re.finditer(
+            r"(?m)^\s*(?:import\s+)?(?:(\w+)\s+)?['\"]([^'\"]+)['\"]",
+            visible,
+        ):
+            names.add(match.group(1) or match.group(2).rsplit("/", 1)[-1])
+    elif suffix == ".java" and re.search(r"(?m)^\s*import\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+        names.update(
+            match.group(1)
+            for match in re.finditer(
+                r"(?m)^\s*import\s+(?:static\s+)?(?:[\w$]+\.)*([A-Za-z_$]\w*)\s*;",
+                visible,
+            )
+        )
+    elif suffix == ".cs" and re.search(r"(?m)^\s*using\b", visible):
+        names.update({"<uppercase>", "<qualified>"})
+    elif suffix == ".sh" and re.search(
+        r"(?m)^\s*(?:source\s+|\.\s+)[^\r\n]+", visible
+    ):
+        names.add("<shell>")
+    return names
+
+
 def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
-    source = path.read_text(encoding="utf-8", errors="replace")
+    # newline="" is required: Path.read_text() performs universal-newline
+    # translation, destroying bare-CR and CRLF source boundaries before the
+    # lexer and grep-line protocol can agree on them.
+    source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)
-    sdk_calls = calls_matching(lexed, SDK_CALL_RE)
+    sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     shell_curls = shell_curl_calls(lexed) if suffix == ".sh" else []
     required_calls: list[tuple[Call, bool]] = [(call, True) for call in sdk_calls]
-    source_resolver = SourceEndpointResolver(lexed, suffix)
+    source_resolver = SourceEndpointResolver(
+        lexed,
+        suffix,
+        external_static_values(path, project_root, source, suffix),
+        external_reference_names(source, suffix),
+    )
     profile_resolver = PayloadStateResolver(
         lexed,
         suffix,
@@ -10443,10 +10941,9 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
             required_calls.append((context, False))
 
     required_calls.sort(key=lambda item: (item[0].start, item[0].end))
-    missing = [
-        call_detail(path, lexed, call)
-        for call, sdk_call in required_calls
-        if not call_has_profile(
+    missing: list[str] = []
+    for call, sdk_call in required_calls:
+        if call_has_profile(
             lexed,
             call,
             suffix,
@@ -10454,8 +10951,15 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
             project_root,
             sdk_call=sdk_call,
             resolver=profile_resolver,
-        )
-    ]
+        ):
+            continue
+        detail = call_detail(path, lexed, call)
+        if call.start in source_resolver.unverified_external_calls:
+            detail += (
+                "  [could not resolve the imported endpoint for this mutating "
+                "request; verify messaging_profile_id manually]"
+            )
+        missing.append(detail)
 
     # Fail-safe backstop: a required endpoint the analysis never accounted for
     # is reported for manual verification rather than passed silently.
@@ -10581,7 +11085,7 @@ def message_body_fields(
 ) -> list[str]:
     """Return real top-level body fields from selected messaging calls."""
 
-    source = path.read_text(encoding="utf-8", errors="replace")
+    source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
     lexed = lex_source(source, suffix)

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -38,6 +38,10 @@ JS_TS_SUFFIXES = {
     ".tsx",
 }
 TYPESCRIPT_SUFFIXES = {".ts", ".tsx", ".mts", ".cts"}
+# Babel, SWC, esbuild, and React Native commonly accept JSX in ordinary
+# JavaScript module files. TypeScript reserves JSX for `.tsx`, so applying JSX
+# masking to `.ts`/`.mts`/`.cts` would risk hiding valid type assertions.
+JSX_CAPABLE_SUFFIXES = {".cjs", ".js", ".jsx", ".mjs", ".tsx"}
 # Keys a request-style config object may carry its URL under. Shared so the
 # named-argument path and the config-object path cannot recognise different
 # spellings, which is how `uri` came to work as a named argument but not as
@@ -582,12 +586,98 @@ def _ruby_interpolation_ranges(
         if backslashes % 2:
             cursor = marker + 2
             continue
-        balanced = _balanced_brace_ranges(source, [marker + 1])
-        if not balanced or balanced[0][1] > end:
+        closing = _ruby_interpolation_closing(source, marker + 1, end)
+        if closing is None:
             break
-        ranges.append(balanced[0])
-        cursor = balanced[0][1] + 1
+        ranges.append((marker + 2, closing))
+        cursor = closing + 1
     return ranges
+
+
+def _ruby_interpolation_closing(
+    source: str, opening: int, end: int
+) -> int | None:
+    """Return a Ruby-aware closing brace for one interpolation expression.
+
+    Generic brace matching is insufficient here: Ruby regexp and percent
+    literals may legally contain ``}``, and comments may contain arbitrary
+    braces. Treat those regions as opaque while balancing executable braces so
+    a data character cannot truncate the restored expression.
+    """
+
+    depth = 0
+    index = opening
+    code = list(source)
+    last_opaque_end = 0
+    while index < end:
+        character = source[index]
+        if character == "#":
+            line_end = source.find("\n", index + 1, end)
+            index = end if line_end < 0 else line_end + 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            literal_start = index
+            index += 1
+            while index < end:
+                if source[index] == "\\":
+                    index = min(end, index + 2)
+                    continue
+                if quote in {'"', "`"} and source.startswith("#{", index):
+                    nested_closing = _ruby_interpolation_closing(
+                        source, index + 1, end
+                    )
+                    if nested_closing is None:
+                        return None
+                    index = nested_closing + 1
+                    continue
+                if source[index] == quote:
+                    index += 1
+                    _blank(code, literal_start, index)
+                    last_opaque_end = index
+                    break
+                index += 1
+            else:
+                return None
+            continue
+        if character == "%":
+            percent_literal = _ruby_percent_literal(source, index)
+            if percent_literal is not None and percent_literal[0] <= end:
+                literal_end = percent_literal[0]
+                _blank(code, index, literal_end)
+                last_opaque_end = literal_end
+                index = literal_end
+                continue
+        if character == "/":
+            regexp_context = _ruby_regex_can_start(
+                source, code, index, last_opaque_end
+            )
+            regexp = (
+                _ruby_slash_regex(
+                    source,
+                    index,
+                    allow_newlines=regexp_context == "command",
+                )
+                if regexp_context
+                else None
+            )
+            if regexp is not None and regexp[0] <= end and (
+                regexp_context != "command"
+                or _ruby_command_regex_has_valid_tail(source, regexp[0])
+            ):
+                regexp_end = regexp[0]
+                _blank(code, index, regexp_end)
+                last_opaque_end = regexp_end
+                index = regexp_end
+                continue
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
 
 
 def _ruby_percent_literal(
@@ -1112,50 +1202,69 @@ def _jsx_element(
 def _mask_jsx_markup(source: str, suffix: str) -> str:
     """Blank definite JSX markup/text while retaining expression containers."""
 
-    # Locate roots in lexed code so `<Panel>` inside an ordinary string or
-    # comment cannot cause subsequent JavaScript to be hidden. The JSX parser
-    # itself uses the raw source after a root is established because inert text
-    # may legally contain quote characters that are not JavaScript strings.
-    lexical = lex_source(source, suffix).code
     output = list(source)
-    cursor = 0
-    while cursor < len(source):
-        start = lexical.find("<", cursor)
-        if start < 0:
-            break
-        previous = start - 1
-        while previous >= 0 and lexical[previous].isspace():
-            previous -= 1
-        previous_word = _word_before(list(lexical), previous + 1).lower()
-        expression_context = (
-            previous < 0
-            or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
-            or (
-                lexical[previous] == ")"
-                and _javascript_control_paren(list(lexical), previous)
+    # Process expression containers with an explicit worklist. The former
+    # recursive call overflowed Python's stack on valid deeply nested JSX.
+    # Each queued span is strictly contained by the JSX element that exposed
+    # it, so the traversal always makes progress without a recursion limit.
+    pending = [(0, len(source))]
+    while pending:
+        span_start, span_end = pending.pop()
+        segment = source[span_start:span_end]
+        # Locate roots in lexed code so `<Panel>` inside an ordinary string or
+        # comment cannot hide subsequent JavaScript. The JSX parser itself uses
+        # raw source after a root is established because inert JSX text may
+        # legally contain quote characters that are not JavaScript strings.
+        lexical = lex_source(segment, suffix).code
+        lexical_chars = list(lexical)
+        cursor = 0
+        while cursor < len(segment):
+            start = lexical.find("<", cursor)
+            if start < 0:
+                break
+            previous = start - 1
+            while previous >= 0 and lexical[previous].isspace():
+                previous -= 1
+            previous_word = _word_before(lexical_chars, previous + 1).lower()
+            expression_context = (
+                previous < 0
+                or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
+                or (
+                    lexical[previous] == ")"
+                    and _javascript_control_paren(lexical_chars, previous)
+                )
+                or (
+                    lexical[previous] == "}"
+                    and _javascript_block_brace(lexical_chars, previous)
+                )
+                or previous_word
+                in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
             )
-            or (
-                lexical[previous] == "}"
-                and _javascript_block_brace(list(lexical), previous)
-            )
-            or previous_word
-            in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
-        )
-        if not expression_context:
-            cursor = start + 1
-            continue
-        element = _jsx_element(source, lexical, start, suffix)
-        if element is None:
-            cursor = start + 1
-            continue
-        end, expressions = element
-        _blank(output, start, end)
-        for expression_start, expression_end in expressions:
-            nested = _mask_jsx_markup(
-                source[expression_start:expression_end], suffix
-            )
-            output[expression_start:expression_end] = list(nested)
-        cursor = end
+            if not expression_context:
+                cursor = start + 1
+                continue
+            element = _jsx_element(segment, lexical, start, suffix)
+            if element is None:
+                cursor = start + 1
+                continue
+            element_end, expressions = element
+            absolute_start = span_start + start
+            absolute_end = span_start + element_end
+            _blank(output, absolute_start, absolute_end)
+            for expression_start, expression_end in expressions:
+                absolute_expression_start = span_start + expression_start
+                absolute_expression_end = span_start + expression_end
+                output[
+                    absolute_expression_start:absolute_expression_end
+                ] = list(
+                    source[
+                        absolute_expression_start:absolute_expression_end
+                    ]
+                )
+                pending.append(
+                    (absolute_expression_start, absolute_expression_end)
+                )
+            cursor = element_end
     return "".join(output)
 
 
@@ -1163,7 +1272,7 @@ def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
     ranges: list[tuple[int, int]] = []
-    if suffix in {".jsx", ".tsx"}:
+    if suffix in JSX_CAPABLE_SUFFIXES:
         return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
         # Comments may contain complete, syntactically valid examples. Preserve
@@ -2381,6 +2490,26 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                     len(source) if terminator is None else terminator.start()
                 )
                 _blank(code, body_start, body_end)
+                _blank(without_comments, body_start, body_end)
+                if suffix == ".rb" and opener.group("q") != "'":
+                    for expression_start, expression_end in _ruby_interpolation_ranges(
+                        source, body_start, body_end
+                    ):
+                        nested = lex_source(
+                            source[expression_start:expression_end], suffix, dialect
+                        )
+                        code[expression_start:expression_end] = list(nested.code)
+                        without_comments[expression_start:expression_end] = list(
+                            nested.without_comments
+                        )
+                        strings.extend(
+                            StringToken(
+                                expression_start + token.start,
+                                expression_start + token.end,
+                                token.contents,
+                            )
+                            for token in nested.strings
+                        )
                 strings.append(
                     StringToken(
                         body_start, body_end, source[body_start:body_end]
@@ -2445,6 +2574,18 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         ) and not (csharp_verbatim or jvm_raw)
         terminated = False
         while index < len(source):
+            if (
+                suffix == ".rb"
+                and delimiter in {'"', "`"}
+                and source.startswith("#{", index)
+            ):
+                interpolation_end = _ruby_interpolation_closing(
+                    source, index + 1, len(source)
+                )
+                if interpolation_end is None:
+                    break
+                index = interpolation_end + 1
+                continue
             if python_f_string or csharp_interpolates or jvm_interpolates:
                 brace_count = csharp_brace_count if csharp_interpolates else 1
                 opener = "${" if jvm_interpolates else "{" * brace_count

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -968,10 +968,203 @@ def _php_executable_ranges(source: str) -> list[tuple[int, int]]:
     return ranges
 
 
+def _jsx_tag_end(
+    source: str, lexical: str, start: int, suffix: str
+) -> int | None:
+    """Return the first JSX tag-closing ``>`` outside quotes/expressions."""
+
+    index = start + 1
+    quote = ""
+    escaped = False
+    while index < len(source):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+        elif character in {"'", '"', "`"}:
+            quote = character
+        elif character == "{":
+            expression = _jsx_brace_range(
+                source, lexical, index, suffix
+            )
+            if expression is None:
+                return None
+            index = expression[1] + 1
+            continue
+        elif character == ">":
+            return index + 1
+        index += 1
+    return None
+
+
+def _jsx_brace_range(
+    source: str, lexical: str, opening: int, suffix: str
+) -> tuple[int, int] | None:
+    """Return one JSX expression range after masking JS lexical data."""
+
+    balanced = _balanced_brace_ranges(lexical, [opening])
+    if balanced:
+        return balanced[0]
+    # JSX text may contain quote characters which the host lexer paired across
+    # an expression. Retry only this exceptional span locally; normal files use
+    # the single cached lexical projection above and remain linear.
+    local = lex_source(source[opening:], suffix).code
+    balanced = _balanced_brace_ranges(local, [0])
+    if balanced:
+        start, end = balanced[0]
+        return opening + start, opening + end
+    return None
+
+
+def _jsx_element(
+    source: str,
+    lexical: str,
+    start: int,
+    suffix: str,
+    depth: int = 0,
+) -> tuple[int, list[tuple[int, int]]] | None:
+    """Parse one balanced JSX element and return its executable expressions."""
+
+    if depth > 128:
+        return None
+    fragment = source.startswith("<>", start)
+    identifier_start = r"(?:[^\W\d]|[$_])"
+    name_match = re.match(
+        rf"<({identifier_start}[\w$:.-]*)(?=[\s/>])", source[start:]
+    )
+    if not fragment and name_match is None:
+        return None
+    name = "" if fragment else name_match.group(1)
+    opening_end = _jsx_tag_end(source, lexical, start, suffix)
+    if opening_end is None:
+        return None
+
+    expressions: list[tuple[int, int]] = []
+    opening = source[start:opening_end]
+    # Attribute expressions execute even though tag names and quoted values do
+    # not. Keep only outermost balanced braces found outside quoted values.
+    cursor = start + 1
+    quote = ""
+    escaped = False
+    while cursor < opening_end:
+        character = source[cursor]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            cursor += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            cursor += 1
+            continue
+        if character == "{":
+            balanced = _jsx_brace_range(source, lexical, cursor, suffix)
+            if balanced is None or balanced[1] >= opening_end:
+                return None
+            expressions.append(balanced)
+            cursor = balanced[1] + 1
+            continue
+        cursor += 1
+
+    if opening.rstrip().endswith("/>"):
+        return opening_end, expressions
+
+    cursor = opening_end
+    while cursor < len(source):
+        if source[cursor] == "{":
+            balanced = _jsx_brace_range(source, lexical, cursor, suffix)
+            if balanced is None:
+                return None
+            expressions.append(balanced)
+            cursor = balanced[1] + 1
+            continue
+        if source[cursor] == "<":
+            if fragment and source.startswith("</>", cursor):
+                return cursor + 3, expressions
+            closing = re.match(
+                rf"</\s*({identifier_start}[\w$:.-]*)\s*>",
+                source[cursor:],
+            )
+            if closing and closing.group(1) == name:
+                return cursor + closing.end(), expressions
+            child = _jsx_element(
+                source, lexical, cursor, suffix, depth + 1
+            )
+            if child is not None:
+                child_end, child_expressions = child
+                expressions.extend(child_expressions)
+                cursor = child_end
+                continue
+            if re.match(rf"<{identifier_start}", source[cursor:]):
+                return None
+        cursor += 1
+    return None
+
+
+def _mask_jsx_markup(source: str, suffix: str) -> str:
+    """Blank definite JSX markup/text while retaining expression containers."""
+
+    # Locate roots in lexed code so `<Panel>` inside an ordinary string or
+    # comment cannot cause subsequent JavaScript to be hidden. The JSX parser
+    # itself uses the raw source after a root is established because inert text
+    # may legally contain quote characters that are not JavaScript strings.
+    lexical = lex_source(source, suffix).code
+    output = list(source)
+    cursor = 0
+    while cursor < len(source):
+        start = lexical.find("<", cursor)
+        if start < 0:
+            break
+        previous = start - 1
+        while previous >= 0 and lexical[previous].isspace():
+            previous -= 1
+        previous_word = _word_before(list(lexical), previous + 1).lower()
+        expression_context = (
+            previous < 0
+            or lexical[previous] in "=>([{,:;!?&|^~<>*%+-/"
+            or (
+                lexical[previous] == ")"
+                and _javascript_control_paren(list(lexical), previous)
+            )
+            or (
+                lexical[previous] == "}"
+                and _javascript_block_brace(list(lexical), previous)
+            )
+            or previous_word
+            in (_JS_REGEX_PREFIX_WORDS - {"break", "continue", "debugger"})
+        )
+        if not expression_context:
+            cursor = start + 1
+            continue
+        element = _jsx_element(source, lexical, start, suffix)
+        if element is None:
+            cursor = start + 1
+            continue
+        end, expressions = element
+        _blank(output, start, end)
+        for expression_start, expression_end in expressions:
+            nested = _mask_jsx_markup(
+                source[expression_start:expression_end], suffix
+            )
+            output[expression_start:expression_end] = list(nested)
+        cursor = end
+    return "".join(output)
+
+
 def executable_source(path: Path, source: str) -> str:
     """Extract executable host-language regions from mixed template files."""
     suffix = path.suffix.lower()
     ranges: list[tuple[int, int]] = []
+    if suffix in {".jsx", ".tsx"}:
+        return _mask_jsx_markup(source, suffix)
     if suffix in {".vue", ".svelte", ".astro"}:
         # Comments may contain complete, syntactically valid examples. Preserve
         # their offsets/newlines but remove their contents before discovering
@@ -1790,7 +1983,7 @@ def _javascript_regex_can_start(
     previous = _previous_code_index(code, index)
     if last_opaque_end and (previous is None or previous < last_opaque_end):
         if all(character.isspace() for character in code[last_opaque_end:index]):
-            return False
+            return ""
     if previous is None:
         return True
 
@@ -1862,6 +2055,125 @@ def _javascript_regex_end(source: str, start: int) -> int | None:
     return None
 
 
+_RUBY_REGEXP_PREFIX_WORDS = {
+    "and",
+    "begin",
+    "case",
+    "do",
+    "else",
+    "elsif",
+    "if",
+    "in",
+    "not",
+    "or",
+    "rescue",
+    "return",
+    "then",
+    "unless",
+    "until",
+    "when",
+    "while",
+    "yield",
+}
+
+
+def _ruby_regex_can_start(
+    source: str, code: list[str], index: int, last_opaque_end: int
+) -> str:
+    """Distinguish a Ruby regexp opener from division and ``/=``."""
+
+    if index + 1 < len(code) and code[index + 1] == "=":
+        return ""
+    previous = _previous_code_index(code, index)
+    if last_opaque_end and (previous is None or previous < last_opaque_end):
+        if all(character.isspace() for character in code[last_opaque_end:index]):
+            return False
+    if previous is None:
+        return "exact"
+    character = code[previous]
+    if character in "([{,;:=!?&|^~<>*%":
+        return "exact"
+    if character in "+-":
+        return "exact" if previous == 0 or code[previous - 1] != character else ""
+    if character.isalnum() or character in "_$@":
+        word = _word_before(code, previous + 1).lower()
+        if word in _RUBY_REGEXP_PREFIX_WORDS:
+            return "exact"
+        # Ruby permits a regexp as the unparenthesized argument of a command
+        # call (`warn /pattern/`). Mark the command-shaped form separately so
+        # its closing context can still distinguish chained division.
+        word_start = previous + 1 - len(word)
+        line_start = source.rfind("\n", 0, word_start) + 1
+        prefix = source[line_start:word_start].strip()
+        if not prefix or prefix.endswith((".", "&.")):
+            return "command"
+    return ""
+
+
+def _ruby_slash_regex(
+    source: str, start: int, allow_newlines: bool
+) -> tuple[int, int, int] | None:
+    """Return slash-regexp bounds, respecting escapes, classes and holes."""
+
+    index = start + 1
+    in_class = False
+    while index < len(source):
+        character = source[index]
+        if character in {"\r", "\n"} and not allow_newlines:
+            return None
+        if character == "\\":
+            index += 2
+            continue
+        if source.startswith("#{", index):
+            balanced = _balanced_brace_ranges(source, [index + 1])
+            if not balanced:
+                return None
+            index = balanced[0][1] + 1
+            continue
+        if character == "[":
+            in_class = True
+        elif character == "]" and in_class:
+            in_class = False
+        elif character == "/" and not in_class:
+            contents_end = index
+            index += 1
+            while index < len(source) and source[index].isalpha():
+                index += 1
+            return index, start + 1, contents_end
+        index += 1
+    return None
+
+
+def _ruby_command_regex_has_valid_tail(source: str, regexp_end: int) -> bool:
+    """Reject command-regexp guesses that are actually chained division."""
+
+    line_end = source.find("\n", regexp_end)
+    if line_end < 0:
+        line_end = len(source)
+    tail = source[regexp_end:line_end].strip()
+    if not tail or tail.startswith(("#", ",", ")", "]", "}", ";")):
+        return True
+    if tail.startswith("/"):
+        # Most importantly, do not pair a division slash with the first slash
+        # of a later `https://...` literal when command regexes span lines.
+        return False
+    word = re.match(r"([A-Za-z_]\w*)", tail)
+    if word and word.group(1) in {
+        "and",
+        "do",
+        "if",
+        "or",
+        "rescue",
+        "unless",
+        "until",
+        "while",
+    }:
+        return True
+    # An operand immediately following the second slash identifies `a / b / c`,
+    # not `command /regexp/`.
+    return re.match(r"(?:[+-]\s*)?(?:[$@A-Za-z_\d]|[('\"\[{])", tail) is None
+
+
 def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
@@ -1875,6 +2187,7 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     shell_heredoc_index = 0
     index = 0
     last_js_opaque_end = 0
+    last_ruby_opaque_end = 0
 
     while index < len(source):
         while (
@@ -1907,6 +2220,51 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 _blank(without_comments, index, regex_end)
                 last_js_opaque_end = regex_end
                 index = regex_end
+                continue
+
+        ruby_regex_context = (
+            _ruby_regex_can_start(source, code, index, last_ruby_opaque_end)
+            if suffix == ".rb" and source[index] == "/"
+            else ""
+        )
+        if ruby_regex_context:
+            regexp = _ruby_slash_regex(
+                source,
+                index,
+                allow_newlines=True,
+            )
+            if regexp is not None:
+                regexp_end, contents_start, contents_end = regexp
+                if (
+                    ruby_regex_context == "command"
+                    and not _ruby_command_regex_has_valid_tail(
+                        source, regexp_end
+                    )
+                ):
+                    index += 1
+                    continue
+                _blank(code, index, regexp_end)
+                _blank(without_comments, index, regexp_end)
+                for expression_start, expression_end in _ruby_interpolation_ranges(
+                    source, contents_start, contents_end
+                ):
+                    nested = lex_source(
+                        source[expression_start:expression_end], suffix, dialect
+                    )
+                    code[expression_start:expression_end] = list(nested.code)
+                    without_comments[expression_start:expression_end] = list(
+                        nested.without_comments
+                    )
+                    strings.extend(
+                        StringToken(
+                            expression_start + token.start,
+                            expression_start + token.end,
+                            token.contents,
+                        )
+                        for token in nested.strings
+                    )
+                last_ruby_opaque_end = regexp_end
+                index = regexp_end
                 continue
 
         if c_block_comments and source.startswith("/*", index):
@@ -2270,6 +2628,8 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
         strings.append(
             StringToken(string_start, index, source[contents_start:contents_end])
         )
+        if suffix == ".rb":
+            last_ruby_opaque_end = index
         if suffix in JS_TS_SUFFIXES:
             last_js_opaque_end = index
 

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -267,7 +267,7 @@ def executable_source(path: Path, source: str) -> str:
         ranges.extend(
             match.span(1)
             for match in re.finditer(
-                r"<script\b[^>]*>(.*?)</script\s*>", template_source,
+                r"<script\b[^>]*>(.*?)</script\b[^>]*>", template_source,
                 flags=re.IGNORECASE | re.DOTALL,
             )
         )
@@ -370,7 +370,7 @@ def executable_source(path: Path, source: str) -> str:
             ranges.extend(
                 match.span(1)
                 for match in re.finditer(
-                    r"<script\b[^>]*>(.*?)</script\s*>", source,
+                    r"<script\b[^>]*>(.*?)</script\b[^>]*>", source,
                     flags=re.IGNORECASE | re.DOTALL,
                 )
             )

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -336,6 +336,112 @@ def _razor_continuation_block_ranges(
     return continuations
 
 
+def _html_element_ranges(source: str) -> list[tuple[int, int]]:
+    """Return quote-aware complete HTML element and standalone-tag spans."""
+
+    tokens: list[tuple[int, int, str, bool, bool]] = []
+    cursor = 0
+    while cursor < len(source):
+        opening = source.find("<", cursor)
+        if opening < 0:
+            break
+        match = re.match(r"<\s*(?P<closing>/)?\s*(?P<name>[A-Za-z][\w:.-]*)", source[opening:])
+        if match is None:
+            cursor = opening + 1
+            continue
+        quote = ""
+        escaped = False
+        end = None
+        for index in range(opening + match.end(), len(source)):
+            character = source[index]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = ""
+            elif character in {"'", '"'}:
+                quote = character
+            elif character == ">":
+                end = index + 1
+                break
+        if end is None:
+            break
+        tag_text = source[opening:end]
+        tokens.append(
+            (
+                opening,
+                end,
+                match.group("name").lower(),
+                bool(match.group("closing")),
+                bool(re.search(r"/\s*>$", tag_text)),
+            )
+        )
+        cursor = end
+
+    void_elements = {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    }
+    stack: list[tuple[str, int, int]] = []
+    ranges: list[tuple[int, int]] = []
+    for start, end, name, closing, self_closing in tokens:
+        if closing:
+            for stack_index in range(len(stack) - 1, -1, -1):
+                if stack[stack_index][0] != name:
+                    continue
+                _, element_start, _ = stack[stack_index]
+                del stack[stack_index:]
+                ranges.append((element_start, end))
+                break
+        elif self_closing or name in void_elements:
+            ranges.append((start, end))
+        else:
+            stack.append((name, start, end))
+    return ranges
+
+
+def _mask_razor_markup(
+    source: str, executable_ranges: list[tuple[int, int]]
+) -> str:
+    """Mask nested Razor markup with the innermost syntax region winning.
+
+    Razor control bodies mix raw C# with complete HTML elements. A union of
+    executable ranges retains the markup too, so quotes in prose can become
+    fake C# literals and hide a request. HTML and C# transition spans nest;
+    applying larger spans first and smaller spans last preserves the deepest
+    language boundary (markup -> @code -> nested markup -> @expression).
+    """
+
+    rendered = list(source)
+    markup_ranges = _html_element_ranges(source)
+    markup_ranges.extend(
+        match.span()
+        for match in re.finditer(r"<!--.*?-->", source, flags=re.DOTALL)
+    )
+    markup_ranges.extend(
+        match.span("text")
+        for match in re.finditer(
+            r"(?m)(?:^|(?<=[;{}]))[ \t]*@:(?P<text>[^\r\n]*)", source
+        )
+    )
+    operations = [
+        (end - start, 0, start, end) for start, end in markup_ranges
+    ]
+    operations.extend(
+        (end - start, 1, start, end) for start, end in executable_ranges
+    )
+    for _, keep, start, end in sorted(
+        operations, key=lambda item: (-item[0], item[1])
+    ):
+        if keep:
+            rendered[start:end] = source[start:end]
+        else:
+            _blank(rendered, start, end)
+    return "".join(rendered)
+
+
 def _vue_directive_expression_ranges(source: str) -> list[tuple[int, int]]:
     """Return value and dynamic-argument expressions for every Vue directive."""
 
@@ -444,6 +550,90 @@ def _javascript_template_expression_ranges(
         ranges.append(balanced[0])
         cursor = balanced[0][1] + 1
     return ranges
+
+
+def _ruby_interpolation_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable ``#{...}`` spans within an interpolating literal."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("#{", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        probe = marker - 1
+        while probe >= start and source[probe] == "\\":
+            backslashes += 1
+            probe -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        balanced = _balanced_brace_ranges(source, [marker + 1])
+        if not balanced or balanced[0][1] > end:
+            break
+        ranges.append(balanced[0])
+        cursor = balanced[0][1] + 1
+    return ranges
+
+
+def _ruby_percent_literal(
+    source: str, start: int
+) -> tuple[int, int, int, bool] | None:
+    """Return percent-literal bounds and interpolation behavior at ``start``."""
+
+    if start >= len(source) or source[start] != "%":
+        return None
+    cursor = start + 1
+    kind = "Q"
+    if cursor < len(source) and source[cursor] in "qQwWiIxrs":
+        kind = source[cursor]
+        cursor += 1
+    elif cursor >= len(source) or source[cursor] not in "([{<":
+        # Bare `%` is also modulo/assignment syntax. Its untyped literal form
+        # is unambiguous for paired delimiters; typed forms support every Ruby
+        # delimiter below.
+        return None
+    else:
+        previous = start - 1
+        while previous >= 0 and source[previous].isspace():
+            previous -= 1
+        if previous >= 0 and (
+            source[previous].isalnum() or source[previous] in "_$)]}'\""
+        ):
+            return None
+    if cursor >= len(source):
+        return None
+    opening = source[cursor]
+    if opening.isalnum() or opening.isspace():
+        return None
+    closing = {"(": ")", "[": "]", "{": "}", "<": ">"}.get(
+        opening, opening
+    )
+    paired = closing != opening
+    depth = 1
+    contents_start = cursor + 1
+    cursor = contents_start
+    while cursor < len(source):
+        character = source[cursor]
+        if character == "\\":
+            cursor = min(len(source), cursor + 2)
+            continue
+        if paired and character == opening:
+            depth += 1
+        elif character == closing:
+            depth -= 1
+            if depth == 0:
+                return (
+                    cursor + 1,
+                    contents_start,
+                    cursor,
+                    kind in {"Q", "W", "I", "x", "r"},
+                )
+        cursor += 1
+    return None
 
 
 def executable_source(path: Path, source: str) -> str:
@@ -569,6 +759,7 @@ def executable_source(path: Path, source: str) -> str:
                 razor_source,
             )
         )
+        source = _mask_razor_markup(razor_source, ranges)
     elif suffix in {".php", ".phtml"}:
         # Both extensions may be mixed HTML/PHP templates. Feeding surrounding
         # markup to the PHP lexer lets an apostrophe in page text open a string
@@ -1265,6 +1456,44 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             index = end
             continue
 
+        if suffix == ".rb" and source[index] == "%":
+            percent_literal = _ruby_percent_literal(source, index)
+            if percent_literal is not None:
+                literal_end, contents_start, contents_end, interpolates = (
+                    percent_literal
+                )
+                string_start = index
+                _blank(code, string_start, literal_end)
+                _blank(without_comments, string_start, literal_end)
+                if interpolates:
+                    for expression_start, expression_end in _ruby_interpolation_ranges(
+                        source, contents_start, contents_end
+                    ):
+                        nested = lex_source(
+                            source[expression_start:expression_end], suffix
+                        )
+                        code[expression_start:expression_end] = list(nested.code)
+                        without_comments[expression_start:expression_end] = list(
+                            nested.without_comments
+                        )
+                        strings.extend(
+                            StringToken(
+                                expression_start + token.start,
+                                expression_start + token.end,
+                                token.contents,
+                            )
+                            for token in nested.strings
+                        )
+                strings.append(
+                    StringToken(
+                        string_start,
+                        literal_end,
+                        source[contents_start:contents_end],
+                    )
+                )
+                index = literal_end
+                continue
+
         # Heredoc bodies are DATA, not code. They were lexed as code, so an
         # apostrophe inside one ("Don't edit by hand") paired with a later quote
         # and masked the send that followed.
@@ -1350,6 +1579,29 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             # Nested string tokens are recorded before the enclosing template
             # token so lookups inside an interpolation select the narrow token.
             for expression_start, expression_end in _javascript_template_expression_ranges(
+                source, contents_start, contents_end
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif delimiter in {'"', "`"} and suffix == ".rb":
+            # Ruby double-quoted strings and command literals execute
+            # interpolation expressions.
+            # Preserve the code within each `#{...}` while keeping surrounding
+            # string data masked, just as JavaScript template literals do.
+            for expression_start, expression_end in _ruby_interpolation_ranges(
                 source, contents_start, contents_end
             ):
                 nested = lex_source(

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1522,7 +1522,8 @@ _HEREDOC_OPENER_RE = re.compile(
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
 _SHELL_HEREDOC_REDIRECTION_RE = re.compile(
     r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
-    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"])*\"|(?:\\.|[^ \t\r\n;<>&|])+)",
+    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"\\])*\"|"
+    r"(?:\\.|[^\\ \t\r\n;<>&|])+)",
 )
 
 

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1230,6 +1230,15 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 end = _line_comment_end(source, index + 2, suffix)
                 index = end
                 continue
+            if suffix == ".php" and source.startswith("#[", index):
+                # PHP 8 attributes begin with `#[`. Treating that opener as a
+                # legacy hash comment masks the rest of the physical line,
+                # including a declaration and request that legally follow the
+                # attribute. The attribute body remains ordinary PHP syntax;
+                # the normal string and block-comment branches below still
+                # mask data nested inside it.
+                index += 2
+                continue
             end = _line_comment_end(source, index + 1, suffix)
             _blank(code, index, end)
             _blank(without_comments, index, end)

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -152,6 +152,17 @@ def canonical_suffix(path: Path) -> str:
     return SUFFIX_LANGUAGE_ALIASES.get(suffix, suffix)
 
 
+def source_dialect(path: Path) -> str:
+    """Return a dialect that shares a canonical grammar suffix."""
+
+    suffix = path.suffix.lower()
+    if suffix in {".kt", ".kts"}:
+        return "kotlin"
+    if suffix == ".scala":
+        return "scala"
+    return ""
+
+
 def _blank_outside_ranges(source: str, ranges: list[tuple[int, int]]) -> str:
     """Preserve offsets/newlines while retaining only executable ranges."""
     keep = bytearray(len(source))
@@ -634,6 +645,253 @@ def _ruby_percent_literal(
                 )
         cursor += 1
     return None
+
+
+def _python_f_string_prefix(source: str, quote_start: int) -> str:
+    """Return a valid Python f-string prefix immediately before a quote."""
+
+    start = quote_start
+    while start > 0 and source[start - 1].isalpha():
+        start -= 1
+    prefix = source[start:quote_start].lower()
+    if prefix not in {"f", "fr", "rf"}:
+        return ""
+    if start > 0 and (source[start - 1].isalnum() or source[start - 1] == "_"):
+        return ""
+    return prefix
+
+
+def _csharp_string_info(
+    source: str, quote_start: int, quote_run: int
+) -> tuple[bool, bool, int]:
+    """Return ``(verbatim_or_raw, interpolates, brace_count)`` for C#."""
+
+    if quote_run >= 3:
+        cursor = quote_start
+        while cursor > 0 and source[cursor - 1] == "$":
+            cursor -= 1
+        dollars = quote_start - cursor
+        return True, dollars > 0, max(1, dollars)
+    prefix_start = max(0, quote_start - 2)
+    prefix = source[prefix_start:quote_start]
+    if prefix in {"$@", "@$"}:
+        return True, True, 1
+    if quote_start > 0 and source[quote_start - 1] == "@":
+        return True, False, 1
+    if quote_start > 0 and source[quote_start - 1] == "$":
+        return False, True, 1
+    return False, False, 1
+
+
+def _scala_interpolated_string_prefix(source: str, quote_start: int) -> str:
+    """Return a Scala interpolator prefix immediately before a quote."""
+
+    start = quote_start
+    while start > 0 and source[start - 1].isalpha():
+        start -= 1
+    prefix = source[start:quote_start]
+    if prefix not in {"s", "f", "raw"}:
+        return ""
+    if start > 0 and (source[start - 1].isalnum() or source[start - 1] == "_"):
+        return ""
+    return prefix
+
+
+def _interpolation_expression_end(
+    source: str, start: int, end: int, language: str
+) -> int:
+    """Trim alignment/conversion/format syntax from an interpolation hole."""
+
+    stack: list[str] = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    quote = ""
+    escaped = False
+    for index in range(start, end):
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif character in pairs:
+            stack.append(pairs[character])
+        elif stack and character == stack[-1]:
+            stack.pop()
+        elif not stack and (
+            (language == "python" and character in "!:")
+            or (language == "csharp" and character in ",:")
+        ):
+            return index
+    return end
+
+
+def _interpolation_ranges(
+    source: str,
+    start: int,
+    end: int,
+    *,
+    language: str,
+    brace_count: int = 1,
+    dollar_marker: bool = False,
+) -> list[tuple[int, int]]:
+    """Return executable expression spans within interpolated strings."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    opener = "${" if dollar_marker else "{" * brace_count
+    while cursor < end:
+        marker = source.find(opener, cursor, end)
+        if marker < 0:
+            break
+        if (
+            dollar_marker
+            and language == "scala"
+            and marker > start
+            and source[marker - 1] == "$"
+        ):
+            # Scala's s/f/raw interpolators spell a literal dollar as `$$`.
+            cursor = marker + 2
+            continue
+        if brace_count == 1 and source.startswith("{{", marker):
+            cursor = marker + 2
+            continue
+        expression_start = marker + len(opener)
+        closing = _interpolation_hole_closing(
+            source, expression_start, end, brace_count
+        )
+        if closing is None:
+            break
+        expression_end = _interpolation_expression_end(
+            source, expression_start, closing, language
+        )
+        if expression_start < expression_end:
+            ranges.append((expression_start, expression_end))
+        if language == "python" and expression_end < closing:
+            # Python format specs can themselves contain replacement fields.
+            ranges.extend(
+                _interpolation_ranges(
+                    source,
+                    expression_end + 1,
+                    closing,
+                    language=language,
+                )
+            )
+        cursor = closing + brace_count
+    return ranges
+
+
+def _interpolation_hole_closing(
+    source: str, start: int, end: int, brace_count: int
+) -> int | None:
+    """Return the closing-brace index for one interpolation expression."""
+
+    closer = "}" * brace_count
+    index = start
+    nested_braces = 0
+    quote = ""
+    escaped = False
+    while index < end:
+        character = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = ""
+            index += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if character == "{":
+            nested_braces += 1
+            index += 1
+            continue
+        if character == "}":
+            if nested_braces:
+                nested_braces -= 1
+                index += 1
+                continue
+            if source.startswith(closer, index):
+                return index
+        index += 1
+    return None
+
+
+def _shell_command_substitution_end(
+    source: str, start: int, end: int
+) -> int | None:
+    """Return the closing parenthesis for a shell ``$(...)`` expression."""
+
+    depth = 1
+    index = start
+    quote = ""
+    escaped = False
+    while index < end:
+        character = source[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if character == "\\":
+            escaped = True
+            index += 1
+            continue
+        if quote:
+            if character == quote:
+                quote = ""
+            index += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+        elif source.startswith("$(", index):
+            depth += 1
+            index += 1
+        elif character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
+
+
+def _shell_command_substitution_ranges(
+    source: str, start: int, end: int
+) -> list[tuple[int, int]]:
+    """Return executable command spans inside a shell double-quoted string."""
+
+    ranges: list[tuple[int, int]] = []
+    cursor = start
+    while cursor < end:
+        marker = source.find("$(", cursor, end)
+        if marker < 0:
+            break
+        backslashes = 0
+        before = marker - 1
+        while before >= start and source[before] == "\\":
+            backslashes += 1
+            before -= 1
+        if backslashes % 2:
+            cursor = marker + 2
+            continue
+        closing = _shell_command_substitution_end(source, marker + 2, end)
+        if closing is None:
+            break
+        ranges.append((marker + 2, closing))
+        ranges.extend(
+            _shell_command_substitution_ranges(source, marker + 2, closing)
+        )
+        cursor = closing + 1
+    return ranges
 
 
 def executable_source(path: Path, source: str) -> str:
@@ -1373,7 +1631,7 @@ def _javascript_regex_end(source: str, start: int) -> int | None:
     return None
 
 
-def lex_source(source: str, suffix: str) -> LexedSource:
+def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
     """Mask comments and strings while preserving offsets and newlines."""
 
     code = list(source)
@@ -1522,7 +1780,32 @@ def lex_source(source: str, suffix: str) -> LexedSource:
             continue
 
         delimiter = quote
-        if quote in {"'", '"'} and source.startswith(quote * 3, index):
+        quote_run = 1
+        while index + quote_run < len(source) and source[index + quote_run] == quote:
+            quote_run += 1
+        python_f_string = suffix == ".py" and bool(
+            _python_f_string_prefix(source, index)
+        )
+        jvm_interpolates = quote == '"' and (
+            dialect == "kotlin"
+            or (
+                dialect == "scala"
+                and bool(_scala_interpolated_string_prefix(source, index))
+            )
+        )
+        jvm_raw = jvm_interpolates and quote_run >= 3
+        csharp_verbatim = False
+        csharp_interpolates = False
+        csharp_brace_count = 1
+        if suffix == ".cs" and quote == '"':
+            (
+                csharp_verbatim,
+                csharp_interpolates,
+                csharp_brace_count,
+            ) = _csharp_string_info(source, index, quote_run)
+            if quote_run >= 3:
+                delimiter = quote * quote_run
+        elif quote in {"'", '"'} and quote_run >= 3:
             delimiter = quote * 3
         string_start = index
         index += len(delimiter)
@@ -1530,12 +1813,54 @@ def lex_source(source: str, suffix: str) -> LexedSource:
         # A backtick delimits a Go RAW string, which has no escape sequences, so
         # a literal `\` inside one previously consumed the closing backtick and
         # ran the "string" to end of file.
-        honours_escapes = not (suffix == ".go" and delimiter == "`")
-        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
-            JS_TS_SUFFIXES | {".py"}
+        honours_escapes = not (
+            (suffix == ".go" and delimiter == "`")
+            or csharp_verbatim
+            or jvm_raw
         )
+        line_bounded = len(delimiter) == 1 and delimiter in {"'", '"'} and suffix in (
+            JS_TS_SUFFIXES | {".py", ".cs", ".java"}
+        ) and not (csharp_verbatim or jvm_raw)
         terminated = False
         while index < len(source):
+            if python_f_string or csharp_interpolates or jvm_interpolates:
+                brace_count = csharp_brace_count if csharp_interpolates else 1
+                opener = "${" if jvm_interpolates else "{" * brace_count
+                if source.startswith(opener, index):
+                    if (
+                        dialect == "scala"
+                        and jvm_interpolates
+                        and index > contents_start
+                        and source[index - 1] == "$"
+                    ):
+                        index += 2
+                        continue
+                    if brace_count == 1 and source.startswith("{{", index):
+                        index += 2
+                        continue
+                    hole_end = _interpolation_hole_closing(
+                        source,
+                        index + len(opener),
+                        len(source),
+                        brace_count,
+                    )
+                    if hole_end is not None:
+                        index = hole_end + brace_count
+                        continue
+            if suffix == ".sh" and delimiter == '"' and source.startswith("$(", index):
+                hole_end = _shell_command_substitution_end(
+                    source, index + 2, len(source)
+                )
+                if hole_end is not None:
+                    index = hole_end + 1
+                    continue
+            if (
+                csharp_verbatim
+                and len(delimiter) == 1
+                and source.startswith('""', index)
+            ):
+                index += 2
+                continue
             if source.startswith(delimiter, index):
                 contents_end = index
                 index += len(delimiter)
@@ -1582,7 +1907,7 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 source, contents_start, contents_end
             ):
                 nested = lex_source(
-                    source[expression_start:expression_end], suffix
+                    source[expression_start:expression_end], suffix, dialect
                 )
                 code[expression_start:expression_end] = list(nested.code)
                 without_comments[expression_start:expression_end] = list(
@@ -1605,7 +1930,63 @@ def lex_source(source: str, suffix: str) -> LexedSource:
                 source, contents_start, contents_end
             ):
                 nested = lex_source(
-                    source[expression_start:expression_end], suffix
+                    source[expression_start:expression_end], suffix, dialect
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif python_f_string or csharp_interpolates or jvm_interpolates:
+            language = (
+                "python"
+                if python_f_string
+                else "csharp"
+                if csharp_interpolates
+                else dialect
+            )
+            brace_count = csharp_brace_count if csharp_interpolates else 1
+            for expression_start, expression_end in _interpolation_ranges(
+                source,
+                contents_start,
+                contents_end,
+                language=language,
+                brace_count=brace_count,
+                dollar_marker=jvm_interpolates,
+            ):
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix, dialect
+                )
+                code[expression_start:expression_end] = list(nested.code)
+                without_comments[expression_start:expression_end] = list(
+                    nested.without_comments
+                )
+                strings.extend(
+                    StringToken(
+                        expression_start + token.start,
+                        expression_start + token.end,
+                        token.contents,
+                    )
+                    for token in nested.strings
+                )
+        elif suffix == ".sh" and delimiter in {'"', "`"}:
+            ranges = (
+                [(contents_start, contents_end)]
+                if delimiter == "`"
+                else _shell_command_substitution_ranges(
+                    source, contents_start, contents_end
+                )
+            )
+            for expression_start, expression_end in ranges:
+                nested = lex_source(
+                    source[expression_start:expression_end], suffix, dialect
                 )
                 code[expression_start:expression_end] = list(nested.code)
                 without_comments[expression_start:expression_end] = list(
@@ -9938,6 +10319,41 @@ def shell_command_span(lexed: LexedSource, offset: int) -> tuple[int, int]:
     return start, end
 
 
+def shell_embedded_command_span(
+    lexed: LexedSource, offset: int
+) -> tuple[int, int] | None:
+    """Bound the narrowest quoted shell command containing ``offset``."""
+
+    candidates: list[tuple[int, int]] = []
+    for token in lexed.strings:
+        if not (token.start < offset < token.end):
+            continue
+        delimiter = lexed.original[token.start]
+        if delimiter == "`":
+            candidates.append((token.start + 1, token.end - 1))
+        elif delimiter == '"':
+            candidates.extend(
+                span
+                for span in _shell_command_substitution_ranges(
+                    lexed.original, token.start + 1, token.end - 1
+                )
+                if span[0] <= offset < span[1]
+            )
+    if not candidates:
+        return None
+    lower, upper = min(candidates, key=lambda span: span[1] - span[0])
+    start, end = lower, upper
+    for index in range(offset - 1, lower - 1, -1):
+        if shell_separator(lexed, index):
+            start = index + 1
+            break
+    for index in range(offset, upper):
+        if shell_separator(lexed, index):
+            end = index
+            break
+    return start, end
+
+
 def shell_curl_is_command(
     lexed: LexedSource, command_start: int, curl_start: int
 ) -> bool:
@@ -9963,7 +10379,9 @@ def shell_curl_calls(lexed: LexedSource) -> list[Call]:
     calls: list[Call] = []
     seen: set[tuple[int, int]] = set()
     for match in SHELL_CURL_RE.finditer(lexed.code):
-        start, end = shell_command_span(lexed, match.start(1))
+        start, end = shell_embedded_command_span(
+            lexed, match.start(1)
+        ) or shell_command_span(lexed, match.start(1))
         if not shell_curl_is_command(lexed, start, match.start(1)):
             continue
         if (start, end) not in seen:
@@ -11526,7 +11944,7 @@ def external_static_values(
     exports. Dynamic/package imports stay unknown instead of being guessed.
     """
 
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     visible = lexed.without_comments
     imports: list[tuple[str, str, str]] = []
     if suffix in JS_TS_SUFFIXES:
@@ -11805,7 +12223,7 @@ def analyze_file(path: Path, project_root: Path) -> tuple[int, list[str]]:
     source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     sdk_calls = calls_matching(lexed, SDK_CALL_RE) + sdk_alias_calls(lexed)
     fetch_calls = calls_matching(lexed, FETCH_CALL_RE)
     if suffix != ".cs":
@@ -12010,7 +12428,7 @@ def message_body_fields(
     source = _read_source_text(path)
     source = executable_source(path, source)
     suffix = canonical_suffix(path)
-    lexed = lex_source(source, suffix)
+    lexed = lex_source(source, suffix, source_dialect(path))
     source_resolver = SourceEndpointResolver(lexed, suffix)
     resolver = PayloadStateResolver(
         lexed,

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -1511,7 +1511,7 @@ def _line_comment_end(source: str, start: int, suffix: str) -> int:
 # as heredoc openers, and since no later line matched the pseudo-tag the "body"
 # ran to EOF and blanked every send below it - a silent pass.
 _HEREDOC_OPENER_RE = re.compile(
-    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)[ \t]*(?=\r?\n|$)"
+    r"<<[<]?[-~]?(?P<q>['\"]?)(?P<tag>[A-Za-z_]\w*)(?P=q)(?!\w)"
 )
 # Requiring end-of-line after the tag is necessary but NOT sufficient. Ruby's
 # singleton-class syntax `class <<self` also puts a bare word straight after
@@ -1520,6 +1520,32 @@ _HEREDOC_OPENER_RE = re.compile(
 # it. That is the same defect the end-of-line anchor was added to fix, one
 # spelling sideways, so the opener needs its LEFT context checked too.
 _NOT_A_HEREDOC_PREFIX_RE = re.compile(r"(?:^|[^\w.])class[ \t]*$")
+_SHELL_HEREDOC_REDIRECTION_RE = re.compile(
+    r"[ \t]*(?:(?:&>>|&>)|(?:\d*)?(?:>>|>\||>&|<&|<>|>|<))[ \t]*"
+    r"(?:&?\d+|-|'[^']*'|\"(?:\\.|[^\"])*\"|(?:\\.|[^ \t\r\n;<>&|])+)",
+)
+
+
+def _shell_heredoc_redirection_tail(tail: str) -> bool:
+    """Accept only shell redirections after a heredoc delimiter.
+
+    A delimiter need not end the physical command: `cat <<EOF >out 2>&1` is
+    valid shell.  The lexer must mask that body, while still rejecting an
+    arbitrary expression containing `<< WORD`.  Consuming a sequence of
+    concrete redirections keeps that boundary explicit.
+    """
+
+    position = 0
+    while position < len(tail):
+        if tail[position:].strip() == "":
+            return True
+        if tail[position:].lstrip().startswith("#"):
+            return True
+        match = _SHELL_HEREDOC_REDIRECTION_RE.match(tail, position)
+        if match is None or match.end() == position:
+            return False
+        position = match.end()
+    return True
 
 
 def _heredoc_opener_at(
@@ -1534,8 +1560,17 @@ def _heredoc_opener_at(
     match = _HEREDOC_OPENER_RE.match(source, index)
     if match is None:
         return None
+    line_start = source.rfind("\n", 0, index) + 1
+    line_end = source.find("\n", match.end())
+    if line_end < 0:
+        line_end = len(source)
+    tail = source[match.end():line_end]
+    if suffix == ".sh":
+        if not _shell_heredoc_redirection_tail(tail):
+            return None
+    elif tail.strip():
+        return None
     if suffix == ".rb":
-        line_start = source.rfind("\n", 0, index) + 1
         if _NOT_A_HEREDOC_PREFIX_RE.search(source[line_start:index]):
             return None
     return match
@@ -1668,7 +1703,23 @@ def _javascript_regex_can_start(
     if character == "}":
         return _javascript_block_brace(code, previous)
     if character.isalnum() or character in "_$":
-        return _word_before(code, previous + 1).lower() in _JS_REGEX_PREFIX_WORDS
+        word = _word_before(code, previous + 1).lower()
+        if word == "default":
+            # `export default /pattern/` expects an expression, but treating
+            # every property named `default` as that keyword would mislex
+            # `config.default / divisor` (ordinary division).  Require the
+            # complete contextual keyword pair.
+            word_start = previous + 1 - len(word)
+            before_word = _previous_code_index(code, word_start)
+            if before_word is None:
+                return False
+            export_word = _word_before(code, before_word + 1).lower()
+            export_start = before_word + 1 - len(export_word)
+            before_export = _previous_code_index(code, export_start)
+            return export_word == "export" and (
+                before_export is None or code[before_export] != "."
+            )
+        return word in _JS_REGEX_PREFIX_WORDS
     return False
 
 
@@ -4067,13 +4118,56 @@ _EXECUTION_LINK_RE = {
     ),
     ".py": r"urlopen\s*\(\s*{name}\b",
     ".go": r"\.\s*Do\s*\(\s*{name}\b",
+    # Net::HTTP::{Post,Put,Patch}.new only constructs a request. Ruby sends it
+    # later through Net::HTTP#request, with either parenthesized or command-call
+    # syntax. Requiring that link prevents fixtures/builders from being
+    # reported as live customer sends.
+    ".rb": r"\.\s*request\s*(?:\(\s*{name}\b|[ \t]+{name}\b)",
 }
 _INLINE_EXECUTION_RE = re.compile(
     # The constructor may be namespaced inside the execution call, as in
     # urlopen(urllib.request.Request(...)), so allow a dotted qualifier.
-    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do)\s*\(\s*"
+    r"(?:urlopen|newCall|SendAsync|Send|Execute\w*|Do|request)\s*\(\s*"
     r"(?:[A-Za-z_][\w.]*\s*\.\s*)?$"
 )
+
+
+def _ruby_function_spans(code: str) -> list[tuple[int, int]]:
+    """Return conservative Ruby `def ... end` spans from masked source."""
+
+    stack: list[tuple[str, int | None]] = []
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for line in code.splitlines(keepends=True):
+        stripped = line.strip()
+        if re.match(r"end\b", stripped) and stack:
+            kind, start = stack.pop()
+            if kind == "def" and start is not None:
+                spans.append((start, cursor + len(line)))
+        else:
+            opener = re.match(r"(def|class|module)\b", stripped)
+            if opener is not None:
+                stack.append((opener.group(1), cursor))
+            elif re.search(r"\bdo(?:\s*\|[^|]*\|)?\s*$", stripped):
+                stack.append(("block", None))
+            elif re.match(
+                r"(?:if|unless|case|begin|for|while|until)\b", stripped
+            ):
+                stack.append(("control", None))
+        cursor += len(line)
+    return spans
+
+
+def _same_ruby_function_scope(
+    code: str, left: int, right: int, spans: list[tuple[int, int]]
+) -> bool:
+    """Whether two offsets belong to the same Ruby method (or top level)."""
+
+    def owner(offset: int) -> tuple[int, int] | None:
+        containing = [span for span in spans if span[0] <= offset < span[1]]
+        return min(containing, key=lambda span: span[1] - span[0]) if containing else None
+
+    return owner(left) == owner(right)
 
 
 def request_object_is_executed(
@@ -4114,15 +4208,34 @@ def request_object_is_executed(
         ) is not None
     # `req, err := http.NewRequest(...)` binds several names; the blank `_` is
     # never the one executed, so every candidate must be tried.
+    name_pattern = (
+        r"(?:@@|@|\$)?[A-Za-z_]\w*" if suffix == ".rb" else r"[A-Za-z_]\w*"
+    )
     names = [
         name
-        for name in re.findall(r"[A-Za-z_]\w*", assignment.group(1))
+        for name in re.findall(name_pattern, assignment.group(1))
         if name != "_"
     ]
-    return any(
-        re.search(pattern.format(name=re.escape(name)), lexed.code[statement_start:])
-        for name in names
-    )
+    tail = lexed.code[call.end:]
+    ruby_spans = _ruby_function_spans(lexed.code) if suffix == ".rb" else []
+    for name in names:
+        execution = re.search(pattern.format(name=re.escape(name)), tail)
+        if execution is None:
+            continue
+        execution_offset = call.end + execution.start()
+        if suffix == ".rb" and not _same_ruby_function_scope(
+            lexed.code, call.start, execution_offset, ruby_spans
+        ):
+            continue
+        # A new reaching definition supersedes this request object. A later
+        # execution of the same variable must not retroactively execute the
+        # discarded constructor.
+        rebound = re.search(
+            rf"(?<![\w@$]){re.escape(name)}\s*=(?!=)", tail[:execution.start()]
+        )
+        if rebound is None:
+            return True
+    return False
 
 
 def php_stream_context_region(
@@ -5425,7 +5538,7 @@ def _request_url_spans(
         # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
         return args[1:2]
     if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
-        return args[0:1]
+        return args[0:1] if request_object_is_executed(lexed, call, suffix) else []
     if callee == "curl_init" and len(args) >= 1:
         # `curl_init($url)` sets CURLOPT_URL directly - it is the documented
         # one-liner form and is at least as common as the setopt spelling.
@@ -11588,7 +11701,30 @@ def consumed_endpoint_tokens(
             break
     consumed |= _tokens_in_span(lexed, (statement_start, statement_end))
 
-    for span in request_url_spans(lexed, call, suffix):
+    resolved_spans = request_url_spans(lexed, call, suffix)
+    if not resolved_spans:
+        # Recognised request-object constructors can be deliberately rejected
+        # because they are never executed (or use a read-only verb). Their URL
+        # is still accounted for by this analysed call; otherwise an alias such
+        # as `uri = URI(URL); req = Net::HTTP::Post.new(uri)` is re-reported by
+        # the fail-safe as an unknown send. Keep this list to constructors whose
+        # URL position is part of an explicit client signature.
+        args = split_arguments(lexed.code, call.open_paren + 1, call.end - 1)
+        callee = normalized_call_callee(lexed, call)
+        if args and callee.endswith("new") and "Net::HTTP::" in callee:
+            resolved_spans = args[0:1]
+        elif args and suffix == ".py" and callee.split(".")[-1] == "Request":
+            resolved_spans = args[0:1]
+        elif args and callee == "HttpRequestMessage":
+            resolved_spans = args[1:2]
+        elif args and callee == "RestRequest":
+            resolved_spans = args[0:1]
+        elif suffix in {".java", ".kt", ".kts", ".scala"}:
+            builder_span = builder_uri_span(lexed, call)
+            if builder_span is not None:
+                resolved_spans = [builder_span]
+
+    for span in resolved_spans:
         consumed |= _tokens_in_span(lexed, span)
         # Follow the alias chain the resolver itself walked. The endpoint is
         # often held one or more hops away - `url = routes.get("pool")` where

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -738,6 +738,7 @@ def _interpolation_ranges(
     language: str,
     brace_count: int = 1,
     dollar_marker: bool = False,
+    backslash_escapes_marker: bool = False,
 ) -> list[tuple[int, int]]:
     """Return executable expression spans within interpolated strings."""
 
@@ -748,6 +749,17 @@ def _interpolation_ranges(
         marker = source.find(opener, cursor, end)
         if marker < 0:
             break
+        if dollar_marker and backslash_escapes_marker:
+            backslashes = 0
+            before = marker - 1
+            while before >= start and source[before] == "\\":
+                backslashes += 1
+                before -= 1
+            if backslashes % 2:
+                # Kotlin normal strings spell a literal dollar as `\$`.
+                # An even run escapes only itself, leaving `$` executable.
+                cursor = marker + 2
+                continue
         if (
             dollar_marker
             and language == "scala"
@@ -1960,6 +1972,9 @@ def lex_source(source: str, suffix: str, dialect: str = "") -> LexedSource:
                 language=language,
                 brace_count=brace_count,
                 dollar_marker=jvm_interpolates,
+                backslash_escapes_marker=(
+                    dialect == "kotlin" and not jvm_raw
+                ),
             ):
                 nested = lex_source(
                     source[expression_start:expression_end], suffix, dialect

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -569,11 +569,14 @@ def executable_source(path: Path, source: str) -> str:
                 razor_source,
             )
         )
-    elif suffix == ".phtml":
-        # PHTML is a mixed HTML/PHP template, not a plain PHP source file.
-        # Feeding its markup to the PHP lexer lets an apostrophe in page text
-        # open a string that masks a later request inside <?php ... ?>.
-        ranges.extend(
+    elif suffix in {".php", ".phtml"}:
+        # Both extensions may be mixed HTML/PHP templates. Feeding surrounding
+        # markup to the PHP lexer lets an apostrophe in page text open a string
+        # that masks a later request inside <?php ... ?>. Preserve only PHP
+        # regions whenever tags are present. Tagless `.php` remains supported
+        # because many analyzer fixtures and generated snippets contain raw PHP
+        # statements without an opening tag; tagless `.phtml` remains markup.
+        php_ranges = [
             match.span("code")
             for match in re.finditer(
                 # Plain ``<?`` is executable when short_open_tag is enabled.
@@ -584,7 +587,14 @@ def executable_source(path: Path, source: str) -> str:
                 source,
                 flags=re.IGNORECASE | re.DOTALL,
             )
-        )
+        ]
+        if (
+            suffix == ".php"
+            and not php_ranges
+            and re.search(r"</?[A-Za-z!]", source) is None
+        ):
+            return source
+        ranges.extend(php_ranges)
     elif suffix in {".ejs", ".erb", ".jsp"}:
         if suffix == ".ejs":
             # EJS scriptlets execute on the server, while ordinary <script>

--- a/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
+++ b/skills/telnyx-twilio-migration/scripts/lint-required-messaging-profile.py
@@ -928,6 +928,24 @@ def _interpolation_hole_closing(
     return None
 
 
+def _shell_comment_start(source: str, index: int, start: int = 0) -> bool:
+    """A shell hash starts a comment only at an unescaped word boundary."""
+    before = index - 1
+    # A continued physical line does not introduce a new shell word.
+    while before > start and source[before - 1:before + 1] == "\\\n":
+        before -= 2
+    if before < start:
+        return True
+    if not (source[before].isspace() or source[before] in ";|&()<>"):
+        return False
+    backslashes = 0
+    cursor = before - 1
+    while cursor >= start and source[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 0
+
+
 def _shell_command_substitution_end(
     source: str, start: int, end: int
 ) -> int | None:
@@ -952,6 +970,12 @@ def _shell_command_substitution_end(
                 quote = ""
             index += 1
             continue
+        if character == "#" and _shell_comment_start(source, index, start):
+            # Parentheses in a shell comment cannot close (or nest) this
+            # substitution. Commands after its newline still execute.
+            newline = source.find("\n", index, end)
+            index = end if newline < 0 else newline + 1
+            continue
         if character in {"'", '"', "`"}:
             quote = character
         elif source.startswith("$(", index):
@@ -970,29 +994,40 @@ def _shell_command_substitution_end(
 def _shell_command_substitution_ranges(
     source: str, start: int, end: int
 ) -> list[tuple[int, int]]:
-    """Return executable command spans inside a shell double-quoted string."""
+    """Return outer substitutions in expanding shell text.
+
+    Each command is lexed in its own shell context by the caller. Descending
+    here would incorrectly execute substitutions inside that command's single
+    quotes or comments. Quotes in the surrounding string/heredoc are data.
+    """
 
     ranges: list[tuple[int, int]] = []
     cursor = start
     while cursor < end:
-        marker = source.find("$(", cursor, end)
-        if marker < 0:
-            break
-        backslashes = 0
-        before = marker - 1
-        while before >= start and source[before] == "\\":
-            backslashes += 1
-            before -= 1
-        if backslashes % 2:
-            cursor = marker + 2
+        if source[cursor] == "\\":
+            cursor += 2
             continue
-        closing = _shell_command_substitution_end(source, marker + 2, end)
+        if source.startswith("$(", cursor):
+            opening = cursor + 2
+            closing = _shell_command_substitution_end(source, opening, end)
+        elif source[cursor] == "`":
+            opening = cursor + 1
+            closing = opening
+            while closing < end:
+                if source[closing] == "\\":
+                    closing += 2
+                elif source[closing] == "`":
+                    break
+                else:
+                    closing += 1
+            if closing >= end:
+                closing = None
+        else:
+            cursor += 1
+            continue
         if closing is None:
             break
-        ranges.append((marker + 2, closing))
-        ranges.extend(
-            _shell_command_substitution_ranges(source, marker + 2, closing)
-        )
+        ranges.append((opening, closing))
         cursor = closing + 1
     return ranges
 
@@ -1804,6 +1839,8 @@ CSHARP_JSON_MUTATING_METHODS = frozenset(
 CSHARP_ONLY_FETCH_METHODS = frozenset(
     {"PutAsync", "PatchAsync", *CSHARP_JSON_MUTATING_METHOD_NAMES}
 )
+# Both net/http constructors share method/URL/body order after optional context.
+GO_REQUEST_METHOD_INDEX = {"NewRequest": 0, "NewRequestWithContext": 1}
 FETCH_CALL_RE = re.compile(
     rf"(?<![\w$])(?:fetch|request|post_form|postAsync|"
     rf"(?:{CSHARP_HTTP_CONTENT_METHOD_PATTERN})|"
@@ -1819,7 +1856,7 @@ FETCH_CALL_RE = re.compile(
     # migrated Ruby uses. Modelling only Net::HTTP.post made the whole shape
     # invisible: zero sends detected, so the fail-safe could not fire either.
     r"Net::HTTP::(?:Post|Put|Patch)\s*\.\s*new|"
-    r"NewRequest|curl_setopt_array|curl_setopt|curl_init|"
+    r"NewRequest(?:WithContext)?|curl_setopt_array|curl_setopt|curl_init|"
     r"HttpRequestMessage|RestRequest|Request|open|file_get_contents|"
     r"axios\s*\.\s*post|axios)\s*\("
 )
@@ -2294,7 +2331,7 @@ def _heredoc_langs(suffix: str) -> bool:
     return suffix in {".php", ".rb"}
 
 
-def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
+def _shell_heredoc_ranges(source: str) -> list[tuple[int, int, bool]]:
     """Return shell heredoc body ranges in one command-aware linear pass.
 
     The scan follows quotes, arithmetic contexts and backslash continuations,
@@ -2304,8 +2341,11 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
     arithmetic shifts and here-strings.
     """
 
-    ranges: list[tuple[int, int]] = []
-    pending: list[tuple[str, bool]] = []
+    ranges: list[tuple[int, int, bool]] = []
+    pending: list[tuple[str, bool, bool]] = []
+    opener_re = re.compile(
+        r'''<<(?P<tabs>-)?[ \t]*(?P<word>(?:\\.|'[^'\n]*'|"[^"\n]*"|[^\s\\'"<>;&|])+)'''
+    )
     quote = ""
     escaped = False
     parenthesis_depth = 0
@@ -2360,9 +2400,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
             quote = character
             index += 1
             continue
-        if character == "#" and (
-            index == command_start or source[index - 1].isspace()
-        ):
+        if character == "#" and _shell_comment_start(source, index, command_start):
             comment_start = index
             newline = source.find("\n", index + 1)
             index = len(source) if newline < 0 else newline
@@ -2370,11 +2408,17 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
         if source.startswith("<<<", index):
             index += 3
             continue
-        opener = _HEREDOC_OPENER_RE.match(source, index)
+        opener = opener_re.match(source, index)
         if opener is not None and (
             index == 0 or source[index - 1] != "<"
         ):
-            pending.append((opener.group("tag"), "<<-" in opener.group(0)))
+            word = opener.group("word")
+            try:
+                tag = shlex.split(word, posix=True)[0]
+            except (ValueError, IndexError):
+                index = opener.end()
+                continue
+            pending.append((tag, bool(opener.group("tabs")), not any(c in word for c in "'\"\\")))
             index = opener.end()
             continue
         if character != "\n":
@@ -2393,7 +2437,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
             continue
 
         body_start = index + 1
-        for tag, strips_tabs in pending:
+        for tag, strips_tabs, expands in pending:
             cursor = body_start
             terminator_start: int | None = None
             terminator_end: int | None = None
@@ -2411,7 +2455,7 @@ def _shell_heredoc_ranges(source: str) -> list[tuple[int, int]]:
                 cursor = line_end + 1
             body_end = len(source) if terminator_start is None else terminator_start
             if body_start < body_end:
-                ranges.append((body_start, body_end))
+                ranges.append((body_start, body_end, expands))
             if terminator_end is None:
                 body_start = len(source)
                 break
@@ -2976,9 +3020,16 @@ def _lex_source_once(
         ):
             shell_heredoc_index += 1
         if shell_heredoc_index < len(shell_heredoc_ranges):
-            body_start, body_end = shell_heredoc_ranges[shell_heredoc_index]
+            body_start, body_end, expands = shell_heredoc_ranges[shell_heredoc_index]
             if body_start <= index < body_end:
                 _blank(code, body_start, body_end)
+                if expands:
+                    for start, end in _shell_command_substitution_ranges(source, body_start, body_end):
+                        nested = lex_source(source[start:end], suffix, dialect)
+                        code[start:end] = list(nested.code)
+                        without_comments[start:end] = list(nested.without_comments)
+                        strings.extend(StringToken(start + token.start, start + token.end, token.contents)
+                                       for token in nested.strings)
                 strings.append(
                     StringToken(
                         body_start, body_end, source[body_start:body_end]
@@ -3062,7 +3113,9 @@ def _lex_source_once(
             index = end
             continue
 
-        if hash_comments and source[index] == "#":
+        if hash_comments and source[index] == "#" and (
+            suffix != ".sh" or _shell_comment_start(source, index)
+        ):
             if suffix == ".sh" and index == 0 and source.startswith("#!", index):
                 end = _line_comment_end(source, index + 2, suffix)
                 index = end
@@ -4251,6 +4304,18 @@ def rest_payload_spans(
         return assigned_named_payload_spans(
             lexed, arguments[0], call.start, suffix
         )
+    if suffix in JS_TS_SUFFIXES and callee == "request":
+        if node_core_request(lexed, call, suffix):
+            return request_write_payload_spans(lexed, call, suffix)
+        # URL/options overloads carry no positional body. In particular the
+        # optional callback must never be inspected as a request payload.
+        config = next((span for span in arguments[:2]
+                       if resolved_config_object_span(lexed, span, call.start, suffix)
+                       is not None), None)
+        if config is not None:
+            configured = named_payload_spans(lexed.code, [config], allow_js_shorthand=True)
+            configured = configured or assigned_named_payload_spans(lexed, config, call.start, suffix)
+            return configured or request_write_payload_spans(lexed, call, suffix)
     named = named_payload_spans(
         lexed.code,
         arguments,
@@ -4263,11 +4328,11 @@ def rest_payload_spans(
         if method is None or method.upper() in MUTATING_HTTP_METHODS:
             return arguments[2:3]
 
-    if callee == "NewRequest" and len(arguments) >= 3:
+    if callee in GO_REQUEST_METHOD_INDEX and len(arguments) >= GO_REQUEST_METHOD_INDEX[callee] + 3:
         # http.NewRequest(method, url, body): the body is the third argument,
         # normally wrapped (bytes.NewBuffer(json.Marshal output)).
         return [
-            resolve_wrapped_payload(lexed, arguments[2], call.start, suffix)
+            resolve_wrapped_payload(lexed, arguments[GO_REQUEST_METHOD_INDEX[callee] + 2], call.start, suffix)
         ]
     if callee.split(".")[-1] == "post_form":
         # Net::HTTP.post_form(uri, k => v, ...): every pair after the URI is
@@ -4832,6 +4897,11 @@ def call_has_profile(
             if resolver.text_presence(value).state == PRESENT:
                 return True
         return False
+    if not sdk_call and suffix in JS_TS_SUFFIXES and normalized_call_callee(lexed, call) == "request":
+        written = request_write_events(lexed, call, suffix)
+        spans = rest_payload_spans(lexed, call, suffix)
+        if node_core_request(lexed, call, suffix) or spans == [event.span for event in written if event.span]:
+            return request_writes_have_profile(lexed, call, suffix, resolver, written)
     return any(
         resolver.span_presence(start, end, call.start).state == PRESENT
         for start, end in payload_spans(
@@ -6020,21 +6090,26 @@ def _top_level_ternary(
         elif char in ")]}":
             depth -= 1
         elif char == "?" and depth == 0:
-            if code[index + 1:index + 2] in (".", "?"):
+            if code[index + 1:index + 2] in (".", "?") or code[index - 1:index] == "?":
                 continue
             question = index
             break
     if question < 0:
         return None
-    depth = 0
+    depth = nested = 0
     for index in range(question + 1, end):
         char = code[index]
         if char in "([{":
             depth += 1
         elif char in ")]}":
             depth -= 1
+        elif char == "?" and depth == 0 and code[index + 1:index + 2] not in (".", "?") and code[index - 1:index] != "?":
+            nested += 1
         elif char == ":" and depth == 0:
-            return (question + 1, index), (index + 1, end)
+            if nested:
+                nested -= 1
+            else:
+                return (question + 1, index), (index + 1, end)
     return None
 
 
@@ -6615,28 +6690,550 @@ ASSIGNED_HANDLE_RE = re.compile(
 )
 
 
-def request_write_payload_spans(
-    lexed: LexedSource, call: Call
-) -> list[tuple[int, int]]:
-    """Return <handle>.write(...) payload spans after a request(...) call."""
+def node_core_request(lexed: LexedSource, call: Call, suffix: str) -> bool:
+    """Resolve core http(s) module ownership without treating library body as core."""
+    source = SourceEndpointResolver(lexed, suffix)
+    receiver = re.search(r"([A-Za-z_$][\w$]*)\s*\.\s*$", lexed.code[:call.start])
+    name = receiver[1] if receiver else "request"
+
+    def owned(name: str, before: int, seen: frozenset[str]) -> bool:
+        if name in seen:
+            return False
+        binding = source.graph.visible_binding(name, source.scope_at(before), before)
+        assignments = [a for a in source.root_assignments if a.start() < before and a[1] == name
+                       and source.graph.visible_binding(name, source.scope_at(a.start()), a.start()) == binding]
+        if assignments:
+            assignment = assignments[-1]
+            end = assignment_end(lexed, assignment.end(), suffix)
+            rhs = lexed.without_comments[assignment.end():end].strip().rstrip(";").strip()
+            if re.fullmatch(r"require\s*\(\s*['\"](?:node:)?https?['\"]\s*\)(?:\s*\.\s*request)?", rhs):
+                return True
+            alias = re.fullmatch(r"([A-Za-z_$][\w$]*)(?:\s*\.\s*request)?", rhs)
+            return bool(alias and owned(alias[1], assignment.start(), seen | {name}))
+        prefix = lexed.without_comments[:before]
+        module = r"['\"](?:node:)?https?['\"]"
+        if receiver:
+            patterns = [r"\bimport\s+(?:\*\s+as\s+)?" + re.escape(name) + r"\s+from\s*" + module]
+        else:
+            patterns = [r"\bimport\s*\{(?P<members>[^{}]*)\}\s*from\s*" + module,
+                        r"\b(?:const|let|var)\s*\{(?P<members>[^{}]*)\}\s*=\s*require\s*\(\s*" + module]
+        for pattern in patterns:
+            for origin in re.finditer(pattern, prefix):
+                # Require executable syntax, and the same binding at its origin:
+                # neither import-looking strings nor shadowed parameters own it.
+                if not re.match(r"(?:import|const|let|var)\b", lexed.code[origin.start():]):
+                    continue
+                if not receiver and not any(re.fullmatch(r"request(?:\s*(?:as|:)\s*request)?", member.strip())
+                                            for member in origin["members"].split(",")):
+                    continue
+                if source.graph.visible_binding(name, source.scope_at(origin.start()), origin.end()) == binding:
+                    return True
+        return False
+
+    return owned(name, call.start, frozenset())
+
+
+@dataclass(frozen=True)
+class RequestWriteEvent:
+    offset: int
+    method: str
+    span: tuple[int, int] | None = None
+    binding: int | tuple[int | None, str] | None = None
+    source_binding: int | tuple[int | None, str] | None = None
+
+
+@dataclass(frozen=True)
+class RequestClosure:
+    start: int
+    parameters: tuple[tuple[int, int], ...]
+    body: int
+    end: int
+    arguments: tuple[tuple[int, int], ...] | None
+    invocation_end: int | None
+
+
+def request_closures(resolver: SourceEndpointResolver) -> list[RequestClosure]:
+    """Balanced closure boundaries, including deferred parameter initializers.
+
+    Only direct synchronous invocations are folded. A callback, stored closure,
+    async function or generator does not establish a write before a later end.
+    """
+    cached = getattr(resolver, "_request_closures", None)
+    if cached is not None:
+        return cached
+    code = resolver.lexed.code
+    pairs: dict[int, int] = {}
+    stack: list[int] = []
+    for index, char in enumerate(code):
+        if char in "([{":
+            stack.append(index)
+        elif char in ")]}" and stack:
+            opening = stack.pop()
+            pairs[opening] = index
+            pairs[index] = opening
+    closures = []
+    for token in re.finditer(r"\bfunction\b|=>", code):
+        start = token.start()
+        if token[0] == "function":
+            header = re.match(r"function\s*\*?\s*(?:[A-Za-z_$][\w$]*\s*)?\(", code[start:])
+            if header is None:
+                continue
+            opening = start + header.end() - 1
+            closing = pairs.get(opening)
+            if closing is None:
+                continue
+            body = closing + 1
+        else:
+            closing = token.start() - 1
+            while closing >= 0 and code[closing].isspace():
+                closing -= 1
+            if code[closing:closing + 1] == ")":
+                opening = pairs.get(closing)
+                if opening is None:
+                    continue
+                start = opening
+            else:
+                parameter = re.search(r"[A-Za-z_$][\w$]*$", code[:closing + 1])
+                if parameter is None:
+                    continue
+                start = parameter.start()
+                opening = start - 1
+            body = token.end()
+        parameters = tuple(span for span in split_arguments(code, opening + 1, closing)
+                           if code[slice(*span)].strip())
+        async_prefix = re.search(r"\basync\s*$", code[:start])
+        if async_prefix:
+            start = async_prefix.start()
+        while body < len(code) and code[body].isspace():
+            body += 1
+        if code[body:body + 1] == "{":
+            if body not in pairs:
+                continue
+            end = pairs[body] + 1
+        else:
+            end = body
+            while end < len(code) and code[end] not in ",;\n)]}":
+                end = pairs[end] + 1 if code[end] in "([{" and end in pairs else end + 1
+        wrapped_start, wrapped_end = start, end
+        while True:
+            before = wrapped_start - 1
+            while before >= 0 and code[before].isspace():
+                before -= 1
+            after = wrapped_end
+            while after < len(code) and code[after].isspace():
+                after += 1
+            if before < 0 or code[before] != "(" or pairs.get(before) != after:
+                break
+            # Parentheses owned by an outer call are not grouping parentheses.
+            if re.search(r"[\w$)\]]\s*$", code[:before]):
+                break
+            wrapped_start, wrapped_end = before, after + 1
+        invocation = re.match(r"\s*(?:\.\s*call\s*)?\(", code[wrapped_end:])
+        # A declaration followed by a parenthesized statement is not an IIFE.
+        if (re.match(r"function\s+[A-Za-z_$][\w$]*\s*\(", code[start:])
+                and wrapped_start == start
+                and not re.search(r"[=(:,\[!&|?]\s*$|\breturn\s*$", code[:start])):
+            invocation = None
+        arguments = None
+        invocation_end = None
+        if invocation and not async_prefix and not re.match(r"function\s*\*", code[start:]):
+            argument_open = wrapped_end + invocation.end() - 1
+            argument_end = pairs.get(argument_open)
+            if argument_end is not None:
+                invocation_end = argument_end + 1
+                arguments = tuple(span for span in split_arguments(code, argument_open + 1, argument_end)
+                                  if code[slice(*span)].strip())
+                if "." in invocation[0]:
+                    arguments = arguments[1:]
+        closures.append(RequestClosure(start, parameters, body, end, arguments, invocation_end))
+    resolver._request_closures = closures
+    return closures
+
+
+def request_argument_is_undefined(resolver: SourceEndpointResolver, span: tuple[int, int]) -> bool:
+    """Recognize undefined values without running code or guessing call results."""
+    start, end = span
+    code = resolver.lexed.code
+    while start < end and code[start].isspace():
+        start += 1
+    while end > start and code[end - 1].isspace():
+        end -= 1
+    while code[start:start + 1] == "(" and matching_delimiter(code, start, "(", ")") == end - 1:
+        start, end = start + 1, end - 1
+        while start < end and code[start].isspace():
+            start += 1
+        while end > start and code[end - 1].isspace():
+            end -= 1
+    value = code[start:end]
+    if value == "undefined":
+        return resolver.graph.visible_binding("undefined", resolver.scope_at(start), start) is None
+    # The operand may have effects; event ordering evaluates it before defaults.
+    void = re.match(r"void\b\s*", value)
+    if void:
+        cursor = start + void.end()
+        # A unary void expression is undefined; a binary/conditional
+        # expression containing void need not be. Consume one primary and
+        # balanced postfix operations, not a prefix of an arbitrary expression.
+        primary = re.match(r"[A-Za-z_$][\w$]*|\d+(?:\.\d+)?", code[cursor:end])
+        if primary:
+            cursor += primary.end()
+        elif code[cursor:cursor + 1] != "(":
+            return False
+        while cursor < end:
+            if code[cursor] in "([":
+                closing = matching_delimiter(code, cursor, code[cursor], {"(": ")", "[": "]"}[code[cursor]])
+                if closing is None or closing >= end:
+                    return False
+                cursor = closing + 1
+            elif code[cursor].isspace():
+                cursor += 1
+            elif code[cursor] == ".":
+                member = re.match(r"\.\s*[A-Za-z_$][\w$]*", code[cursor:end])
+                if member is None:
+                    return False
+                cursor += member.end()
+            else:
+                return False
+        return True
+    for closure in request_closures(resolver):
+        if (closure.start < start or code[start:closure.start].strip("( \t\r\n")
+                or closure.invocation_end != end or closure.parameters):
+            continue
+        body = code[closure.body:closure.end]
+        returned = re.fullmatch(r"\{\s*return\s*(undefined|void\s+0)?\s*;?\s*\}", body)
+        if returned:
+            return returned[1] != "undefined" or resolver.graph.visible_binding(
+                "undefined", resolver.scope_at(closure.body), closure.body
+            ) is None
+    return False
+
+
+def request_event_order(resolver: SourceEndpointResolver, offset: int) -> tuple[int, ...]:
+    """Arguments execute before parameters/body, despite their source positions."""
+    key: list[int] = []
+    for closure in sorted(request_closures(resolver), key=lambda item: item.start):
+        if closure.invocation_end is not None and closure.start <= offset < closure.invocation_end:
+            key.extend((closure.start, int(offset < closure.end)))
+    return (*key, offset)
+
+
+def request_argument_has_unknown_call(resolver: SourceEndpointResolver, span: tuple[int, int]) -> bool:
+    """Do not lend ownership across calls whose side effects are unmodelled.
+
+    Direct closures have explicit events. A named no-argument empty function
+    is also harmless, but arbitrary helpers need interprocedural analysis and
+    conservatively invalidate ownership even when void fixes their result.
+    """
+    code = resolver.lexed.code
+    closures = request_closures(resolver)
+    for called in re.finditer(r"(?<![\w$])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)\s*\(", code[slice(*span)]):
+        offset = span[0] + called.start()
+        if called[1] == "void" or any(closure.start <= offset < closure.body for closure in closures):
+            continue
+        candidates = [closure for closure in closures
+                      if not closure.parameters
+                      and re.fullmatch(r"\{\s*\}", code[closure.body:closure.end])
+                      and re.match(rf"function\s+{re.escape(called[1])}\s*\(", code[closure.start:])
+                      and resolver.scope_at(closure.start) in resolver.graph.ancestors(resolver.scope_at(offset))]
+        if len(candidates) != 1 or resolver.graph.visible_binding(
+            called[1], resolver.scope_at(offset), offset
+        ) is not None:
+            return True
+    # Parenthesized callee expressions are not ordinary direct closures.
+    for invoked in re.finditer(r"\)\s*\(", code[slice(*span)]):
+        opening = span[0] + invoked.end() - 1
+        if not any(closure.invocation_end is not None and closure.end <= opening
+                   and re.fullmatch(r"\s*\)*\s*\(", code[closure.end:opening + 1])
+                   for closure in closures):
+            return True
+    return False
+
+
+def request_execution_scope(resolver: SourceEndpointResolver, offset: int) -> int:
+    """Fold invoked closures, but not skipped defaults, into their caller."""
+    closures = request_closures(resolver)
+    containing = [closure for closure in closures if closure.start <= offset < closure.end]
+    for closure in containing:
+        if closure.arguments is None:
+            return -closure.start - 1
+        for index, (start, end) in enumerate(closure.parameters):
+            if not start <= offset < end:
+                continue
+            # Destructuring adds property-level defaults whose execution
+            # depends on the supplied/default object's shape. Do not lend
+            # those effects without resolving that additional condition.
+            if not re.match(r"\s*[A-Za-z_$][\w$]*\s*=", resolver.lexed.code[start:end]):
+                return -closure.start - 1
+            if index < len(closure.arguments):
+                if not request_argument_is_undefined(resolver, closure.arguments[index]):
+                    return -closure.start - 1
+    execution = resolver.graph.execution_scope(resolver.scope_at(offset))
+    while execution:
+        scope = resolver.graph.scopes[execution]
+        if not any(closure.body == scope.start for closure in containing):
+            break
+        execution = resolver.graph.execution_scope(scope.parent or 0)
+    return execution
+
+
+def request_write_events(
+    lexed: LexedSource, call: Call, suffix: str = ".js"
+) -> list[RequestWriteEvent]:
+    """Return write/end bodies belonging to this request handle's lifetime."""
+    chained = re.match(r"\s*\.\s*end\s*\(", lexed.code[call.end:])
+    if chained:
+        opening = call.end + chained.end() - 1
+        closing = matching_delimiter(lexed.code, opening, "(", ")")
+        if closing is not None:
+            args = split_arguments(lexed.code, opening + 1, closing)
+            return [RequestWriteEvent(call.end, "init"),
+                    RequestWriteEvent(call.end, "end", args[0] if args else None)]
     prefix = lexed.code[max(0, call.start - 160):call.start]
-    match = ASSIGNED_HANDLE_RE.search(prefix)
+    match = re.search(
+        r"(?<![\w$.])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)"
+        r"\s*=\s*(?:new\s+)?(?:[A-Za-z_$][\w$]*\s*\.\s*)?$", prefix
+    )
     if match is None:
         return []
-    handle = match.group(1)
+    handle = re.sub(r"\s+", "", match.group(1))
+    resolver = SourceEndpointResolver(lexed, suffix)
+
+    def receiver_binding(receiver: str, offset: int) -> int | tuple[int | None, str] | None:
+        root, separator, members = re.sub(r"\s+", "", receiver).partition(".")
+        # Parameters are in scope during later initializers as well as the body.
+        parameter_owner = [closure for closure in request_closures(resolver)
+                           if closure.start <= offset < closure.body]
+        lookup = max(parameter_owner, key=lambda item: item.start).body if parameter_owner else offset
+        root_binding = resolver.graph.visible_binding(root, resolver.scope_at(lookup), lookup)
+        return ((root_binding, members if root_binding is not None else root + "." + members)
+                if separator else root_binding)
+
+    binding = receiver_binding(handle, call.start)
+    execution = request_execution_scope(resolver, call.start)
+    assignments: list[RequestWriteEvent] = []
+    # Direct invocation binds arguments before entering the closure body.
+    # Parameter bindings remain lexical, so a stored callback or shadowing
+    # parameter cannot acquire ownership from a similarly named request.
+    for closure in request_closures(resolver):
+        if closure.start <= call.end or closure.arguments is None or request_execution_scope(resolver, closure.body) != execution:
+            continue
+        for index, parameter in enumerate(closure.parameters):
+            declared = re.fullmatch(r"\s*([A-Za-z_$][\w$]*)\s*(?:=([\s\S]*))?", lexed.code[slice(*parameter)])
+            if declared is None:
+                continue
+            name = declared[1]
+            argument = closure.arguments[index] if index < len(closure.arguments) else None
+            defaulted = argument is None or request_argument_is_undefined(resolver, argument)
+            value = (declared[2] or "").strip() if defaulted else lexed.code[slice(*argument)].strip()
+            if not re.fullmatch(
+                r"[A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*", value
+            ):
+                continue
+            target = resolver.graph.visible_binding(name, resolver.scope_at(closure.body), closure.body)
+            source = receiver_binding(value, parameter[0] if defaulted else argument[0])
+            # Supplied arguments capture their value before subsequent
+            # arguments can rebind it; defaults run in parameter order later.
+            assigned_at = parameter[1] if defaulted else argument[1]
+            assignments.append(RequestWriteEvent(assigned_at, "assign", binding=target, source_binding=source))
+            if isinstance(binding, tuple):
+                assignments.append(RequestWriteEvent(
+                    assigned_at, "assign", binding=(target, binding[1]),
+                    source_binding=(source, binding[1]) if isinstance(source, int) else None,
+                ))
+    # A broad typed-declaration match can cross an object literal and swallow
+    # a later bare assignment. Recover those lifetime mutations independently
+    # of the endpoint graph's declaration parser.
+    root_assignments = {assignment.start(): assignment for assignment in resolver.root_assignments}
+    parameter_starts = {start + len(lexed.code[start:end]) - len(lexed.code[start:end].lstrip())
+                        for closure in request_closures(resolver) for start, end in closure.parameters}
+    for assignment in re.finditer(r"(?<![\w$.>])([A-Za-z_$][\w$]*)\s*=(?!=|>)", lexed.code):
+        if assignment.start() not in parameter_starts:
+            root_assignments.setdefault(assignment.start(), assignment)
+    for assignment in root_assignments.values():
+        if assignment.start() <= call.end:
+            continue
+        scope = resolver.scope_at(assignment.start())
+        if request_execution_scope(resolver, assignment.start()) != execution:
+            continue
+        assigned_binding = receiver_binding(assignment[1], assignment.start())
+        end = assignment_end(lexed, assignment.end(), suffix)
+        rhs = lexed.code[assignment.end():end].strip().rstrip(";").strip()
+        source_binding = (receiver_binding(rhs, assignment.start())
+                          if re.fullmatch(r"[A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*", rhs) else None)
+        assignments.append(RequestWriteEvent(assignment.start(), "assign",
+                                             binding=assigned_binding, source_binding=source_binding))
+        if isinstance(binding, tuple):
+            # Root aliases carry the owned member at this point in time.
+            # A later root rebind kills only that root's view, not aliases
+            # which still point at the original owner object.
+            assignments.append(RequestWriteEvent(
+                assignment.start(), "assign", binding=(assigned_binding, binding[1]),
+                source_binding=(source_binding, binding[1])
+                if isinstance(source_binding, int) else None,
+            ))
+    if isinstance(binding, tuple):
+        for reference, start, _, _ in direct_member_assignments(lexed, len(lexed.code), suffix):
+            if start <= call.end or request_execution_scope(resolver, start) != execution:
+                continue
+            target = receiver_binding(".".join(reference), start)
+            if isinstance(target, tuple) and (
+                target[1] == binding[1] or binding[1].startswith(target[1] + ".")
+            ):
+                assignments.append(RequestWriteEvent(start, "member_assign", binding=(target[0], binding[1])))
+    # Finite alias closure keeps unrelated assignments/branches out of the
+    # path product. Runtime ownership is still evaluated per environment below.
+    aliases = {binding}
+    for _ in range(len(assignments)):
+        expanded = aliases | {event.binding for event in assignments
+                              if event.source_binding is not None and event.source_binding in aliases}
+        if expanded == aliases:
+            break
+        aliases = expanded
     write_re = re.compile(
-        r"(?<![\w$])" + re.escape(handle) + r"\s*\.\s*write\s*\("
+        r"(?<![\w$.])([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)"
+        r"\s*\.\s*(write|end)\s*\("
     )
-    spans: list[tuple[int, int]] = []
+    events = [RequestWriteEvent(call.end, "init", binding=binding)]
+    events.extend(event for event in assignments if event.binding in aliases)
+    for closure in request_closures(resolver):
+        for argument in closure.arguments or ():
+            if (argument[0] > call.end and request_execution_scope(resolver, argument[0]) == execution
+                    and request_argument_is_undefined(resolver, argument)
+                    and request_argument_has_unknown_call(resolver, argument)):
+                events.append(RequestWriteEvent(argument[1], "invalidate"))
+    # Abrupt completion skips the remainder of this closure on its active
+    # branch. Keep return-expression effects before the skip boundary.
+    for abrupt in re.finditer(r"\b(?:return|throw)\b", lexed.code[call.end:]):
+        position = call.end + abrupt.start()
+        if lexed.code[:position].rstrip().endswith("."):
+            continue
+        containing = [closure for closure in request_closures(resolver)
+                      if closure.body <= position < closure.end]
+        if not containing or request_execution_scope(resolver, position) != execution:
+            continue
+        closure = max(containing, key=lambda item: item.start)
+        after = position + len(abrupt[0])
+        while after < closure.end and lexed.code[after] not in ";\n}":
+            if lexed.code[after] in "([{":
+                closing = matching_delimiter(lexed.code, after, lexed.code[after],
+                                             {"(": ")", "[": "]", "{": "}"}[lexed.code[after]])
+                if closing is not None:
+                    after = closing + 1
+                    continue
+            after += 1
+        # Return leaves the closure only after enclosing finally bodies run.
+        # Preserve their writes AND lifetime mutations (e.g. req = other).
+        finalizers: list[tuple[int, int]] = []
+        for attempt in re.finditer(r"\btry\s*\{", lexed.code[closure.body:position]):
+            opening = closure.body + attempt.end() - 1
+            try_end = matching_delimiter(lexed.code, opening, "{", "}")
+            if try_end is None:
+                continue
+            protected = opening < position < try_end
+            tail = try_end + 1
+            catcher = re.match(r"\s*catch\s*(?:\([^()]*\)\s*)?\{", lexed.code[tail:])
+            if catcher:
+                catch_end = matching_delimiter(lexed.code, tail + catcher.end() - 1, "{", "}")
+                if catch_end is None:
+                    continue
+                protected = protected or tail + catcher.end() - 1 < position < catch_end
+                tail = catch_end + 1
+            if not protected:
+                continue
+            finalizer = re.match(r"\s*finally\s*\{", lexed.code[tail:])
+            if finalizer:
+                final_open = tail + finalizer.end() - 1
+                final_end = matching_delimiter(lexed.code, final_open, "{", "}")
+                if final_end is not None:
+                    finalizers.append((final_open, final_end + 1))
+        skip = after
+        for final_start, final_end in sorted(finalizers):
+            events.append(RequestWriteEvent(position, "terminate", (skip, final_start)))
+            skip = final_end
+        events.append(RequestWriteEvent(position, "terminate", (skip, closure.end)))
+        if abrupt[0] == "throw":
+            # Catch dispatch is not modelled as a callable return. It can
+            # change ownership before control resumes; do not certify later
+            # writes through handles whose lifetime crossed that exception.
+            events.append(RequestWriteEvent(position, "throw"))
     for found in write_re.finditer(lexed.code, call.end):
+        if lexed.code[:found.start()].rstrip().endswith("."):
+            continue
+        event_binding = receiver_binding(found[1], found.start())
+        if event_binding not in aliases or (event_binding is None and found[1] != handle):
+            continue
+        if request_execution_scope(resolver, found.start()) != execution:
+            continue
         open_paren = lexed.code.index("(", found.end() - 1)
         closing = matching_delimiter(lexed.code, open_paren, "(", ")")
         if closing is None:
             continue
         arguments = split_arguments(lexed.code, open_paren + 1, closing)
-        if arguments:
-            spans.append(arguments[0])
-    return spans
+        events.append(RequestWriteEvent(found.start(), found[2], arguments[0] if arguments else None,
+                                        binding=event_binding))
+    return sorted(events, key=lambda event: request_event_order(resolver, event.offset))
+
+
+def request_write_payload_spans(lexed: LexedSource, call: Call, suffix: str = ".js") -> list[tuple[int, int]]:
+    return [event.span for event in request_write_events(lexed, call, suffix) if event.span]
+
+
+def request_writes_have_profile(lexed: LexedSource, call: Call, suffix: str,
+                               resolver: PayloadStateResolver,
+                               events: list[RequestWriteEvent]) -> bool:
+    control = resolver.control
+    paths = [control.path(event.offset) for event in events]
+    environments = control.environments(paths, control.path(call.start))
+    # Refine literal conditions within the same branch model. Unknown tests
+    # retain every environment; no conditional write alone certifies a send.
+    literal: dict[int, bool] = {}
+    for path in paths:
+        for group, _ in path:
+            condition = re.match(r"if\s*\(\s*(true|false)\s*\)", lexed.code[group:])
+            if condition:
+                literal[group] = condition[1] == "true"
+    environments = [env for env in environments if all(
+        (env.get(group) == 0) == value for group, value in literal.items())]
+    if not environments:
+        return False
+    for environment in environments:
+        present = False
+        aliases: set[int | tuple[int | None, str] | None] = set()
+        terminated: list[tuple[int, int]] = []
+        for event, path in zip(events, paths):
+            if not control.active(path, environment) or any(
+                start <= event.offset < end for start, end in terminated
+            ):
+                continue
+            if event.method == "terminate":
+                if event.span:
+                    terminated.append(event.span)
+                continue
+            if event.method in {"throw", "invalidate"}:
+                aliases.clear()
+                continue
+            if event.method == "init":
+                aliases.add(event.binding)
+                continue
+            if event.method == "member_assign":
+                if event.binding in aliases:
+                    aliases = {alias for alias in aliases if not isinstance(alias, tuple)}
+                continue
+            if event.method == "assign":
+                if event.source_binding is not None and event.source_binding in aliases:
+                    aliases.add(event.binding)
+                else:
+                    aliases.discard(event.binding)
+                continue
+            if event.binding not in aliases:
+                continue
+            if event.span and resolver.span_presence(*event.span, event.offset).state == PRESENT:
+                present = True
+            if event.method == "end":
+                break
+        if not present:
+            return False
+    return True
 
 
 URL_CONSTRUCTOR_RE = re.compile(
@@ -7087,10 +7684,11 @@ def _request_url_spans(
         # ENDPOINT, unlike net/http.Post(url, contentType, body). Without this
         # the whole send was invisible.
         return args[0:1]
-    if callee == "NewRequest" and len(args) >= 2:
+    if callee in GO_REQUEST_METHOD_INDEX and len(args) >= GO_REQUEST_METHOD_INDEX[callee] + 3:
         # Go net/http: http.NewRequest(method, url, body) + client.Do(req).
         # The idiomatic non-shortcut form; only mutating methods matter here.
-        method = static_method_value(lexed, args[0], call.start, suffix)
+        method_index = GO_REQUEST_METHOD_INDEX[callee]
+        method = static_method_value(lexed, args[method_index], call.start, suffix)
         if method is not None and method not in MUTATING_HTTP_METHODS:
             return []
         # NOTE: http.NewRequest is NOT gated on a client.Do(req) execution link.
@@ -7100,7 +7698,7 @@ def _request_url_spans(
         # behaviour change beyond the scope of this work, so it is left as-is;
         # the execution requirement applies only to the clients newly modelled
         # in this change (OkHttp, HttpRequestMessage, RestSharp, urllib).
-        return args[1:2]
+        return args[method_index + 1:method_index + 2]
     if callee.endswith("new") and "Net::HTTP::" in callee and len(args) >= 1:
         return args[0:1] if request_object_is_executed(lexed, call, suffix) else []
     if callee == "curl_init" and len(args) >= 1:
@@ -7525,12 +8123,27 @@ def c_function_headers(
     if suffix not in supported:
         return {}
     headers: dict[int, tuple[int, int]] = {}
+    if suffix in JS_TS_SUFFIXES:
+        # Grouping and default expressions can contain parentheses/braces
+        # before the function body; index its balanced parameter pair directly.
+        for function in re.finditer(r"\bfunction\s*\*?\s*(?:[A-Za-z_$][\w$]*\s*)?\(", lexed.code):
+            params_open = function.end() - 1
+            params_close = matching_delimiter(lexed.code, params_open, "(", ")")
+            if params_close is None:
+                continue
+            body = params_close + 1
+            while body < len(lexed.code) and lexed.code[body].isspace():
+                body += 1
+            if lexed.code[body:body + 1] == "{":
+                headers[body] = (params_open + 1, params_close)
     controls = {
         "catch", "checked", "fixed", "for", "foreach", "if", "lock",
         "switch", "synchronized", "try", "unchecked", "using", "while",
         "with",
     }
     for opening in (index for index, char in enumerate(lexed.code) if char == "{"):
+        if opening in headers:
+            continue
         statement_start = max(
             lexed.code.rfind(";", 0, opening),
             lexed.code.rfind("{", 0, opening),
@@ -7555,7 +8168,7 @@ def c_function_headers(
                 params_open = matching_opening(
                     lexed.code, cursor, "(", ")"
                 )
-                if params_open is not None and params_open >= statement_start:
+                if params_open is not None:
                     headers[opening] = (params_open + 1, cursor)
                 continue
             parameter = re.search(
@@ -10505,6 +11118,7 @@ class ControlIndex:
         self.lexed, self.suffix = lexed, suffix
         self.arms: list[ControlArm] = []
         self.exhaustive: set[int] = set()
+        self.logical_traces: list[list[dict[int, int | None]]] = []
         if suffix in self.C_SUFFIXES:
             self._curly()
             # Expression-level guards are not a JavaScript peculiarity: PHP,
@@ -10549,6 +11163,57 @@ class ControlIndex:
             index += 1
         return None
 
+    def _logical_expression_traces(self, start: int, end: int) -> None:
+        """Keep short-circuit choices correlated by expression evaluation.
+
+        In ``a && b || c``, skipping b forces c to run. Independent optional
+        guards invent a path which skips both. Leaves have unknown truthiness;
+        no API-specific return-value assumptions are needed.
+        """
+        code = self.lexed.code
+        if len(re.findall(r"&&|\|\|", code[start:end])) > 6:
+            return  # Preserve the existing conservative finite-path bound.
+
+        def traces(left: int, right: int) -> list[tuple[bool, dict[int, int | None]]]:
+            while left < right and code[left].isspace():
+                left += 1
+            while right > left and code[right - 1].isspace():
+                right -= 1
+            if left < right and code[left] == "(" and matching_delimiter(code, left, "(", ")") == right - 1:
+                return traces(left + 1, right - 1)
+            operators: list[tuple[int, str]] = []
+            index = left
+            while index < right:
+                if code[index] in "([{":
+                    closing = matching_delimiter(code, index, code[index], {"(": ")", "[": "]", "{": "}"}[code[index]])
+                    if closing is None:
+                        return [(True, {}), (False, {})]
+                    index = closing + 1
+                    continue
+                if code[index:index + 2] in {"&&", "||"} and code[index + 2:index + 3] != "=":
+                    operators.append((index, code[index:index + 2]))
+                    index += 2
+                    continue
+                index += 1
+            if not operators:
+                return [(True, {}), (False, {})]
+            # Lowest precedence, rightmost operator is the expression root.
+            position, operator = next((item for item in reversed(operators) if item[1] == "||"), operators[-1])
+            before, after = traces(left, position), traces(position + 2, right)
+            right_groups = {group for _, path in after for group in path}
+            result = []
+            for value, path in before:
+                evaluate = value if operator == "&&" else not value
+                if evaluate:
+                    result.extend((outcome, path | tail | {position: 0}) for outcome, tail in after)
+                else:
+                    result.append((value, path | dict.fromkeys(right_groups) | {position: None}))
+            return result
+
+        choices = [path for _, path in traces(start, end)]
+        if any(choices):
+            self.logical_traces.append(choices)
+
     def _expression_guards(self) -> None:
         """Index short-circuit and ternary expression arms in JS/TS.
 
@@ -10569,15 +11234,15 @@ class ControlIndex:
         word_ops = self.suffix in {".php", ".rb", ".py"}
         logical_re = (
             r"&&=?|\|\|=?|(?<![\w])(?:and|or)(?![\w])" if word_ops
-            else r"&&=?|\|\|=?"
+            else r"&&=?|\|\|=?|\?\?=?"
         )
         dangling = re.compile(
             r"(?:&&|\|\||\?|(?<![\w])(?:and|or))\s*$" if word_ops
-            else r"(?:&&|\|\||\?)\s*$"
+            else r"(?:&&|\|\||\?\?|\?)\s*$"
         )
         continuing = re.compile(
             r"[ \t]*(?:&&|\|\||\?|:|(?<![\w])(?:and|or)(?![\w]))" if word_ops
-            else r"[ \t]*(?:&&|\|\||\?|:)"
+            else r"[ \t]*(?:&&|\|\||\?\?|\?|:)"
         )
         statement_start = 0
         for match in re.finditer(r"[;\n]|$", code):
@@ -10596,26 +11261,99 @@ class ControlIndex:
             profile = PROFILE_IDENTIFIER_RE.search(
                 self.lexed.original[statement_start:statement_end]
             )
-            if profile is not None:
-                absolute_profile = statement_start + profile.start()
+            if profile is not None or self.suffix in JS_TS_SUFFIXES:
+                absolute_profile = statement_start + profile.start() if profile else statement_end
                 logical = list(re.finditer(logical_re, segment))
                 for operator in logical:
                     operator_end = statement_start + operator.end()
-                    if operator_end <= absolute_profile:
+                    if self.suffix in JS_TS_SUFFIXES or operator_end <= absolute_profile:
+                        guard_end = statement_end
+                        if self.suffix in JS_TS_SUFFIXES and not operator[0].endswith("="):
+                            # A logical RHS may be skipped, but a surrounding
+                            # ternary still chooses an arm after evaluating
+                            # its whole condition: `a ?? b ? yes : no`.
+                            # Logical assignments instead guard the entire
+                            # RHS ternary, due to their lower precedence.
+                            stack: list[int] = []
+                            for index in range(statement_start, operator_end):
+                                if code[index] in "([{":
+                                    stack.append(index)
+                                elif code[index] in ")]}" and stack:
+                                    stack.pop()
+                            expression_start = statement_start
+                            if stack:
+                                opening = stack[-1]
+                                closing = matching_delimiter(code, opening, code[opening], {"(": ")", "[": "]", "{": "}"}[code[opening]])
+                                if closing is not None:
+                                    expression_start, guard_end = opening + 1, closing
+                            outer = _top_level_ternary(code, expression_start, guard_end)
+                            if outer and operator_end < outer[0][0]:
+                                guard_end = outer[0][0] - 1
+                        if self.suffix in JS_TS_SUFFIXES:
+                            # The RHS stops at its own comma/closing delimiter
+                            # or an enclosing ternary's alternate arm. Nested
+                            # expressions keep their internal separators.
+                            depth = ternaries = 0
+                            for index in range(operator_end, guard_end):
+                                char = code[index]
+                                if char in "([{":
+                                    depth += 1
+                                elif char in ")]}":
+                                    if not depth:
+                                        guard_end = index
+                                        break
+                                    depth -= 1
+                                elif not depth:
+                                    if not operator[0].endswith("=") and (
+                                        code[index:index + 2] == "||" or
+                                        code[index:index + 2] == "&&" and operator[0] == "&&"
+                                    ):
+                                        guard_end = index
+                                        break
+                                    if char == "?" and code[index:index + 2] not in {"??", "?."} and code[index - 1] != "?":
+                                        ternaries += 1
+                                    elif char == ":" and ternaries:
+                                        ternaries -= 1
+                                    elif char == "," or char == ":":
+                                        guard_end = index
+                                        break
                         self.arms.append(
-                            ControlArm(statement_start, 0, operator_end, statement_end)
+                            ControlArm(statement_start + operator.start(), 0, operator_end, guard_end)
                         )
-                question = segment.find("?")
-                colon = segment.find(":", question + 1) if question >= 0 else -1
-                if question >= 0 and colon >= 0 and absolute_profile > statement_start + question:
-                    self.arms.append(
-                        ControlArm(
-                            statement_start,
-                            0 if absolute_profile < statement_start + colon else 1,
-                            statement_start + question + 1,
-                            statement_end,
-                        )
-                    )
+                # Visit balanced subexpressions too: a ternary inside `(…)`
+                # or a call argument still guards its mutations. Balanced
+                # extraction avoids mistaking object-key colons for `?:`.
+                pending = [(statement_start, statement_end)]
+                seen: set[tuple[int, int]] = set()
+                while pending:
+                    start, end = pending.pop()
+                    if (start, end) in seen:
+                        continue
+                    seen.add((start, end))
+                    if self.suffix in JS_TS_SUFFIXES:
+                        # Comma has lower precedence than ?:; a following
+                        # expression is outside both conditional arms.
+                        expressions = split_arguments(code, start, end)
+                        if len(expressions) > 1:
+                            pending.extend(expressions)
+                            continue
+                    ternary = _top_level_ternary(code, start, end)
+                    if self.suffix in JS_TS_SUFFIXES and ternary is None:
+                        self._logical_expression_traces(start, end)
+                    if ternary is not None:
+                        group = ternary[0][0] - 1
+                        for branch, (arm_start, arm_end) in enumerate(ternary):
+                            self.arms.append(ControlArm(group, branch, arm_start, arm_end))
+                        self.exhaustive.add(group)
+                        pending.extend(ternary)
+                    stack: list[int] = []
+                    for index in range(start, end):
+                        if code[index] in "([{":
+                            stack.append(index)
+                        elif code[index] in ")]}" and stack:
+                            opening = stack.pop()
+                            if not stack:
+                                pending.append((opening + 1, index))
             statement_start = match.end()
 
     def _body_arm(self, group: int, branch: int, after: int) -> int | None:
@@ -11402,7 +12140,11 @@ class ControlIndex:
             environments = expanded
             if len(environments) > 64:
                 return []
-        return environments
+        return [environment for environment in environments if all(
+            any(all(group not in environment or environment[group] == choice
+                    for group, choice in trace.items()) for trace in traces)
+            for traces in self.logical_traces
+        )]
 
     @staticmethod
     def active(path: tuple[tuple[int, int], ...], environment: dict[int, int | None]) -> bool:
@@ -12186,6 +12928,10 @@ def shell_embedded_command_span(
     """Bound the narrowest quoted shell command containing ``offset``."""
 
     candidates: list[tuple[int, int]] = []
+    for start, end, expands in _shell_heredoc_ranges(lexed.original):
+        if expands and start <= offset < end:
+            candidates.extend(span for span in _shell_command_substitution_ranges(lexed.original, start, end)
+                              if span[0] <= offset < span[1])
     for token in lexed.strings:
         if not (token.start < offset < token.end):
             continue

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -99,6 +99,21 @@ ci_glob() {
   esac
 }
 
+# grep returns 1 when it found no matches and >1 for an operational error.
+# Static-analysis discovery may accept the former, but must never translate
+# the latter into a clean migration result.
+grep_allow_no_match() {
+  local status
+  set +e
+  grep "$@"
+  status=$?
+  set -e
+  if [ "$status" -gt 1 ]; then
+    return "$status"
+  fi
+  return 0
+}
+
 # Extensionless executables with shebangs (package.json "bin" entry points,
 # repo CLIs) are source files no --include glob can ever match; the Phase-1
 # scanner greps without includes and sees them, so skipping them here made
@@ -153,7 +168,7 @@ grep_shebang_files() {
     list=$(shebang_files_for_glob "$glob")
     [ -z "$list" ] && continue
     while IFS= read -r _f; do
-      [ -n "$_f" ] && { grep -nH -E "$pattern" "$_f" 2>/dev/null || true; }
+      [ -n "$_f" ] && grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
     done <<< "$list"
   done
 }
@@ -180,14 +195,6 @@ expand_source_globs() {
   done
 }
 
-# Comment-leading lines are prose, not residual code: '# migrated from
-# twilio' must not fail a completed migration. Live code with a TRAILING
-# comment still matches, since only lines STARTING with a comment marker are
-# stripped.
-strip_comment_lines() {
-  grep -v '^\([^:]*:[0-9]*:\)[[:space:]]*\(#\|//\|/\*\|\*\|--\|%\|<!--\)' || true
-}
-
 # Filter grep hits through the same lexer used by the messaging-profile
 # analyzer.  Line-prefix filters cannot distinguish a trailing dead comment
 # from live code, and syntax checks must not treat a quoted migration note as
@@ -210,6 +217,7 @@ filter_backend_matches() {
   scripts_dir=$(cd "$(dirname "$0")" && pwd)
   python3 -B "$scripts_dir/filter-source-matches.py" \
     --mode comments --region backend --pattern "$pattern" \
+    --exclude-suffix .vue --exclude-suffix .svelte --exclude-suffix .astro \
     --analyzer "$scripts_dir/lint-required-messaging-profile.py"
 }
 
@@ -246,7 +254,7 @@ search_raw_files() {
   done
   # shellcheck disable=SC2086
   set +f
-  grep -rn $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep_allow_no_match -a -rnH --null $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT"
   grep_shebang_files "$pattern" "$@"
 }
 
@@ -357,17 +365,21 @@ hybrid_waiver_applies() {
     [ -n "$MIGRATED_FILES" ] || return 0
     while IFS= read -r match; do
       [ -n "$match" ] || continue
-      path=$(printf '%s\n' "$match" | sed -E 's/:[0-9]+:.*$//')
-      case "$path" in
-        "$PROJECT_ROOT"/*) path=${path#"$PROJECT_ROOT"/} ;;
-        ./*) path=${path#./} ;;
-      esac
       while IFS= read -r migrated_file; do
         [ -n "$migrated_file" ] || continue
+        migrated_path="$PROJECT_ROOT/$migrated_file"
+        # Filtered grep output is `<absolute path>:<line>:<text>`. Do not
+        # recover the path with a colon regex: POSIX paths may themselves
+        # contain `:<digits>:`. Instead compare each complete, known migrated
+        # path and then validate only its numeric locator suffix.
+        remainder=${match#"$migrated_path:"}
+        if [ "$remainder" != "$match" ] && [[ "$remainder" =~ ^[0-9]+: ]]; then
+          return 1
+        fi
         # A directory finding covers every file below it. Do not waive a
         # Twilio-named directory when any explicitly migrated file lives in
         # that directory, even though the grep finding names only the parent.
-        if [ "$migrated_file" = "$path" ] || [[ "$migrated_file" = "$path"/* ]]; then
+        if [ "$migrated_path" = "$match" ] || [[ "$migrated_path" = "$match"/* ]]; then
           return 1
         fi
       done <<<"$MIGRATED_FILES"
@@ -848,19 +860,16 @@ if product_applies "all"; then
   # cross-file heuristic after applying the normal executable-source filter.
   webhook_pattern="(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)"
   webhook_handlers=$(search_raw_files "$webhook_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-    | filter_backend_matches "$webhook_pattern" \
-    | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+    | filter_backend_matches "$webhook_pattern")
   webhook_count=$(count_matches "$webhook_handlers")
   if [ "$webhook_count" -gt 0 ]; then
     ed25519_pattern="(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)"
     ed25519_refs=$(search_raw_files "$ed25519_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-      | filter_backend_matches "$ed25519_pattern" \
-      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+      | filter_backend_matches "$ed25519_pattern")
     ed25519_count=$(count_matches "$ed25519_refs")
     webhook_parse_pattern="(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])"
     telnyx_webhook_parse=$(search_raw_files "$webhook_parse_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
-      | filter_backend_matches "$webhook_parse_pattern" \
-      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
+      | filter_backend_matches "$webhook_parse_pattern")
     telnyx_parse_count=$(count_matches "$telnyx_webhook_parse")
     if [ "$telnyx_parse_count" -gt 0 ] && [ "$ed25519_count" -eq 0 ]; then
       lint_issue "webhook_ed25519_missing" \

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -147,15 +147,16 @@ grep_shebang_files() {
 }
 
 # A caller asking for "*.js" means "JavaScript", not "files whose name ends in
-# .js". Node resolves .cjs/.mjs and bundlers resolve .jsx/.tsx/.mts/.cts as the
-# same source language, so a check that only globs the bare extension silently
-# passes any project using them. Expanding here fixes every call site at once;
-# per-call glob lists drift apart as checks are added.
+# .js". Node resolves .cjs/.mjs, bundlers resolve .jsx/.tsx/.mts/.cts, and
+# component frameworks embed JavaScript in .vue/.svelte/.astro files. A check
+# that only globs the bare extension silently passes projects using them.
+# Expanding here fixes every call site at once; per-call glob lists drift apart
+# as checks are added.
 expand_source_globs() {
   local glob
   for glob in "$@"; do
     case "$glob" in
-      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' ;;
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' ;;
       '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
       '*.py') echo '*.py' '*.pyw' ;;
       '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -48,7 +48,7 @@ HYBRID_PRODUCTS=""
 MIGRATED_FILES=""
 JSON_CHECKS="[]"
 
-EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build"
+EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build .next .nuxt coverage .tox"
 EXCLUDE_LOCK_FILES="--exclude=package-lock.json --exclude=yarn.lock --exclude=pnpm-lock.yaml --exclude=Gemfile.lock --exclude=Pipfile.lock --exclude=poetry.lock --exclude=go.sum"
 EXCLUDE_SCAN_FILES="--exclude=twilio-scan.json --exclude=twilio-deep-scan.json --exclude=migration-state.json --exclude=MIGRATION-PLAN.md --exclude=MIGRATION-REPORT.md"
 
@@ -70,21 +70,153 @@ build_exclude_args() {
   done
   args="$args $EXCLUDE_LOCK_FILES"
   args="$args $EXCLUDE_SCAN_FILES"
-  args="$args --exclude=*.md --exclude=*.min.js"
+  args="$args --exclude=*.md --exclude=*.min.js --exclude=*.min.css --exclude=*.bundle.js --exclude=*.chunk.js"
   echo "$args"
 }
 
 GREP_EXCLUDES=""
 
+
+# grep --include globs are case-sensitive; SEND.JS is the same JavaScript as
+# send.js. Rewrite '*.ext' into a character-class glob matching any casing.
+ci_glob() {
+  local glob="$1"
+  case "$glob" in
+    \*.*)
+      local ext="${glob#\*.}" out="*." i c upper
+      for ((i = 0; i < ${#ext}; i++)); do
+        c="${ext:$i:1}"
+        if [[ "$c" == [a-z] ]]; then
+          upper=$(printf '%s' "$c" | tr '[:lower:]' '[:upper:]')
+          out+="[${c}${upper}]"
+        else
+          out+="$c"
+        fi
+      done
+      echo "$out"
+      ;;
+    *) echo "$glob" ;;
+  esac
+}
+
+# Extensionless executables with shebangs (package.json "bin" entry points,
+# repo CLIs) are source files no --include glob can ever match; the Phase-1
+# scanner greps without includes and sees them, so skipping them here made
+# the validator certify trees the scanner had put in migration scope.
+SHEBANG_JS_FILES=""
+SHEBANG_PY_FILES=""
+SHEBANG_RB_FILES=""
+SHEBANG_SH_FILES=""
+
+collect_shebang_files() {
+  local _f _first
+  while IFS= read -r -d '' _f; do
+    IFS= read -r _first < "$_f" 2>/dev/null || _first=""
+    case "$_first" in
+      '#!'*node*)   SHEBANG_JS_FILES="${SHEBANG_JS_FILES}${_f}"$'\n' ;;
+      '#!'*python*) SHEBANG_PY_FILES="${SHEBANG_PY_FILES}${_f}"$'\n' ;;
+      '#!'*ruby*)   SHEBANG_RB_FILES="${SHEBANG_RB_FILES}${_f}"$'\n' ;;
+      '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
+    esac
+  done < <(find "$PROJECT_ROOT" \
+    \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
+       -o -name venv -o -name .venv -o -name dist -o -name build \
+       -o -name .next -o -name .nuxt -o -name coverage -o -name .tox \) -prune \
+    -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
+}
+
+shebang_files_for_glob() {
+  case "$1" in
+    '*.js'|'*.ts') printf '%s' "$SHEBANG_JS_FILES" ;;
+    '*.py')        printf '%s' "$SHEBANG_PY_FILES" ;;
+    '*.rb')        printf '%s' "$SHEBANG_RB_FILES" ;;
+    '*.sh')        printf '%s' "$SHEBANG_SH_FILES" ;;
+  esac
+}
+
+grep_shebang_files() {
+  local pattern="$1"; shift
+  local glob list _f
+  for glob in "$@"; do
+    list=$(shebang_files_for_glob "$glob")
+    [ -z "$list" ] && continue
+    while IFS= read -r _f; do
+      [ -n "$_f" ] && { grep -nH -E "$pattern" "$_f" 2>/dev/null || true; }
+    done <<< "$list"
+  done
+}
+
+# A caller asking for "*.js" means "JavaScript", not "files whose name ends in
+# .js". Node resolves .cjs/.mjs and bundlers resolve .jsx/.tsx/.mts/.cts as the
+# same source language, so a check that only globs the bare extension silently
+# passes any project using them. Expanding here fixes every call site at once;
+# per-call glob lists drift apart as checks are added.
+expand_source_globs() {
+  local glob
+  for glob in "$@"; do
+    case "$glob" in
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' ;;
+      '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
+      '*.py') echo '*.py' '*.pyw' ;;
+      '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;
+      '*.php') echo '*.php' '*.phtml' ;;
+      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' ;;
+      '*.cs') echo '*.cs' '*.cshtml' ;;
+      *) echo "$glob" ;;
+    esac
+  done
+}
+
+# Comment-leading lines are prose, not residual code: '# migrated from
+# twilio' must not fail a completed migration. Live code with a TRAILING
+# comment still matches, since only lines STARTING with a comment marker are
+# stripped.
+strip_comment_lines() {
+  grep -v '^\([^:]*:[0-9]*:\)[[:space:]]*\(#\|//\|/\*\|\*\|--\|%\|<!--\)' || true
+}
+
+# Filter grep hits through the same lexer used by the messaging-profile
+# analyzer.  Line-prefix filters cannot distinguish a trailing dead comment
+# from live code, and syntax checks must not treat a quoted migration note as
+# an executable builder call.  `comments` preserves string literals (needed
+# for imports, URLs, and configuration); `code` masks both comments and
+# strings (needed for identifiers such as VoiceResponse()).
+filter_source_matches() {
+  local mode="$1"
+  local pattern="$2"
+  local scripts_dir
+  scripts_dir=$(cd "$(dirname "$0")" && pwd)
+  python3 -B "$scripts_dir/filter-source-matches.py" \
+    --mode "$mode" --pattern "$pattern" \
+    --analyzer "$scripts_dir/lint-required-messaging-profile.py"
+}
+
+search_live_files() {
+  local mode="$1"
+  local pattern="$2"
+  shift 2
+  search_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
+}
+
 search_files() {
   local pattern="$1"
   shift
   local include_args=""
-  for glob in "$@"; do
-    include_args="$include_args --include=$glob"
+  local glob
+  # shellcheck disable=SC2046
+  # `for glob in $(...)` lets the shell PATHNAME-EXPAND each glob against the
+  # CALLER'S cwd: if a matching file happens to exist there the glob collapses
+  # to that basename, silently restricting grep to it; if none matches the glob
+  # survives. Either way whole languages could stop being scanned. set -f keeps
+  # the patterns literal.
+  set -f
+  for glob in $(expand_source_globs "$@"); do
+    include_args="$include_args --include=$(ci_glob "$glob")"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  set +f
+  grep -rn $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep_shebang_files "$pattern" "$@"
 }
 
 count_matches() {
@@ -231,6 +363,17 @@ while [ $# -gt 0 ]; do
     --product)
       if [ $# -lt 2 ]; then echo "Error: --product requires a value" >&2; usage; fi
       PRODUCT_FILTER="$2"
+      # An unvalidated value silently matches no check_products list, so a typo
+      # skips every product-scoped check and still exits 0 — a silent pass.
+      # Same accepted set as validate-migration.sh.
+      case "$PRODUCT_FILTER" in
+        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup) ;;
+        *)
+          echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
+          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup" >&2
+          exit 2
+          ;;
+      esac
       shift 2
       ;;
     --json)
@@ -288,6 +431,7 @@ fi
 
 PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
 GREP_EXCLUDES=$(build_exclude_args)
+collect_shebang_files
 
 if [ -z "$STATE_FILE" ] && [ -f "$PROJECT_ROOT/migration-state.json" ]; then
   STATE_FILE="$PROJECT_ROOT/migration-state.json"
@@ -326,9 +470,55 @@ fi
 ORIGINAL_HAD_WEBHOOK_VALIDATION="unknown"
 SCAN_PRODUCTS=""
 if [ -n "$SCAN_JSON" ] && [ -f "$SCAN_JSON" ] && command -v jq >/dev/null 2>&1; then
-  ORIGINAL_HAD_WEBHOOK_VALIDATION=$(jq -r '.has_webhook_validation // false' "$SCAN_JSON" 2>/dev/null || echo "unknown")
+  ORIGINAL_HAD_WEBHOOK_VALIDATION=$(jq -r 'if (.summary.has_webhook_validation != null) then .summary.has_webhook_validation elif (.has_webhook_validation != null) then .has_webhook_validation else "unknown" end' "$SCAN_JSON" 2>/dev/null || echo "unknown")
   SCAN_PRODUCTS=$(jq -r '.products_used // [] | map(ascii_downcase) | join(",")' "$SCAN_JSON" 2>/dev/null || true)
 fi
+
+# Hybrid awareness, mirroring validate-migration.sh: a product recorded as
+# kept on Twilio in migration-state.json is a skill-sanctioned deployment
+# state, so residual-Twilio findings for it are expected and must not hard-
+# fail Phase 4 forever.
+if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ] && command -v jq >/dev/null 2>&1; then
+  # Only products with a truthy keep reason stay in hybrid scope. An
+  # operator reverses a decision with `set kept_on_twilio.X false`
+  # (there is no unset command), so false/null/empty means NOT kept.
+  KEPT_ON_TWILIO=$(jq -r '.kept_on_twilio // {} | to_entries | map(select(.value != false and .value != null and .value != "")) | map(.key) | join(",")' "$STATE_FILE" 2>/dev/null || true)
+elif [ -n "$STATE_FILE" ] && [ ! -f "$STATE_FILE" ]; then
+  echo "Warning: --state-file '$STATE_FILE' not found, ignoring" >&2
+fi
+
+# Waive only for the product that is actually KEPT on Twilio.
+#
+# Testing `-n "$KEPT_ON_TWILIO"` alone made ANY hybrid state a GLOBAL waiver: in
+# a `--product messaging` run, a leftover Twilio messaging import was downgraded
+# to a warning - and the linter exited clean - merely because an unrelated
+# product such as voice was kept on Twilio. That is a silent pass on exactly the
+# residue the check exists to find.
+#
+# The product is passed per call site because these checks are not all inside a
+# product-scoped block; the global ones (residual imports, client instantiation,
+# directory names, docs) legitimately span products and pass "any", which waives
+# whenever ANY product is kept - the original behaviour, but now stated at the
+# call site rather than applied silently everywhere.
+kept_on_twilio() {
+  local product="$1"
+  [ -n "$KEPT_ON_TWILIO" ] || return 1
+  [ "$product" = "any" ] && return 0
+  case ",$KEPT_ON_TWILIO," in
+    *",$product,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+lint_issue_or_hybrid_warn() {
+  local product="$1"
+  shift
+  if kept_on_twilio "$product"; then
+    lint_warn "$1" "$2 (hybrid deployment — $KEPT_ON_TWILIO kept on Twilio)" "$3" "${4:-}"
+  else
+    lint_issue "$1" "$2" "$3" "${4:-}"
+  fi
+}
 
 # Helper: returns 0 if a product was detected in the scan (or if no scan data)
 scan_has_product() {
@@ -355,56 +545,78 @@ fi
 if product_applies "messaging"; then
   section_header "Messaging Correctness"
 
-  # Check 1: .messages.create( — Twilio pattern, Telnyx uses .send() or messages.create differently
-  matches=$(search_files '\.messages\.create\(' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
-  count=$(count_matches "$matches")
+  # Check 1: Twilio and Telnyx both expose messages.create() in some SDKs.
+  # Classify the call by its request field: Twilio uses `body`, while Telnyx
+  # uses `text`. Reuse the quote-aware source lexer so strings, comments, URLs,
+  # nested objects, and adjacent calls cannot create false classifications.
+  messaging_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
+  if ! command -v python3 >/dev/null 2>&1 || [ ! -f "$messaging_source_analyzer" ]; then
+    echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
+    exit 2
+  fi
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields "$PROJECT_ROOT"); then
+    echo "Error: Twilio messages.create analysis failed" >&2
+    exit 2
+  fi
+  count=$(count_matches "$twilio_create_calls")
   if [ "$count" -gt 0 ]; then
-    lint_issue "twilio_messages_create" \
-      "Twilio .messages.create() pattern found in $count file(s)" \
-      "Use telnyx.messages.send() (Python) or telnyx.messages.create() with text parameter (JS/Ruby)" \
-      "$(matches_to_json "$matches")"
+    lint_issue_or_hybrid_warn "messaging" "twilio_messages_create" \
+      "Twilio .messages.create() request using body found at $count call site(s)" \
+      "Use telnyx.messages.send() (Python) or telnyx.messages.create() with the text parameter (JavaScript/Ruby)" \
+      "$(matches_to_json "$twilio_create_calls")"
   else
-    lint_pass "twilio_messages_create" "No Twilio .messages.create() pattern found"
+    lint_pass "twilio_messages_create" "No Twilio .messages.create() request using body found"
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  matches=$(search_files '(\.send\(|\.create\().*body[=:]' "*.py" "*.js" "*.ts" "*.rb")
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields "$PROJECT_ROOT"); then
+    echo "Error: messaging body-field analysis failed" >&2
+    exit 2
+  fi
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    # Filter to only lines that also reference telnyx or messaging context
-    telnyx_context=$(echo "$matches" | grep -iE "telnyx|message|sms|mms" || true)
-    tcount=$(count_matches "$telnyx_context")
-    if [ "$tcount" -gt 0 ]; then
-      lint_issue "body_not_text" \
-        "Message send with 'body' parameter found in $tcount file(s)" \
-        "Telnyx uses 'text' not 'body' for message content" \
-        "$(matches_to_json "$telnyx_context")"
-    else
-      lint_pass "body_not_text" "No 'body' parameter in Telnyx messaging context"
-    fi
+    lint_issue "body_not_text" \
+      "Message send with 'body' parameter found at $count call site(s)" \
+      "Telnyx uses 'text' not 'body' for message content" \
+      "$(matches_to_json "$matches")"
   else
     lint_pass "body_not_text" "No 'body' parameter in message send calls"
   fi
 
-  # Check 3: messaging_profile_id missing in send calls (skip if messaging not detected in scan)
-  if scan_has_product "messaging"; then
-    telnyx_send=$(search_files '(telnyx.*message|message.*send|messages\.create)' "*.py" "*.js" "*.ts" "*.rb" "*.go")
-    send_count=$(count_matches "$telnyx_send")
-    if [ "$send_count" -gt 0 ]; then
-      profile_refs=$(search_files 'messaging_profile_id' "*.py" "*.js" "*.ts" "*.rb" "*.go")
-      profile_count=$(count_matches "$profile_refs")
-      if [ "$profile_count" -eq 0 ]; then
-        lint_warn "missing_messaging_profile_id" \
-          "Telnyx messaging calls found but no messaging_profile_id reference" \
-          "Include messaging_profile_id in send calls or set a default on the messaging profile"
-      else
-        lint_pass "missing_messaging_profile_id" "messaging_profile_id referenced in code"
-      fi
-    fi
+  # Check 3: number-pool and alphanumeric-sender sends require a Messaging
+  # Profile ID. Normal phone-number sends may omit it when the sender already
+  # belongs to the intended profile, which source inspection cannot infer.
+  # Run the source analyzer unconditionally inside the messaging section.
+  # The scanner and analyzer intentionally recognize different evidence; using
+  # scanner attribution as a gate let newly-supported URL builders disappear
+  # before the analyzer could evaluate them (a silent false pass).
+  if ! required_profile_analysis=$(python3 -B "$messaging_source_analyzer" "$PROJECT_ROOT"); then
+    echo "Error: required Messaging Profile analysis failed" >&2
+    exit 2
+  fi
+  required_sender_count=$(printf '%s\n' "$required_profile_analysis" | sed -n '1p')
+  case "$required_sender_count" in
+    ''|*[!0-9]*)
+      echo "Error: required Messaging Profile analysis returned an invalid count" >&2
+      exit 2
+      ;;
+  esac
+  missing_profile_calls=$(printf '%s\n' "$required_profile_analysis" | sed '1d; /^$/d')
+  missing_profile_count=$(count_matches "$missing_profile_calls")
+
+  if [ "$missing_profile_count" -gt 0 ]; then
+    lint_issue "required_messaging_profile_id" \
+      "Number-pool or dedicated alphanumeric-sender call sites found without a messaging_profile_id ($missing_profile_count)" \
+      "Include messaging_profile_id for every number-pool or alphanumeric-sender send. Phone-number sends may omit it when from already resolves to the intended Messaging Profile." \
+      "$(matches_to_json "$missing_profile_calls")"
+  elif [ "$required_sender_count" -gt 0 ]; then
+    lint_pass "required_messaging_profile_id" "Every detected required-profile messaging call has a messaging_profile_id"
+  else
+    lint_pass "required_messaging_profile_id" "No dedicated number-pool or alphanumeric-sender call sites detected"
   fi
 
   # Check 4: MessagingResponse builder class (doesn't exist in Telnyx)
-  matches=$(search_files 'MessagingResponse\(' "*.py" "*.js" "*.ts" "*.rb")
+  matches=$(search_live_files code 'MessagingResponse\(' "*.py" "*.js" "*.ts" "*.rb")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     lint_issue "messaging_response_builder" \
@@ -423,7 +635,7 @@ if product_applies "voice"; then
   section_header "Voice Correctness"
 
   # Check 5: VoiceResponse builder (Twilio TwiML — doesn't exist in Telnyx SDK)
-  matches=$(search_files 'VoiceResponse\(' "*.py" "*.js" "*.ts" "*.rb" "*.java" "*.php")
+  matches=$(search_live_files code 'VoiceResponse\(' "*.py" "*.js" "*.ts" "*.rb" "*.java" "*.php")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     lint_issue "voice_response_builder" \
@@ -448,7 +660,7 @@ excluded = {
     ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__",
     "build", "coverage", "dist", "node_modules", "vendor", "venv",
 }
-suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
+  suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
 tag_pattern = re.compile(
     r"<(?P<closing>/)?\s*(?P<tag>[A-Za-z_][\w:.-]*)"
     r"(?P<attrs>(?:\"[^\"]*\"|'[^']*'|[^>])*)>",
@@ -549,7 +761,14 @@ if product_applies "verify"; then
 
   # Check 9: verify_profile_id missing (skip if verify not detected in scan)
   if scan_has_product "verify"; then
-    telnyx_verify=$(search_files '(telnyx.*verif|verif.*telnyx|verify_profile|verification)' "*.py" "*.js" "*.ts" "*.rb" "*.go")
+    # "verification" alone matched WEBHOOK SIGNATURE verification - which every
+    # correctly migrated app now has - so repos with no Verify product at all
+    # were told to add a verify_profile_id. Match the Verify PRODUCT's own API
+    # surface instead, and exclude the signature/webhook sense explicitly.
+    telnyx_verify=$(search_files \
+      '(telnyx.*\bverifications?\b|\bverifications?\b.*telnyx|verify_profile|/v2/verifications|verifications\.(create|by_phone_number)|\bVerifyProfile\b)' \
+      "*.py" "*.js" "*.ts" "*.rb" "*.go" \
+      | grep -v -iE '(webhook|signature|ed25519|unwrap|construct_event|verify_webhook|verification_key|public_key)' || true)
     verify_count=$(count_matches "$telnyx_verify")
     if [ "$verify_count" -gt 0 ]; then
       profile_refs=$(search_files 'verify_profile_id' "*.py" "*.js" "*.ts" "*.rb" "*.go")
@@ -655,7 +874,7 @@ fi
 if product_applies "voice"; then
   section_header "Polly Voice Compatibility"
 
-  # Check 14: Non-Neural Polly voices (may fall back to default voice)
+  # Check 14: Named Polly voices are valid and must retain caller-facing audio.
   polly_refs=$(search_files "Polly\.[A-Z][a-z]+" "*.xml" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
   polly_count=$(count_matches "$polly_refs")
   if [ "$polly_count" -gt 0 ]; then
@@ -679,18 +898,33 @@ section_header "Documentation Updates"
 
 # Check 15: README and docs still referencing Twilio
 doc_files=""
-for f in README.md README README.rst CONTRIBUTING.md; do
-  if [ -f "$PROJECT_ROOT/$f" ]; then
-    twilio_in_doc=$(grep -in "twilio" "$PROJECT_ROOT/$f" 2>/dev/null | grep -v -iE '(migrat|port|formerly|previously|was twilio|from twilio to)' || true)
+while IFS= read -r -d '' doc_path; do
+    # Prose EXPLAINING the migration is not residual Twilio. Two defects here:
+    #  - 'formerly' did not cover 'the former Twilio Verify SID', so an
+    #    operator's mapping note gated a correctly migrated repo with exit 1;
+    #  - bare 'port' matched inside 'support', 'important' and 'export', which
+    #    silently excluded real leftovers. Both are now word-anchored.
+    # A HYBRID deployment also documents its remaining Twilio use on purpose -
+    # the skill mandates recording it - so those lines are expected too.
+    # Upstream repository ownership is historical provenance, not a runtime
+    # dependency. Rewriting a TwilioDevEd badge/clone URL would create a dead
+    # link while leaving the actual migration unchanged.
+    # NOTE: no \b before 'behaviour change'. Markdown bold writes
+    # __Behavior change from the Twilio integration__, and '_' is a WORD
+    # character, so \bbehavior could never match after it - the same
+    # word-boundary trap that made (?<![\w$]) never match $var in shell.
+    doc_exclusions='(\bmigrat|\bported\b|\bporting\b|\bformer|\bpreviousl|\bwas twilio\b|from twilio to|\breplaces?\b|\bno longer\b|\binstead of\b|\bequivalent\b|behaviou?r change|\btwilio integration\b|\bcounterpart\b|\bunlike twilio\b|\bcompared (to|with)\b|\bhybrid\b|\bstill uses? twilio\b|\bno telnyx equivalent\b|github\.com[:/]twiliodeved/)'
+    twilio_in_doc=$(grep -in "twilio" "$doc_path" 2>/dev/null | grep -v -iE "$doc_exclusions" || true)
     if [ -n "$twilio_in_doc" ]; then
-      doc_files+="$PROJECT_ROOT/$f"$'\n'
+      doc_files+="$doc_path"$'\n'
     fi
-  fi
-done
+done < <(find "$PROJECT_ROOT" -maxdepth 1 -type f \
+  \( -iname README -o -iname README.md -o -iname README.rst -o -iname CONTRIBUTING.md \) \
+  -print0 2>/dev/null)
 doc_files=$(echo "$doc_files" | sed '/^$/d')
 doc_count=$(echo "$doc_files" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$doc_count" -gt 0 ]; then
-  lint_issue "docs_still_twilio" \
+  lint_issue_or_hybrid_warn "any" "docs_still_twilio" \
     "Documentation files still reference Twilio (not migration-related references) in $doc_count file(s)" \
     "Update README/docs: replace Twilio service names, env vars, setup instructions, and URLs with Telnyx equivalents" \
     "$(echo "$doc_files" | sed '/^$/d' | head -10 | jq -R -s '{files: (split("\n") | map(select(length > 0)))}' 2>/dev/null || echo '{"files":[]}')"
@@ -704,7 +938,7 @@ fi
 section_header "Residual Twilio Patterns"
 
 # Check 10: Residual Twilio imports still present alongside Telnyx code
-matches=$(search_files '(from twilio|import twilio|require.*twilio|using Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
+matches=$(search_live_files comments '(from twilio|import[ (].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then
@@ -723,7 +957,7 @@ else
 fi
 
 # Check 11: Twilio client instantiation patterns
-matches=$(search_files '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -1008,7 +1008,7 @@ else
 fi
 
 # Check 11: Twilio client instantiation patterns
-matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+matches=$(search_live_files code '(Client\(.*account_sid|Twilio\(|twilio\.Twilio\(|new Twilio\.|TwilioClient[[:space:]]*\.[[:space:]]*Init[[:space:]]*\()' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -142,38 +142,36 @@ grep_allow_no_match() {
 # repo CLIs) are source files no --include glob can ever match; the Phase-1
 # scanner greps without includes and sees them, so skipping them here made
 # the validator certify trees the scanner had put in migration scope.
-SHEBANG_JS_FILES=""
-SHEBANG_PY_FILES=""
-SHEBANG_RB_FILES=""
-SHEBANG_SH_FILES=""
+SHEBANG_FILES=()
+SHEBANG_CATEGORIES=()
 
 collect_shebang_files() {
-  local _f _first
+  local _f _first _category
   while IFS= read -r -d '' _f; do
-    IFS= read -r _first < "$_f" 2>/dev/null || _first=""
+    _first=""
+    IFS= read -r _first < "$_f" 2>/dev/null || [ -n "$_first" ] || _first=""
     case "$_first" in
-      '#!'*node*)   SHEBANG_JS_FILES="${SHEBANG_JS_FILES}${_f}"$'\n' ;;
-      '#!'*python*) SHEBANG_PY_FILES="${SHEBANG_PY_FILES}${_f}"$'\n' ;;
-      '#!'*ruby*)   SHEBANG_RB_FILES="${SHEBANG_RB_FILES}${_f}"$'\n' ;;
-      '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
+      '#!'*node*)   _category="javascript" ;;
+      '#!'*python*) _category="python" ;;
+      '#!'*ruby*)   _category="ruby" ;;
+      '#!'*sh*)     _category="shell" ;;
+      *)            _category="" ;;
     esac
+    if [ -n "$_category" ]; then
+      # Bash variables cannot contain NUL, and LF-delimited path lists cannot
+      # represent every legal pathname. Indexed arrays retain each `find
+      # -print0` record as one argument all the way through grep.
+      SHEBANG_FILES+=("$_f")
+      SHEBANG_CATEGORIES+=("$_category")
+    fi
   done < <(find "$PROJECT_ROOT" \
     \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
     -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
 }
 
-shebang_files_for_glob() {
-  case "$1" in
-    '*.js'|'*.ts') printf '%s' "$SHEBANG_JS_FILES" ;;
-    '*.py')        printf '%s' "$SHEBANG_PY_FILES" ;;
-    '*.rb')        printf '%s' "$SHEBANG_RB_FILES" ;;
-    '*.sh')        printf '%s' "$SHEBANG_SH_FILES" ;;
-  esac
-}
-
 grep_shebang_files() {
   local pattern="$1"; shift
-  local glob list _f category seen_categories=""
+  local glob _index _f category seen_categories=""
   for glob in "$@"; do
     case "$glob" in
       '*.js'|'*.ts') category="javascript" ;;
@@ -187,11 +185,11 @@ grep_shebang_files() {
       *" $category "*) continue ;;
     esac
     seen_categories="$seen_categories $category"
-    list=$(shebang_files_for_glob "$glob")
-    [ -z "$list" ] && continue
-    while IFS= read -r _f; do
-      [ -n "$_f" ] && grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
-    done <<< "$list"
+    for _index in "${!SHEBANG_FILES[@]}"; do
+      [ "${SHEBANG_CATEGORIES[$_index]}" = "$category" ] || continue
+      _f=${SHEBANG_FILES[$_index]}
+      grep_allow_no_match -a -nH --null -E "$pattern" "$_f"
+    done
   done
 }
 

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -76,6 +76,18 @@ build_exclude_args() {
 
 GREP_EXCLUDES=""
 
+# Build every find(1) prune expression from the same policy as grep.  Keeping
+# literal copies in each traversal caused generated directories to re-enter
+# through the directory-name and shebang scans after source scanning excluded
+# them.
+FIND_EXCLUDE_EXPR=()
+for excluded_dir in $EXCLUDE_DIRS; do
+  if [ ${#FIND_EXCLUDE_EXPR[@]} -gt 0 ]; then
+    FIND_EXCLUDE_EXPR+=(-o)
+  fi
+  FIND_EXCLUDE_EXPR+=(-name "$excluded_dir")
+done
+
 
 # grep --include globs are case-sensitive; SEND.JS is the same JavaScript as
 # send.js. Rewrite '*.ext' into a character-class glob matching any casing.
@@ -134,9 +146,7 @@ collect_shebang_files() {
       '#!'*sh*)     SHEBANG_SH_FILES="${SHEBANG_SH_FILES}${_f}"$'\n' ;;
     esac
   done < <(find "$PROJECT_ROOT" \
-    \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
-       -o -name venv -o -name .venv -o -name dist -o -name build \
-       -o -name .next -o -name .nuxt -o -name coverage -o -name .tox \) -prune \
+    \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
     -o -type f ! -name '*.*' -size -1048576c -print0 2>/dev/null)
 }
 
@@ -189,7 +199,7 @@ expand_source_globs() {
       '*.rb') echo '*.rb' '*.rake' 'Rakefile' 'rakefile' '*.erb' ;;
       '*.php') echo '*.php' '*.phtml' ;;
       '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' '*.jsp' ;;
-      '*.cs') echo '*.cs' '*.cshtml' ;;
+      '*.cs') echo '*.cs' '*.cshtml' '*.razor' ;;
       *) echo "$glob" ;;
     esac
   done
@@ -648,7 +658,7 @@ if product_applies "voice"; then
   # a documented attribute on a Language child of ConversationRelay. Inspect
   # tag ancestry instead of rejecting every textual occurrence.
   speech_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
-  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" <<'PYEOF'
+  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" "$EXCLUDE_DIRS" <<'PYEOF'
 import importlib.util
 import os
 import re
@@ -663,16 +673,13 @@ if spec is None or spec.loader is None:
 analyzer = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = analyzer
 spec.loader.exec_module(analyzer)
-excluded_dirs = {
-    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__", "build",
-    "coverage", "dist", "node_modules", "vendor", "venv",
-}
+excluded_dirs = set(sys.argv[3].split())
 excluded_files = {
     "MIGRATION-PLAN.md", "MIGRATION-REPORT.md", "migration-state.json",
     "twilio-deep-scan.json", "twilio-scan.json",
 }
 suffixes = {
-    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".dart", ".ejs", ".erb",
+    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".razor", ".dart", ".ejs", ".erb",
     ".ksh", ".zsh", ".go", ".handlebars", ".hbs", ".java", ".jinja",
     ".jinja2", ".cts", ".j2", ".js", ".jsp", ".jsx", ".kt", ".kts",
     ".mjs", ".mts", ".mustache", ".php", ".phtml", ".py", ".pyw",
@@ -1011,8 +1018,7 @@ fi
 
 # Check 12: Directory/path names containing "twilio"
 twilio_dirs=$(find "$PROJECT_ROOT" -mindepth 1 \
-  \( -name node_modules -o -name .git -o -name vendor -o -name __pycache__ \
-     -o -name venv -o -name .venv -o -name dist -o -name build \) -prune \
+  \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
   -o -type d -iname '*twilio*' -print 2>/dev/null || true)
 twilio_dir_count=$(echo "$twilio_dirs" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$twilio_dir_count" -gt 0 ] && [ -n "$(echo "$twilio_dirs" | sed '/^$/d')" ]; then

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -136,8 +136,20 @@ shebang_files_for_glob() {
 
 grep_shebang_files() {
   local pattern="$1"; shift
-  local glob list _f
+  local glob list _f category seen_categories=""
   for glob in "$@"; do
+    case "$glob" in
+      '*.js'|'*.ts') category="javascript" ;;
+      '*.py') category="python" ;;
+      '*.rb') category="ruby" ;;
+      '*.sh') category="shell" ;;
+      *) category="" ;;
+    esac
+    [ -z "$category" ] && continue
+    case " $seen_categories " in
+      *" $category "*) continue ;;
+    esac
+    seen_categories="$seen_categories $category"
     list=$(shebang_files_for_glob "$glob")
     [ -z "$list" ] && continue
     while IFS= read -r _f; do
@@ -156,12 +168,12 @@ expand_source_globs() {
   local glob
   for glob in "$@"; do
     case "$glob" in
-      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' ;;
+      '*.js') echo '*.js' '*.jsx' '*.cjs' '*.mjs' '*.vue' '*.svelte' '*.astro' '*.ejs' ;;
       '*.ts') echo '*.ts' '*.tsx' '*.mts' '*.cts' ;;
       '*.py') echo '*.py' '*.pyw' ;;
-      '*.rb') echo '*.rb' '*.rake' 'Rakefile' ;;
+      '*.rb') echo '*.rb' '*.rake' 'Rakefile' 'rakefile' '*.erb' ;;
       '*.php') echo '*.php' '*.phtml' ;;
-      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' ;;
+      '*.java') echo '*.java' '*.kt' '*.kts' '*.scala' '*.jsp' ;;
       '*.cs') echo '*.cs' '*.cshtml' ;;
       *) echo "$glob" ;;
     esac
@@ -192,14 +204,32 @@ filter_source_matches() {
     --analyzer "$scripts_dir/lint-required-messaging-profile.py"
 }
 
+filter_backend_matches() {
+  local pattern="$1"
+  local scripts_dir
+  scripts_dir=$(cd "$(dirname "$0")" && pwd)
+  python3 -B "$scripts_dir/filter-source-matches.py" \
+    --mode comments --region backend --pattern "$pattern" \
+    --analyzer "$scripts_dir/lint-required-messaging-profile.py"
+}
+
 search_live_files() {
   local mode="$1"
   local pattern="$2"
   shift 2
-  search_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
+  search_raw_files "$pattern" "$@" | filter_source_matches "$mode" "$pattern"
 }
 
 search_files() {
+  local pattern="$1"
+  shift
+  # All source searches share the executable-region/comment contract. This
+  # keeps component markup and server-template prose out of semantic checks;
+  # callers needing identifiers with strings masked use search_live_files code.
+  search_raw_files "$pattern" "$@" | filter_source_matches comments "$pattern"
+}
+
+search_raw_files() {
   local pattern="$1"
   shift
   local include_args=""
@@ -368,10 +398,10 @@ while [ $# -gt 0 ]; do
       # skips every product-scoped check and still exits 0 — a silent pass.
       # Same accepted set as validate-migration.sh.
       case "$PRODUCT_FILTER" in
-        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup) ;;
+        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
         *)
           echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
-          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup" >&2
+          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
           exit 2
           ;;
       esac
@@ -425,8 +455,10 @@ if [ ! -d "$PROJECT_ROOT" ]; then
   exit 2
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "Error: python3 is required for correctness analysis" >&2
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c \
+  'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' \
+  >/dev/null 2>&1; then
+  echo "Error: Python 3.10+ is required for correctness analysis" >&2
   exit 2
 fi
 
@@ -466,7 +498,6 @@ if [ -n "$STATE_FILE" ]; then
     }
   fi
 fi
-
 # Load scan context if provided (for context-aware checks like webhook validation)
 ORIGINAL_HAD_WEBHOOK_VALIDATION="unknown"
 SCAN_PRODUCTS=""
@@ -555,7 +586,7 @@ if product_applies "messaging"; then
     echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
     exit 2
   fi
-  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields "$PROJECT_ROOT"); then
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
     echo "Error: Twilio messages.create analysis failed" >&2
     exit 2
   fi
@@ -570,7 +601,7 @@ if product_applies "messaging"; then
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields "$PROJECT_ROOT"); then
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
     echo "Error: messaging body-field analysis failed" >&2
     exit 2
   fi
@@ -650,18 +681,38 @@ if product_applies "voice"; then
   # Check 6: speechModel must be translated on Gather/Transcription, but it is
   # a documented attribute on a Language child of ConversationRelay. Inspect
   # tag ancestry instead of rejecting every textual occurrence.
-  matches=$(python3 - "$PROJECT_ROOT" <<'PYEOF'
+  speech_source_analyzer="$(cd "$(dirname "$0")" && pwd)/lint-required-messaging-profile.py"
+  matches=$(python3 -B - "$PROJECT_ROOT" "$speech_source_analyzer" <<'PYEOF'
+import importlib.util
 import os
-import pathlib
 import re
 import sys
+from pathlib import Path
 
-root = pathlib.Path(sys.argv[1])
-excluded = {
-    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__",
-    "build", "coverage", "dist", "node_modules", "vendor", "venv",
+root = Path(sys.argv[1])
+analyzer_path = Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("telnyx_source_lexer", analyzer_path)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Could not load {analyzer_path}")
+analyzer = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = analyzer
+spec.loader.exec_module(analyzer)
+excluded_dirs = {
+    ".git", ".next", ".nuxt", ".tox", ".venv", "__pycache__", "build",
+    "coverage", "dist", "node_modules", "vendor", "venv",
 }
-  suffixes = {".xml", ".py", ".js", ".ts", ".rb", ".java", ".php"}
+excluded_files = {
+    "MIGRATION-PLAN.md", "MIGRATION-REPORT.md", "migration-state.json",
+    "twilio-deep-scan.json", "twilio-scan.json",
+}
+suffixes = {
+    ".astro", ".bash", ".cjs", ".cs", ".cshtml", ".dart", ".ejs", ".erb",
+    ".ksh", ".zsh", ".go", ".handlebars", ".hbs", ".java", ".jinja",
+    ".jinja2", ".cts", ".j2", ".js", ".jsp", ".jsx", ".kt", ".kts",
+    ".mjs", ".mts", ".mustache", ".php", ".phtml", ".py", ".pyw",
+    ".rb", ".rake", ".scala", ".sh", ".svelte", ".swift", ".texml",
+    ".tmpl", ".ts", ".tsx", ".twiml", ".twig", ".vue", ".xml",
+}
 tag_pattern = re.compile(
     r"<(?P<closing>/)?\s*(?P<tag>[A-Za-z_][\w:.-]*)"
     r"(?P<attrs>(?:\"[^\"]*\"|'[^']*'|[^>])*)>",
@@ -670,23 +721,33 @@ tag_pattern = re.compile(
 speech_model = re.compile(r"(?<![\w:.-])speechModel\s*(?:=|:)")
 
 for directory, child_dirs, filenames in os.walk(root):
-    child_dirs[:] = sorted(name for name in child_dirs if name not in excluded)
+    child_dirs[:] = sorted(name for name in child_dirs if name not in excluded_dirs)
     for filename in sorted(filenames):
-        path = pathlib.Path(directory, filename)
-        if path.suffix.lower() not in suffixes:
+        path = Path(directory, filename)
+        if filename in excluded_files or path.suffix.lower() not in suffixes:
             continue
         source = path.read_text(encoding="utf-8", errors="replace")
-        source = re.sub(
-            r"<!--.*?-->|<!\[CDATA\[.*?\]\]>",
+        executable = analyzer.executable_source(path, source)
+        masked_executable = analyzer.lex_source(
+            executable, analyzer.canonical_suffix(path)
+        ).without_comments
+        scan_source = "".join(
+            masked if code != " " or raw in "\r\n" else raw
+            for raw, code, masked in zip(source, executable, masked_executable)
+        )
+        scan_source = re.sub(
+            r"<!--.*?-->|<!\[CDATA\[.*?\]\]>|"
+            r"<%#.*?%>|<%--.*?--%>|"
+            r"\{\{!--.*?--\}\}|\{\{!.*?\}\}|\{#.*?#\}",
             lambda match: "".join(
                 char if char in "\r\n" else " " for char in match.group(0)
             ),
-            source,
+            scan_source,
             flags=re.DOTALL,
         )
         stack = []
         tagged_speech_model = set()
-        for match in tag_pattern.finditer(source):
+        for match in tag_pattern.finditer(scan_source):
             tag = match.group("tag").rsplit(":", 1)[-1]
             if match.group("closing"):
                 if stack and stack[-1] == tag:
@@ -699,20 +760,17 @@ for directory, child_dirs, filenames in os.walk(root):
             tagged_speech_model.update(
                 attr_start + occurrence.start() for occurrence in attr_occurrences
             )
-            if attr_occurrences:
-                if not (tag == "Language" and stack[-1:] == ["ConversationRelay"]):
-                    line = source.count("\n", 0, match.start()) + 1
-                    print(f"{path}:{line}: <{tag}> speechModel")
+            if attr_occurrences and not (
+                tag == "Language" and stack[-1:] == ["ConversationRelay"]
+            ):
+                line = scan_source.count("\n", 0, match.start()) + 1
+                print(f"{path}:{line}: <{tag}> speechModel")
             if not match.group("attrs").rstrip().endswith("/"):
                 stack.append(tag)
-        # Builder/object forms (for example `{speechModel: "phone_call"}`)
-        # are migration-sensitive even when no literal XML tag exists. Only
-        # suppress occurrences already classified inside an XML tag, including
-        # the valid ConversationRelay <Language> form above.
-        for occurrence in speech_model.finditer(source):
+        for occurrence in speech_model.finditer(scan_source):
             if occurrence.start() in tagged_speech_model:
                 continue
-            line = source.count("\n", 0, occurrence.start()) + 1
+            line = scan_source.count("\n", 0, occurrence.start()) + 1
             print(f"{path}:{line}: non-XML speechModel")
 PYEOF
 )
@@ -831,12 +889,24 @@ if product_applies "all"; then
   section_header "Webhook Signature Validation"
 
   # Check 12: Webhook handlers without Ed25519 signature verification
-  webhook_handlers=$(search_files "(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+  # Vue/Svelte/Astro expressions are executable client code, but never server
+  # route declarations. Exclude those component files from this backend-only
+  # cross-file heuristic after applying the normal executable-source filter.
+  webhook_pattern="(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|http\.HandleFunc|post.*do)"
+  webhook_handlers=$(search_raw_files "$webhook_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+    | filter_backend_matches "$webhook_pattern" \
+    | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
   webhook_count=$(count_matches "$webhook_handlers")
   if [ "$webhook_count" -gt 0 ]; then
-    ed25519_refs=$(search_files "(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+    ed25519_pattern="(telnyx-signature-ed25519|ed25519|verify_signature|verifySignature|construct_event|webhooks\.unwrap|TELNYX_PUBLIC_KEY)"
+    ed25519_refs=$(search_raw_files "$ed25519_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+      | filter_backend_matches "$ed25519_pattern" \
+      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
     ed25519_count=$(count_matches "$ed25519_refs")
-    telnyx_webhook_parse=$(search_files "(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")
+    webhook_parse_pattern="(data\.payload|data\[.payload.\]|data\.event_type|data\[.event_type.\])"
+    telnyx_webhook_parse=$(search_raw_files "$webhook_parse_pattern" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" \
+      | filter_backend_matches "$webhook_parse_pattern" \
+      | grep -vE '\.(vue|svelte|astro):[0-9]+:' || true)
     telnyx_parse_count=$(count_matches "$telnyx_webhook_parse")
     if [ "$telnyx_parse_count" -gt 0 ] && [ "$ed25519_count" -eq 0 ]; then
       lint_issue "webhook_ed25519_missing" \
@@ -939,7 +1009,7 @@ fi
 section_header "Residual Twilio Patterns"
 
 # Check 10: Residual Twilio imports still present alongside Telnyx code
-matches=$(search_live_files comments '(from twilio|import[ (].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
+matches=$(search_live_files comments '(from twilio|import[ (=].*twilio|require.*twilio|using Twilio|import com\.twilio|use[[:space:]]+\\?Twilio|new[[:space:]]+\\?Twilio)' "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php" "*.cs")
 count=$(count_matches "$matches")
 if [ "$count" -gt 0 ]; then
   if hybrid_waiver_applies "$matches"; then

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -45,7 +45,7 @@ PROJECT_ROOT=""
 SCAN_JSON=""
 STATE_FILE=""
 HYBRID_PRODUCTS=""
-MIGRATED_FILES=""
+MIGRATED_FILES_JSON="[]"
 JSON_CHECKS="[]"
 
 EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build .next .nuxt coverage .tox"
@@ -75,6 +75,18 @@ build_exclude_args() {
 }
 
 GREP_EXCLUDES=""
+
+# Finding records are LF-delimited, so path identity uses a reversible display
+# encoding. Escape backslashes first to distinguish a literal `\n` filename
+# segment from an actual newline. The Python analyzer and grep adapter use this
+# exact contract too.
+escape_record_path() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\n'/\\n}
+  printf '%s' "$value"
+}
 
 # Build every find(1) prune expression from the same policy as grep.  Keeping
 # literal copies in each traversal caused generated directories to re-enter
@@ -372,12 +384,12 @@ hybrid_waiver_applies() {
     # A retained product never waives a residual inside a file explicitly
     # recorded as migrated. Only downgrade when every matched path is outside
     # that set; mixed or migrated-only results must keep the gate blocking.
-    [ -n "$MIGRATED_FILES" ] || return 0
+    [ "$MIGRATED_FILES_JSON" != "[]" ] || return 0
     while IFS= read -r match; do
       [ -n "$match" ] || continue
-      while IFS= read -r migrated_file; do
+      while IFS= read -r -d '' migrated_file; do
         [ -n "$migrated_file" ] || continue
-        migrated_path="$PROJECT_ROOT/$migrated_file"
+        migrated_path=$(escape_record_path "$PROJECT_ROOT/$migrated_file")
         # Filtered grep output is `<absolute path>:<line>:<text>`. Do not
         # recover the path with a colon regex: POSIX paths may themselves
         # contain `:<digits>:`. Instead compare each complete, known migrated
@@ -392,7 +404,7 @@ hybrid_waiver_applies() {
         if [ "$migrated_path" = "$match" ] || [[ "$migrated_path" = "$match"/* ]]; then
           return 1
         fi
-      done <<<"$MIGRATED_FILES"
+      done < <(printf '%s' "$MIGRATED_FILES_JSON" | jq -j '.[] | ., "\u0000"')
     done <<<"${1:-}"
     return 0
   fi
@@ -507,13 +519,13 @@ if [ -n "$STATE_FILE" ]; then
       echo "Error: --state-file '$STATE_FILE' is not valid migration state JSON" >&2
       exit 2
     }
-    MIGRATED_FILES=$(jq -r --arg root "$PROJECT_ROOT/" '
+    MIGRATED_FILES_JSON=$(jq -c --arg root "$PROJECT_ROOT/" '
       [(.migrated_files? // {}) | .. | arrays | .[]?
        | select(type == "string")
        | if startswith($root) then .[($root | length):]
          elif startswith("./") then .[2:]
          else . end]
-      | unique[]
+      | unique
     ' "$STATE_FILE" 2>/dev/null) || {
       echo "Error: --state-file '$STATE_FILE' has invalid migrated_files" >&2
       exit 2
@@ -1017,9 +1029,12 @@ else
 fi
 
 # Check 12: Directory/path names containing "twilio"
-twilio_dirs=$(find "$PROJECT_ROOT" -mindepth 1 \
+twilio_dirs=""
+while IFS= read -r -d '' twilio_dir; do
+  twilio_dirs+="$(escape_record_path "$twilio_dir")"$'\n'
+done < <(find "$PROJECT_ROOT" -mindepth 1 \
   \( "${FIND_EXCLUDE_EXPR[@]}" \) -prune \
-  -o -type d -iname '*twilio*' -print 2>/dev/null || true)
+  -o -type d -iname '*twilio*' -print0 2>/dev/null || true)
 twilio_dir_count=$(echo "$twilio_dirs" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$twilio_dir_count" -gt 0 ] && [ -n "$(echo "$twilio_dirs" | sed '/^$/d')" ]; then
   if hybrid_waiver_applies "$twilio_dirs"; then

--- a/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
+++ b/skills/telnyx-twilio-migration/scripts/lint-telnyx-correctness.sh
@@ -398,10 +398,10 @@ while [ $# -gt 0 ]; do
       # skips every product-scoped check and still exits 0 — a silent pass.
       # Same accepted set as validate-migration.sh.
       case "$PRODUCT_FILTER" in
-        voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
+        all|voice|messaging|verify|webrtc|sip|fax|video|iot|lookup|numbers|phone-numbers|porting) ;;
         *)
           echo "Error: Unknown product '$PRODUCT_FILTER'" >&2
-          echo "Valid products: voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
+          echo "Valid products: all, voice, messaging, verify, webrtc, sip, fax, video, iot, lookup, numbers, phone-numbers, porting" >&2
           exit 2
           ;;
       esac
@@ -458,7 +458,7 @@ fi
 if ! command -v python3 >/dev/null 2>&1 || ! python3 -c \
   'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' \
   >/dev/null 2>&1; then
-  echo "Error: Python 3.10+ is required for correctness analysis" >&2
+  echo "Error: python3 is required for correctness analysis; Python 3.10+ is required for correctness analysis" >&2
   exit 2
 fi
 
@@ -506,52 +506,6 @@ if [ -n "$SCAN_JSON" ] && [ -f "$SCAN_JSON" ] && command -v jq >/dev/null 2>&1; 
   SCAN_PRODUCTS=$(jq -r '.products_used // [] | map(ascii_downcase) | join(",")' "$SCAN_JSON" 2>/dev/null || true)
 fi
 
-# Hybrid awareness, mirroring validate-migration.sh: a product recorded as
-# kept on Twilio in migration-state.json is a skill-sanctioned deployment
-# state, so residual-Twilio findings for it are expected and must not hard-
-# fail Phase 4 forever.
-if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ] && command -v jq >/dev/null 2>&1; then
-  # Only products with a truthy keep reason stay in hybrid scope. An
-  # operator reverses a decision with `set kept_on_twilio.X false`
-  # (there is no unset command), so false/null/empty means NOT kept.
-  KEPT_ON_TWILIO=$(jq -r '.kept_on_twilio // {} | to_entries | map(select(.value != false and .value != null and .value != "")) | map(.key) | join(",")' "$STATE_FILE" 2>/dev/null || true)
-elif [ -n "$STATE_FILE" ] && [ ! -f "$STATE_FILE" ]; then
-  echo "Warning: --state-file '$STATE_FILE' not found, ignoring" >&2
-fi
-
-# Waive only for the product that is actually KEPT on Twilio.
-#
-# Testing `-n "$KEPT_ON_TWILIO"` alone made ANY hybrid state a GLOBAL waiver: in
-# a `--product messaging` run, a leftover Twilio messaging import was downgraded
-# to a warning - and the linter exited clean - merely because an unrelated
-# product such as voice was kept on Twilio. That is a silent pass on exactly the
-# residue the check exists to find.
-#
-# The product is passed per call site because these checks are not all inside a
-# product-scoped block; the global ones (residual imports, client instantiation,
-# directory names, docs) legitimately span products and pass "any", which waives
-# whenever ANY product is kept - the original behaviour, but now stated at the
-# call site rather than applied silently everywhere.
-kept_on_twilio() {
-  local product="$1"
-  [ -n "$KEPT_ON_TWILIO" ] || return 1
-  [ "$product" = "any" ] && return 0
-  case ",$KEPT_ON_TWILIO," in
-    *",$product,"*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-lint_issue_or_hybrid_warn() {
-  local product="$1"
-  shift
-  if kept_on_twilio "$product"; then
-    lint_warn "$1" "$2 (hybrid deployment — $KEPT_ON_TWILIO kept on Twilio)" "$3" "${4:-}"
-  else
-    lint_issue "$1" "$2" "$3" "${4:-}"
-  fi
-}
-
 # Helper: returns 0 if a product was detected in the scan (or if no scan data)
 scan_has_product() {
   local product="$1"
@@ -586,13 +540,13 @@ if product_applies "messaging"; then
     echo "Error: messaging source analysis requires python3 and $messaging_source_analyzer" >&2
     exit 2
   fi
-  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
+  if ! twilio_create_calls=$(python3 -B "$messaging_source_analyzer" --twilio-body-fields --kept-products "$HYBRID_PRODUCTS" "$PROJECT_ROOT"); then
     echo "Error: Twilio messages.create analysis failed" >&2
     exit 2
   fi
   count=$(count_matches "$twilio_create_calls")
   if [ "$count" -gt 0 ]; then
-    lint_issue_or_hybrid_warn "messaging" "twilio_messages_create" \
+    lint_issue "twilio_messages_create" \
       "Twilio .messages.create() request using body found at $count call site(s)" \
       "Use telnyx.messages.send() (Python) or telnyx.messages.create() with the text parameter (JavaScript/Ruby)" \
       "$(matches_to_json "$twilio_create_calls")"
@@ -601,7 +555,7 @@ if product_applies "messaging"; then
   fi
 
   # Check 2: body= or body: in message send context — Telnyx uses 'text' not 'body'
-  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$KEPT_ON_TWILIO" "$PROJECT_ROOT"); then
+  if ! matches=$(python3 -B "$messaging_source_analyzer" --message-body-fields --kept-products "$HYBRID_PRODUCTS" "$PROJECT_ROOT"); then
     echo "Error: messaging body-field analysis failed" >&2
     exit 2
   fi
@@ -995,7 +949,7 @@ done < <(find "$PROJECT_ROOT" -maxdepth 1 -type f \
 doc_files=$(echo "$doc_files" | sed '/^$/d')
 doc_count=$(echo "$doc_files" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$doc_count" -gt 0 ]; then
-  lint_issue_or_hybrid_warn "any" "docs_still_twilio" \
+  lint_issue "docs_still_twilio" \
     "Documentation files still reference Twilio (not migration-related references) in $doc_count file(s)" \
     "Update README/docs: replace Twilio service names, env vars, setup instructions, and URLs with Telnyx equivalents" \
     "$(echo "$doc_files" | sed '/^$/d' | head -10 | jq -R -s '{files: (split("\n") | map(select(length > 0)))}' 2>/dev/null || echo '{"files":[]}')"

--- a/skills/telnyx-twilio-migration/scripts/preflight-check.sh
+++ b/skills/telnyx-twilio-migration/scripts/preflight-check.sh
@@ -240,32 +240,48 @@ echo -e "${BOLD}Twilio SDKs Detected (to be replaced)${NC}"
 
 TWILIO_FOUND=false
 
-# Python
-if python3 -c "import twilio" 2>/dev/null; then
+# Python. With a project root, report project manifests only; a globally
+# installed package belongs to the host and says nothing about this migration.
+if [ -n "$PROJECT_ROOT" ] && find "$PROJECT_ROOT" -maxdepth 3 \
+  \( -name requirements.txt -o -name pyproject.toml -o -name setup.py -o -name Pipfile \) \
+  -exec grep -liE '(^|[^A-Za-z0-9_-])twilio([^A-Za-z0-9_-]|$)' {} + \
+  2>/dev/null | head -1 | grep -q .; then
+  check_info "Python: twilio (declared in project)"
+  TWILIO_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && python3 -c "import twilio" 2>/dev/null; then
   TWILIO_VER=$(python3 -c "import twilio; print(twilio.__version__)" 2>/dev/null || echo "unknown")
   check_info "Python: twilio $TWILIO_VER"
   TWILIO_FOUND=true
-elif python -c "import twilio" 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && python -c "import twilio" 2>/dev/null; then
   check_info "Python: twilio (version unknown)"
   TWILIO_FOUND=true
 fi
 
 # Node.js
-if [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/twilio" ]; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/package.json" ] && \
+  grep -qE '"twilio"[[:space:]]*:' "$PROJECT_ROOT/package.json" 2>/dev/null; then
+  TWILIO_NODE_VER=$(sed -nE 's/.*"twilio"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$PROJECT_ROOT/package.json" | head -1)
+  check_info "Node.js: twilio ${TWILIO_NODE_VER:-version unknown} (declared in project)"
+  TWILIO_FOUND=true
+elif [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/twilio" ]; then
   TWILIO_NODE_VER=$(node -e "console.log(require('$PROJECT_ROOT/node_modules/twilio/package.json').version)" 2>/dev/null || echo "unknown")
   check_info "Node.js: twilio $TWILIO_NODE_VER"
   TWILIO_FOUND=true
-elif [ -d "node_modules/twilio" ] 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && [ -d "node_modules/twilio" ] 2>/dev/null; then
   TWILIO_NODE_VER=$(node -e "console.log(require('twilio/package.json').version)" 2>/dev/null || echo "unknown")
   check_info "Node.js: twilio $TWILIO_NODE_VER"
   TWILIO_FOUND=true
-elif npm list twilio 2>/dev/null | grep -q twilio; then
+elif [ -z "$PROJECT_ROOT" ] && npm list twilio 2>/dev/null | grep -q twilio; then
   check_info "Node.js: twilio (installed globally or in project)"
   TWILIO_FOUND=true
 fi
 
 # Ruby
-if gem list twilio-ruby 2>/dev/null | grep -q twilio-ruby; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/Gemfile" ] && \
+  grep -qE "gem[[:space:]]+['\"]twilio(-ruby)?['\"]" "$PROJECT_ROOT/Gemfile" 2>/dev/null; then
+  check_info "Ruby: twilio-ruby (declared in project Gemfile)"
+  TWILIO_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && gem list twilio-ruby 2>/dev/null | grep -q twilio-ruby; then
   TWILIO_RUBY_VER=$(gem list twilio-ruby 2>/dev/null | grep -o '([^)]*)')
   check_info "Ruby: twilio-ruby $TWILIO_RUBY_VER"
   TWILIO_FOUND=true
@@ -277,13 +293,17 @@ if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/go.mod" ]; then
     check_info "Go: twilio-go (found in project go.mod)"
     TWILIO_FOUND=true
   fi
-elif go list -m github.com/twilio/twilio-go 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && go list -m github.com/twilio/twilio-go 2>/dev/null; then
   check_info "Go: twilio-go (found in go.mod)"
   TWILIO_FOUND=true
 fi
 
-# Java (check for jar in common locations)
+# Java/Kotlin manifests and local jars.
 SEARCH_DIR="${PROJECT_ROOT:-.}"
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" twilio-jvm-declared "$PROJECT_ROOT"; then
+  check_info "Java/Kotlin: Twilio SDK (declared in project)"
+  TWILIO_FOUND=true
+fi
 if find "$SEARCH_DIR" -name "twilio-*.jar" -maxdepth 3 2>/dev/null | grep -q twilio; then
   check_info "Java: twilio jar found in project"
   TWILIO_FOUND=true
@@ -291,7 +311,7 @@ fi
 
 # PHP
 if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/composer.json" ]; then
-  if grep -q "twilio" "$PROJECT_ROOT/composer.json" 2>/dev/null; then
+  if grep -qE '"twilio/sdk"[[:space:]]*:' "$PROJECT_ROOT/composer.json" 2>/dev/null; then
     check_info "PHP: twilio/sdk found in composer.json"
     TWILIO_FOUND=true
   fi
@@ -315,29 +335,50 @@ echo -e "${BOLD}Telnyx SDKs Installed${NC}"
 
 TELNYX_FOUND=false
 
+# Composer declarations belong in require/require-dev, not metadata or scripts.
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" composer "$PROJECT_ROOT"; then
+  check_pass "PHP: telnyx/telnyx-php (declared in project)"
+  TELNYX_FOUND=true
+fi
+
 # Python
-if python3 -c "import telnyx" 2>/dev/null; then
+if [ -n "$PROJECT_ROOT" ] && find "$PROJECT_ROOT" -maxdepth 3 \
+  \( -name requirements.txt -o -name pyproject.toml -o -name setup.py -o -name Pipfile \) \
+  -exec grep -liE '(^|[^A-Za-z0-9_-])telnyx([^A-Za-z0-9_-]|$)' {} + \
+  2>/dev/null | head -1 | grep -q .; then
+  check_pass "Python: telnyx (declared in project)"
+  TELNYX_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && python3 -c "import telnyx" 2>/dev/null; then
   TELNYX_PY_VER=$(python3 -c "import telnyx; print(telnyx.VERSION)" 2>/dev/null || echo "unknown")
   check_pass "Python: telnyx $TELNYX_PY_VER"
   TELNYX_FOUND=true
 fi
 
 # Node.js
-if [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/telnyx" ]; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/package.json" ] && \
+  grep -qE '"telnyx"[[:space:]]*:' "$PROJECT_ROOT/package.json" 2>/dev/null; then
+  TELNYX_NODE_VER=$(sed -nE 's/.*"telnyx"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$PROJECT_ROOT/package.json" | head -1)
+  check_pass "Node.js: telnyx ${TELNYX_NODE_VER:-version unknown} (declared in project)"
+  TELNYX_FOUND=true
+elif [ -n "$PROJECT_ROOT" ] && [ -d "$PROJECT_ROOT/node_modules/telnyx" ]; then
   TELNYX_NODE_VER=$(node -e "console.log(require('$PROJECT_ROOT/node_modules/telnyx/package.json').version)" 2>/dev/null || echo "unknown")
   check_pass "Node.js: telnyx $TELNYX_NODE_VER"
   TELNYX_FOUND=true
-elif [ -d "node_modules/telnyx" ] 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && [ -d "node_modules/telnyx" ] 2>/dev/null; then
   TELNYX_NODE_VER=$(node -e "console.log(require('telnyx/package.json').version)" 2>/dev/null || echo "unknown")
   check_pass "Node.js: telnyx $TELNYX_NODE_VER"
   TELNYX_FOUND=true
-elif npm list telnyx 2>/dev/null | grep -q telnyx; then
+elif [ -z "$PROJECT_ROOT" ] && npm list telnyx 2>/dev/null | grep -q telnyx; then
   check_pass "Node.js: telnyx (installed)"
   TELNYX_FOUND=true
 fi
 
 # Ruby
-if gem list telnyx 2>/dev/null | grep -q "^telnyx "; then
+if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/Gemfile" ] && \
+  grep -qE "gem[[:space:]]+['\"]telnyx['\"]" "$PROJECT_ROOT/Gemfile" 2>/dev/null; then
+  check_pass "Ruby: telnyx (declared in project Gemfile)"
+  TELNYX_FOUND=true
+elif [ -z "$PROJECT_ROOT" ] && gem list telnyx 2>/dev/null | grep -q "^telnyx "; then
   TELNYX_RUBY_VER=$(gem list telnyx 2>/dev/null | grep "^telnyx " | grep -o '([^)]*)')
   check_pass "Ruby: telnyx $TELNYX_RUBY_VER"
   TELNYX_FOUND=true
@@ -349,8 +390,14 @@ if [ -n "$PROJECT_ROOT" ] && [ -f "$PROJECT_ROOT/go.mod" ]; then
     check_pass "Go: telnyx-go (found in project go.mod)"
     TELNYX_FOUND=true
   fi
-elif go list -m github.com/telnyx/telnyx-go 2>/dev/null; then
+elif [ -z "$PROJECT_ROOT" ] && go list -m all 2>/dev/null | \
+  grep -E '^github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]' >/dev/null; then
   check_pass "Go: telnyx-go (found in go.mod)"
+  TELNYX_FOUND=true
+fi
+
+if [ -n "$PROJECT_ROOT" ] && python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
+  check_pass "Java/Kotlin: Telnyx SDK (declared in project)"
   TELNYX_FOUND=true
 fi
 

--- a/skills/telnyx-twilio-migration/scripts/run-discovery.sh
+++ b/skills/telnyx-twilio-migration/scripts/run-discovery.sh
@@ -21,7 +21,7 @@
 #
 # Exit codes:
 #   0 — Discovery complete (scan succeeded; preflight may have warnings)
-#   2 — Invalid arguments (project root doesn't exist, etc.)
+#   2 — Invalid arguments or incomplete usage scan
 
 set -uo pipefail
 
@@ -83,11 +83,12 @@ echo -e "  ${BLUE}INFO${NC}  Scanning source code for Twilio patterns (no API ke
 echo ""
 
 SCAN_OUTPUT="$PROJECT_ROOT/twilio-scan.json"
-bash "$SCRIPT_DIR/scan-twilio-usage.sh" "$PROJECT_ROOT" > "$SCAN_OUTPUT" 2>/dev/null
+bash "$SCRIPT_DIR/scan-twilio-usage.sh" "$PROJECT_ROOT" > "$SCAN_OUTPUT"
 SCAN_EXIT=$?
 
 if [ "$SCAN_EXIT" -ne 0 ]; then
-  echo -e "  ${YELLOW}WARN${NC}  Scanner exited with code $SCAN_EXIT"
+  echo -e "  ${RED}ERROR${NC}  Discovery incomplete: scanner exited with code $SCAN_EXIT. Do not use $SCAN_OUTPUT as a complete inventory." >&2
+  exit 2
 fi
 
 if [ -f "$SCAN_OUTPUT" ] && [ -s "$SCAN_OUTPUT" ]; then
@@ -105,7 +106,8 @@ if [ -f "$SCAN_OUTPUT" ] && [ -s "$SCAN_OUTPUT" ]; then
     echo "  Files:      $FILE_COUNT files with Twilio patterns"
   fi
 else
-  echo -e "  ${YELLOW}WARN${NC}  Scan produced no output — the project may have no Twilio code"
+  echo -e "  ${RED}ERROR${NC}  Discovery incomplete: scanner produced no report." >&2
+  exit 2
 fi
 
 echo ""
@@ -143,7 +145,7 @@ DEEP_SCAN_OUTPUT="$PROJECT_ROOT/twilio-deep-scan.json"
 if command -v python3 &>/dev/null; then
   if [ -f "$SCRIPT_DIR/scan-twilio-deep.py" ]; then
     echo -e "  ${BLUE}INFO${NC}  Running scan-twilio-deep.py..."
-    python3 "$SCRIPT_DIR/scan-twilio-deep.py" "$PROJECT_ROOT" > "$DEEP_SCAN_OUTPUT" 2>/dev/null
+    python3 "$SCRIPT_DIR/scan-twilio-deep.py" "$PROJECT_ROOT" > "$DEEP_SCAN_OUTPUT"
     DEEP_EXIT=$?
     if [ "$DEEP_EXIT" -eq 0 ] && [ -f "$DEEP_SCAN_OUTPUT" ] && [ -s "$DEEP_SCAN_OUTPUT" ]; then
       echo -e "  ${GREEN}PASS${NC}  Deep scan results saved to: $DEEP_SCAN_OUTPUT"

--- a/skills/telnyx-twilio-migration/scripts/run-validation.sh
+++ b/skills/telnyx-twilio-migration/scripts/run-validation.sh
@@ -138,6 +138,34 @@ fi
 
 echo ""
 
+# --- Step 5.1b: Telnyx Correctness Linter ---
+# This integration belongs with the source-aware analyzer. Without it the full
+# Phase 5 wrapper can certify a required sender that lacks
+# messaging_profile_id even though the standalone linter would block it.
+echo -e "${BOLD}Step 5.1b: Telnyx Correctness${NC}"
+echo "────────────────────────────────"
+
+CORRECTNESS_ARGS=("$PROJECT_ROOT")
+# Discovery records whether the original app intentionally omitted webhook
+# validation. Preserve that context so the wrapper and standalone linter reach
+# the same verdict instead of upgrading an intentional warning to an issue.
+[ -f "$PROJECT_ROOT/twilio-scan.json" ] && \
+  CORRECTNESS_ARGS+=("--scan-json" "$PROJECT_ROOT/twilio-scan.json")
+bash "$SCRIPT_DIR/lint-telnyx-correctness.sh" "${CORRECTNESS_ARGS[@]}"
+CORRECTNESS_EXIT=$?
+if [ "$CORRECTNESS_EXIT" -eq 0 ]; then
+  echo ""
+  echo -e "  ${GREEN}PASS${NC}  Correctness checks passed"
+  RESULTS="${RESULTS}correctness:pass,"
+else
+  echo ""
+  echo -e "  ${RED}FAIL${NC}  Correctness checks failed (exit code: $CORRECTNESS_EXIT)"
+  OVERALL_PASS=false
+  RESULTS="${RESULTS}correctness:fail,"
+fi
+
+echo ""
+
 # --- Step 5.2: TeXML Validation (optional) ---
 if [ "$INCLUDE_TEXML" = true ]; then
   echo -e "${BOLD}Step 5.2: TeXML Validation${NC}"

--- a/skills/telnyx-twilio-migration/scripts/run-validation.sh
+++ b/skills/telnyx-twilio-migration/scripts/run-validation.sh
@@ -104,6 +104,9 @@ fi
 if [ -z "$STATE_FILE" ] && [ -f "$PROJECT_ROOT/migration-state.json" ]; then
   STATE_FILE="$PROJECT_ROOT/migration-state.json"
 fi
+if [ -z "$SCAN_JSON" ] && [ -f "$PROJECT_ROOT/twilio-scan.json" ]; then
+  SCAN_JSON="$PROJECT_ROOT/twilio-scan.json"
+fi
 
 OVERALL_PASS=true
 RESULTS=""
@@ -146,11 +149,13 @@ echo -e "${BOLD}Step 5.1b: Telnyx Correctness${NC}"
 echo "────────────────────────────────"
 
 CORRECTNESS_ARGS=("$PROJECT_ROOT")
+# Keep the correctness linter in the same hybrid scope as migration
+# validation. An external state file is not discoverable from PROJECT_ROOT.
+[ -n "$STATE_FILE" ] && CORRECTNESS_ARGS+=("--state-file" "$STATE_FILE")
 # Discovery records whether the original app intentionally omitted webhook
 # validation. Preserve that context so the wrapper and standalone linter reach
 # the same verdict instead of upgrading an intentional warning to an issue.
-[ -f "$PROJECT_ROOT/twilio-scan.json" ] && \
-  CORRECTNESS_ARGS+=("--scan-json" "$PROJECT_ROOT/twilio-scan.json")
+[ -n "$SCAN_JSON" ] && CORRECTNESS_ARGS+=("--scan-json" "$SCAN_JSON")
 bash "$SCRIPT_DIR/lint-telnyx-correctness.sh" "${CORRECTNESS_ARGS[@]}"
 CORRECTNESS_EXIT=$?
 if [ "$CORRECTNESS_EXIT" -eq 0 ]; then

--- a/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -181,7 +181,7 @@ GO_EXTENSIONS = {".go"}
 RUBY_EXTENSIONS = {".rb", ".rake"}
 JAVA_EXTENSIONS = {".java", ".kt", ".kts", ".scala"}
 PHP_EXTENSIONS = {".php", ".phtml"}
-CSHARP_EXTENSIONS = {".cs", ".cshtml"}
+CSHARP_EXTENSIONS = {".cs", ".cshtml", ".razor"}
 OTHER_TEXT_EXTENSIONS = {".xml", ".yaml", ".yml"}
 
 # Directories to skip
@@ -794,14 +794,14 @@ _CSHARP_ENV_RE = re.compile(
 _CSHARP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 
 
-def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
+def scan_go_file(filepath: Path, lines: List[str], go_clients: frozenset[str] = frozenset()) -> List[Detection]:
     """Regex-based scanning for Go files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
     source = "\n".join(lines)
     lexed = _ownership.lexed_source(source, ".go")
     lines = lexed.without_comments.split("\n")
-    for line, product in _ownership.contextual_calls(source, ".go"):
+    for line, product in _ownership.contextual_calls(source, ".go", go_clients=go_clients):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
             context=get_context_lines(lines, line), confidence="high", product=product))
@@ -1353,6 +1353,7 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
 
     paths = list(walk_project(project_root))
     global_usings = _ownership.CsharpGlobalUsings(project_root, paths)
+    go_clients = _ownership.GoPackageClients(paths)
     for filepath in paths:
         ext = filepath.suffix.lower()
         name = filepath.name
@@ -1471,11 +1472,12 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
                 text = filepath.read_text(errors="replace")
             except (OSError, PermissionError):
                 continue
-            if "twilio" not in text.lower():
+            package_clients = go_clients.for_file(filepath)
+            if "twilio" not in text.lower() and not package_clients:
                 continue
             lines = text.splitlines()
             rel = str(filepath.relative_to(project_root))
-            go_detections = scan_go_file(filepath, lines)
+            go_detections = scan_go_file(filepath, lines, package_clients)
             if go_detections:
                 fr = FileResult(rel, "go")
                 fr.detections = go_detections

--- a/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import importlib.util
 import json
 import os
 import re
@@ -26,6 +27,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 SCAN_VERSION = "1.0.0"
 SCANNER_NAME = "deep"
+
+_ownership_spec = importlib.util.spec_from_file_location(
+    "sdk_source_ownership", Path(__file__).with_name("sdk-source-ownership.py"))
+_ownership = importlib.util.module_from_spec(_ownership_spec)
+_ownership_spec.loader.exec_module(_ownership)
 
 # ---------------------------------------------------------------------------
 # Product mapping -- Twilio module path fragment -> product name
@@ -105,6 +111,14 @@ METHOD_PRODUCT_MAP: Dict[str, str] = {
     "CreateVerification": "verify",
     "FetchMessage": "messaging",
     "FetchCall": "voice",
+    "/Messages.json": "messaging",
+    "messaging.twilio.com": "messaging",
+    "/Calls.json": "voice",
+    "verify.twilio.com": "verify",
+    "lookups.twilio.com": "lookup",
+    "video.twilio.com": "video",
+    "fax.twilio.com": "fax",
+    "/IncomingPhoneNumbers.json": "phone-numbers",
 }
 
 # Twilio env var patterns
@@ -161,13 +175,13 @@ DEPENDENCY_FILE_NAMES = {
 }
 
 # File extensions to scan
-PY_EXTENSIONS = {".py"}
-JS_EXTENSIONS = {".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"}
+PY_EXTENSIONS = {".py", ".pyw"}
+JS_EXTENSIONS = {".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs", ".mts", ".cts"}
 GO_EXTENSIONS = {".go"}
-RUBY_EXTENSIONS = {".rb"}
-JAVA_EXTENSIONS = {".java", ".kt", ".scala"}
-PHP_EXTENSIONS = {".php"}
-CSHARP_EXTENSIONS = {".cs"}
+RUBY_EXTENSIONS = {".rb", ".rake"}
+JAVA_EXTENSIONS = {".java", ".kt", ".kts", ".scala"}
+PHP_EXTENSIONS = {".php", ".phtml"}
+CSHARP_EXTENSIONS = {".cs", ".cshtml"}
 OTHER_TEXT_EXTENSIONS = {".xml", ".yaml", ".yml"}
 
 # Directories to skip
@@ -276,8 +290,9 @@ def resolve_product(module_path: str) -> str:
 
 def infer_product_from_text(text: str) -> str:
     """Best-effort product inference from arbitrary text."""
+    lowered = text.lower()
     for pattern, product in METHOD_PRODUCT_MAP.items():
-        if pattern in text:
+        if pattern.lower() in lowered:
             return product
     return "general"
 
@@ -758,10 +773,6 @@ _RUBY_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # Java / Kotlin / Scala patterns
 _JAVA_IMPORT_RE = re.compile(r"import\s+(com\.twilio\.[^\s;]+)", re.IGNORECASE)
 _JAVA_INIT_RE = re.compile(r"Twilio\.init\s*\(", re.IGNORECASE)
-_JAVA_CREATOR_RE = re.compile(
-    r"com\.twilio\.rest\.api\.v2010\.account\.(Call|Message|IncomingPhoneNumber)\.creator",
-    re.IGNORECASE,
-)
 _JAVA_TWIML_RE = re.compile(r"com\.twilio\.twiml\.(VoiceResponse|MessagingResponse)", re.IGNORECASE)
 _JAVA_ENV_RE = re.compile(r'System\.getenv\s*\(\s*"(TWILIO_\w+)"', re.IGNORECASE)
 _JAVA_WEBHOOK_RE = re.compile(r"X-Twilio-Signature|RequestValidator", re.IGNORECASE)
@@ -770,7 +781,6 @@ _JAVA_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # PHP patterns
 _PHP_USE_RE = re.compile(r"use\s+Twilio\\([^\s;]+)", re.IGNORECASE)
 _PHP_CLIENT_RE = re.compile(r"new\s+Client\s*\(\s*\$\w+\s*,\s*\$\w+", re.IGNORECASE)
-_PHP_METHOD_RE = re.compile(r"\$twilio->\s*(\w+)", re.IGNORECASE)
 _PHP_ENV_RE = re.compile(r"""(?:getenv\s*\(\s*['"]|\$_ENV\[['"])(TWILIO_\w+)""", re.IGNORECASE)
 _PHP_WEBHOOK_RE = re.compile(r"RequestValidator", re.IGNORECASE)
 _PHP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
@@ -778,10 +788,6 @@ _PHP_TWILIO_RE = re.compile(r"\btwilio\b", re.IGNORECASE)
 # C# patterns
 _CSHARP_USING_RE = re.compile(r"using\s+(Twilio[^\s;]*)", re.IGNORECASE)
 _CSHARP_INIT_RE = re.compile(r"TwilioClient\.Init\s*\(", re.IGNORECASE)
-_CSHARP_RESOURCE_RE = re.compile(
-    r"(MessageResource|CallResource|IncomingPhoneNumberResource|AccountResource)\.(Create|Read|Update|Fetch)",
-    re.IGNORECASE,
-)
 _CSHARP_ENV_RE = re.compile(
     r'Environment\.GetEnvironmentVariable\s*\(\s*"(TWILIO_\w+)"', re.IGNORECASE
 )
@@ -792,8 +798,18 @@ def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
     """Regex-based scanning for Go files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, ".go")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, ".go"):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
 
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # Import statements
@@ -836,9 +852,10 @@ def scan_go_file(filepath: Path, lines: List[str]) -> List[Detection]:
         stripped = line.strip()
         if stripped.startswith("//"):
             continue
-        # Check for API method calls (e.g. CreateMessage, messages.create)
+        # SDK calls were attributed above. A generic application method name
+        # alone is not ownership evidence; retain explicit Twilio hints only.
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _GO_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -924,11 +941,22 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
 
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # import com.twilio.*
-        m = _JAVA_IMPORT_RE.search(stripped)
+        m = _JAVA_IMPORT_RE.search(syntax_lines[i - 1])
         if m:
             pkg = m.group(1).lower()
             product = "general"
@@ -963,26 +991,6 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
                     context=get_context_lines(lines, i), confidence="high", product="general",
-                )
-            )
-            detected_lines.add(i)
-            continue
-
-        # Creator patterns: Call.creator, Message.creator
-        m = _JAVA_CREATOR_RE.search(stripped)
-        if m:
-            resource = m.group(1).lower()
-            product = "general"
-            if resource == "call":
-                product = "voice"
-            elif resource == "message":
-                product = "messaging"
-            elif resource == "incomingphonenumber":
-                product = "phone-numbers"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
                 )
             )
             detected_lines.add(i)
@@ -1033,7 +1041,7 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _JAVA_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1059,11 +1067,22 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
 
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # use Twilio\* namespace imports
-        m = _PHP_USE_RE.search(stripped)
+        m = _PHP_USE_RE.search(syntax_lines[i - 1])
         if m:
             ns = m.group(1).lower()
             product = "general"
@@ -1106,30 +1125,6 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
             detected_lines.add(i)
             continue
 
-        # $twilio-> method calls
-        m = _PHP_METHOD_RE.search(stripped)
-        if m:
-            method = m.group(1).lower()
-            product = "general"
-            if method in ("messages", "message"):
-                product = "messaging"
-            elif method in ("calls", "call"):
-                product = "voice"
-            elif method in ("verify", "verification"):
-                product = "verify"
-            elif method in ("video",):
-                product = "video"
-            elif method in ("lookups", "lookup"):
-                product = "lookup"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
-                )
-            )
-            detected_lines.add(i)
-            continue
-
         # Env vars: getenv('TWILIO_*'), $_ENV['TWILIO_*']
         m = _PHP_ENV_RE.search(stripped)
         if m:
@@ -1161,7 +1156,7 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("#") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _PHP_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1186,12 +1181,23 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
     """Regex-based scanning for C# files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
+    source = "\n".join(lines)
+    lexed = _ownership.lexed_source(source, filepath.suffix)
+    syntax_lines = lexed.code.split("\n")
+    lines = lexed.without_comments.split("\n")
+    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+        detections.append(Detection(
+            pattern=lines[line - 1].strip(), line=line, detection_method="regex",
+            context=get_context_lines(lines, line), confidence="high", product=product))
+        detected_lines.add(line)
 
     for i, line in enumerate(lines, start=1):
+        if i in detected_lines:
+            continue
         stripped = line.strip()
 
         # using Twilio* imports
-        m = _CSHARP_USING_RE.search(stripped)
+        m = _CSHARP_USING_RE.search(syntax_lines[i - 1])
         if m:
             ns = m.group(1).lower()
             product = "general"
@@ -1234,26 +1240,6 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
             detected_lines.add(i)
             continue
 
-        # Resource method calls: MessageResource.Create, CallResource.Create, etc.
-        m = _CSHARP_RESOURCE_RE.search(stripped)
-        if m:
-            resource = m.group(1).lower()
-            product = "general"
-            if "message" in resource:
-                product = "messaging"
-            elif "call" in resource:
-                product = "voice"
-            elif "incomingphonenumber" in resource:
-                product = "phone-numbers"
-            detections.append(
-                Detection(
-                    pattern=stripped, line=i, detection_method="regex",
-                    context=get_context_lines(lines, i), confidence="high", product=product,
-                )
-            )
-            detected_lines.add(i)
-            continue
-
         # Env vars: Environment.GetEnvironmentVariable("TWILIO_*")
         m = _CSHARP_ENV_RE.search(stripped)
         if m:
@@ -1274,7 +1260,7 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
         if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
             continue
         inferred = infer_product_from_text(stripped)
-        if inferred != "general":
+        if inferred != "general" and _CSHARP_TWILIO_RE.search(stripped):
             detections.append(
                 Detection(
                     pattern=stripped, line=i, detection_method="regex",
@@ -1326,7 +1312,9 @@ def walk_project(root: Path):
     """Yield file paths, skipping common non-source directories."""
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune skip dirs in-place
-        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS and not d.startswith(".")]
+        # Hidden source folders (for example .github/scripts) are still source.
+        # Exclude named generated/tool directories, not every dot-directory.
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
         for fname in filenames:
             yield Path(dirpath) / fname
 
@@ -1523,7 +1511,7 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
             rel = str(filepath.relative_to(project_root))
             java_detections = scan_java_file(filepath, lines)
             if java_detections:
-                lang = "kotlin" if ext == ".kt" else "scala" if ext == ".scala" else "java"
+                lang = "kotlin" if ext in {".kt", ".kts"} else "scala" if ext == ".scala" else "java"
                 fr = FileResult(rel, lang)
                 fr.detections = java_detections
                 file_results.append(fr)

--- a/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -945,6 +945,9 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
     lexed = _ownership.lexed_source(source, filepath.suffix)
     syntax_lines = lexed.code.split("\n")
     lines = lexed.without_comments.split("\n")
+    scala_selectors = (_ownership.scala_import_bindings(lexed.code, {
+        "Message": "messaging", "Call": "voice",
+        "IncomingPhoneNumber": "phone-numbers"}) if filepath.suffix == ".scala" else [])
     for line, product in _ownership.contextual_calls(source, filepath.suffix):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
@@ -958,6 +961,21 @@ def scan_java_file(filepath: Path, lines: List[str]) -> List[Detection]:
         # import com.twilio.*
         m = _JAVA_IMPORT_RE.search(syntax_lines[i - 1])
         if m:
+            if filepath.suffix == ".scala" and re.search(
+                r"\bimport\s+(?:_root_\.)?com\.twilio\.rest\.api\.v2010\.account\.\s*\{",
+                syntax_lines[i - 1],
+            ):
+                # Selector text is not a package name: Message => _ excludes
+                # Message, while Message => Sms imports it under another name.
+                products = {product for offset, selected, _ in scala_selectors
+                            if source.count("\n", 0, offset) + 1 == i
+                            for product in selected.values() if product}
+                for product in sorted(products or {"general"}):
+                    detections.append(Detection(
+                        pattern=stripped, line=i, detection_method="regex",
+                        context=get_context_lines(lines, i), confidence="high", product=product))
+                detected_lines.add(i)
+                continue
             pkg = m.group(1).lower()
             product = "general"
             if "messaging" in pkg or "message" in pkg:

--- a/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
+++ b/skills/telnyx-twilio-migration/scripts/scan-twilio-deep.py
@@ -1195,7 +1195,7 @@ def scan_php_file(filepath: Path, lines: List[str]) -> List[Detection]:
     return detections
 
 
-def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
+def scan_csharp_file(filepath: Path, lines: List[str], global_using_code: str = "") -> List[Detection]:
     """Regex-based scanning for C# files."""
     detections: List[Detection] = []
     detected_lines: Set[int] = set()
@@ -1203,7 +1203,7 @@ def scan_csharp_file(filepath: Path, lines: List[str]) -> List[Detection]:
     lexed = _ownership.lexed_source(source, filepath.suffix)
     syntax_lines = lexed.code.split("\n")
     lines = lexed.without_comments.split("\n")
-    for line, product in _ownership.contextual_calls(source, filepath.suffix):
+    for line, product in _ownership.contextual_calls(source, filepath.suffix, global_using_code):
         detections.append(Detection(
             pattern=lines[line - 1].strip(), line=line, detection_method="regex",
             context=get_context_lines(lines, line), confidence="high", product=product))
@@ -1351,7 +1351,9 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
     method_counts: Dict[str, int] = {"ast": 0, "regex": 0, "heuristic": 0}
     confidence_counts: Dict[str, int] = {"high": 0, "medium": 0, "low": 0}
 
-    for filepath in walk_project(project_root):
+    paths = list(walk_project(project_root))
+    global_usings = _ownership.CsharpGlobalUsings(project_root, paths)
+    for filepath in paths:
         ext = filepath.suffix.lower()
         name = filepath.name
 
@@ -1592,11 +1594,12 @@ def run_scan(project_root: Path) -> Dict[str, Any]:
                 text = filepath.read_text(errors="replace")
             except (OSError, PermissionError):
                 continue
-            if "twilio" not in text.lower():
+            global_using_code = global_usings.for_file(filepath)
+            if "twilio" not in text.lower() and not global_using_code:
                 continue
             lines = text.splitlines()
             rel = str(filepath.relative_to(project_root))
-            csharp_detections = scan_csharp_file(filepath, lines)
+            csharp_detections = scan_csharp_file(filepath, lines, global_using_code)
             if csharp_detections:
                 fr = FileResult(rel, "csharp")
                 fr.detections = csharp_detections

--- a/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
+++ b/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
@@ -118,6 +118,21 @@ run_grep() {
   grep -rnI "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
+run_source_fixed_grep() {
+  grep -rnI "${EXCLUDE_ARGS[@]}" --exclude='*.razor' --exclude='*.cshtml' "$@" "$PROJECT_ROOT" 2>/dev/null || true
+  # Razor mixes inert markup and executable C#. Recheck candidate lines on
+  # the shared executable view, retaining the original fixed-string semantics.
+  local filter_pattern script_dir filepath locator
+  filter_pattern="$(printf '%s' "$2" | sed 's/[][\\.^$*+?(){}|]/\\&/g')"
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  while IFS= read -r -d '' filepath && IFS= read -r locator; do
+    printf '%s\0%s\n' "$filepath" "$locator" |
+      python3 "$script_dir/filter-source-matches.py" --mode code \
+        --analyzer "$script_dir/lint-required-messaging-profile.py" --pattern "$filter_pattern"
+  done < <(grep -rnIH --null --include='*.razor' --include='*.cshtml' \
+    "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true)
+}
+
 # Detect language from file extension
 detect_language() {
   local f="$1"
@@ -130,7 +145,7 @@ detect_language() {
     *.java)                   echo "java" ;;
     *.php|*.phtml)             echo "php" ;;
     *.scala)                  echo "scala" ;;
-    *.cs|*.cshtml)             echo "csharp" ;;
+    *.cs|*.cshtml|*.razor)     echo "csharp" ;;
     *.sh|*.bash)              echo "shell" ;;
     *.xml)                    echo "xml" ;;
     *.json)                   echo "json" ;;
@@ -340,7 +355,7 @@ for pat in "${SDK_PATTERNS[@]}"; do
         record_file "$rel" "$lang" "$p" "$trimmed"
       done
     fi
-  done < <(run_grep -F "$pat")
+  done < <(run_source_fixed_grep -F "$pat")
 done
 
 for pat in "${SDK_REGEX_PATTERNS[@]}"; do
@@ -427,7 +442,7 @@ for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
     fi
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
-  done < <(run_grep -F "$pat")
+  done < <(run_source_fixed_grep -F "$pat")
 done
 
 # Case-insensitive regex patterns for common method calls

--- a/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
+++ b/skills/telnyx-twilio-migration/scripts/scan-twilio-usage.sh
@@ -115,21 +115,22 @@ declare -A API_URL_MAP       # url -> comma-separated files
 # Runs grep -rn inside PROJECT_ROOT with standard excludes and returns
 # matching lines (path:lineno:content). Returns 0 even if nothing matched.
 run_grep() {
-  grep -rn "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI "${EXCLUDE_ARGS[@]}" "$@" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Detect language from file extension
 detect_language() {
   local f="$1"
   case "$f" in
-    *.py)                     echo "python" ;;
-    *.js|*.mjs|*.cjs)        echo "javascript" ;;
-    *.ts|*.tsx)               echo "typescript" ;;
+    *.py|*.pyw)               echo "python" ;;
+    *.js|*.jsx|*.mjs|*.cjs)    echo "javascript" ;;
+    *.ts|*.tsx|*.mts|*.cts)    echo "typescript" ;;
     *.go)                     echo "go" ;;
-    *.rb)                     echo "ruby" ;;
+    *.rb|*.rake|*/Rakefile|Rakefile) echo "ruby" ;;
     *.java)                   echo "java" ;;
-    *.php)                    echo "php" ;;
-    *.cs)                     echo "csharp" ;;
+    *.php|*.phtml)             echo "php" ;;
+    *.scala)                  echo "scala" ;;
+    *.cs|*.cshtml)             echo "csharp" ;;
     *.sh|*.bash)              echo "shell" ;;
     *.xml)                    echo "xml" ;;
     *.json)                   echo "json" ;;
@@ -179,7 +180,7 @@ pattern_to_products() {
     products="$products fax"
   fi
   # Lookup
-  if echo "$pat" | grep -qiE 'twilio/rest/lookups|PhoneNumber|lookups'; then
+  if echo "$pat" | grep -qiE 'twilio/rest/lookups|lookups'; then
     products="$products lookup"
   fi
   # TeXML (TwiML)
@@ -293,8 +294,8 @@ SDK_PATTERNS=(
   'import com.twilio'
   'com.twilio.'
   # PHP
-  'use Twilio\\'
-  'Twilio\\'
+  "use Twilio\\"
+  "Twilio\\"
   # C# / .NET
   'using Twilio'
   'Twilio.'
@@ -407,8 +408,8 @@ PRODUCT_PATTERNS_FIXED=(
 )
 
 for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
-  pat="${entry%%:*}"
-  product="${entry#*:}"
+  pat="${entry%:*}"
+  product="${entry##*:}"
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     filepath="${line%%:*}"
@@ -416,6 +417,14 @@ for entry in "${PRODUCT_PATTERNS_FIXED[@]}"; do
     content="${rest#*:}"
     rel="${filepath#"$PROJECT_ROOT"/}"
     lang="$(detect_language "$rel")"
+    # C# resource names can be application-defined. The shared scoped
+    # resolver below attributes these calls; a bare name is not SDK evidence.
+    if [[ "$lang" == csharp && ( "$pat" == MessageResource || "$pat" == CallResource || \
+      "$pat" == VerificationResource || "$pat" == FaxResource || "$pat" == SimResource || \
+      "$pat" == ConversationResource || "$pat" == NotificationResource || \
+      "$pat" == WorkflowResource ) ]]; then
+      continue
+    fi
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
   done < <(run_grep -F "$pat")
@@ -425,6 +434,14 @@ done
 PRODUCT_PATTERNS_REGEX=(
   'messages\.create:messaging'
   'messages\.list:messaging'
+  'api\.twilio\.com/.*/Messages(\.json)?:messaging'
+  'messaging\.twilio\.com:messaging'
+  'api\.twilio\.com/.*/Calls(\.json)?:voice'
+  'verify\.twilio\.com:verify'
+  'lookups\.twilio\.com:lookup'
+  'video\.twilio\.com:video'
+  'fax\.twilio\.com:fax'
+  'api\.twilio\.com/.*/IncomingPhoneNumbers(\.json)?:phone-numbers'
   '\.calls\.create:voice'
   '\.calls\.list:voice'
   'verify\.v2:verify'
@@ -438,7 +455,6 @@ PRODUCT_PATTERNS_REGEX=(
   'twiml\.voice:voice'
   'twiml\.messaging:messaging'
   'VoiceGrant:voice'
-  'SipGrant:voice'
   # SIP trunking
   'twilio\.rest\.trunking:sip'
   'trunking\.v1:sip'
@@ -496,8 +512,8 @@ PRODUCT_PATTERNS_REGEX=(
 )
 
 for entry in "${PRODUCT_PATTERNS_REGEX[@]}"; do
-  pat="${entry%%:*}"
-  product="${entry#*:}"
+  pat="${entry%:*}"
+  product="${entry##*:}"
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     filepath="${line%%:*}"
@@ -507,8 +523,22 @@ for entry in "${PRODUCT_PATTERNS_REGEX[@]}"; do
     lang="$(detect_language "$rel")"
     trimmed="$(echo "$content" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
     record_file "$rel" "$lang" "$product" "$trimmed"
-  done < <(run_grep -iE "$pat")
+  done < <(run_grep -iE -- "$pat")
 done
+
+# Ambiguous JVM class names and PHP receivers use the same ownership resolver
+# as deep discovery. NUL records preserve filenames and source text verbatim.
+while IFS= read -r -d '' filepath && IFS= read -r -d '' product && IFS= read -r -d '' content; do
+  rel="${filepath#"$PROJECT_ROOT"/}"
+  lang="$(detect_language "$rel")"
+  record_file "$rel" "$lang" "$product" "$content"
+done < <(python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sdk-source-ownership.py" "$PROJECT_ROOT")
+# A process-substitution failure does not propagate through `set -e`.
+# Do not serialize partial discovery as a successful complete scan.
+if ! wait "$!"; then
+  echo "SDK ownership discovery failed; scan is incomplete" >&2
+  exit 2
+fi
 
 # ---------------------------------------------------------------------------
 # 3. Environment variables

--- a/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Shared, bounded SDK ownership for ambiguous JVM/PHP/Go discovery call names.
+
+This is discovery evidence, not a whole-program type checker. A comment, string,
+unrelated import, or receiver name alone never establishes SDK ownership.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+import importlib.util
+from pathlib import Path
+import re
+import os
+import sys
+
+
+@lru_cache(maxsize=None)
+def load_script(name: str):
+    spec = importlib.util.spec_from_file_location(
+        name.replace("-", "_"), Path(__file__).with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def lexed_source(source: str, suffix: str):
+    analyzer = load_script("lint-required-messaging-profile")
+    path = Path("source" + suffix)
+    return analyzer.lex_source(analyzer.executable_source(path, source),
+                               analyzer.canonical_suffix(path), analyzer.source_dialect(path))
+
+
+def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
+    lexed = lexed_source(source, suffix)
+    code = lexed.code
+    if suffix == ".go":
+        return go_contextual_calls(source, lexed)
+    if suffix in {".cs", ".cshtml"}:
+        analyzer = load_script("lint-required-messaging-profile")
+        resolver = analyzer.SourceEndpointResolver(lexed, ".cs")
+        resources = (
+            ("Twilio.Rest.Api.V2010.Account.MessageResource", "messaging"),
+            ("Twilio.Rest.Api.V2010.Account.CallResource", "voice"),
+            ("Twilio.Rest.Api.V2010.Account.IncomingPhoneNumberResource", "phone-numbers"),
+            ("Twilio.Rest.Api.V2010.AccountResource", "general"),
+            ("Twilio.Rest.Verify.V2.Service.VerificationResource", "verify"),
+            ("Twilio.Rest.Fax.V1.FaxResource", "fax"),
+            ("Twilio.Rest.Supersim.V1.SimResource", "iot"),
+            ("Twilio.Rest.Wireless.V1.SimResource", "iot"),
+            ("Twilio.Rest.Conversations.V1.ConversationResource", "conversations"),
+            ("Twilio.Rest.Conversations.V1.Service.ConversationResource", "conversations"),
+            ("Twilio.Rest.Notify.V1.Service.NotificationResource", "notify"),
+            ("Twilio.Rest.Taskrouter.V1.Workspace.WorkflowResource", "taskrouter"),
+        )
+        methods = tuple(
+            method + suffix
+            for method in ("Create", "Read", "Update", "Fetch", "Delete", "List")
+            for suffix in ("", "Async")
+        )
+        return [(source.count("\n", 0, call.start) + 1, product)
+                for target, product in resources
+                for call in analyzer.csharp_twilio_resource_calls(lexed,
+                    target, methods, resolver)]
+    result = []
+    products = {"Message": "messaging", "Call": "voice",
+                "IncomingPhoneNumber": "phone-numbers"}
+    if suffix in {".java", ".kt", ".kts", ".scala"}:
+        analyzer = load_script("lint-required-messaging-profile")
+        resolver = analyzer.SourceEndpointResolver(lexed, ".java")
+        parameter_scopes = []
+        parameter_headers = []
+        if suffix != ".java":
+            # Kotlin/Scala name:type parameters differ from Java Type name.
+            # Keep that dialect distinction local to SDK ownership, without
+            # changing the endpoint resolver's advertised Java contract.
+            for function in re.finditer(r"\b(?:fun|def)\s+\w+\s*\(", code):
+                opening = code.rfind("(", function.start(), function.end())
+                closing = analyzer.matching_delimiter(code, opening, "(", ")")
+                if closing is None:
+                    continue
+                parameter_headers.append((opening, closing))
+                body = code.find("{", closing)
+                if body < 0 or not re.fullmatch(r"\s*(?::[^{}\n=]+)?\s*=?\s*", code[closing + 1:body]):
+                    continue
+                end = analyzer.matching_delimiter(code, body, "{", "}")
+                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
+                if end is not None:
+                    parameter_scopes.append((body, end, names))
+        prefix = "com.twilio.rest.api.v2010.account."
+        imports = {}
+        explicit = {}
+        for match in re.finditer(r"\bimport\s+(com\.twilio\.rest\.api\.v2010\.account\.\*|[\w.]+)(?:\s+as\s+(\w+))?", code):
+            target = match[1]
+            if target == prefix + "*":
+                imports.update(products)
+            elif target.startswith(prefix) and target[len(prefix):] in products:
+                explicit[match[2] or target.rsplit(".", 1)[-1]] = products[target[len(prefix):]]
+            else:
+                explicit[match[2] or target.rsplit(".", 1)[-1]] = None
+        imports.update(explicit)  # Single imports shadow wildcard imports in either order.
+        for match in re.finditer(r"(?<![\w.])([\w.]+)\s*\.\s*creator\s*\(", code):
+            receiver = match[1]
+            first = receiver.split(".", 1)[0]
+            binding_id = resolver.graph.visible_binding(first, resolver.scope_at(match.start()), match.start())
+            if binding_id is not None:
+                binding = resolver.graph.bindings[binding_id]
+                if ((suffix == ".java" or binding.kind != "parameter")
+                        and not any(start < binding.declaration_start < end
+                                    for start, end in parameter_headers)
+                        and analyzer.scope_contains(code, binding.declaration_start, match.start())):
+                    continue
+            if any(start < match.start() < end and first in names
+                   for start, end, names in parameter_scopes):
+                continue
+            product = imports.get(receiver)
+            if receiver.startswith(prefix):
+                product = products.get(receiver[len(prefix):])
+            if product:
+                result.append((source.count("\n", 0, match.start()) + 1, product))
+        return result
+
+    namespaces = list(re.finditer(r"\bnamespace(?:\s+[\w\\]+)?\s*[;{]", code))
+
+    def namespace_at(offset: int) -> int:
+        return next((match.start() for match in reversed(namespaces)
+                     if match.start() < offset), -1)
+
+    def global_namespace(offset: int) -> bool:
+        match = next((match for match in reversed(namespaces) if match.start() < offset), None)
+        return match is None or bool(re.fullmatch(r"namespace\s*\{", match[0]))
+
+    aliases = {}
+    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*;", code, re.I):
+        aliases[(namespace_at(match.start()), (match[2] or match[1]).lower())] = match[1].lower()
+    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\\{([^{};]+)\}\s*;", code, re.I):
+        for member in match[1].split(","):
+            imported = re.fullmatch(
+                r"\s*(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*",
+                member,
+                re.I,
+            )
+            if imported:
+                aliases[(namespace_at(match.start()),
+                         (imported[2] or imported[1]).lower())] = imported[1].lower()
+
+    def kind(type_name: str, offset: int) -> str | None:
+        normalized = type_name.lstrip("\\").lower()
+        if normalized in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"} and (type_name.startswith("\\") or global_namespace(offset)):
+            return normalized.rsplit("\\", 1)[-1]
+        return aliases.get((namespace_at(offset), normalized))
+
+    analyzer = load_script("lint-required-messaging-profile")
+    # Index braces once so bindings cannot leak between functions/classes.
+    braces = {}
+    stack = []
+    for offset, character in enumerate(code):
+        if character == "{":
+            stack.append(offset)
+        elif character == "}" and stack:
+            braces[stack.pop()] = offset
+    functions = []
+    classes = []
+    for pattern, spans in ((r"\bfunction\s*\w*\s*\([^;{]*\)[^;{]*\{", functions),
+                           (r"\bclass\s+\w+[^;{]*\{", classes)):
+        for match in re.finditer(pattern, code):
+            opening = match.end() - 1
+            if opening in braces:
+                spans.append((match.start(), braces[opening]))
+
+    def owner(offset: int, spans: list[tuple[int, int]]):
+        return next((span for span in reversed(spans) if span[0] <= offset < span[1]), None)
+
+    variable = r"\$[A-Za-z_]\w*(?:\s*->\s*[A-Za-z_]\w*)?"
+    assignments = list(re.finditer(r"(" + variable + r")\s*=(?!=|>)\s*([^;\n]+)", code))
+    typed = list(re.finditer(r"(?<![\w\\])([\\\w]+)\s+(\$\w+)\b", code))
+
+    def compact(value: str) -> str:
+        return re.sub(r"\s+", "", value)
+
+    def resolve(expression: str, use: int, seen: frozenset = frozenset()) -> str | None:
+        expression = expression.strip()
+        identity = (expression, use)
+        if identity in seen or len(seen) > 32:
+            return None
+        seen = seen | {identity}
+        constructed = re.match(r"new\s+([\\\w]+)\s*\(", expression, re.I)
+        if constructed:
+            return kind(constructed[1], use)
+        factory = re.match(r"(" + variable + r")\s*->\s*create\s*\(", expression, re.I)
+        if factory:
+            return "client" if resolve(factory[1], use, seen) == "clientfactory" else None
+        if not re.fullmatch(variable, expression):
+            return None
+        name = compact(expression)
+        candidates = []
+        for match in assignments:
+            if compact(match[1]) != name:
+                continue
+            if name.startswith("$this->"):
+                # Only a constructor initializes an instance property for a
+                # later method; arbitrary other method writes are not definite.
+                function = owner(match.start(), functions)
+                same_function = function == owner(use, functions)
+                constructor = function and re.match(r"function\s+__construct\b", code[function[0]:], re.I)
+                if owner(use, classes) is None or owner(use, classes) != owner(match.start(), classes) or not (same_function or constructor):
+                    continue
+                if same_function and match.start() >= use:
+                    continue
+            elif owner(use, functions) != owner(match.start(), functions):
+                continue
+            elif match.start() >= use:
+                continue
+            if namespace_at(match.start()) != namespace_at(use):
+                continue
+            if not name.startswith("$this->") and not analyzer.scope_contains(code, match.start(), use):
+                continue
+            # An assignment in the currently executing method overrides a
+            # constructor initializer regardless of source declaration order.
+            candidates.append((owner(match.start(), functions) == owner(use, functions), match.start(), match[2]))
+        if candidates:
+            _, offset, value = max(candidates)
+            return resolve(value, offset, seen)
+        for match in reversed(typed):
+            if namespace_at(match.start()) != namespace_at(use):
+                continue
+            function = owner(match.start(), functions)
+            # A type hint is in the parameter header, not `return $client` or
+            # another keyword/expression in the function body.
+            parameter = function is not None and match.start() < code.find("{", function[0])
+            if parameter and match.start() < use and compact(match[2]) == name and owner(use, functions) == function:
+                return kind(match[1], match.start())
+            promoted = False
+            if parameter:
+                parameter_start = max(code.rfind("(", function[0], match.start()),
+                                      code.rfind(",", function[0], match.start()))
+                promoted = bool(re.search(
+                    r"\b(?:public|protected|private)\b",
+                    code[parameter_start + 1:match.start()],
+                    re.I,
+                ))
+            if (promoted and name == "$this->" + match[2][1:]
+                    and re.match(r"function\s+__construct\b", code[function[0]:], re.I)
+                    and owner(use, classes) == owner(match.start(), classes)):
+                return kind(match[1], match.start())
+            if name == "$this->" + match[2][1:] and owner(match.start(), functions) is None and owner(use, classes) is not None and owner(use, classes) == owner(match.start(), classes):
+                return kind(match[1], match.start())
+        return None
+
+    php_products = {"messages": "messaging", "calls": "voice", "verify": "verify",
+                    "video": "video", "lookups": "lookup"}
+    for match in re.finditer(r"(" + variable + r")\s*->\s*(messages|calls|verify|video|lookups)\b", code, re.I):
+        if resolve(match[1], match.start()) == "client":
+            result.append((source.count("\n", 0, match.start()) + 1, php_products[match[2].lower()]))
+    return result
+
+
+def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
+    """Attribute standard Go SDK service calls through local client bindings."""
+    analyzer = load_script("lint-required-messaging-profile")
+    code = lexed.code
+    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+    # The shared graph already indexes initialized locals and parameters. Add
+    # Go's uninitialized `var client Type` form so it shadows an outer SDK
+    # binding in exactly the same lexical lookup.
+    for declaration in re.finditer(
+            r"(?m)\bvar\s+([A-Za-z_]\w*)\s+(?![=(])[^=;\n]+(?=;|\n|$)", code):
+        scope = resolver.scope_at(declaration.start())
+        resolver.graph.add_binding(
+            declaration[1], scope, declaration.start(), declaration.start(),
+            "declaration")
+    packages = set()
+    for token in lexed.strings:
+        if token.contents != "github.com/twilio/twilio-go":
+            continue
+        line_start = code.rfind("\n", 0, token.start) + 1
+        prefix = code[line_start:token.start]
+        single = re.fullmatch(r"\s*import\s+(?:(\w+)\s+)?", prefix)
+        grouped = re.fullmatch(r"\s*(?:(\w+)\s+)?", prefix)
+        group_start = code.rfind("import", 0, token.start)
+        in_group = group_start >= 0 and re.match(r"import\s*\(", code[group_start:])
+        if in_group:
+            opening = code.find("(", group_start)
+            closing = analyzer.matching_delimiter(code, opening, "(", ")")
+            in_group = closing is not None and token.start < closing
+        imported = single or (grouped if in_group else None)
+        if imported:
+            packages.add(imported[1] or "twilio")
+    # This shared pattern excludes selector suffixes (`holder.client = ...`),
+    # which are mutations of a different binding.
+    assignments = resolver.root_assignments
+
+    def assignment(name: str, before: int):
+        use_binding = resolver.graph.visible_binding(
+            name, resolver.scope_at(before), before)
+        for match in reversed(assignments):
+            if (match[1].lstrip("$") != name or match.start() >= before
+                    or not analyzer.scope_contains(code, match.start(), before)):
+                continue
+            binding = resolver.assignment_bindings.get(match.start())
+            if binding is None:
+                binding = resolver.graph.visible_binding(
+                    name, resolver.scope_at(match.start()), match.start())
+            if binding == use_binding:
+                value = re.match(r"([^;\n]+)", code[match.end():])
+                return (match, value[1].strip()) if value else None
+        return None
+
+    def client(name: str, before: int, seen: frozenset = frozenset()) -> bool:
+        identity = (name, before)
+        if identity in seen or len(seen) >= 32:
+            return False
+        resolved = assignment(name, before)
+        if resolved is None:
+            return False
+        match, value = resolved
+        created = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", value)
+        if created:
+            package_binding = resolver.graph.visible_binding(
+                created[1], resolver.scope_at(match.start()), match.start())
+            return created[1] in packages and package_binding is None
+        return bool(re.fullmatch(r"\w+", value) and client(value, match.start(), seen | {identity}))
+
+    products = {"Api": {"Message": "messaging", "Call": "voice", "IncomingPhoneNumber": "phone-numbers"},
+                "VerifyV2": {"Verification": "verify"},
+                "LookupsV2": {"PhoneNumber": "lookup"},
+                "VideoV1": {"Room": "video"}}
+    result = []
+    for match in re.finditer(r"\b(\w+)\s*\.\s*(\w+)\s*\.\s*"
+                            r"(?:Create|Fetch|Update|Delete|Read|List)(\w+)\s*\(", code):
+        product = products.get(match[2], {}).get(match[3])
+        if product and client(match[1], match.start()):
+            result.append((source.count("\n", 0, match.start()) + 1, product))
+    return result
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        return 2
+    root = Path(sys.argv[1])
+    scanner = load_script("scan-twilio-deep")
+    failed = False
+    for path in scanner.walk_project(root):
+        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
+            continue
+        try:
+            if not path.stat().st_mode & 0o444 or not os.access(path, os.R_OK):
+                raise OSError("source is not readable")
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            print(f"Cannot inspect SDK ownership in {str(path)!r}: {error}", file=sys.stderr)
+            failed = True
+            continue
+        if "\x00" in source:
+            continue
+        lines = source.splitlines()
+        for line, product in contextual_calls(source, path.suffix):
+            for value in (str(path), product, lines[line - 1].strip()):
+                sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
+    return 2 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -93,7 +93,61 @@ def scala_indent_regions(code: str) -> list[tuple[int, int]]:
     return regions
 
 
-def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
+class CsharpGlobalUsings:
+    """Index unconditional source global usings within project-directory bounds.
+
+    This does not evaluate MSBuild or preprocessor symbols. Conditional imports
+    are not promoted to project-wide evidence. Without a csproj, the scan root
+    is the boundary; nested/sibling csproj directories never share imports.
+    """
+
+    def __init__(self, root: Path, paths: list[Path]):
+        self.root = root
+        self.projects = {path.parent for path in paths if path.suffix.lower() == ".csproj"}
+        self.imports: dict[Path, list[str]] = {}
+        for path in paths:
+            if path.suffix.lower() != ".cs":
+                continue
+            try:
+                source = path.read_text(encoding="utf-8-sig")
+            except (OSError, UnicodeError):
+                continue  # The scanner retains its own read-error policy.
+            if "global" not in source or "\x00" in source:
+                continue
+            code = lexed_source(source, ".cs").code
+            # Preserve offsets while removing conditional regions. A using in
+            # one possible build configuration is not definite ownership.
+            depth, unconditional = 0, []
+            for line in code.splitlines(keepends=True):
+                directive = re.match(r"\s*#\s*(if|endif)\b", line)
+                if directive and directive[1] == "if":
+                    depth += 1
+                unconditional.append("\n" if depth or directive else line)
+                if directive and directive[1] == "endif":
+                    depth = max(0, depth - 1)
+            code = "".join(unconditional)
+            analyzer = load_script("lint-required-messaging-profile")
+            for match in re.finditer(
+                r"\bglobal\s+using\s+(?:static\s+)?(?:\w+\s*=\s*)?"
+                r"(?:global\s*::\s*)?\w+(?:\s*\.\s*\w+)*\s*;", code
+            ):
+                # Global directives are compilation-unit declarations, never
+                # members of a namespace/type body.
+                if analyzer.curly_ancestry(code, match.start()):
+                    continue
+                self.imports.setdefault(self.owner(path), []).append(match[0])
+        self.contexts = {owner: "\n".join(dict.fromkeys(imports))
+                         for owner, imports in self.imports.items()
+                         if any(re.search(r"\bTwilio\s*\.", item) for item in imports)}
+
+    def owner(self, path: Path) -> Path:
+        return next((parent for parent in path.parents if parent in self.projects), self.root)
+
+    def for_file(self, path: Path) -> str:
+        return self.contexts.get(self.owner(path), "")
+
+
+def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
     if suffix == ".go":
@@ -123,7 +177,7 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
         return [(source.count("\n", 0, call.start) + 1, product)
                 for target, product in resources
                 for call in analyzer.csharp_twilio_resource_calls(lexed,
-                    target, methods, resolver)]
+                    target, methods, resolver, global_using_code)]
     result = []
     products = {"Message": "messaging", "Call": "voice",
                 "IncomingPhoneNumber": "phone-numbers"}
@@ -458,7 +512,9 @@ def main() -> int:
     root = Path(sys.argv[1])
     scanner = load_script("scan-twilio-deep")
     failed = False
-    for path in scanner.walk_project(root):
+    paths = list(scanner.walk_project(root))
+    global_usings = CsharpGlobalUsings(root, paths)
+    for path in paths:
         if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
             continue
         try:
@@ -472,7 +528,7 @@ def main() -> int:
         if "\x00" in source:
             continue
         lines = source.splitlines()
-        for line, product in contextual_calls(source, path.suffix):
+        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path)):
             for value in (str(path), product, lines[line - 1].strip()):
                 sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
     return 2 if failed else 0

--- a/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -31,6 +31,68 @@ def lexed_source(source: str, suffix: str):
                                analyzer.canonical_suffix(path), analyzer.source_dialect(path))
 
 
+def scala_import_bindings(code: str, products: dict[str, str]) -> list[tuple[int, dict, dict]]:
+    """Read Scala 2/3 selectors, preserving renames and wildcard exclusions.
+
+    Import positions are retained because Scala permits block-local imports.
+    This recognizes literal package imports, not arbitrary stable-path aliases.
+    """
+    analyzer = load_script("lint-required-messaging-profile")
+    prefix = "com.twilio.rest.api.v2010.account"
+    result = []
+    for statement in re.finditer(r"\bimport\s+((?:[.,]\s*\n\s*|[^;\n{}]|\{[^{}]*\})+)", code):
+        for start, end in analyzer.split_arguments(code, statement.start(1), statement.end(1)):
+            expression = code[start:end].strip()
+            grouped = re.fullmatch(r"([\w.]+)\.\s*\{([^{}]*)\}", expression)
+            if grouped:
+                package, selectors = grouped[1], grouped[2].split(",")
+            else:
+                single = re.fullmatch(r"([\w.]+)\.\s*([\w*]+)(?:\s+as\s+(\w+))?", expression)
+                if not single:
+                    continue
+                package = single[1]
+                selectors = [single[2] + (" as " + single[3] if single[3] else "")]
+            package = package.removeprefix("_root_.")
+            explicit, wildcard, excluded = {}, False, set()
+            for selector in selectors:
+                member = re.fullmatch(r"\s*([\w*]+)(?:\s*(?:=>|\bas\b)\s*(\w+))?\s*", selector)
+                if not member:
+                    continue
+                name, alias = member[1], member[2]
+                if name in {"_", "*"} and alias is None:
+                    wildcard = True
+                else:
+                    excluded.add(name)
+                    if alias != "_":
+                        explicit[alias or name] = products.get(name) if package == prefix else None
+            wildcards = ({name: product for name, product in products.items() if name not in excluded}
+                         if wildcard and package == prefix else {})
+            result.append((statement.start(), explicit, wildcards))
+    return result
+
+
+def scala_indent_regions(code: str) -> list[tuple[int, int]]:
+    """Index Scala 3 indentation regions alongside (not instead of) braces."""
+    regions, stack = [], []
+    previous, previous_indent, offset = "", 0, 0
+    for line in code.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped:
+            indent = len(line) - len(line.lstrip(" \t"))
+            while stack and indent < stack[-1][0]:
+                _, start = stack.pop()
+                regions.append((start, offset))
+            if indent > previous_indent and re.search(
+                r"(?::|=|=>|\bthen|\bdo|\bmatch|\btry|\bcatch|\bfinally|\belse|\byield)$",
+                previous,
+            ):
+                stack.append((indent, offset))
+            previous, previous_indent = stripped, indent
+        offset += len(line)
+    regions.extend((start, len(code)) for _, start in stack)
+    return regions
+
+
 def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
@@ -68,6 +130,12 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
     if suffix in {".java", ".kt", ".kts", ".scala"}:
         analyzer = load_script("lint-required-messaging-profile")
         resolver = analyzer.SourceEndpointResolver(lexed, ".java")
+        indent_regions = scala_indent_regions(code) if suffix == ".scala" else []
+
+        def scope_path(offset: int) -> tuple[int, ...]:
+            return tuple(sorted((*analyzer.curly_ancestry(code, offset),
+                                 *(start for start, end in indent_regions if start <= offset < end))))
+
         parameter_scopes = []
         parameter_headers = []
         if suffix != ".java":
@@ -80,11 +148,22 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
                 if closing is None:
                     continue
                 parameter_headers.append((opening, closing))
+                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
+                expression = re.match(r"\s*(?::[^{}\n=]+)?\s*=\s*", code[closing + 1:])
+                if expression:
+                    start = closing + 1 + expression.end()
+                    if start < len(code) and code[start] != "{":
+                        end = analyzer.assignment_end(lexed, start, ".java")
+                        # A multiline indentation body includes following
+                        # expressions, but not a dedented sibling definition.
+                        body_regions = [end for begin, end in indent_regions
+                                        if closing < begin <= start < end]
+                        parameter_scopes.append((start - 1, min(body_regions) if body_regions else end, names))
+                        continue
                 body = code.find("{", closing)
                 if body < 0 or not re.fullmatch(r"\s*(?::[^{}\n=]+)?\s*=?\s*", code[closing + 1:body]):
                     continue
                 end = analyzer.matching_delimiter(code, body, "{", "}")
-                names = set(re.findall(r"(?:^|,)\s*(?:\w+\s+)*?(\w+)\s*:", code[opening + 1:closing]))
                 if end is not None:
                     parameter_scopes.append((body, end, names))
         prefix = "com.twilio.rest.api.v2010.account."
@@ -99,21 +178,48 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
             else:
                 explicit[match[2] or target.rsplit(".", 1)[-1]] = None
         imports.update(explicit)  # Single imports shadow wildcard imports in either order.
+        scala_imports = scala_import_bindings(code, products) if suffix == ".scala" else []
+        scala_objects = list(re.finditer(r"\bobject\s+(\w+)", code)) if suffix == ".scala" else []
         for match in re.finditer(r"(?<![\w.])([\w.]+)\s*\.\s*creator\s*\(", code):
             receiver = match[1]
             first = receiver.split(".", 1)[0]
+            use_scope = scope_path(match.start()) if suffix == ".scala" else ()
             binding_id = resolver.graph.visible_binding(first, resolver.scope_at(match.start()), match.start())
-            if binding_id is not None:
-                binding = resolver.graph.bindings[binding_id]
+            bindings = ([resolver.graph.bindings[index]
+                         for index in resolver.graph.bindings_by_name.get(first, [])]
+                        if suffix == ".scala" else
+                        [resolver.graph.bindings[binding_id]] if binding_id is not None else [])
+            shadowed = False
+            for binding in bindings:
+                binding_scope = scope_path(binding.declaration_start) if suffix == ".scala" else ()
                 if ((suffix == ".java" or binding.kind != "parameter")
                         and not any(start < binding.declaration_start < end
                                     for start, end in parameter_headers)
-                        and analyzer.scope_contains(code, binding.declaration_start, match.start())):
-                    continue
+                        and (use_scope[:len(binding_scope)] == binding_scope if suffix == ".scala"
+                             else analyzer.scope_contains(code, binding.declaration_start, match.start()))):
+                    shadowed = True
+                    break
+            if shadowed or any(obj[1] == first and use_scope[:len(scope_path(obj.start()))] == scope_path(obj.start())
+                               for obj in scala_objects):
+                continue
             if any(start < match.start() < end and first in names
                    for start, end, names in parameter_scopes):
                 continue
             product = imports.get(receiver)
+            if suffix == ".scala":
+                # A deeper lexical scope wins; within a scope, explicit
+                # selectors take precedence over wildcard selectors.
+                candidates = []
+                for position, selected, wildcard in scala_imports:
+                    import_scope = scope_path(position)
+                    if position >= match.start() or use_scope[:len(import_scope)] != import_scope:
+                        continue
+                    depth = len(import_scope)
+                    if receiver in selected:
+                        candidates.append((depth, 1, position, selected[receiver]))
+                    elif receiver in wildcard:
+                        candidates.append((depth, 0, position, wildcard[receiver]))
+                product = max(candidates, key=lambda item: item[:3])[3] if candidates else None
             if receiver.startswith(prefix):
                 product = products.get(receiver[len(prefix):])
             if product:

--- a/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -237,24 +237,18 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
         return match is None or bool(re.fullmatch(r"namespace\s*\{", match[0]))
 
     aliases = {}
-    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*;", code, re.I):
-        aliases[(namespace_at(match.start()), (match[2] or match[1]).lower())] = match[1].lower()
-    for match in re.finditer(r"\buse\s+\\?Twilio\\Rest\\\{([^{};]+)\}\s*;", code, re.I):
-        for member in match[1].split(","):
-            imported = re.fullmatch(
-                r"\s*(ClientFactory|Client)(?:\s+as\s+(\w+))?\s*",
-                member,
-                re.I,
-            )
-            if imported:
-                aliases[(namespace_at(match.start()),
-                         (imported[2] or imported[1]).lower())] = imported[1].lower()
 
     def kind(type_name: str, offset: int) -> str | None:
         normalized = type_name.lstrip("\\").lower()
         if normalized in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"} and (type_name.startswith("\\") or global_namespace(offset)):
             return normalized.rsplit("\\", 1)[-1]
-        return aliases.get((namespace_at(offset), normalized))
+        if not type_name.startswith("\\"):
+            first, separator, rest = normalized.partition("\\")
+            imported = aliases.get((namespace_at(offset), first))
+            expanded = imported + separator + rest if imported else ""
+            if expanded in {"twilio\\rest\\client", "twilio\\rest\\clientfactory"}:
+                return expanded.rsplit("\\", 1)[-1]
+        return None
 
     analyzer = load_script("lint-required-messaging-profile")
     # Index braces once so bindings cannot leak between functions/classes.
@@ -265,6 +259,24 @@ def contextual_calls(source: str, suffix: str) -> list[tuple[int, str]]:
             stack.append(offset)
         elif character == "}" and stack:
             braces[stack.pop()] = offset
+    namespace_braces = {match.end() - 1 for match in namespaces if match[0].endswith("{")}
+    for statement in re.finditer(r"\buse\s+([^;()]+);", code, re.I):
+        # Trait uses and closure captures are not namespace imports.
+        if re.match(r"(?:function|const)\b", statement[1], re.I):
+            continue
+        if any(start < statement.start() < end and start not in namespace_braces
+               for start, end in braces.items()):
+            continue
+        for start, end in analyzer.split_arguments(code, statement.start(1), statement.end(1)):
+            item = code[start:end].strip()
+            group = re.fullmatch(r"(\\?[\w\\]+\\)\s*\{([^{}]*)\}", item)
+            members = [(group[1], member) for member in group[2].split(",")] if group else [("", item)]
+            for prefix, member in members:
+                imported = re.fullmatch(r"\s*(\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)(?:\s+as\s+([A-Za-z_]\w*))?\s*", member, re.I)
+                if imported:
+                    qualified = (prefix + imported[1]).lstrip("\\").lower()
+                    alias = (imported[2] or imported[1].rsplit("\\", 1)[-1]).lower()
+                    aliases[(namespace_at(statement.start()), alias)] = qualified
     functions = []
     classes = []
     for pattern, spans in ((r"\bfunction\s*\w*\s*\([^;{]*\)[^;{]*\{", functions),

--- a/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
+++ b/skills/telnyx-twilio-migration/scripts/sdk-source-ownership.py
@@ -147,13 +147,21 @@ class CsharpGlobalUsings:
         return self.contexts.get(self.owner(path), "")
 
 
-def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> list[tuple[int, str]]:
+def contextual_calls(source: str, suffix: str, global_using_code: str = "",
+                     go_clients: frozenset[str] = frozenset()) -> list[tuple[int, str]]:
     lexed = lexed_source(source, suffix)
     code = lexed.code
     if suffix == ".go":
-        return go_contextual_calls(source, lexed)
-    if suffix in {".cs", ".cshtml"}:
+        return go_contextual_calls(source, lexed, go_clients)
+    if suffix in {".cs", ".cshtml", ".razor"}:
         analyzer = load_script("lint-required-messaging-profile")
+        if suffix in {".cshtml", ".razor"}:
+            # Razor @using directives are newline-terminated, unlike C# using
+            # declarations. Only executable lexer output can supply imports.
+            directives = re.findall(
+                r"(?m)^\s*@using\s+((?:static\s+)?(?:\w+\s*=\s*)?"
+                r"(?:global\s*::\s*)?\w+(?:\s*\.\s*\w+)*)\s*;?\s*$", code)
+            global_using_code += "\n" + "\n".join("using " + item + ";" for item in directives)
         resolver = analyzer.SourceEndpointResolver(lexed, ".cs")
         resources = (
             ("Twilio.Rest.Api.V2010.Account.MessageResource", "messaging"),
@@ -427,20 +435,10 @@ def contextual_calls(source: str, suffix: str, global_using_code: str = "") -> l
     return result
 
 
-def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
-    """Attribute standard Go SDK service calls through local client bindings."""
+def go_import_packages(lexed) -> set[str]:
+    """Return file-local names importing the actual Twilio Go SDK."""
     analyzer = load_script("lint-required-messaging-profile")
     code = lexed.code
-    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
-    # The shared graph already indexes initialized locals and parameters. Add
-    # Go's uninitialized `var client Type` form so it shadows an outer SDK
-    # binding in exactly the same lexical lookup.
-    for declaration in re.finditer(
-            r"(?m)\bvar\s+([A-Za-z_]\w*)\s+(?![=(])[^=;\n]+(?=;|\n|$)", code):
-        scope = resolver.scope_at(declaration.start())
-        resolver.graph.add_binding(
-            declaration[1], scope, declaration.start(), declaration.start(),
-            "declaration")
     packages = set()
     for token in lexed.strings:
         if token.contents != "github.com/twilio/twilio-go":
@@ -458,9 +456,117 @@ def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
         imported = single or (grouped if in_group else None)
         if imported:
             packages.add(imported[1] or "twilio")
+    return packages
+
+
+def go_var_declarations(code: str):
+    """Yield Go var bindings; multi-name declarations only establish shadows."""
+    analyzer = load_script("lint-required-messaging-profile")
+    declaration = re.compile(r"([A-Za-z_]\w*)[ \t]*(?:[^=;,\n)]+)?(?P<equals>=)?")
+    for keyword in re.finditer(r"\bvar\s+", code):
+        start = keyword.end()
+        if code[start:start + 1] == "(":
+            end = analyzer.matching_delimiter(code, start, "(", ")")
+            if end is None:
+                continue
+            starts, stack = [start + 1], []
+            for position in range(start + 1, end):
+                char = code[position]
+                if char in "([{":
+                    stack.append(char)
+                elif char in ")]}":
+                    if stack:
+                        stack.pop()
+                elif char in ";\n" and not stack:
+                    starts.append(position + 1)
+        else:
+            starts, end = [start], len(code)
+        for position in starts:
+            while position < end and code[position] in " \t\r":
+                position += 1
+            multiple = re.compile(r"(?:\w+[ \t]*,[ \t]*)+\w+").match(code, position, end)
+            if multiple:
+                yield from re.compile(r"(\w+)(?P<equals>=)?").finditer(code, position, multiple.end())
+                continue
+            match = declaration.match(code, position, end)
+            if match:
+                yield match
+
+
+class GoPackageClients:
+    """Resolve static package client initializers without sharing file imports."""
+
+    def __init__(self, paths: list[Path]):
+        self.keys: dict[Path, tuple[Path, str]] = {}
+        declarations: dict[tuple[Path, str], dict[str, list[tuple[bool, str]]]] = {}
+        analyzer = load_script("lint-required-messaging-profile")
+        for path in paths:
+            if path.suffix != ".go":
+                continue
+            try:
+                source = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            lexed = lexed_source(source, ".go")
+            package = re.search(r"\bpackage\s+(\w+)", lexed.code)
+            if package is None:
+                continue
+            key = (path.parent, package[1])
+            self.keys[path] = key
+            # Test declarations and build-constrained variants must not seed
+            # unconditional ownership in production files.
+            if path.name.endswith("_test.go") or re.search(r"(?m)^\s*//\s*(?:go:build|\+build)\b", source):
+                continue
+            imports = go_import_packages(lexed)
+            resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+            assignments = list(resolver.root_assignments)
+            known_ends = {(match[1], match.end()) for match in assignments}
+            assignments.extend(match for match in go_var_declarations(lexed.code)
+                               if match["equals"] and (match[1], match.end()) not in known_ends)
+            for match in assignments:
+                if analyzer.curly_ancestry(lexed.code, match.start()):
+                    continue
+                value = re.match(r"[^;\n]+", lexed.code[match.end():])
+                if not value:
+                    continue
+                expression = value[0].strip()
+                constructor = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", expression)
+                owned = bool(constructor and constructor[1] in imports)
+                declarations.setdefault(key, {}).setdefault(match[1], []).append((owned, expression))
+        self.clients: dict[tuple[Path, str], frozenset[str]] = {}
+        for key, bindings in declarations.items():
+            known: set[str] = set()
+            for _ in range(len(bindings) + 1):
+                added = {name for name, values in bindings.items() if len(values) == 1
+                         and (values[0][0] or values[0][1] in known)} - known
+                if not added:
+                    break
+                known.update(added)
+            self.clients[key] = frozenset(known)
+
+    def for_file(self, path: Path) -> frozenset[str]:
+        return self.clients.get(self.keys.get(path), frozenset())
+
+
+def go_contextual_calls(source: str, lexed, package_clients: frozenset[str] = frozenset()) -> list[tuple[int, str]]:
+    """Attribute SDK calls through local bindings, then package initializers."""
+    analyzer = load_script("lint-required-messaging-profile")
+    code = lexed.code
+    resolver = analyzer.SourceEndpointResolver(lexed, ".go")
+    assignments = list(resolver.root_assignments)
+    known_ends = {(match[1], match.end()) for match in assignments}
+    for declaration in go_var_declarations(code):
+        if declaration["equals"] and (declaration[1], declaration.end()) in known_ends:
+            continue
+        scope = resolver.scope_at(declaration.start())
+        binding = resolver.graph.add_binding(declaration[1], scope, declaration.start(), declaration.start(), "declaration")
+        if declaration["equals"]:
+            assignments.append(declaration)
+            resolver.assignment_bindings[declaration.start()] = binding
+    packages = go_import_packages(lexed)
     # This shared pattern excludes selector suffixes (`holder.client = ...`),
     # which are mutations of a different binding.
-    assignments = resolver.root_assignments
+    assignments.sort(key=lambda match: match.start())
 
     def assignment(name: str, before: int):
         use_binding = resolver.graph.visible_binding(
@@ -484,7 +590,10 @@ def go_contextual_calls(source: str, lexed) -> list[tuple[int, str]]:
             return False
         resolved = assignment(name, before)
         if resolved is None:
-            return False
+            binding = resolver.graph.visible_binding(name, resolver.scope_at(before), before)
+            return name in package_clients and (binding is None or (
+                resolver.graph.bindings[binding].kind != "parameter"
+                and not analyzer.curly_ancestry(code, resolver.graph.bindings[binding].declaration_start)))
         match, value = resolved
         created = re.match(r"(\w+)\s*\.\s*NewRestClient(?:WithParams)?\s*\(", value)
         if created:
@@ -514,8 +623,9 @@ def main() -> int:
     failed = False
     paths = list(scanner.walk_project(root))
     global_usings = CsharpGlobalUsings(root, paths)
+    go_clients = GoPackageClients(paths)
     for path in paths:
-        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml"}:
+        if path.suffix not in {".java", ".kt", ".kts", ".scala", ".php", ".phtml", ".go", ".cs", ".cshtml", ".razor"}:
             continue
         try:
             if not path.stat().st_mode & 0o444 or not os.access(path, os.R_OK):
@@ -528,7 +638,7 @@ def main() -> int:
         if "\x00" in source:
             continue
         lines = source.splitlines()
-        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path)):
+        for line, product in contextual_calls(source, path.suffix, global_usings.for_file(path), go_clients.for_file(path)):
             for value in (str(path), product, lines[line - 1].strip()):
                 sys.stdout.buffer.write(value.encode("utf-8") + b"\x00")
     return 2 if failed else 0

--- a/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -20,6 +20,7 @@
 #   2 — Usage error
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # --- Colors (disabled if not a terminal) ---
 # shellcheck disable=SC2034  # BLUE reserved for info lines; kept for palette consistency
@@ -204,7 +205,7 @@ search_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Search helper that excludes .md files and minified JS (for config/env var checks)
@@ -217,7 +218,18 @@ search_source_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rn $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+}
+
+# Auth-related names are common in unrelated SDKs. Require Telnyx context in
+# the same file before reporting static evidence, not cryptographic assurance.
+search_telnyx_auth_files() {
+  local pattern="$1" file
+  while IFS= read -r -d '' file; do
+    if grep -qiE 'telnyx' "$file"; then
+      grep -nH -E "$pattern" "$file" || true
+    fi
+  done < <(grep -rlI --null $GREP_EXCLUDES --exclude='*.md' -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true)
 }
 
 # Search helper that filters out comment-only lines to reduce false positives.
@@ -407,10 +419,52 @@ fi
 # ============================================================
 section_header "Residual Twilio References"
 
+# Grep suppresses permission errors below; make scan incompleteness visible.
+# Use the same exclusions as the content checks, including caller exclusions.
+unreadable_files=$(python3 - "$PROJECT_ROOT" "$EXCLUDE_DIRS $EXTRA_EXCLUDE_DIRS" "$EXCLUDE_FILES" "$EXCLUDE_LOCK_FILES" <<'PY'
+import fnmatch
+import json
+import os
+import stat
+import sys
+root, excluded_dirs, excluded_files, excluded_locks = sys.argv[1:]
+excluded_dirs = excluded_dirs.split()
+excluded_files = excluded_files.split() + [arg.removeprefix("--exclude=") for arg in excluded_locks.split()]
+unreadable = []
+def excluded(name, patterns):
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+def walk_error(error):
+    unreadable.append(error.filename)
+for directory, dirs, files in os.walk(root, onerror=walk_error):
+    dirs[:] = [name for name in dirs if not excluded(name, excluded_dirs)]
+    for name in files:
+        if excluded(name, excluded_files):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            mode = os.stat(path).st_mode
+            if stat.S_ISREG(mode) and (not mode & 0o444 or not os.access(path, os.R_OK)):
+                unreadable.append(path)
+        except OSError:
+            unreadable.append(path)
+print(json.dumps({"files": unreadable}))
+PY
+)
+if [ "$(jq '.files | length' <<< "$unreadable_files")" -gt 0 ]; then
+  check_fail "source_readability" "Files could not be read; migration validation is incomplete:" "$unreadable_files"
+fi
+
+# Rust is not a supported SDK analyzer. Concrete Twilio imports must not be
+# hidden by an unrelated supported-language Telnyx dependency.
+matches=$(search_code_only '(^|[;[:space:]])(use|extern[[:space:]]+crate)[[:space:]]+twilio([[:space:]:;]|$)' "*.rs")
+if [ -n "$matches" ]; then
+  check_residual_matches_with_hybrid_scope "unsupported_twilio_source" "Twilio Rust source found; this validator cannot analyse Rust SDK migration completeness. Manual review is required:" "$matches"
+fi
+
 # --- Check 1: Twilio SDK imports ---
 # Python
 if product_applies "all"; then
-  matches=$(search_files "(from twilio|import twilio)" "*.py")
+  matches=$(search_files "(from twilio|import twilio)" "*.py" "*.pyw")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_python_imports" "Twilio Python imports found in $count file(s):" "$matches"
@@ -421,7 +475,7 @@ fi
 
 # JavaScript / TypeScript
 if product_applies "all"; then
-  matches=$(search_files "(require\(['\"]twilio['\"]|from ['\"]twilio['\"])" "*.js" "*.ts" "*.jsx" "*.tsx" "*.mjs" "*.cjs")
+  matches=$(search_files "(require\(['\"]twilio['\"]|from ['\"]twilio['\"])" "*.js" "*.ts" "*.jsx" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_js_imports" "Twilio JS/TS imports found in $count file(s):" "$matches"
@@ -443,7 +497,7 @@ fi
 
 # Ruby
 if product_applies "all"; then
-  matches=$(search_files "(require ['\"]twilio-ruby['\"]|require ['\"]twilio['\"])" "*.rb")
+  matches=$(search_files "(require ['\"]twilio-ruby['\"]|require ['\"]twilio['\"])" "*.rb" "*.rake")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_ruby_imports" "Twilio Ruby imports found in $count file(s):" "$matches"
@@ -454,7 +508,7 @@ fi
 
 # Java
 if product_applies "all"; then
-  matches=$(search_files "import com\.twilio\." "*.java" "*.kt" "*.scala")
+  matches=$(search_files "import com\.twilio\." "*.java" "*.kt" "*.kts" "*.scala")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_java_imports" "Twilio Java imports found in $count file(s):" "$matches"
@@ -465,7 +519,7 @@ fi
 
 # PHP
 if product_applies "all"; then
-  matches=$(search_files "(use Twilio|require.*twilio.php)" "*.php")
+  matches=$(search_files "(use Twilio|require.*twilio.php)" "*.php" "*.phtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_php_imports" "Twilio PHP imports found in $count file(s):" "$matches"
@@ -476,7 +530,7 @@ fi
 
 # C#
 if product_applies "all"; then
-  matches=$(search_files "using Twilio" "*.cs")
+  matches=$(search_files "using Twilio" "*.cs" "*.cshtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope "twilio_csharp_imports" "Twilio C# imports found in $count file(s):" "$matches"
@@ -487,7 +541,7 @@ fi
 
 # --- Check 2: Twilio API URLs (excludes .md docs and minified JS) ---
 if product_applies "all"; then
-  matches=$(search_source_files "(api\.twilio\.com|verify\.twilio\.com|video\.twilio\.com|taskrouter\.twilio\.com|chat\.twilio\.com|conversations\.twilio\.com|sync\.twilio\.com|proxy\.twilio\.com|studio\.twilio\.com)")
+  matches=$(search_source_files "(api\.twilio\.com|verify\.twilio\.com|video\.twilio\.com|taskrouter\.twilio\.com|chat\.twilio\.com|conversations\.twilio\.com|sync\.twilio\.com|proxy\.twilio\.com|studio\.twilio\.com|twimlets\.com)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_residual_matches_with_hybrid_scope \
@@ -549,11 +603,15 @@ if product_applies "all"; then
   # Go
   dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/go.mod 2>/dev/null || true)
   # Java/Kotlin (build.gradle, build.gradle.kts, pom.xml, libs.versions.toml)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 4 \( -name pom.xml -o -name build.gradle -o -name build.gradle.kts -o -name "libs.versions.toml" \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/build/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
+    dep_matches+=$'\nJVM dependency declaration\n'
+  fi
   # iOS (Swift Package Manager — project.pbxproj, Package.swift)
   dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 4 \( -name "project.pbxproj" -o -name "Package.swift" \) -not -path "*/.git/*" -exec grep -l -i "telnyx" {} \; 2>/dev/null || true)
   # PHP
-  dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/composer.json 2>/dev/null || true)
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" composer "$PROJECT_ROOT"; then
+    dep_matches+=$'\nComposer dependency declaration\n'
+  fi
   # C#
   dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name "*.csproj" -exec grep -l "Telnyx" {} \; 2>/dev/null || true)
   # Flutter
@@ -570,7 +628,10 @@ if product_applies "all"; then
   else
     # Before failing, check if Telnyx imports exist in source — if so, SDK is present
     # but in a dependency file we don't recognize (e.g., monorepo, custom build system)
-    source_imports=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/telnyx|@telnyx/|com\.telnyx\.|TelnyxRTC|TelnyxClient)")
+    source_imports=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/(team-)?telnyx|@telnyx/|com\.telnyx\.|TelnyxRTC|TelnyxClient)" \
+      "*.py" "*.pyw" "*.js" "*.jsx" "*.ts" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts" "*.rb" "*.rake" \
+      "*.go" "*.java" "*.kt" "*.kts" "*.scala" "*.php" "*.phtml" "*.cs" "*.cshtml" \
+      "*.swift" "*.dart")
     source_count=$(count_matches "$source_imports")
     if [ "$source_count" -gt 0 ]; then
       check_warn "telnyx_sdk_dependency" "Telnyx SDK not found in standard dependency files, but Telnyx imports found in $source_count source file(s) — likely using a non-standard dependency manager"
@@ -593,9 +654,19 @@ if product_applies "all"; then
   if grep -qE "gem\s+['\"]telnyx['\"].*~>" "$PROJECT_ROOT"/Gemfile 2>/dev/null; then
     version_pinned=true
   fi
+  # Go modules always require an explicit semantic version. Recognize both the
+  # current /v4 module path and an eventual later major-version path.
+  if grep -qE 'github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]+v[0-9]+\.' "$PROJECT_ROOT"/go.mod 2>/dev/null; then
+    version_pinned=true
+  fi
+  # Inspect dependency fields structurally. App/parent/unrelated versions are
+  # not evidence that this SDK dependency has a constrained version.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-pinned "$PROJECT_ROOT"; then
+    version_pinned=true
+  fi
   # If no dependency files found at all, skip the check
   has_deps=false
-  for f in requirements.txt setup.py setup.cfg pyproject.toml Pipfile package.json Gemfile go.mod; do
+  for f in requirements.txt setup.py setup.cfg pyproject.toml Pipfile package.json Gemfile go.mod pom.xml build.gradle build.gradle.kts composer.json; do
     if [ -f "$PROJECT_ROOT/$f" ]; then has_deps=true; break; fi
   done
   if [ "$has_deps" = true ]; then
@@ -637,7 +708,9 @@ fi
 
 # --- Check 7: Telnyx imports in source code ---
 if product_applies "all"; then
-  matches=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/telnyx)")
+  matches=$(search_files "(import telnyx|from telnyx|require.*telnyx|use Telnyx|using Telnyx|github\.com/(team-)?telnyx|com\.telnyx\.)" \
+    "*.py" "*.pyw" "*.js" "*.jsx" "*.ts" "*.tsx" "*.mjs" "*.cjs" "*.mts" "*.cts" "*.rb" "*.rake" \
+    "*.go" "*.java" "*.kt" "*.kts" "*.scala" "*.php" "*.phtml" "*.cs" "*.cshtml")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
     check_pass "telnyx_source_imports" "Telnyx imports found in $count source file(s)"
@@ -655,10 +728,10 @@ section_header "Auth Patterns"
 
 # --- Check 8: Bearer auth ---
 if product_applies "all"; then
-  matches=$(search_files "(Authorization.*Bearer|bearer.*auth|Bearer.*TELNYX|TELNYX.*Bearer)")
+  matches=$(search_telnyx_auth_files "(Authorization.*Bearer|bearer.*auth|Bearer.*TELNYX|TELNYX.*Bearer)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    check_pass "bearer_auth" "Bearer auth pattern found in $count file(s)"
+    check_pass "bearer_auth" "Bearer auth pattern found in $count Telnyx-related match(es) (static evidence only)"
   else
     check_pass "bearer_auth" "No explicit Bearer auth pattern (SDK may handle this)"
   fi
@@ -682,10 +755,10 @@ section_header "Webhook Validation"
 
 # --- Check 10: Ed25519 signature validation ---
 if product_applies "voice,messaging,verify,sip,fax"; then
-  matches=$(search_files "(ed25519|Ed25519|telnyx-signature-ed25519|verify_signature|construct_event|webhooks\.unwrap|webhook.*signature.*telnyx)")
+  matches=$(search_telnyx_auth_files "(telnyx-signature-ed25519|verify_signature|construct_event|webhooks\.unwrap|webhook.*signature.*telnyx|ed25519.*[Vv]erify|Ed25519.*[Vv]erify)")
   count=$(count_matches "$matches")
   if [ "$count" -gt 0 ]; then
-    check_pass "ed25519_validation" "Ed25519 webhook signature validation found in $count file(s)"
+    check_pass "ed25519_validation" "Telnyx webhook verification pattern found in $count match(es) (static evidence only; review signature enforcement)"
   else
     # Check if the project has webhook handlers — if so, missing validation is a FAIL
     webhook_handlers=$(search_files "(app\.(post|put)|router\.(post|put)|@app\.route|@csrf_exempt|HandleFunc|post '/)" "*.py" "*.js" "*.ts" "*.rb" "*.go" "*.java" "*.php")

--- a/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -204,8 +204,10 @@ search_files() {
   for glob in "$@"; do
     include_args="$include_args --include=$glob"
   done
+  # GNU grep defaults unmatched files to included if an exclusion comes first.
+  # Put the allowlist first and exclusions last so both GNU and BSD grep agree.
   # shellcheck disable=SC2086
-  grep -rnI $GREP_EXCLUDES $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $include_args $GREP_EXCLUDES -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Search helper that excludes .md files and minified JS (for config/env var checks)
@@ -218,7 +220,7 @@ search_source_files() {
     include_args="$include_args --include=$glob"
   done
   # shellcheck disable=SC2086
-  grep -rnI $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' $include_args -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
+  grep -rnI $include_args $GREP_EXCLUDES --exclude='*.md' --exclude='*.min.js' -E "$pattern" "$PROJECT_ROOT" 2>/dev/null || true
 }
 
 # Auth-related names are common in unrelated SDKs. Require Telnyx context in

--- a/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -594,14 +594,10 @@ section_header "Telnyx SDK Present"
 # --- Check 6: Telnyx SDK in dependency files ---
 if product_applies "all"; then
   dep_matches=""
-  # Python (root + subdirectories)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 \( -name requirements.txt -o -name setup.py -o -name setup.cfg -o -name pyproject.toml -o -name Pipfile \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/vendor/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
-  # Node (root + subdirectories)
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name package.json -not -path "*/node_modules/*" -not -path "*/.git/*" -exec grep -l '"telnyx"\|"@telnyx/' {} \; 2>/dev/null || true)
-  # Ruby
-  dep_matches+=$(find "$PROJECT_ROOT" -maxdepth 3 -name Gemfile -not -path "*/vendor/*" -exec grep -l "telnyx" {} \; 2>/dev/null || true)
-  # Go
-  dep_matches+=$(grep -rn $GREP_EXCLUDES -l "telnyx" "$PROJECT_ROOT"/go.mod 2>/dev/null || true)
+  # Python, Node, Ruby and Go: dependency declarations, not comments or metadata.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" other-declared "$PROJECT_ROOT"; then
+    dep_matches+=$'\nSDK dependency declaration\n'
+  fi
   # Java/Kotlin (build.gradle, build.gradle.kts, pom.xml, libs.versions.toml)
   if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-declared "$PROJECT_ROOT"; then
     dep_matches+=$'\nJVM dependency declaration\n'
@@ -642,26 +638,18 @@ if product_applies "all"; then
 
   # --- Check 6a: Telnyx SDK version pinning ---
   version_pinned=false
-  # Python: check for version constraint (>=, <, ~=, ==)
-  if grep -qE 'telnyx[><=~!]+' "$PROJECT_ROOT"/{requirements.txt,setup.py,setup.cfg,pyproject.toml,Pipfile} 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Node: check package.json for version constraint (^, ~, >=)
-  if grep -qE '"telnyx"\s*:\s*"[\^~>=]' "$PROJECT_ROOT"/package.json 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Ruby: check Gemfile for version constraint (~>)
-  if grep -qE "gem\s+['\"]telnyx['\"].*~>" "$PROJECT_ROOT"/Gemfile 2>/dev/null; then
-    version_pinned=true
-  fi
-  # Go modules always require an explicit semantic version. Recognize both the
-  # current /v4 module path and an eventual later major-version path.
-  if grep -qE 'github\.com/team-telnyx/telnyx-go(/v[0-9]+)?[[:space:]]+v[0-9]+\.' "$PROJECT_ROOT"/go.mod 2>/dev/null; then
+  # Reuse the declaration owners for literal versions and supported ranges.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" other-pinned "$PROJECT_ROOT"; then
     version_pinned=true
   fi
   # Inspect dependency fields structurally. App/parent/unrelated versions are
   # not evidence that this SDK dependency has a constrained version.
   if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" jvm-pinned "$PROJECT_ROOT"; then
+    version_pinned=true
+  fi
+  # Composer accepts caret/tilde/range constraints as well as exact versions.
+  # Only require/require-dev links for the SDK count, never unrelated metadata.
+  if python3 "$SCRIPT_DIR/inspect-sdk-dependencies.py" composer-pinned "$PROJECT_ROOT"; then
     version_pinned=true
   fi
   # If no dependency files found at all, skip the check

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -268,6 +268,17 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 self.assertIn(":2:", output)
                 self.assertIn("VoiceResponse", output)
 
+        # grep counts only LF. A preceding bare CR must stay inside the same
+        # grep record instead of becoming a synthetic lexer line.
+        output = self.run_filter_source_matches(
+            "app.py",
+            "# removed VoiceResponse()\rVoiceResponse()\n",
+            "code",
+            "VoiceResponse",
+        )
+        self.assertIn(":1:", output)
+        self.assertIn("VoiceResponse", output)
+
     def test_filter_source_matches_preserves_numeric_colons_in_paths(self) -> None:
         # The old `<path>:<line>:<text>` regex treated `:123:` inside a valid
         # path as the locator, then fell back to filtering the raw comment.
@@ -1564,6 +1575,22 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 self.assertEqual("issue", check["status"], payload)
                 self.assertEqual(1, result.returncode, result.stdout)
 
+        # A bare CR is a Python source line terminator but not a grep -n record
+        # delimiter. The live builder after it must not inherit the comment.
+        result, payload = self.run_messaging_linter(
+            {"app.py": "# removed VoiceResponse()\rVoiceResponse()\n"},
+            product="voice",
+        )
+        self.assertEqual(1, result.returncode, payload)
+        self.assertTrue(
+            any(
+                check["name"] == "voice_response_builder"
+                and check["status"] == "issue"
+                for check in payload["checks"]
+            ),
+            payload,
+        )
+
     def test_factory_created_rest_clients_are_scanned(self) -> None:
         # requests.Session().post(...) and axios.create(...).post(...) have a
         # factory-call receiver, so call_receiver() returns None and the
@@ -1648,8 +1675,22 @@ class CorrectnessLinterContracts(unittest.TestCase):
                     {name: f"requests.post('{url}', json={{'to':'+1','messaging_profile_id': {value}}})"}
                 )
                 self.assert_required_profile_detected(payload, name)
-        # A usable value must still pass: string, non-zero number, env var.
-        for value in ("'abc'", "123", "process.env.MP"):
+        # Numeric literals are not UUID strings, regardless of radix, sign,
+        # exponent or language suffix.
+        for value in ("42", "-1", "+2.5", "1e3", "0x2a", "0b10", "0o52", "42n"):
+            with self.subTest(numeric=value):
+                name = "send.js"
+                _, payload = self.run_messaging_linter(
+                    {
+                        name: (
+                            f"fetch('{url}', {{method:'POST', body: "
+                            f"JSON.stringify({{to:'+1', messaging_profile_id: {value}}})}});"
+                        )
+                    }
+                )
+                self.assert_required_profile_detected(payload, name)
+        # A usable value must still pass: non-empty string or dynamic value.
+        for value in ("'abc'", "process.env.MP"):
             with self.subTest(valid=value):
                 self.assert_required_profile_passes(
                     {
@@ -1659,6 +1700,240 @@ class CorrectnessLinterContracts(unittest.TestCase):
                         )
                     }
                 )
+
+    def test_required_sdk_method_aliases_are_analyzed(self) -> None:
+        """Method values/delegates retain the required-profile contract."""
+
+        cases = {
+            "send.py": (
+                "send_pool = client.messages.send_number_pool\n"
+                "send_pool({'to': '+1'%s})\n"
+            ),
+            "send.js": (
+                "const sendPool = client.messages.sendNumberPool.bind(client.messages);\n"
+                "sendPool({to: '+1'%s});\n"
+            ),
+            "destructured.ts": (
+                "const {sendNumberPool: sendPool} = client.messages;\n"
+                "sendPool({to: '+1'%s});\n"
+            ),
+            "send.go": (
+                "sendPool := client.Messages.SendNumberPool\n"
+                "sendPool(map[string]any{\"to\": \"+1\"%s})\n"
+            ),
+            "Send.cs": (
+                "var sendPool = client.Messages.SendNumberPool;\n"
+                "sendPool(new { To = \"+1\"%s });\n"
+            ),
+            "send.rb": (
+                "send_pool = client.messages.method(:send_number_pool)\n"
+                "send_pool.call({to: '+1'%s})\n"
+            ),
+            "send.php": (
+                "<?php\n$sendPool = [$client->messages, 'sendNumberPool'];\n"
+                "$sendPool(['to' => '+1'%s]);\n"
+            ),
+            "Send.java": (
+                "var sendPool = client.messages::sendNumberPool;\n"
+                "sendPool.apply(Map.of(\"to\", \"+1\"%s));\n"
+            ),
+        }
+        for name, template in cases.items():
+            if name.endswith(".py"):
+                separator = ", 'messaging_profile_id': 'abc'"
+            elif name.endswith(".go"):
+                separator = ', "messaging_profile_id": "abc"'
+            elif name.endswith(".cs"):
+                separator = ', MessagingProfileId = "abc"'
+            elif name.endswith(".rb"):
+                separator = ", messaging_profile_id: 'abc'"
+            elif name.endswith(".php"):
+                separator = ", 'messaging_profile_id' => 'abc'"
+            elif name.endswith(".java"):
+                separator = ', "messaging_profile_id", "abc"'
+            else:
+                separator = ", messaging_profile_id: 'abc'"
+            with self.subTest(language=name, polarity="missing"):
+                result = self.run_required_profile_analyzer(
+                    {name: template % ""}
+                )
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                self.assertTrue(any(name in row for row in rows[1:]), result.stdout)
+            with self.subTest(language=name, polarity="present"):
+                result = self.run_required_profile_analyzer(
+                    {name: template % separator}
+                )
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                self.assertFalse(any(row.strip() for row in rows[1:]), result.stdout)
+
+        # Nearest reassignment invalidates an earlier SDK method alias.
+        result = self.run_required_profile_analyzer(
+            {
+                "shadow.js": "let send = client.messages.sendNumberPool;\n"
+                "send = localPreview;\n"
+                "send({to: '+1'});\n"
+            }
+        )
+        self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+    def test_external_endpoint_provenance_fails_closed_across_languages(self) -> None:
+        """Imported mutating endpoints never disappear at a file boundary."""
+
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        cases = {
+            "ruby": (
+                {"config.rb": f"POOL_URL = '{url}'\n"},
+                "send.rb",
+                "require_relative './config'\n"
+                "Net::HTTP.post(URI(POOL_URL), %s.to_json)\n",
+                "{to: '+1'}",
+                "{to: '+1', messaging_profile_id: 'abc'}",
+            ),
+            "go": (
+                {"config/endpoints.go": f'package config\nconst PoolURL = "{url}"\n'},
+                "send.go",
+                'package main\nimport "example/config"\nfunc send() { '
+                'http.Post(config.PoolURL, "application/json", strings.NewReader(`%s`)) }\n',
+                '{"to":"+1"}',
+                '{"to":"+1","messaging_profile_id":"abc"}',
+            ),
+            "java": (
+                {"Config.java": f'class Config {{ static final String POOL_URL = "{url}"; }}\n'},
+                "Send.java",
+                "import example.Config;\nHttpRequest.newBuilder()"
+                ".uri(URI.create(Config.POOL_URL))"
+                '.POST(BodyPublishers.ofString("%s")).build();\n',
+                '{\\"to\\":\\"+1\\"}',
+                '{\\"to\\":\\"+1\\",\\"messaging_profile_id\\":\\"abc\\"}',
+            ),
+            "csharp": (
+                {"Config.cs": f'class Config {{ public const string PoolUrl = "{url}"; }}\n'},
+                "Send.cs",
+                "using Project;\nawait client.PostAsync(Config.PoolUrl, "
+                'new StringContent("%s"));\n',
+                '{\\"to\\":\\"+1\\"}',
+                '{\\"to\\":\\"+1\\",\\"messaging_profile_id\\":\\"abc\\"}',
+            ),
+            "php": (
+                {"config.php": f"<?php const POOL_URL = '{url}';\n"},
+                "send.php",
+                "<?php require 'config.php';\nfile_get_contents(POOL_URL, false, "
+                "stream_context_create(['http' => ['method' => 'POST', "
+                "'content' => '%s']]));\n",
+                '{"to":"+1"}',
+                '{"to":"+1","messaging_profile_id":"abc"}',
+            ),
+            "shell": (
+                {"config.sh": f"POOL_URL='{url}'\n"},
+                "send.sh",
+                ". ./config.sh\ncurl -X POST \"$POOL_URL\" -d '%s'\n",
+                '{"to":"+1"}',
+                '{"to":"+1","messaging_profile_id":"abc"}',
+            ),
+        }
+        for language, (support, filename, template, missing, present) in cases.items():
+            with self.subTest(language=language, polarity="missing"):
+                result = self.run_required_profile_analyzer(
+                    {**support, filename: template % missing}
+                )
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                self.assertTrue(
+                    any(filename in row for row in rows[1:]), result.stdout
+                )
+            with self.subTest(language=language, polarity="present"):
+                result = self.run_required_profile_analyzer(
+                    {**support, filename: template % present}
+                )
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                self.assertFalse(
+                    any(row.strip() for row in rows[1:]), result.stdout
+                )
+
+    def test_relative_module_scalar_endpoints_are_resolved(self) -> None:
+        pool = "https://api.telnyx.com/v2/messages/number_pool"
+        for files in (
+            {
+                "config.js": f"export const POOL_URL = '{pool}';\n",
+                "send.js": (
+                    "import { POOL_URL } from './config.js';\n"
+                    "fetch(POOL_URL, {method:'POST', body: JSON.stringify({to:'+1'})});\n"
+                ),
+            },
+            {
+                "config.js": f"exports.POOL_URL = '{pool}';\n",
+                "send.js": (
+                    "const {POOL_URL: endpoint} = require('./config');\n"
+                    "fetch(endpoint, {method:'POST', body: JSON.stringify({to:'+1'})});\n"
+                ),
+            },
+            {
+                "config.py": f"POOL_URL = '{pool}'\n",
+                "send.py": (
+                    "from config import POOL_URL as endpoint\n"
+                    "requests.post(endpoint, json={'to': '+1'})\n"
+                ),
+            },
+        ):
+            with self.subTest(files=tuple(files)):
+                result, payload = self.run_messaging_linter(files)
+                self.assertEqual(1, result.returncode, payload)
+                self.assert_required_profile_detected(
+                    payload,
+                    next(name for name in files if name.startswith("send.")),
+                )
+
+        self.assert_required_profile_passes(
+            {
+                "config.js": "export const SEND_URL = '/v2/messages';\n",
+                "send.js": (
+                    "import { SEND_URL } from './config.js';\n"
+                    "fetch(SEND_URL, {method:'POST', body: JSON.stringify({to:'+1'})});\n"
+                ),
+            }
+        )
+
+    def test_javascript_line_comment_terminators_do_not_hide_sends(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        for terminator in ("\r", "\u2028", "\u2029"):
+            with self.subTest(terminator=repr(terminator)):
+                self.assert_required_profile_flagged(
+                    {
+                        "send.js": (
+                            "// old send"
+                            + terminator
+                            + f"fetch('{url}', {{method:'POST', body: JSON.stringify({{to:'+1'}})}});\n"
+                        )
+                    }
+                )
+
+    def test_finding_rows_escape_newline_bearing_paths(self) -> None:
+        result = self.run_required_profile_analyzer(
+            {
+                "odd\nname.js": (
+                    "client.messages.sendNumberPool({to:'+1'});\n"
+                )
+            }
+        )
+        rows = result.stdout.splitlines()
+        self.assertEqual("1", rows[0], result.stdout)
+        self.assertEqual(2, len(rows), result.stdout)
+        self.assertIn(r"odd\nname.js:1:", rows[1])
+
+        shell_result, payload = self.run_messaging_linter(
+            {"odd\nname.js": "client.messages.sendNumberPool({to:'+1'});\n"}
+        )
+        check = next(
+            item
+            for item in payload["checks"]
+            if item["name"] == "required_messaging_profile_id"
+        )
+        self.assertEqual(1, shell_result.returncode, payload)
+        self.assertEqual(1, len(check["details"]["files"]), check)
+        self.assertIn(r"odd\nname.js:1:", check["details"]["files"][0])
 
     def test_url_constructor_base_is_combined_with_the_path(self) -> None:
         # new URL(path, base) resolves the path relative to the base, so

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -11024,6 +11024,85 @@ class ComposerConstraintContracts(unittest.TestCase):
 
 
 class DiscoveryAndValidationRegressionContracts(unittest.TestCase):
+    def test_razor_code_blocks_and_markup_siblings(self) -> None:
+        directive = "@using Twilio.Rest.Api.V2010.Account\n"
+        self.global_using_scan({
+            "Code.razor": directive + "@code { void Send() { MessageResource.Create(args); } }",
+            "Block.razor": directive + "@{ CallResource.Create(args); }",
+            "Markup.razor": "<p>using Twilio.Rest.Api.V2010.Account; MessageResource.Create(args);</p>",
+            "Comment.razor": "@* using Twilio.Rest.Api.V2010.Account; MessageResource.Create(args); *@",
+            "Unowned.razor": "@code { void Send() { MessageResource.Create(args); } }",
+        }, {"Code.razor": {"messaging"}, "Block.razor": {"voice"},
+            "Markup.razor": set(), "Comment.razor": set(), "Unowned.razor": set()})
+
+    def test_razor_global_alias_from_another_file(self) -> None:
+        self.global_using_scan({
+            "Imports.cs": "global using Sms = Twilio.Rest.Api.V2010.Account.MessageResource;",
+            "Code.razor": "@code { void Send() { Sms.Create(args); } }",
+            "Block.razor": "@{ Sms.Create(args); }",
+            "Markup.razor": "<p>Sms.Create(args);</p>",
+            "String.razor": '@code { string example = "Sms.Create(args);"; }',
+        }, {"Code.razor": {"messaging"}, "Block.razor": {"messaging"},
+            "Markup.razor": set(), "String.razor": set()})
+
+    def test_go_package_clients_cross_file_siblings(self) -> None:
+        for declaration in (
+            'import "github.com/twilio/twilio-go"\nvar client = twilio.NewRestClient()',
+            'import "github.com/twilio/twilio-go"\nvar client *twilio.RestClient = twilio.NewRestClient()',
+            'import sdk "github.com/twilio/twilio-go"\nvar client = sdk.NewRestClientWithParams(params)',
+            'import (\n sdk "github.com/twilio/twilio-go"\n)\nvar (\n client = sdk.NewRestClient()\n)',
+        ):
+            with self.subTest(declaration=declaration):
+                self.global_using_scan({
+                    "client.go": "package app\n" + declaration,
+                    "alias.go": "package app\nvar copied = client",
+                    "send.go": "package app\nfunc send() { copied.Api.CreateMessage(nil) }",
+                    "voice.go": "package app\nfunc call() { client.Api.CreateCall(nil) }",
+                    "local.go": "package app\nfunc sendLocal() { alias := client; alias.Api.CreateMessage(nil) }",
+                    "shadow.go": "package app\nfunc other(client Other) { client.Api.CreateMessage(nil) }",
+                    "uninitialized.go": "package app\nfunc another() { var client Other; client.Api.CreateMessage(nil) }",
+                    "rebound.go": "package app\nfunc rebound() { client = other; client.Api.CreateMessage(nil) }",
+                    "different.go": "package other\nfunc send() { client.Api.CreateMessage(nil) }",
+                    "sub/send.go": "package app\nfunc send() { client.Api.CreateMessage(nil) }",
+                }, {"send.go": {"messaging"}, "voice.go": {"voice"}, "local.go": {"messaging"},
+                    "shadow.go": set(), "uninitialized.go": set(), "rebound.go": set(),
+                    "different.go": set(), "sub/send.go": set()})
+
+    def test_go_package_clients_reject_nonpackage_evidence(self) -> None:
+        for name, source in (
+            ("client.go", 'package app\nimport "unrelated/sdk"\nvar client = sdk.NewRestClient()'),
+            ("client.go", 'package app\nimport "github.com/twilio/twilio-go"\nfunc initClient() { client := twilio.NewRestClient() }'),
+            ("client_test.go", 'package app\nimport "github.com/twilio/twilio-go"\nvar client = twilio.NewRestClient()'),
+            ("client.go", '//go:build special\npackage app\nimport "github.com/twilio/twilio-go"\nvar client = twilio.NewRestClient()'),
+            ("client.go", 'package app\n// var client = twilio.NewRestClient()'),
+        ):
+            with self.subTest(name=name, source=source):
+                self.global_using_scan({name: source, "send.go": "package app\nfunc send() { client.Api.CreateMessage(nil) }"},
+                                       {"send.go": set()})
+
+    def test_go_package_clients_respect_typed_and_grouped_local_vars(self) -> None:
+        imports = 'package app\nimport "github.com/twilio/twilio-go"\n'
+        declarations = {
+            "pointer": "var client *Other = other",
+            "value": "var client Other = other",
+            "group_pointer": "var (\nclient *Other = other\n)",
+            "group_value": "var (\nclient Other = other\n)",
+            "group_uninitialized": "var (\nclient Other\n)",
+            "multiple": "var a, client *Other",
+            "multiple_initialized": "var a, client *Other = first, other",
+            "group_multiple": "var (\na, client *Other = first, other\n)",
+            "sdk_pointer": "var client *twilio.RestClient = twilio.NewRestClient()",
+            "sdk_group": "var (\nclient *twilio.RestClient = twilio.NewRestClient()\n)",
+        }
+        files = {"client.go": imports + "var client = twilio.NewRestClient()"}
+        expected = {}
+        for name, declaration in declarations.items():
+            filename = name + ".go"
+            files[filename] = (imports + "func send() {\n" + declaration
+                               + "\nclient.Api.CreateMessage(nil)\n}")
+            expected[filename] = {"messaging"} if name.startswith("sdk_") else set()
+        self.global_using_scan(files, expected)
+
     def global_using_scan(self, files: dict[str, str], expected: dict[str, set[str]]) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -11038,6 +11117,12 @@ class DiscoveryAndValidationRegressionContracts(unittest.TestCase):
                 found = {item["path"]: set(item["products"]) - {"general"} for item in report["files"]}
                 for name, products in expected.items():
                     self.assertEqual(products, found.get(name, set()), (command, name, report))
+                    if name.endswith(".razor"):
+                        if not products:
+                            self.assertNotIn(name, found, report)
+                        else:
+                            item = next(item for item in report["files"] if item["path"] == name)
+                            self.assertEqual("csharp", item["language"], report)
 
     def test_csharp_global_using_forms_across_files(self) -> None:
         for resource, product in (("MessageResource", "messaging"), ("CallResource", "voice"),

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -1642,6 +1642,77 @@ class CorrectnessLinterContracts(unittest.TestCase):
             }
         )
 
+    def test_razor_nested_markup_does_not_mask_or_invent_csharp(self) -> None:
+        declarations = (
+            '@{ var payload = new MessageSendNumberPoolParams { To = "+1"%s }; }\n'
+        )
+        controls = {
+            "siblings": (
+                "@if (true) {\n"
+                "<p>It's ready</p>\n"
+                "client.Messages.SendNumberPool(payload);\n"
+                "<p>User's result</p>\n}\n"
+            ),
+            "nested": (
+                "@if (true) {\n"
+                '<section title="before"><p>Don\'t run prose</p></section>\n'
+                "client.Messages.SendNumberPool(payload);\n"
+                '<section title="after"><p>Customer\'s result</p></section>\n}\n'
+            ),
+            "transition-in-markup": (
+                "@if (true) {\n"
+                "<div>@client.Messages.SendNumberPool(payload)</div>\n}\n"
+            ),
+            "explicit-transition-in-markup": (
+                "@if (true) {\n"
+                "<div>@(client.Messages.SendNumberPool(payload))</div>\n}\n"
+            ),
+            "nested-control-in-markup": (
+                "<div>@if (true) { "
+                "client.Messages.SendNumberPool(payload); }</div>\n"
+            ),
+            "line-markup": (
+                "@if (true) {\n"
+                "@:It's ready\n"
+                "client.Messages.SendNumberPool(payload);\n"
+                "@:User's result\n}\n"
+            ),
+            "html-comment": (
+                "@if (true) {\n"
+                "<!-- It's an old example -->\n"
+                "client.Messages.SendNumberPool(payload);\n"
+                "<!-- User's result -->\n}\n"
+            ),
+        }
+        for suffix in (".cshtml", ".razor"):
+            for label, control in controls.items():
+                fixture = f"View{suffix}"
+                with self.subTest(suffix=suffix, shape=label, polarity="missing"):
+                    _, payload = self.run_messaging_linter(
+                        {fixture: declarations % "" + control}
+                    )
+                    self.assert_required_profile_detected(payload, fixture)
+                with self.subTest(suffix=suffix, shape=label, polarity="compliant"):
+                    self.assert_required_profile_passes(
+                        {
+                            fixture: declarations
+                            % ', MessagingProfileId = "mp"'
+                            + control
+                        }
+                    )
+
+        # Complete HTML elements containing call-like prose are inert even
+        # inside a Razor control body.
+        self.assert_required_profile_passes(
+            {
+                "Docs.cshtml": (
+                    "@if (true) {\n"
+                    "<p>It's client.Messages.SendNumberPool(payload)</p>\n"
+                    "<p>User's example</p>\n}\n"
+                )
+            }
+        )
+
     def test_typescript_component_scripts_keep_typescript_resolution(self) -> None:
         source = "\n".join(
             (
@@ -6530,6 +6601,68 @@ class CorrectnessLinterContracts(unittest.TestCase):
         for fixture_name, source in cases.items():
             with self.subTest(fixture=fixture_name):
                 self.assert_required_profile_passes({fixture_name: source})
+
+    def test_ruby_percent_literals_mask_data_and_preserve_interpolation(
+        self,
+    ) -> None:
+        call = "client.messages.send_number_pool({to: '+1'})"
+        inert_literals = {
+            "q-brace": f"%q{{{call}}}",
+            "q-paren": f"%q({call})",
+            "q-bracket": f"%q[{call}]",
+            "q-angle": f"%q<{call}>",
+            "q-unpaired": f"%q!{call}!",
+            "Q-template": f"%Q{{{call}}}",
+            "default": f"%{{{call}}}",
+            "words": f"%w[{call}]",
+            "symbols": f"%i[{call}]",
+            "symbol": f"%s!{call}!",
+            "regex": f"%r!{call}!",
+            "command": f"%x{{echo {call}}}",
+            "escaped-delimiter": rf"%q!example \! {call}!",
+        }
+        for label, literal in inert_literals.items():
+            with self.subTest(literal=label):
+                result = self.run_required_profile_analyzer(
+                    {"example.rb": f"template = {literal}\n"}
+                )
+                self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+        interpolating_literals = {
+            "Q": f"%Q{{#{{{call}}}}}",
+            "default": f"%{{#{{{call}}}}}",
+            "W": f"%W[#{{{call}}}]",
+            "I": f"%I[#{{{call}}}]",
+            "regex": f"%r!#{{{call}}}!",
+            "command": f"%x{{#{{{call}}}}}",
+            "double-quoted": f'"#{{{call}}}"',
+            "backtick": f"`#{{{call}}}`",
+        }
+        for label, literal in interpolating_literals.items():
+            with self.subTest(interpolation=label):
+                result = self.run_required_profile_analyzer(
+                    {"live.rb": f"value = {literal}\n"}
+                )
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+
+        # Non-interpolating and escaped forms remain data, and scanning resumes
+        # after a percent literal so a later real call is still visible.
+        result = self.run_required_profile_analyzer(
+            {
+                "mixed.rb": (
+                    f"a = %q{{#{{{call}}}}}\n"
+                    f'b = "\\#{{{call}}}"\n'
+                    f"{call}\n"
+                )
+            }
+        )
+        self.assertEqual("1", result.stdout.splitlines()[0], result.stdout)
+
+        # Public-entry polarity for the originally reported false blocker.
+        self.assert_required_profile_passes(
+            {"example.rb": f"template = %q{{{call}}}\n"}
+        )
 
     def test_profile_field_name_inside_message_text_does_not_satisfy_request(
         self,

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -1288,6 +1288,51 @@ class CorrectnessLinterContracts(unittest.TestCase):
         _, payload = self.run_messaging_linter({"raw.php": missing + "\n"})
         self.assert_required_profile_detected(payload, "raw.php")
 
+    def test_php_closing_tags_inside_data_do_not_end_executable_regions(self) -> None:
+        """Only a lexical PHP closing tag can return to template markup."""
+
+        send = (
+            "$client->post('https://api.telnyx.com/v2/messages/number_pool', "
+            "['json' => ['to' => '+1'%s]]);"
+        )
+        prefixes = {
+            "single-quoted": "$value = '?>';\n",
+            "double-quoted": '$value = "?>";\n',
+            "backtick": "$value = `printf '?>'`;\n",
+            "block-comment": "/* ?> is documentation */\n",
+            "heredoc": "$value = <<<TEXT\n?>\nTEXT;\n",
+            "nowdoc": "$value = <<<'TEXT'\n?>\nTEXT;\n",
+        }
+        for suffix in (".php", ".phtml"):
+            for label, prefix in prefixes.items():
+                for polarity, profile in (
+                    ("missing", ""),
+                    ("present", ", 'messaging_profile_id' => 'mp'"),
+                ):
+                    with self.subTest(
+                        suffix=suffix, data=label, polarity=polarity
+                    ):
+                        files = {
+                            "send" + suffix: "<?php\n" + prefix + send % profile + "\n?>"
+                        }
+                        if polarity == "missing":
+                            _, payload = self.run_messaging_linter(files)
+                            self.assert_required_profile_detected(
+                                payload, "send" + suffix
+                            )
+                        else:
+                            self.assert_required_profile_passes(files)
+
+        # A real closing tag still excludes call-shaped markup that follows.
+        self.assert_required_profile_passes(
+            {
+                "template.phtml": (
+                    "<?php $value = 'safe'; ?>\n"
+                    "<pre>client.messages['sendNumberPool']({to: '+1'})</pre>\n"
+                )
+            }
+        )
+
     def test_multiline_template_comments_preserve_speech_model_line(self) -> None:
         source = (
             "<!-- comment\n"
@@ -2143,6 +2188,63 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
                 self.assertFalse(any(row.strip() for row in rows[1:]), result.stdout)
 
+    def test_static_computed_sdk_methods_are_analyzed(self) -> None:
+        """JS/TS bracket members retain the required-profile SDK contract."""
+
+        shapes = {
+            "single": "client.messages['%s']({to: '+1'%s});",
+            "double": 'client.messages["%s"]({to: "+1"%s});',
+            "template": "client.messages[`%s`]({to: '+1'%s});",
+            "optional-member": "client.messages?.['%s']?.({to: '+1'%s});",
+            "nested-computed": "client['messages']['%s']({to: '+1'%s});",
+        }
+        methods = (
+            "sendNumberPool",
+            "send_number_pool",
+            "SendNumberPool",
+            "sendWithAlphanumericSender",
+            "send_with_alphanumeric_sender",
+            "SendWithAlphanumericSender",
+        )
+        for suffix in (".js", ".ts"):
+            for shape, template in shapes.items():
+                for method in methods:
+                    with self.subTest(
+                        suffix=suffix, shape=shape, method=method, polarity="missing"
+                    ):
+                        result = self.run_required_profile_analyzer(
+                            {"send" + suffix: template % (method, "")}
+                        )
+                        rows = result.stdout.splitlines()
+                        self.assertEqual(1, int(rows[0]), result.stdout)
+                        self.assertTrue(any(row.strip() for row in rows[1:]))
+                    with self.subTest(
+                        suffix=suffix, shape=shape, method=method, polarity="present"
+                    ):
+                        result = self.run_required_profile_analyzer(
+                            {
+                                "send" + suffix: template
+                                % (method, ", messaging_profile_id: 'mp'")
+                            }
+                        )
+                        rows = result.stdout.splitlines()
+                        self.assertEqual(1, int(rows[0]), result.stdout)
+                        self.assertFalse(
+                            any(row.strip() for row in rows[1:]), result.stdout
+                        )
+
+        inert = {
+            "object-key.js": "const handlers = {'sendNumberPool': fn};",
+            "array-item.js": "const handlers = ['sendNumberPool'];",
+            "dynamic.js": "client.messages[method]({to: '+1'});",
+            "unrelated.js": "client.messages['send']({to: '+1'});",
+            "prose.js": "const example = \"client.messages['sendNumberPool']({})\";",
+        }
+        for name, source in inert.items():
+            with self.subTest(inert=name):
+                result = self.run_required_profile_analyzer({name: source})
+                self.assertEqual("0", result.stdout.splitlines()[0], result.stdout)
+
         # Nearest reassignment invalidates an earlier SDK method alias.
         result = self.run_required_profile_analyzer(
             {
@@ -2532,6 +2634,10 @@ class CorrectnessLinterContracts(unittest.TestCase):
             "unary-operand": "const x = !/[/*]/.test(v);",
             "case-body": "switch(x){case 1: /[/*]/.test(x); break;}",
             "object-value": "const o = {r: /[/*]/};",
+            "function-block-start": "function f(){ /[/*]/.test(v); }",
+            "arrow-block-start": "const f = () => { /[/*]/.test(v); };",
+            "control-block-start": "if (ok) { /[/*]/.test(v); }",
+            "try-block-start": "try { /[/*]/.test(v); } finally {}",
         }
         send = (
             f"fetch('{url}',{{method:'POST',body:JSON.stringify("

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -11024,6 +11024,81 @@ class ComposerConstraintContracts(unittest.TestCase):
 
 
 class DiscoveryAndValidationRegressionContracts(unittest.TestCase):
+    def global_using_scan(self, files: dict[str, str], expected: dict[str, set[str]]) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for name, text in files.items():
+                path = root / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(text, encoding="utf-8")
+            for command in ([BASH, str(SCAN_USAGE_SCRIPT)], [sys.executable, str(DEEP_SCAN_SCRIPT)]):
+                result = subprocess.run(command + [str(root)], capture_output=True, text=True, timeout=45)
+                self.assertEqual(0, result.returncode, result.stderr)
+                report = json.loads(result.stdout)
+                found = {item["path"]: set(item["products"]) - {"general"} for item in report["files"]}
+                for name, products in expected.items():
+                    self.assertEqual(products, found.get(name, set()), (command, name, report))
+
+    def test_csharp_global_using_forms_across_files(self) -> None:
+        for resource, product in (("MessageResource", "messaging"), ("CallResource", "voice"),
+                                  ("IncomingPhoneNumberResource", "phone-numbers")):
+            target = "Twilio.Rest.Api.V2010.Account."
+            for directive, call in (
+                ("global using " + target[:-1] + ";", resource + ".Create(args);"),
+                ("global using Resource = global::" + target + resource + ";", "Resource.ReadAsync(args);"),
+                ("global using Account = " + target[:-1] + ";", "Account." + resource + ".Fetch(args);"),
+                ("global using static " + target + resource + ";", "CreateAsync(args);"),
+            ):
+                with self.subTest(directive=directive):
+                    self.global_using_scan({"Imports.cs": directive, "Send.cs": call,
+                                            "View.cshtml": "@{ " + call + " }"},
+                                           {"Send.cs": {product}, "View.cshtml": {product}})
+
+    def test_csharp_global_using_negative_and_shadow_siblings(self) -> None:
+        directive = "global using Twilio.Rest.Api.V2010.Account;"
+        for imports, consumer in (
+            ("// " + directive, "MessageResource.Create(args);"),
+            ('var text = "' + directive + '";', "MessageResource.Create(args);"),
+            ('var text = """' + directive + '""";', "MessageResource.Create(args);"),
+            ("using Twilio.Rest.Api.V2010.Account;", "MessageResource.Create(args);"),
+            ("#if false\n" + directive + "\n#endif", "MessageResource.Create(args);"),
+            ("global using Unrelated;", "MessageResource.Create(args);"),
+            (directive, "class MessageResource {}\nMessageResource.Create(args);"),
+            ("global using Resource = Twilio.Rest.Api.V2010.Account.MessageResource;",
+             "using Resource = Unrelated.MessageResource;\nResource.Create(args);"),
+            ("global using Resource = Twilio.Rest.Api.V2010.Account.MessageResource;",
+             "var Resource = other;\nResource.Create(args);"),
+            ("global using static Twilio.Rest.Api.V2010.Account.MessageResource;",
+             "class App { void Create(object x) {} void Run() { Create(args); } }"),
+            ("global using static Twilio.Rest.Api.V2010.Account.MessageResource;",
+             "Action<object> Create = handler; Create(args);"),
+            ("global using static Twilio.Rest.Api.V2010.Account.MessageResource;",
+             "var x = new Create(args) { Value = 1 };"),
+        ):
+            with self.subTest(imports=imports, consumer=consumer):
+                self.global_using_scan({"Imports.cs": imports, "Send.cs": consumer}, {"Send.cs": set()})
+
+    def test_csharp_global_usings_stay_in_project(self) -> None:
+        call = "MessageResource.Create(args);"
+        ownership = runpy.run_path(str(DEEP_SCAN_SCRIPT.parent / "sdk-source-ownership.py"))
+        self.assertEqual([(2, "messaging")], ownership["contextual_calls"](
+            "var x = new Create(args) { Value = 1 };\nCreate(args);", ".cs",
+            "global using static Twilio.Rest.Api.V2010.Account.MessageResource;"))
+        self.global_using_scan({"Imports.cs": "global using static Twilio.Rest.Api.V2010.Account.MessageResource;",
+                                "Send.cs": "var x = new Create(args) { Value = 1 }; Create(args);"},
+                               {"Send.cs": {"messaging"}})
+        self.global_using_scan({"Config/Imports.cs": "global using Twilio.Rest.Api.V2010.Account;",
+                                "Services/Send.cs": call}, {"Services/Send.cs": {"messaging"}})
+        self.global_using_scan({
+            "A/A.csproj": '<Project Sdk="Microsoft.NET.Sdk"/>',
+            "A/Imports.cs": "global using Twilio.Rest.Api.V2010.Account;",
+            "A/Send.cs": call, "A/Sub/Send.cs": call,
+            "B/B.csproj": '<Project Sdk="Microsoft.NET.Sdk"/>', "B/Send.cs": call,
+            "A/Nested/Nested.csproj": '<Project Sdk="Microsoft.NET.Sdk"/>',
+            "A/Nested/Send.cs": call, "Send.cs": call,
+        }, {"A/Send.cs": {"messaging"}, "A/Sub/Send.cs": {"messaging"},
+            "B/Send.cs": set(), "A/Nested/Send.cs": set(), "Send.cs": set()})
+
     maxDiff = None
 
     def test_discovery_pipeline_does_not_certify_failed_or_empty_scans(self) -> None:

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -10516,6 +10516,368 @@ class GradleMapDependencySiblings(unittest.TestCase):
 
 
 
+class DeclaredSdkVersionContracts(unittest.TestCase):
+    def checks(self, files: dict[str, str]) -> dict[str, str]:
+        with tempfile.TemporaryDirectory(prefix="declared-sdk-version-") as directory:
+            for name, content in files.items():
+                path = Path(directory) / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            result = subprocess.run(
+                [BASH, str(VALIDATE_MIGRATION_SCRIPT), directory, "--json"],
+                cwd=ROOT, capture_output=True, text=True, timeout=30, check=False,
+            )
+        self.assertNotIn("Traceback", result.stderr)
+        return {item["name"]: item["status"]
+                for item in json.loads(result.stdout)["checks"]}
+
+    def assert_manifest(self, files: dict[str, str], declared: bool, pinned: bool) -> None:
+        checks = self.checks(files)
+        self.assertEqual("pass" if declared else "fail", checks["telnyx_sdk_dependency"])
+        self.assertEqual("pass" if pinned else "warn", checks["telnyx_sdk_version_pinned"])
+
+    def test_node_exact_and_declared_dependency_sections(self) -> None:
+        for section in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies"):
+            with self.subTest(section=section):
+                self.assert_manifest({"package.json": json.dumps({section: {"telnyx": "6.0.0"}})}, True, True)
+
+    def test_node_metadata_does_not_supply_sdk_or_version(self) -> None:
+        for dependencies, declared in (({}, False), ({"telnyx": "*"}, True)):
+            with self.subTest(dependencies=dependencies):
+                self.assert_manifest({"package.json": json.dumps({
+                    "dependencies": dependencies, "config": {"telnyx": "^6.0"}, "version": "1.0.0",
+                })}, declared, False)
+
+    def test_node_unbounded_alternative_is_not_a_constraint(self) -> None:
+        for value in ("", "*", "latest", "^6.0 || *"):
+            with self.subTest(value=value):
+                self.assert_manifest({"package.json": json.dumps({"dependencies": {"telnyx": value}})}, True, False)
+
+    def test_python_literal_manifest_forms(self) -> None:
+        fixtures = (
+            {"requirements.txt": "telnyx == 4.0.0\n"},
+            {"Pipfile": '[packages]\ntelnyx = "==4.0.0"\n'},
+            {"Pipfile": '[dev-packages]\ntelnyx = {version = ">=4.0,<5.0"}\n'},
+            {"pyproject.toml": '[project]\ndependencies = ["telnyx >= 4.0, < 5.0"]\n'},
+            {"pyproject.toml": '[tool.poetry.dependencies]\ntelnyx = "^4.0"\n'},
+            {"setup.cfg": '[options]\ninstall_requires =\n    telnyx == 4.0.0\n'},
+            {"setup.py": 'from setuptools import setup\nsetup(install_requires=["telnyx == 4.0.0"])\n'},
+        )
+        for files in fixtures:
+            with self.subTest(files=files):
+                self.assert_manifest(files, True, True)
+
+    def test_python_requirements_hash_options_and_continuations(self) -> None:
+        digest = "a" * 64
+        for source in (
+            f"telnyx==4.0 --hash=sha256:{digest}\n",
+            "telnyx==4.0 \\" + f"\n    --hash=sha256:{digest}\n",
+            f"telnyx[aiohttp]==4.0 \\\r\n    --hash sha256:{digest} --hash=sha256:{digest}\r\n",
+            f'telnyx==4.0; python_version >= "3.10" --hash=sha256:{digest}\n',
+            "telnyx>=4.0,\\\n    <5.0 # bounded range\n",
+        ):
+            with self.subTest(source=source):
+                self.assert_manifest({"requirements.txt": source}, True, True)
+
+    def test_python_requirement_options_do_not_supply_version_evidence(self) -> None:
+        for source, declared in (
+            ("telnyx --hash=sha256:abcd\n", True),
+            ("telnyx\nother==4.0 --hash=sha256:abcd\n", True),
+            ("# telnyx==4.0 --hash=sha256:abcd\n", False),
+            ("other==4.0 --config-settings=telnyx==4.0\n", False),
+            ("telnyx>=4banana --hash=sha256:abcd\n", True),
+        ):
+            with self.subTest(source=source):
+                self.assert_manifest({"requirements.txt": source}, declared, False)
+
+    def test_setup_literal_bindings_reach_their_own_call(self) -> None:
+        for source in (
+            'REQS=["telnyx>=4.0"]\nsetup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\nALIAS=REQS\nsetup(install_requires=ALIAS)',
+            'BASE=["other"]\nREQS=BASE + ["telnyx>=4.0"]\nsetup(install_requires=REQS)',
+            'EXTRAS={"sms": ["telnyx>=4.0"]}\nsetup(extras_require=EXTRAS)',
+            'REQS: list[str] = ["telnyx>=4.0"]\nsetup(install_requires=REQS)',
+            'def configure():\n    REQS=["telnyx>=4.0"]\n    setup(install_requires=REQS)',
+        ):
+            with self.subTest(source=source):
+                self.assert_manifest({"setup.py": "from setuptools import setup\n" + source}, True, True)
+
+    def test_setup_binding_scope_reassignment_and_mutation_are_not_stale_evidence(self) -> None:
+        for source in (
+            'REQS=["telnyx>=4.0"]\nREQS=[]\nsetup(install_requires=REQS)',
+            'setup(install_requires=REQS)\nREQS=["telnyx>=4.0"]',
+            'def unrelated():\n    REQS=["telnyx>=4.0"]\nsetup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\ndef configure(REQS):\n    setup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\ndef configure():\n    setup(install_requires=REQS)\n    REQS=[]',
+            'REQS=["telnyx>=4.0"]\nREQS.clear()\nsetup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\nALIAS=REQS\nALIAS.clear()\nsetup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\nCONFIG={"requires": REQS}\nCONFIG["requires"].clear()\nsetup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\nCONFIG={"requires": REQS}\nmutate(CONFIG)\nsetup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\nfor REQS in [[]]:\n    setup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\nwith open("x") as REQS:\n    setup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\ntry:\n    load()\nexcept Exception as REQS:\n    setup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\nif mutate(REQS):\n    setup(install_requires=REQS)',
+            'REQS=["telnyx>=4.0"]\n[setup(install_requires=REQS) for REQS in [[]]]',
+            'REQS=["telnyx>=4.0"]\nif dynamic:\n    REQS=[]\nsetup(install_requires=REQS)',
+            'REQS=read_requirements()\nsetup(install_requires=REQS)',
+        ):
+            with self.subTest(source=source):
+                self.assert_manifest({"setup.py": "from setuptools import setup\n" + source}, False, False)
+
+    def test_ruby_conditional_modifiers_preserve_argument_ownership(self) -> None:
+        for modifier in ("if", "unless"):
+            for source, pinned in (
+                (f"gem 'telnyx', '~> 4.0' {modifier} ENV['SMS']", True),
+                (f"gem('telnyx', '>= 4.0', '< 5.0') {modifier} enabled", True),
+                (f"gem 'telnyx' {modifier} enabled('4.0')", False),
+                (f"gem 'telnyx', version {modifier} enabled('4.0')", False),
+                (f"gem 'telnyx', '~> 4.0' + suffix {modifier} enabled", False),
+            ):
+                with self.subTest(source=source):
+                    self.assert_manifest({"Gemfile": source}, True, pinned)
+
+    def test_python_comments_metadata_and_other_packages_are_not_evidence(self) -> None:
+        fixtures = (
+            ({"requirements.txt": "telnyx\n# Old: telnyx==4.0.0\n"}, True),
+            ({"requirements.txt": "# telnyx==4.0.0\n"}, False),
+            ({"requirements.txt": "not-telnyx==4.0.0\n"}, False),
+            ({"pyproject.toml": '[project]\ndescription = "telnyx==4.0.0"\n'}, False),
+            ({"setup.py": 'from setuptools import setup\nsetup(description="telnyx==4.0.0")\n'}, False),
+        )
+        for files, declared in fixtures:
+            with self.subTest(files=files):
+                self.assert_manifest(files, declared, False)
+
+    def test_ruby_exact_ranges_and_multiline_calls(self) -> None:
+        for source in ("gem 'telnyx', '5.0.0'", "gem('telnyx', '>= 5.0', '< 6.0')",
+                       'gem "telnyx", "5.0.0"', "gem %q{telnyx}, %q{~> 5.0}",
+                       "gem 'telnyx',\n  '~> 5.0'"):
+            with self.subTest(source=source):
+                self.assert_manifest({"Gemfile": source}, True, True)
+
+    def test_ruby_statement_boundaries_and_comments(self) -> None:
+        for source, declared in (
+            ("gem 'telnyx'; gem 'rake', '~> 13.0'", True),
+            ("gem 'telnyx' # previously '~> 5.0'", True),
+            ("# gem 'telnyx', '~> 5.0'", False),
+            ('help = "gem \'telnyx\', \'~> 5.0\'"', False),
+            ("gem 'telnyx', '5.0' + suffix", True),
+            ("gem 'telnyx' + suffix, '5.0'", False),
+            ("gem `telnyx`, '~> 5.0'", False),
+            ("gem 'telnyx', `5.0.0`", True),
+            ('gem "telnyx", "#{version}"', True),
+        ):
+            with self.subTest(source=source):
+                self.assert_manifest({"Gemfile": source}, declared, False)
+
+    def test_go_requires_not_comments_or_exclusions(self) -> None:
+        for line, declared in (
+            ("require github.com/team-telnyx/telnyx-go/v4 v4.98.0", True),
+            ("require (\n github.com/team-telnyx/telnyx-go/v4 v4.98.0 // indirect\n)", True),
+            ("// require github.com/team-telnyx/telnyx-go/v4 v4.98.0", False),
+            ("exclude github.com/team-telnyx/telnyx-go/v4 v4.98.0", False),
+        ):
+            with self.subTest(line=line):
+                self.assert_manifest({"go.mod": "module example.test/app\ngo 1.24\n" + line}, declared, declared)
+
+    def test_python_specifier_grammar_and_poetry_context(self) -> None:
+        helper = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("inspect-sdk-dependencies.py")))
+        for value in (">=4banana", ">=4.*", "==4..0", "~=4", "==4.0.0garbage", "4.0", "^4.0", "~4.0"):
+            with self.subTest(value=value):
+                self.assertFalse(helper["python_version_is_constrained"](value))
+        for value in ("==4.0", ">=4.0, <5.0", "~=4.0", "==4.*", "!=4.1", "==4.0rc1", "==4.0.post1", "==4.0+local"):
+            with self.subTest(value=value):
+                self.assertTrue(helper["python_version_is_constrained"](value))
+        for value in ("4.0", "^4.0", "~4.0", "4.*"):
+            with self.subTest(value=value):
+                self.assertTrue(helper["python_version_is_constrained"](value, poetry=True))
+        self.assert_manifest({"requirements.txt": "telnyx>=4banana\n"}, True, False)
+
+    def test_python_literal_toml_fallback_without_tomllib(self) -> None:
+        helper = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("inspect-sdk-dependencies.py")))
+        globals_ = helper["read_mapping"].__globals__
+        original = globals_["tomllib"]
+        globals_["tomllib"] = None
+        try:
+            fixtures = (
+                ("Pipfile", '[packages]\ntelnyx = "==4.0"\n', True),
+                ("Pipfile", '[packages]\n"telnyx" = { version = ">=4.0,<5.0", extras = ["aiohttp"] }\n', True),
+                ("pyproject.toml", '[project]\ndependencies = [\n "telnyx >=4.0,<5.0", # comment\n]\n', True),
+                ("pyproject.toml", '[tool.poetry.dependencies]\ntelnyx = {version = "^4.0", optional = true}\n', True),
+                ("pyproject.toml", '[project]\ndependencies = ["telnyx\\u003e=4.0"]\n', True),
+                ("pyproject.toml", '[project]\ndependencies = ["\\U00000074elnyx>=4.0"]\n', True),
+                ("Pipfile", '[packages]\ntelnyx = "==4.0\\t"\n', True),
+                ("Pipfile", '["pack\\u0061ges"]\n"tel\\u006eyx" = {"vers\\u0069on" = "==4.0"}\n', True),
+                ("Pipfile", '[packages]\ntelnyx = "==4.0\\x20"\n', False),
+                ("Pipfile", '[packages]\ntelnyx = "==4.0\\uD800"\n', False),
+                ("pyproject.toml", '[project]\ndescription = "telnyx==4.0"\n', False),
+                ("Pipfile", '# [packages]\n# telnyx = "==4.0"\n', False),
+                ("Pipfile", '[packages]\ntelnyx = "*"\n', False),
+                ("Pipfile", '[packages]\ntelnyx = "==4.0" + dynamic\n', False),
+                ("pyproject.toml", '[project]\ndependencies = ("telnyx>=4.0",)\n', False),
+                ("Pipfile", '[packages]\ntelnyx = {"version": "==4.0"}\n', False),
+                ("Pipfile", '[packages]\ntelnyx = {version="*", version="==4.0"}\n', False),
+                ("Pipfile", '[packages]\ntelnyx = "==4.0"\n[packages]\nother="*"\n', False),
+            )
+            for name, contents, expected in fixtures:
+                with self.subTest(contents=contents), tempfile.TemporaryDirectory() as directory:
+                    (Path(directory) / name).write_text(contents, encoding="utf-8")
+                    self.assertEqual(expected, helper["other_pinned"](Path(directory)))
+                    if original is not None:
+                        globals_["tomllib"] = original
+                        self.assertEqual(expected, helper["other_pinned"](Path(directory)))
+                        globals_["tomllib"] = None
+        finally:
+            globals_["tomllib"] = original
+
+    def test_escaped_toml_dependencies_through_public_validator(self) -> None:
+        self.assert_manifest({"pyproject.toml": '[project]\ndependencies = ["telnyx\\u003e=4.0"]\n'}, True, True)
+        self.assert_manifest({"Pipfile": '[packages]\ntelnyx = "==4.0\\t"\n'}, True, True)
+        self.assert_manifest({"Pipfile": '["pack\\u0061ges"]\n"tel\\u006eyx" = {"vers\\u0069on" = "==4.0"}\n'}, True, True)
+
+    def test_maven_hard_exact_and_bounded_ranges(self) -> None:
+        for version in ("[6.89.0]", "[6.89.0,7.0)"):
+            with self.subTest(version=version):
+                self.assert_manifest({"pom.xml": "<project><dependencies><dependency>"
+                    "<groupId>com.telnyx.sdk</groupId><artifactId>telnyx</artifactId>"
+                    f"<version>{version}</version></dependency></dependencies></project>"}, True, True)
+
+    @unittest.skipIf(sys.version_info < (3, 11), "stdlib tomllib requires Python 3.11")
+    def test_consumed_gradle_catalog_rich_versions(self) -> None:
+        for version in ('{ strictly = "6.89.0" }', '{ require = "6.89.0" }'):
+            with self.subTest(version=version):
+                catalog = '[libraries]\ntelnyx = { module = "com.telnyx.sdk:telnyx", version = ' + version + ' }\n'
+                self.assert_manifest({"build.gradle.kts": "dependencies { implementation(libs.telnyx) }",
+                                      "gradle/libs.versions.toml": catalog}, True, True)
+                self.assert_manifest({"build.gradle.kts": "dependencies { implementation(libs.other) }",
+                                      "gradle/libs.versions.toml": catalog}, False, False)
+
+
+class ComposerConstraintContracts(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.helper_path = DEEP_SCAN_SCRIPT.with_name("inspect-sdk-dependencies.py")
+        cls.helper = runpy.run_path(str(cls.helper_path))
+
+    def validator_checks(self, manifest: object) -> dict[str, str]:
+        with tempfile.TemporaryDirectory(prefix="composer-constraint-") as directory:
+            path = Path(directory) / "composer.json"
+            if isinstance(manifest, bytes):
+                path.write_bytes(manifest)
+            else:
+                path.write_text(json.dumps(manifest), encoding="utf-8")
+            result = subprocess.run(
+                [BASH, str(VALIDATE_MIGRATION_SCRIPT), directory, "--json"],
+                cwd=ROOT, capture_output=True, text=True, timeout=30, check=False,
+            )
+        self.assertNotIn("Traceback", result.stderr)
+        return {item["name"]: item["status"]
+                for item in json.loads(result.stdout)["checks"]}
+
+    def test_validator_accepts_composer_caret_in_both_dependency_sections(self) -> None:
+        for section in ("require", "require-dev"):
+            with self.subTest(section=section):
+                checks = self.validator_checks({section: {"telnyx/telnyx-php": "^7.0"}})
+                self.assertEqual("pass", checks["telnyx_sdk_dependency"])
+                self.assertEqual("pass", checks["telnyx_sdk_version_pinned"])
+
+    def test_supported_composer_constraint_families(self) -> None:
+        constraints = (
+            "7", "7.0", "7.0.1", "v7.0.1", "=7.0.1", "== 7.0.1",
+            "^7.0", "~7.0.1", "~ 7.0", ">=7.0", "<8.0", "!=7.0.1",
+            ">=7.0 <8.0", ">= 7.0, < 8.0", "7.0 - 8.0", "7 - 8",
+            "^6.0 || ^7.0", "^6.0 | ^7.0", "7.*", "7.0.x", "7.X",
+            "7.*.*", "7.0.0-RC1", "7.0.0-beta.2", "7.0.0-stable",
+            "7.0.0-beta2-dev", "7.0.0+build.1", "^7.0.0-beta.2.1",
+            "^7.0@beta", "7.*@dev", "dev-main", "dev-feature/sdk-fix",
+            "7.x-dev", "v7.x-dev", "dev-main#abc123", "7.x-dev#abc123",
+            "* >=7.0", "^7.0 || 8.*@beta",
+        )
+        for constraint in constraints:
+            with self.subTest(constraint=constraint):
+                self.assertTrue(self.helper["composer_version_is_constrained"](constraint))
+
+    def test_unbounded_or_unsupported_constraints_do_not_supply_version_evidence(self) -> None:
+        constraints = (
+            None, True, 7, 7.0, [], {}, "", "  ", "*", "*.*", "x", "X.X",
+            "@dev", "@stable", "@RC", "@alpha", "@beta", "*@stable",
+            "*.*@beta", "^7.0 || *", "* | ^7.0", "^7.0 || *@dev",
+            "^7.0 || @dev", "latest", "stable", "^", ">=", "7..0",
+            "7.0 garbage", "^7.0 ||", "|| ^7.0", ">=7.0,", "7.*.1",
+            "^7.0@unknown", "dev-", "7.0.0#abc123", "dev-main#",
+            "7.0.0-dev3", "7.0.0+", ">=7.0,,<8.0", "dev-main as 7.0.0",
+            "7.0.0-beta" + "1" * 2000 + "!",
+        )
+        for constraint in constraints:
+            with self.subTest(constraint=constraint):
+                self.assertFalse(self.helper["composer_version_is_constrained"](constraint))
+
+    def test_validator_accepts_other_composer_constraint_families(self) -> None:
+        for constraint in ("7.0.1", "~7.0", ">=7.0 <8", "7 - 8", "7.*",
+                           "^7@beta", "dev-main", "7.x-dev"):
+            with self.subTest(constraint=constraint):
+                checks = self.validator_checks({"require": {"telnyx/telnyx-php": constraint}})
+                self.assertEqual("pass", checks["telnyx_sdk_dependency"])
+                self.assertEqual("pass", checks["telnyx_sdk_version_pinned"])
+
+    def test_validator_warns_for_unbounded_or_malformed_versions(self) -> None:
+        for constraint in ("*", "@dev", "^7 || *", "", "latest", None, 7, ["^7"]):
+            with self.subTest(constraint=constraint):
+                checks = self.validator_checks({"require": {"telnyx/telnyx-php": constraint}})
+                self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
+
+    def test_unrelated_sections_and_packages_cannot_supply_version_evidence(self) -> None:
+        for section in ("extra", "suggest", "provide", "replace", "conflict",
+                        "repositories", "scripts"):
+            with self.subTest(section=section):
+                checks = self.validator_checks({
+                    "require": {"telnyx/telnyx-php": "*", "other/package": "^7.0"},
+                    "version": "7.0.1", section: {"telnyx/telnyx-php": "^7.0"},
+                })
+                self.assertEqual("pass", checks["telnyx_sdk_dependency"])
+                self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
+        checks = self.validator_checks({"extra": {"telnyx/telnyx-php": "^7.0"}})
+        self.assertEqual("fail", checks["telnyx_sdk_dependency"])
+        self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
+
+    def test_malformed_composer_files_fail_closed_without_tracebacks(self) -> None:
+        for manifest in (b"{broken", b"\xff", [], None, 7,
+                         {"require": ["telnyx/telnyx-php", "^7.0"]}):
+            with self.subTest(manifest=manifest):
+                checks = self.validator_checks(manifest)
+                self.assertEqual("fail", checks["telnyx_sdk_dependency"])
+                self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
+
+    def test_cli_preserves_presence_mode_and_checks_require_dev(self) -> None:
+        for manifest, declared, constrained in (
+            ({"require": {"telnyx/telnyx-php": "*"}}, True, False),
+            ({"require-dev": {"telnyx/telnyx-php": "^7.0"}}, True, True),
+            ({"require": {"telnyx/telnyx-php": "*"},
+              "require-dev": {"telnyx/telnyx-php": "^7.0"}}, True, True),
+            ({"extra": {"telnyx/telnyx-php": "^7.0"}}, False, False),
+            ({"require": {"other/package": "^7.0"}}, False, False),
+        ):
+            with self.subTest(manifest=manifest), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                (root / "composer.json").write_text(json.dumps(manifest), encoding="utf-8")
+                for mode, expected in (("composer", declared), ("composer-pinned", constrained)):
+                    result = subprocess.run(
+                        [sys.executable, str(self.helper_path), mode, directory],
+                        capture_output=True, text=True, timeout=30, check=False,
+                    )
+                    self.assertEqual(0 if expected else 1, result.returncode, result.stderr)
+                    self.assertEqual("", result.stderr)
+
+    def test_missing_or_nonfile_manifest_has_no_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for is_directory in (False, True):
+                if is_directory:
+                    (root / "composer.json").mkdir()
+                self.assertFalse(self.helper["composer_declared"](root))
+                self.assertFalse(self.helper["composer_pinned"](root))
+
+
 class DiscoveryAndValidationRegressionContracts(unittest.TestCase):
     maxDiff = None
 
@@ -10700,6 +11062,8 @@ class DiscoveryAndValidationRegressionContracts(unittest.TestCase):
             ("import com.twilio.rest.api.v2010.account.Message;\nclass X { void send() { var Message = new Queue(); Message.creator(); } }", ".java", None),
             ("import com.twilio.rest.api.v2010.account.Message as Sms\nfun send() { val Sms = Queue(); Sms.creator() }", ".kt", None),
             ("import com.twilio.rest.api.v2010.account.Message as Sms\nfun send(Sms: Queue) { Sms.creator() }", ".kt", None),
+            ("import com.twilio.rest.api.v2010.account.Message as Sms\nfun send(Sms: Queue) = Sms.creator()", ".kt", None),
+            ("import com.twilio.rest.api.v2010.account.Message as Sms\nfun other(Sms: Queue) = Sms.creator()\nfun send() = Sms.creator()", ".kts", "messaging"),
             ("import com.twilio.rest.api.v2010.account.Message\nobject X { def send(Message: Queue) = { Message.creator() } }", ".scala", None),
             ("import com.twilio.rest.api.v2010.account.Message as Sms\nfun other(Sms: Queue) {}\nfun send() { Sms.creator() }", ".kt", "messaging"),
             ("import com.twilio.rest.api.v2010.account.Message\nobject X { def other(Message: Queue) = {}\ndef send() = { Message.creator() } }", ".scala", "messaging"),
@@ -10715,6 +11079,102 @@ class DiscoveryAndValidationRegressionContracts(unittest.TestCase):
             with self.subTest(source=source):
                 found = {product for _, product in calls(source, suffix)}
                 self.assertEqual({expected} if expected else set(), found)
+
+    def test_scala_import_selector_matrix(self) -> None:
+        calls = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name(
+            "sdk-source-ownership.py")))["contextual_calls"]
+        prefix = "com.twilio.rest.api.v2010.account"
+        for resource, product in (("Message", "messaging"), ("Call", "voice"),
+                                  ("IncomingPhoneNumber", "phone-numbers")):
+            selectors = (
+                ("_", resource, True), ("*", resource, True),
+                ("{_}", resource, True), ("{*}", resource, True),
+                ("{" + resource + "}", resource, True),
+                ("{" + resource + " => Api}", "Api", True),
+                ("{" + resource + " as Api}", "Api", True),
+                (resource + " as Api", "Api", True),
+                ("{" + resource + " => _, _}", resource, False),
+                ("{" + resource + " as _, *}", resource, False),
+                ("{" + resource + " => Api, _}", resource, False),
+                ("{" + resource + " => Api, _}", "Api", True),
+                ("\n  {" + resource + " => Api, _}", "Api", True),
+                ("\n  _", resource, True), ("\n  *", resource, True),
+            )
+            for selector, receiver, expected in selectors:
+                source = f"import {prefix}.{selector}\nobject X {{ def send() = {{ {receiver}.creator() }} }}"
+                with self.subTest(resource=resource, selector=selector, receiver=receiver):
+                    self.assertEqual({product} if expected else set(),
+                                     {p for _, p in calls(source, ".scala")})
+
+    def test_scala_import_scope_and_negative_controls(self) -> None:
+        calls = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name(
+            "sdk-source-ownership.py")))["contextual_calls"]
+        prefix = "com.twilio.rest.api.v2010.account"
+        for source, expected in (
+            (f"// import {prefix}._\nMessage.creator()", False),
+            (f'val text = "import {prefix}._"\nMessage.creator()', False),
+            (f"import unrelated.{{Message}}\nimport {prefix}._\nMessage.creator()", False),
+            (f"import {prefix}._\nimport unrelated.{{Message}}\nMessage.creator()", False),
+            (f"object A {{ import {prefix}._ }}\nobject B {{ Message.creator() }}", False),
+            (f"object A {{ Message.creator(); import {prefix}._ }}", False),
+            (f"object A {{ import {prefix}._; Message.creator() }}", True),
+            (f"import {prefix}._\nobject X {{ def send(Message: Queue) = {{ Message.creator() }} }}", False),
+            (f"import {prefix}._\nobject X {{ def send() = {{ val Message = new Queue(); Message.creator() }} }}", False),
+            (f"import {prefix}._\nobject X {{ def other(Message: Queue) = {{}}; def send() = {{ Message.creator() }} }}", True),
+            (f"import {prefix}.{{Message => _, _}}\nCall.creator()", True),
+            (f"import {prefix}._\nobject X {{ def send(Message: Queue) = Message.creator() }}", False),
+            (f"import {prefix}._\nobject X {{ def other(Message: Queue) = Message.creator(); def send() = {{ Message.creator() }} }}", True),
+            (f"object A:\n  import {prefix}.*\n  def noOp() = ()\nobject B:\n  object Message {{ def creator() = 1 }}\n  val x = Message.creator()\n", False),
+            (f"object A:\n  import {prefix}._\n  def send() =\n    Message.creator()\n", True),
+            (f"import {prefix}._\nobject X:\n  def send(Message: Queue) =\n    Message.creator()\n", False),
+            (f"import {prefix}._\nobject X {{ def send(Message: Queue, flag: Boolean) = if (flag) {{ 1 }} else Message.creator() }}", False),
+            (f"import {prefix}._\nobject X {{ def send(Message: Queue) = (\nMessage.creator()\n) }}", False),
+            (f"object A:\n  val Message = new Queue()\nobject B:\n  import {prefix}.*\n  def send() = Message.creator()\n", True),
+            (f"import {prefix}._\nobject X {{ object Message {{ def creator() = 1 }}; val x=Message.creator() }}", False),
+            (f"import {prefix}._\nobject A:\n  val Message = new Queue()\n  val x=Message.creator()\nobject B:\n  def send() = Message.creator()\n", True),
+        ):
+            with self.subTest(source=source):
+                self.assertEqual(expected, bool(calls(source, ".scala")))
+        for suffix in (".java", ".kt", ".kts"):
+            with self.subTest(suffix=suffix):
+                self.assertFalse(calls(f"import {prefix}._;\nMessage.creator();", suffix))
+                self.assertTrue(calls(f"import {prefix}.*;\nMessage.creator();", suffix))
+
+    def test_scala_selectors_reach_both_public_scanners(self) -> None:
+        prefix = "com.twilio.rest.api.v2010.account"
+        for selector, receiver, expected in (
+            ("_", "Message", True), ("{Message => Sms, _}", "Sms", True),
+            ("{Message as Sms, *}", "Sms", True),
+            ("{Message => _, _}", "Message", False),
+            ("\n  {Message => Sms, _}", "Sms", True),
+        ):
+            with self.subTest(selector=selector):
+                shallow, deep = self._scan({"Send.scala":
+                    f"import {prefix}.{selector}\nobject X {{ def send() = {{ {receiver}.creator() }} }}\n"})
+                for report in (shallow, deep):
+                    self.assertEqual(expected, "messaging" in report["products_used"], report)
+
+    def test_scala_scope_and_other_product_public_controls(self) -> None:
+        prefix = "com.twilio.rest.api.v2010.account"
+        for source, expected in (
+            (f"import {prefix}._\nclass Queue {{ def creator() = 1 }}\nobject X {{ def send(Message: Queue) = Message.creator() }}", False),
+            (f"object A:\n  import {prefix}.*\n  def noOp() = ()\nobject B:\n  object Message {{ def creator() = 1 }}\n  val x = Message.creator()\n", False),
+            (f"object A:\n  import {prefix}._\n  def send() =\n    Message.creator(to, from, body)\n", True),
+        ):
+            with self.subTest(source=source):
+                for report in self._scan({"Send.scala": source}):
+                    self.assertEqual(expected, "messaging" in report["products_used"], report)
+        _, deep = self._scan({"Verify.scala": "import com.twilio.rest.verify.v2.{Service}\n"})
+        self.assertIn("verify", deep["products_used"])
+
+    def test_scala_comma_continued_imports_reach_public_scanners(self) -> None:
+        prefix = "com.twilio.rest.api.v2010.account"
+        for selector, receiver in (("_", "Message"), ("*", "Message"),
+                                   ("{Message}", "Message"), ("{Message => Sms}", "Sms")):
+            with self.subTest(selector=selector):
+                for report in self._scan({"Send.scala":
+                    f"import scala.util.Try,\n  {prefix}.{selector}\nobject X {{ def send() = {receiver}.creator(to, from, body) }}\n"}):
+                    self.assertIn("messaging", report["products_used"], report)
 
     def test_structured_dependency_pin_siblings(self) -> None:
         helper = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("inspect-sdk-dependencies.py")))

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -523,6 +523,8 @@ class CorrectnessLinterContracts(unittest.TestCase):
         ".tsx",
     )
 
+    JS_COMPONENT_FAMILY = (".astro", ".svelte", ".vue")
+
     def test_messaging_profile_linter_reads_every_js_module_extension(self) -> None:
         for suffix in self.JS_TS_FAMILY:
             with self.subTest(suffix=suffix):
@@ -538,6 +540,26 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 }
                 _, payload = self.run_messaging_linter(files)
                 self.assert_required_profile_detected(payload, name)
+
+    def test_correctness_linter_reads_javascript_component_files(self) -> None:
+        for suffix in self.JS_COMPONENT_FAMILY:
+            with self.subTest(suffix=suffix):
+                _, payload = self.run_messaging_linter(
+                    {
+                        f"Component{suffix}": (
+                            "<script>\n"
+                            "const twilio = require('twilio');\n"
+                            "</script>\n"
+                        )
+                    }
+                )
+                flagged = [
+                    check
+                    for check in payload["checks"]
+                    if check["name"] == "residual_twilio_imports"
+                    and check["status"] in {"warn", "issue"}
+                ]
+                self.assertTrue(flagged, json.dumps(payload["checks"]))
 
     def test_language_aliases_are_analysed_as_their_canonical_language(self) -> None:
         # An extension is not a language. A .bash file is a shell script and a

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -1181,6 +1181,35 @@ class CorrectnessLinterContracts(unittest.TestCase):
         )
         self.assertEqual("issue", check["status"], json.dumps(payload["checks"]))
 
+    def test_phtml_php_tag_family_preserves_only_executable_regions(self) -> None:
+        missing = (
+            '$client->post("https://api.telnyx.com/v2/messages/number_pool", '
+            '["json" => ["to" => "+1", "text" => "hi"]]);'
+        )
+        valid = missing.replace(
+            '"text" => "hi"',
+            '"text" => "hi", "messaging_profile_id" => "mp"',
+        )
+        for label, opening in (("normal", "<?php "), ("short", "<? ")):
+            for polarity, body in (("missing", missing), ("valid", valid)):
+                with self.subTest(tag=label, polarity=polarity):
+                    files = {"send.phtml": opening + body + " ?>\n"}
+                    if polarity == "missing":
+                        _, payload = self.run_messaging_linter(files)
+                        self.assert_required_profile_detected(payload, "send.phtml")
+                    else:
+                        self.assert_required_profile_passes(files)
+
+        # An XML processing instruction is markup, not a PHP short tag.
+        self.assert_required_profile_passes(
+            {
+                "feed.phtml": (
+                    '<?xml version="1.0" note="client.sendNumberPool({to: 1})"?>\n'
+                    "<feed/>\n"
+                )
+            }
+        )
+
     def test_multiline_template_comments_preserve_speech_model_line(self) -> None:
         source = (
             "<!-- comment\n"
@@ -1362,6 +1391,142 @@ class CorrectnessLinterContracts(unittest.TestCase):
         )
         self.assert_required_profile_detected(payload, "Nested.vue")
 
+    def test_vue_directive_expression_family_is_executable_javascript(self) -> None:
+        missing = "{to: '+1', text: 'hi'}"
+        valid = "{to: '+1', text: 'hi', messaging_profile_id: 'mp'}"
+        directives = {
+            "if": 'v-if="client.sendNumberPool(%s)"',
+            "show": 'v-show="client.sendNumberPool(%s)"',
+            "bind": 'v-bind:data-result="client.sendNumberPool(%s)"',
+            "bind-shorthand": ':data-result="client.sendNumberPool(%s)"',
+            "prop-shorthand": '.dataResult="client.sendNumberPool(%s)"',
+            "unquoted": "v-if=client.sendNumberPool(payload)",
+        }
+        for label, directive in directives.items():
+            for polarity, body in (("missing", missing), ("valid", valid)):
+                with self.subTest(directive=label, polarity=polarity):
+                    if label == "unquoted":
+                        profile = (
+                            ",messaging_profile_id:'mp'"
+                            if polarity == "valid"
+                            else ""
+                        )
+                        prefix = (
+                            "<script>const payload={to:'+1',text:'hi'"
+                            f"{profile}}};</script>\n"
+                        )
+                        attribute = directive
+                    else:
+                        prefix = ""
+                        attribute = directive % body
+                    source = (
+                        prefix
+                        + f"<template><div {attribute}>x</div></template>\n"
+                    )
+                    if polarity == "missing":
+                        _, payload = self.run_messaging_linter(
+                            {"Send.vue": source}
+                        )
+                        self.assert_required_profile_detected(payload, "Send.vue")
+                    else:
+                        self.assert_required_profile_passes({"Send.vue": source})
+
+        # Directive-looking documentation is text, not an opening-tag
+        # attribute, and HTML comments are not executable Vue templates.
+        self.assert_required_profile_passes(
+            {
+                "Docs.vue": (
+                    '<template><pre>v-if="client.sendNumberPool('
+                    "{to: '+1', text: 'hi'})\"</pre>\n"
+                    '<!-- <div v-bind:x="client.sendNumberPool('
+                    "{to: '+1', text: 'hi'})\"></div> -->\n"
+                    '<div title=\'example v-if="client.sendNumberPool('
+                    "{to: 1})\"\'>documentation</div>\n"
+                    '<div data-v-if="client.sendNumberPool({to: 1})">'
+                    "ordinary attribute</div>\n"
+                    "</template>\n"
+                )
+            }
+        )
+
+    def test_razor_implicit_expression_family_is_executable_csharp(self) -> None:
+        declarations = {
+            "missing": (
+                '@{ var payload = new MessageSendNumberPoolParams { To = "+1" }; }\n'
+            ),
+            "valid": (
+                '@{ var payload = new MessageSendNumberPoolParams { To = "+1", '
+                'MessagingProfileId = "mp" }; }\n'
+            ),
+        }
+        expressions = {
+            "member": "@client.Messages.SendNumberPool(payload)",
+            "indexer": "@clients[0].Messages.SendNumberPool(payload)",
+            "conditional": "@client?.Messages.SendNumberPool(payload)",
+            "await": "@await client.Messages.SendNumberPool(payload)",
+        }
+        for suffix in (".cshtml", ".razor"):
+            for label, expression in expressions.items():
+                for polarity in ("missing", "valid"):
+                    with self.subTest(
+                        suffix=suffix, expression=label, polarity=polarity
+                    ):
+                        fixture = f"View{suffix}"
+                        files = {
+                            fixture: (
+                                declarations[polarity]
+                                + f"<div>{expression}</div>\n"
+                            )
+                        }
+                        if polarity == "missing":
+                            _, payload = self.run_messaging_linter(files)
+                            self.assert_required_profile_detected(payload, fixture)
+                        else:
+                            self.assert_required_profile_passes(files)
+
+        continuations = {
+            "else": (
+                "@if (false) { Work(); } else { "
+                "client.Messages.SendNumberPool(payload); }\n"
+            ),
+            "catch": (
+                "@try { Work(); } catch (Exception) { "
+                "client.Messages.SendNumberPool(payload); }\n"
+            ),
+            "finally": (
+                "@try { Work(); } finally { "
+                "client.Messages.SendNumberPool(payload); }\n"
+            ),
+            "do": (
+                "@do { client.Messages.SendNumberPool(payload); } while (false);\n"
+            ),
+        }
+        for suffix in (".cshtml", ".razor"):
+            for label, control in continuations.items():
+                for polarity in ("missing", "valid"):
+                    with self.subTest(
+                        suffix=suffix, control=label, polarity=polarity
+                    ):
+                        fixture = f"Control{suffix}"
+                        files = {fixture: declarations[polarity] + control}
+                        if polarity == "missing":
+                            _, payload = self.run_messaging_linter(files)
+                            self.assert_required_profile_detected(payload, fixture)
+                        else:
+                            self.assert_required_profile_passes(files)
+
+        # Razor comments and escaped transitions render as text and must not
+        # turn SDK examples into live calls.
+        self.assert_required_profile_passes(
+            {
+                "Docs.cshtml": (
+                    "@* @client.Messages.SendNumberPool(payload) *@\n"
+                    "<code>@@client.Messages.SendNumberPool(payload)</code>\n"
+                    "<p>support@client.Messages.SendNumberPool(payload)</p>\n"
+                )
+            }
+        )
+
     def test_typescript_component_scripts_keep_typescript_resolution(self) -> None:
         source = "\n".join(
             (
@@ -1482,6 +1647,30 @@ class CorrectnessLinterContracts(unittest.TestCase):
             if c["status"] in {"warn", "issue"} and "speech_model" in c["name"]
         ]
         self.assertTrue(flagged, json.dumps(payload["checks"]))
+
+    def test_every_generated_directory_is_excluded_by_every_linter_phase(self) -> None:
+        shell = CORRECTNESS_LINTER.read_text(encoding="utf-8")
+        declared = re.search(r'^EXCLUDE_DIRS="([^"]*)"', shell, re.MULTILINE)
+        self.assertIsNotNone(declared)
+        violating = (
+            "#!/usr/bin/env node\n"
+            "client.messages.sendNumberPool({to: '+1', text: 'hi'});\n"
+        )
+        for directory in declared.group(1).split():
+            with self.subTest(directory=directory):
+                result, payload = self.run_messaging_linter(
+                    {f"{directory}/twilio-generated/send": violating}
+                )
+                statuses = {
+                    check["name"]: check["status"] for check in payload["checks"]
+                }
+                self.assertEqual(
+                    "pass", statuses.get("required_messaging_profile_id"), payload
+                )
+                self.assertEqual(
+                    "pass", statuses.get("twilio_directory_names"), payload
+                )
+                self.assertEqual(0, result.returncode, payload)
 
     def test_state_file_does_not_cross_waive_selected_product(self) -> None:
         # A retained TaskRouter product must not waive residual checks while
@@ -7247,14 +7436,25 @@ class AnalyzerConsistencyContracts(unittest.TestCase):
             r'^EXCLUDE_DIRS="([^"]*)"', shell, re.MULTILINE
         )
         self.assertIsNotNone(declared, "shell linter has no EXCLUDE_DIRS")
-        self.assertEqual(set(), canonical - set(declared.group(1).split()))
+        shell_dirs = set(declared.group(1).split())
+        self.assertEqual(set(), canonical - shell_dirs)
+        self.assertGreaterEqual(
+            shell.count('\\( "${FIND_EXCLUDE_EXPR[@]}" \\) -prune'),
+            2,
+            "every shell find traversal must derive pruning from EXCLUDE_DIRS",
+        )
+        self.assertIn(
+            "excluded_dirs = set(sys.argv[3].split())",
+            shell,
+            "the embedded Python traversal must derive the same policy",
+        )
 
         analyzer = MESSAGING_SOURCE_ANALYZER.read_text(encoding="utf-8")
         block = analyzer.split("EXCLUDED_DIRS = {", 1)[1]
         analyzer_dirs = set(
             re.findall(r'"([^"]+)"', block[: block.index("}")])
         )
-        self.assertEqual(set(), canonical - analyzer_dirs)
+        self.assertEqual(shell_dirs, analyzer_dirs)
 
 
 if __name__ == "__main__":

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -2085,6 +2085,142 @@ class CorrectnessLinterContracts(unittest.TestCase):
             }
         )
 
+    def test_javascript_default_module_endpoint_provenance_matrix(self) -> None:
+        pool = "https://api.telnyx.com/v2/messages/number_pool"
+        normal = "https://api.telnyx.com/v2/messages"
+        forms = {
+            "esm-direct": (
+                "export default '%s';\n",
+                "import endpoint from './config.js';\n",
+            ),
+            "esm-template": (
+                "export default `%s`;\n",
+                "import endpoint from './config.js';\n",
+            ),
+            "esm-alias": (
+                "const pool = '%s'; export default pool;\n",
+                "import endpoint from './config.js';\n",
+            ),
+            "esm-braced-alias": (
+                "const pool = '%s'; const other = '/health'; "
+                "export {other, pool as default};\n",
+                "import endpoint from './config.js';\n",
+            ),
+            "esm-default-plus-named": (
+                "export default '%s'; export const other = '/health';\n",
+                "import endpoint, {other} from './config.js';\n",
+            ),
+            "esm-default-plus-namespace": (
+                "export default '%s'; export const other = '/health';\n",
+                "import endpoint, * as config from './config.js';\n",
+            ),
+            "commonjs-module": (
+                "module.exports = '%s';\n",
+                "const endpoint = require('./config');\n",
+            ),
+            "commonjs-default-member": (
+                "exports.default = '%s';\n",
+                "const endpoint = require('./config').default;\n",
+            ),
+            "commonjs-default-destructure": (
+                "module.exports.default = '%s';\n",
+                "const {default: endpoint} = require('./config');\n",
+            ),
+        }
+
+        def run_form(exporter: str, importer: str, url: str, profile: bool):
+            payload = "{to:'+1'"
+            if profile:
+                payload += ",messaging_profile_id:'mp'"
+            payload += "}"
+            return self.run_required_profile_analyzer(
+                {
+                    "config.js": exporter % url,
+                    "send.js": importer
+                    + "fetch(endpoint,{method:'POST',body:JSON.stringify("
+                    + payload
+                    + ")});\n",
+                }
+            )
+
+        for label, (exporter, importer) in forms.items():
+            with self.subTest(form=label, polarity="missing"):
+                result = run_form(exporter, importer, pool, False)
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                self.assertTrue(
+                    any("send.js" in row for row in rows[1:]), result.stdout
+                )
+            with self.subTest(form=label, polarity="valid"):
+                result = run_form(exporter, importer, pool, True)
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                self.assertFalse(any(row.strip() for row in rows[1:]), result.stdout)
+            with self.subTest(form=label, polarity="non-required"):
+                result = run_form(exporter, importer, normal, False)
+                self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+        # A dynamic local default export cannot be classified statically, but
+        # its mutating use must fail closed rather than certify the migration.
+        result = self.run_required_profile_analyzer(
+            {
+                "config.js": "export default chooseEndpoint();\n",
+                "send.js": (
+                    "import endpoint from './config.js';\n"
+                    "fetch(endpoint,{method:'POST',body:JSON.stringify({to:'+1'})});\n"
+                ),
+            }
+        )
+        self.assertIn("could not resolve the imported endpoint", result.stdout)
+
+        result = self.run_required_profile_analyzer(
+            {
+                "config.js": (
+                    f"export default '/health'; export const pool = '{pool}';\n"
+                ),
+                "send.js": (
+                    "import health, * as config from './config.js';\n"
+                    "fetch(config.pool,{method:'POST',"
+                    "body:JSON.stringify({to:'+1'})});\n"
+                ),
+            }
+        )
+        self.assertIn("could not resolve the imported endpoint", result.stdout)
+
+        # Package defaults are outside this bounded local-module contract and
+        # must not be guessed to be customer endpoints.
+        result = self.run_required_profile_analyzer(
+            {
+                "send.js": (
+                    "import endpoint from 'third-party-config';\n"
+                    "fetch(endpoint,{method:'POST',body:JSON.stringify({to:'+1'})});\n"
+                )
+            }
+        )
+        self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+    def test_default_esm_endpoint_is_enforced_by_public_wrapper(self) -> None:
+        pool = "https://api.telnyx.com/v2/messages/number_pool"
+        support = {"config.js": f"export default '{pool}';\n"}
+        missing = (
+            "import endpoint from './config.js';\n"
+            "fetch(endpoint,{method:'POST',body:JSON.stringify({to:'+1'})});\n"
+        )
+        result, payload = self.run_messaging_linter(
+            {**support, "send.js": missing}
+        )
+        self.assertEqual(1, result.returncode, payload)
+        self.assert_required_profile_detected(payload, "send.js")
+
+        self.assert_required_profile_passes(
+            {
+                **support,
+                "send.js": missing.replace(
+                    "{to:'+1'}", "{to:'+1',messaging_profile_id:'mp'}"
+                ),
+            }
+        )
+
     def test_javascript_line_comment_terminators_do_not_hide_sends(self) -> None:
         url = "https://api.telnyx.com/v2/messages/number_pool"
         for terminator in ("\r", "\u2028", "\u2029"):

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -3066,7 +3066,7 @@ class CorrectnessLinterContracts(unittest.TestCase):
 
     def test_shell_heredocs_accept_trailing_redirections(self) -> None:
         url = "https://api.telnyx.com/v2/messages/number_pool"
-        redirections = (
+        command_tails = (
             ">sample.txt",
             ">> sample.txt 2>&1",
             "2>/dev/null >'sample file.txt'",
@@ -3075,11 +3075,15 @@ class CorrectnessLinterContracts(unittest.TestCase):
             "&>> sample.txt # generated fixture",
             ">sample.txt # generated fixture",
             r">sample\ file.txt",
+            "| sed 's/x/y/'",
+            "|& tee sample.txt",
+            "&& echo done",
+            "; echo done",
         )
-        for redirection in redirections:
-            with self.subTest(redirection=redirection):
+        for command_tail in command_tails:
+            with self.subTest(command_tail=command_tail):
                 inert = (
-                    f"cat <<'DOC' {redirection}\n"
+                    f"cat <<'DOC' {command_tail}\n"
                     "client.messages.sendNumberPool({to:'+1'})\n"
                     "DOC\n"
                 )
@@ -3091,6 +3095,115 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 rows = result.stdout.splitlines()
                 self.assertEqual("1", rows[0], result.stdout)
                 self.assertTrue(any("send.sh" in row for row in rows[1:]), result.stdout)
+
+        # Compact shell bit shifts look exactly like unquoted heredoc openers
+        # to a regex. They must not mask the real send that follows.
+        arithmetic = (
+            "mask=$((1<<SHIFT))",
+            "((mask=1<<SHIFT))",
+            "mask=$[1<<SHIFT]",
+            "mask=$((nested(1)<<SHIFT))",
+            "mask=$((\n  1<<SHIFT\n))",
+            "((\n  mask=1<<SHIFT\n))",
+            "mask=$[\n  1<<SHIFT\n]",
+        )
+        for expression in arithmetic:
+            with self.subTest(expression=expression):
+                source = (
+                    expression
+                    + "\n"
+                    + f"curl -X POST '{url}' -d '{{\"to\":\"+1\"}}'\n"
+                )
+                result = self.run_required_profile_analyzer(
+                    {"arithmetic.sh": source}
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertTrue(
+                    any("arithmetic.sh" in row for row in rows[1:]),
+                    result.stdout,
+                )
+
+        for here_string in ("cat <<<WORD", "cat <<<'WORD'"):
+            with self.subTest(here_string=here_string):
+                source = (
+                    here_string
+                    + "\n"
+                    + f"curl -X POST '{url}' -d '{{\"to\":\"+1\"}}'\n"
+                )
+                result = self.run_required_profile_analyzer(
+                    {"here-string.sh": source}
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertTrue(
+                    any("here-string.sh" in row for row in rows[1:]),
+                    result.stdout,
+                )
+
+        multiple = (
+            "cat <<'FIRST' <<SECOND\n"
+            "client.messages.sendNumberPool({to:'+1'})\n"
+            "FIRST\n"
+            "client.messages.sendNumberPool({to:'+1'})\n"
+            "SECOND\n"
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer(
+                {"multiple-inert.sh": multiple}
+            ).stdout.strip(),
+        )
+        result = self.run_required_profile_analyzer(
+            {
+                "multiple-live.sh": multiple
+                + f"curl -X POST '{url}' -d '{{\"to\":\"+1\"}}'\n"
+            }
+        )
+        rows = result.stdout.splitlines()
+        self.assertEqual("1", rows[0], result.stdout)
+        self.assertTrue(
+            any("multiple-live.sh" in row for row in rows[1:]), result.stdout
+        )
+
+        continued_live = (
+            "cat <<'DOC' \\\n"
+            f"| curl -X POST '{url}' -d '{{\"to\":\"+1\"}}'\n"
+            "inert\nDOC\n"
+        )
+        result = self.run_required_profile_analyzer(
+            {"continued-live.sh": continued_live}
+        )
+        rows = result.stdout.splitlines()
+        self.assertEqual("1", rows[0], result.stdout)
+        self.assertTrue(
+            any("continued-live.sh" in row for row in rows[1:]), result.stdout
+        )
+
+        continued_multiple = (
+            "cat <<'FIRST' \\\n  <<'SECOND'\n"
+            "plain\nFIRST\n"
+            "client.messages.sendNumberPool({to:'+1'})\nSECOND\n"
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer(
+                {"continued-multiple.sh": continued_multiple}
+            ).stdout.strip(),
+        )
+
+        # Only `<<-` strips leading tabs from delimiter lines. An indented word
+        # in an ordinary heredoc body is data, not an early terminator.
+        indented_non_terminator = (
+            "cat <<DOC\n  DOC\n"
+            "client.messages.sendNumberPool({to:'+1'})\nDOC\n"
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer(
+                {"indented-delimiter.sh": indented_non_terminator}
+            ).stdout.strip(),
+        )
 
     def test_ruby_request_constructors_require_an_execution_link(self) -> None:
         url = "https://api.telnyx.com/v2/messages/number_pool"
@@ -3162,6 +3275,75 @@ class CorrectnessLinterContracts(unittest.TestCase):
             self.run_required_profile_analyzer(
                 {"cross-scope.rb": cross_scope}
             ).stdout.strip(),
+        )
+
+        # An out-of-scope execution must not hide a later execution in the
+        # constructor's real scope. Rebinding likewise follows exact local
+        # identity, not a same-spelled member or an unrelated method local.
+        later_in_scope = (
+            f"uri = URI('{url}')\nreq = Net::HTTP::Post.new(uri)\n"
+            "req.body = {to:'+1'}.to_json\n"
+            "def helper\n  http.request(req)\nend\n"
+            "http.request(req)\n"
+        )
+        member_rebind = (
+            f"uri = URI('{url}')\nreq = Net::HTTP::Post.new(uri)\n"
+            "req.body = {to:'+1'}.to_json\n"
+            "self.req = cached_request\nhttp.request(req)\n"
+        )
+        nested_rebind = (
+            f"uri = URI('{url}')\nreq = Net::HTTP::Post.new(uri)\n"
+            "req.body = {to:'+1'}.to_json\n"
+            "def helper\n  req = cached_request\nend\n"
+            "http.request(req)\n"
+        )
+        compact_hash_rebind = (
+            f"uri = URI('{url}')\nreq = Net::HTTP::Post.new(uri)\n"
+            "req.body = {to:'+1'}.to_json\n"
+            "x = {foo:req = cached_request}\nhttp.request(req)\n"
+        )
+        for name, source in (
+            ("later-in-scope", later_in_scope),
+            ("member-rebind", member_rebind),
+            ("nested-rebind", nested_rebind),
+        ):
+            with self.subTest(name=name):
+                result = self.run_required_profile_analyzer(
+                    {f"{name}.rb": source}
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertTrue(
+                    any(f"{name}.rb" in row for row in rows[1:]),
+                    result.stdout,
+                )
+
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer(
+                {"compact-hash-rebind.rb": compact_hash_rebind}
+            ).stdout.strip(),
+        )
+
+        # Ruby's sigiled bindings retain identity across method boundaries.
+        sigiled_cross_scope = (
+            "class Sender\n"
+            "  def prepare\n"
+            f"    uri = URI('{url}')\n"
+            "    @req = Net::HTTP::Post.new(uri)\n"
+            "    @req.body = {to:'+1'}.to_json\n"
+            "  end\n"
+            "  def deliver\n    http.request(@req)\n  end\n"
+            "end\n"
+        )
+        result = self.run_required_profile_analyzer(
+            {"sigiled-cross-scope.rb": sigiled_cross_scope}
+        )
+        rows = result.stdout.splitlines()
+        self.assertEqual("1", rows[0], result.stdout)
+        self.assertTrue(
+            any("sigiled-cross-scope.rb" in row for row in rows[1:]),
+            result.stdout,
         )
 
     def test_review_regressions_hold_through_public_wrapper(self) -> None:

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -2278,6 +2278,136 @@ class CorrectnessLinterContracts(unittest.TestCase):
                     }
                 )
 
+    def test_javascript_regex_literals_do_not_become_comments(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        contexts = {
+            "character-class-block-marker": "const r = /[/*]/gu;",
+            "character-class-line-marker": "const r = /[//]/;",
+            "escaped-block-marker": r"const r = /\/\*/;",
+            "escaped-url-slashes": r"const r = /https?:\/\/[^/]+/;",
+            "return-expression": "function f(){ return /[/*]/; }",
+            "control-body": "if (ok) /[/*]/.test(value);",
+            "array-element": "const xs = [/[/*]/];",
+            "call-argument": "use(/[/*]/);",
+            "template-interpolation": "const x = `${/[/*]/.test(v)}`;",
+            "after-block": "if(ok) {}\n/[/*]/.test(v);",
+            "arrow-expression": "const f = () => /[/*]/;",
+            "ternary-arms": "const x = ok ? /[/*]/ : /[//]/;",
+            "throw-expression": "function f(){ throw /[/*]/; }",
+            "yield-expression": "function* f(){ yield /[/*]/; }",
+            "await-expression": "async function f(){ await /[/*]/.test(v); }",
+            "else-body": "if(ok) use(); else /[/*]/.test(v);",
+            "do-body": "do /[/*]/.test(v); while(false);",
+            "while-body": "while(false) /[/*]/.test(v);",
+            "for-body": "for(;false;) /[/*]/.test(v);",
+            "catch-body": "try{} catch(e) /[/*]/.test(e);",
+            "logical-rhs": "const x = ok && /[/*]/.test(v);",
+            "unary-operand": "const x = !/[/*]/.test(v);",
+            "case-body": "switch(x){case 1: /[/*]/.test(x); break;}",
+            "object-value": "const o = {r: /[/*]/};",
+        }
+        send = (
+            f"fetch('{url}',{{method:'POST',body:JSON.stringify("
+            "{to:'+1'PROFILE})});"
+        )
+        for context, prefix in contexts.items():
+            for polarity, profile in (
+                ("missing", ""),
+                ("valid", ",messaging_profile_id:'mp'"),
+            ):
+                with self.subTest(context=context, polarity=polarity):
+                    result = self.run_required_profile_analyzer(
+                        {"send.js": prefix + "\n" + send.replace("PROFILE", profile)}
+                    )
+                    rows = result.stdout.splitlines()
+                    self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                    findings = [row for row in rows[1:] if "send.js" in row]
+                    if polarity == "missing":
+                        self.assertTrue(findings, result.stdout)
+                    else:
+                        self.assertEqual([], findings, result.stdout)
+
+    def test_javascript_division_and_comments_remain_distinct_from_regex(
+        self,
+    ) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        prefixes = {
+            "division": "const ratio = total / count;",
+            "division-assignment": "total /= count;",
+            "parenthesized-operand": "const ratio = (total + 1) / count;",
+            "string-operand": 'const ratio = "xx".length / count;',
+            "regex-operand": "const ratio = /x/.source.length / count;",
+            "postfix-operand": "const ratio = value++ / count;",
+            "object-operand": "const ratio = ({n: 1}).n / count;",
+            "call-operand": "const ratio = fn() / count;",
+            "array-operand": "const ratio = arr[0] / count;",
+            "number-operand": "const ratio = 10 / count;",
+            "boolean-operand": "const ratio = true / count;",
+            "null-operand": "const ratio = null / count;",
+            "template-operand": "const ratio = `xx`.length / count;",
+            "regex-direct-operand": "const ratio = /x/ / count;",
+            "block-comment": "/* regex example: /[/*]/ */",
+            "line-comment": "// regex example: /[/*]/",
+        }
+        send = (
+            f"fetch('{url}',{{method:'POST',"
+            "body:JSON.stringify({to:'+1'})});"
+        )
+        for context, prefix in prefixes.items():
+            with self.subTest(context=context):
+                result = self.run_required_profile_analyzer(
+                    {"send.js": prefix + "\n" + send}
+                )
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                self.assertTrue(
+                    any("send.js" in row for row in rows[1:]), result.stdout
+                )
+
+        # Regex text is data, not an SDK call or endpoint-bearing request.
+        result = self.run_required_profile_analyzer(
+            {
+                "decoy.js": (
+                    r"const example = /client\.messages\.sendNumberPool\(\{to:1\}\)/;"
+                    "\n"
+                )
+            }
+        )
+        self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+        # JSX closing tags also use slash but cannot begin regexp literals.
+        result = self.run_required_profile_analyzer(
+            {
+                "view.jsx": (
+                    "const view = <Panel><span>/[/*]/</span></Panel>;\n"
+                    + send
+                )
+            }
+        )
+        rows = result.stdout.splitlines()
+        self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+        self.assertTrue(any("view.jsx" in row for row in rows[1:]), result.stdout)
+
+    def test_javascript_regex_comment_ambiguity_is_blocked_by_public_wrapper(
+        self,
+    ) -> None:
+        source = (
+            "const separator = /[/*]/;\n"
+            "client.messages.sendNumberPool({to:'+1',text:'hi'PROFILE});\n"
+        )
+        result, payload = self.run_messaging_linter(
+            {"send.js": source.replace("PROFILE", "")}
+        )
+        self.assertEqual(1, result.returncode, payload)
+        self.assert_required_profile_detected(payload, "send.js")
+        self.assert_required_profile_passes(
+            {
+                "send.js": source.replace(
+                    "PROFILE", ",messaging_profile_id:'mp'"
+                )
+            }
+        )
+
     def test_finding_rows_escape_newline_bearing_paths(self) -> None:
         result = self.run_required_profile_analyzer(
             {

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -3346,6 +3346,246 @@ class CorrectnessLinterContracts(unittest.TestCase):
             result.stdout,
         )
 
+        compact_scope_decoys = (
+            "def helper; http.request(req); end",
+            "class Helper; def run; http.request(req); end; end",
+            "def helper = http.request(req)",
+            "def helper() = http.request(req)",
+            "def req=(value); http.request(req); end",
+            "def ==(other); http.request(req); end",
+            "def []=(key, value); http.request(req); end",
+            "private def helper = http.request(req)",
+            "class Helper; http.request(req); end",
+            "module Helper; http.request(req); end",
+        )
+        for decoy in compact_scope_decoys:
+            with self.subTest(decoy=decoy):
+                source = (
+                    f"uri = URI('{url}')\n"
+                    "req = Net::HTTP::Post.new(uri)\n"
+                    "req.body = {to:'+1'}.to_json\n"
+                    f"{decoy}\n"
+                )
+                self.assertEqual(
+                    "0",
+                    self.run_required_profile_analyzer(
+                        {"compact-scope.rb": source}
+                    ).stdout.strip(),
+                )
+
+        for polarity, profile in (
+            ("missing", ""),
+            ("valid", ",messaging_profile_id:mp"),
+        ):
+            with self.subTest(compact_method=polarity):
+                source = (
+                    f"def deliver; uri = URI('{url}'); "
+                    "req = Net::HTTP::Post.new(uri); "
+                    f"req.body = {{to:'+1'{profile}}}.to_json; "
+                    "http.request(req); end\n"
+                )
+                result = self.run_required_profile_analyzer(
+                    {"compact-method.rb": source}
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                findings = [
+                    row for row in rows[1:] if "compact-method.rb" in row
+                ]
+                self.assertEqual(
+                    polarity == "missing", bool(findings), result.stdout
+                )
+
+        scoped_body_cases = {
+            "foreign-present-does-not-satisfy": (
+                f"uri = URI('{url}')\n"
+                "req = Net::HTTP::Post.new(uri)\n"
+                "def helper; req.body = {messaging_profile_id:mp}.to_json; end\n"
+                "http.request(req)\n",
+                True,
+            ),
+            "body-after-send-does-not-satisfy": (
+                f"uri = URI('{url}')\n"
+                "req = Net::HTTP::Post.new(uri)\n"
+                "http.request(req)\n"
+                "req.body = {messaging_profile_id:mp}.to_json\n",
+                True,
+            ),
+            "foreign-missing-does-not-override-present": (
+                f"uri = URI('{url}')\n"
+                "req = Net::HTTP::Post.new(uri)\n"
+                "def helper; req.body = {to:'+1'}.to_json; end\n"
+                "req.body = {messaging_profile_id:mp,to:'+1'}.to_json\n"
+                "http.request(req)\n",
+                False,
+            ),
+        }
+        for name, (source, should_find) in scoped_body_cases.items():
+            with self.subTest(scoped_body=name):
+                result = self.run_required_profile_analyzer(
+                    {f"{name}.rb": source}
+                )
+                findings = [
+                    row for row in result.stdout.splitlines()[1:]
+                    if f"{name}.rb" in row
+                ]
+                self.assertEqual(should_find, bool(findings), result.stdout)
+
+        for sigil in ("@", "@@", "$"):
+            with self.subTest(sigil=sigil):
+                source = (
+                    f"uri = URI('{url}')\n"
+                    f"{sigil}req = Net::HTTP::Post.new(uri)\n"
+                    f"{sigil}req.body = "
+                    "{messaging_profile_id:mp,to:'+1'}.to_json\n"
+                    f"http.request({sigil}req)\n"
+                )
+                result = self.run_required_profile_analyzer(
+                    {"sigiled-request.rb": source}
+                )
+                self.assertEqual("1", result.stdout.splitlines()[0])
+                self.assertFalse(
+                    any(
+                        "sigiled-request.rb" in row
+                        for row in result.stdout.splitlines()[1:]
+                    ),
+                    result.stdout,
+                )
+
+        cross_method_sigil = (
+            "class Sender\n"
+            f"  def prepare; uri=URI('{url}'); "
+            "@req=Net::HTTP::Post.new(uri); "
+            "@req.body={messaging_profile_id:mp}.to_json; end\n"
+            "  def deliver; http.request(@req); end\n"
+            "end\n"
+        )
+        result = self.run_required_profile_analyzer(
+            {"cross-method-sigil.rb": cross_method_sigil}
+        )
+        self.assertEqual("1", result.stdout.splitlines()[0])
+        self.assertFalse(
+            any(
+                "cross-method-sigil.rb" in row
+                for row in result.stdout.splitlines()[1:]
+            ),
+            result.stdout,
+        )
+
+    def test_okhttp_request_lifecycle_requires_network_execution(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        body = 'RequestBody.create("{\\"to\\":\\"+1\\"}", JSON)'
+        request = f'new Request.Builder().url("{url}").post({body}).build()'
+        inert = {
+            "builder-only": request + ";",
+            "new-call-only": f"client.newCall({request});",
+            "stored-call-only": f"Call pending = client.newCall({request});",
+            "bound-request-new-call-only": (
+                f"Request req = {request};\nclient.newCall(req);"
+            ),
+            "rebound-call": (
+                f"Request req = {request};\n"
+                "Call pending = client.newCall(req);\n"
+                "pending = client.newCall(healthRequest);\n"
+                "pending.execute();"
+            ),
+            "stored-inline-call-only": (
+                f"Call pending = client.newCall({request});"
+            ),
+        }
+        for name, source in inert.items():
+            with self.subTest(name=name):
+                self.assertEqual(
+                    "0",
+                    self.run_required_profile_analyzer(
+                        {f"{name}.java": source}
+                    ).stdout.strip(),
+                )
+
+        live = {
+            "inline-execute": f"client.newCall({request}).execute();",
+            "inline-enqueue": f"client.newCall({request}).enqueue(callback);",
+            "bound-direct": (
+                f"Request req = {request};\nclient.newCall(req).execute();"
+            ),
+            "stored-execute": (
+                f"Request req = {request};\n"
+                "Call pending = client.newCall(req);\npending.execute();"
+            ),
+            "stored-enqueue": (
+                f"Request req = {request};\n"
+                "var pending = client.newCall(req);\npending.enqueue(callback);"
+            ),
+            "stored-final-execute": (
+                f"Request req = {request};\n"
+                "final Call pending = client.newCall(req);\npending.execute();"
+            ),
+            "stored-inline-execute": (
+                f"Call pending = client.newCall({request});\npending.execute();"
+            ),
+            "request-rebound-after-capture": (
+                f"Request req = {request};\n"
+                "Call pending = client.newCall(req);\n"
+                "req = healthRequest;\n"
+                "pending.execute();"
+            ),
+        }
+        for name, source in live.items():
+            with self.subTest(name=name):
+                result = self.run_required_profile_analyzer(
+                    {f"{name}.java": source}
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertTrue(
+                    any(f"{name}.java" in row for row in rows[1:]),
+                    result.stdout,
+                )
+
+        compliant_body = body.replace(
+            '\\"to\\":\\"+1\\"',
+            '\\"messaging_profile_id\\":\\"MP_OK\\",\\"to\\":\\"+1\\"',
+        )
+        for name, source in live.items():
+            with self.subTest(name=name, polarity="compliant"):
+                compliant_source = source.replace(body, compliant_body)
+                result = self.run_required_profile_analyzer(
+                    {f"{name}-compliant.java": compliant_source}
+                )
+                self.assertEqual(
+                    "1",
+                    result.stdout.splitlines()[0],
+                )
+                self.assertFalse(
+                    any(
+                        f"{name}-compliant.java" in row
+                        for row in result.stdout.splitlines()[1:]
+                    )
+                )
+
+        kotlin_missing = (
+            f"val req = {request}\n"
+            "client?.newCall(req)?.execute()"
+        )
+        kotlin_inert = f"client!!.newCall({request})"
+        kotlin_result = self.run_required_profile_analyzer(
+            {"kotlin-live.kt": kotlin_missing}
+        )
+        self.assertEqual("1", kotlin_result.stdout.splitlines()[0])
+        self.assertTrue(
+            any(
+                "kotlin-live.kt" in row
+                for row in kotlin_result.stdout.splitlines()[1:]
+            ),
+            kotlin_result.stdout,
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer(
+                {"kotlin-inert.kt": kotlin_inert}
+            ).stdout.strip(),
+        )
+
     def test_review_regressions_hold_through_public_wrapper(self) -> None:
         url = "https://api.telnyx.com/v2/messages/number_pool"
         missing = {

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -6747,6 +6747,7 @@ class CorrectnessLinterContracts(unittest.TestCase):
             "client.messages.sendNumberPool(new MessageSendNumberPoolParams()"
             '.setTo("+1"))'
         )
+        alias_call = "client.messages.sendNumberPool(payload)"
         live = {
             "lower.kt": f'val value = "${{{call}}}"\n',
             "script.kts": f'val value = "${{{call}}}"\n',
@@ -6754,6 +6755,8 @@ class CorrectnessLinterContracts(unittest.TestCase):
             "s.scala": f'val value = s"${{{call}}}"\n',
             "f.scala": f'val value = f"${{{call}}}%s"\n',
             "raw.scala": f'val value = raw"""${{{call}}}"""\n',
+            "even-backslash.kt": f'val value = "\\\\${{{alias_call}}}"\n',
+            "raw-backslash.kt": f'val value = """\\${{{alias_call}}}"""\n',
         }
         for fixture, source in live.items():
             with self.subTest(live=fixture):
@@ -6762,7 +6765,10 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
 
         inert = {
-            "escaped.kt": f'val value = "\\${{{call}}}"\n',
+            # Keep the reviewed payload-variable form: a nested quote in the
+            # expression once ended the outer string early and made this test
+            # pass without exercising marker restoration at all.
+            "escaped.kt": f'val value = "\\${{{alias_call}}}"\n',
             "ordinary.scala": f'val value = "${{{call}}}"\n',
             "escaped.scala": f'val value = s"$${{{call}}}"\n',
             "ordinary.java": f'String value = "${{{call}}}";\n',

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -3034,6 +3034,195 @@ class CorrectnessLinterContracts(unittest.TestCase):
                     else:
                         self.assertEqual([], findings, result.stdout)
 
+    def test_jsx_markup_is_inert_but_expression_containers_execute(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        decoy = "client.messages.sendNumberPool({to: '+1'})"
+        inert = {
+            "text.jsx": f"export default () => <code>{decoy}</code>;",
+            "nested.tsx": (
+                f"export default () => <Panel><span>{decoy}</span></Panel>;"
+            ),
+            "attribute.jsx": f"export default () => <Panel title=\"{decoy}\" />;",
+            "braced-attribute.tsx": f"export default () => <Panel title=\"{{{decoy}}}\" />;",
+            "comment.tsx": (
+                f"export default () => <Panel>{{/* {decoy} */}}</Panel>;"
+            ),
+            "fragment.jsx": f"export default () => <><code>{decoy}</code></>;",
+            "nested-expression.tsx": (
+                f"export default () => <Panel>{{ok ? <code>{decoy}</code> : null}}</Panel>;"
+            ),
+            "control-body.jsx": f"if (ok) <Panel>{decoy}</Panel>;",
+            "await-operand.tsx": (
+                f"async function render() {{ await <Panel>{decoy}</Panel>; }}"
+            ),
+            "typeof-operand.jsx": f"const kind = typeof <Panel>{decoy}</Panel>;",
+            "underscore-component.jsx": (
+                f"export default () => <_Panel>{decoy}</_Panel>;"
+            ),
+            "dollar-component.tsx": (
+                f"export default () => <$Panel>{decoy}</$Panel>;"
+            ),
+            "unicode-component.tsx": (
+                f"export default () => <Élément>{decoy}</Élément>;"
+            ),
+            "attribute-comment.jsx": (
+                f"export default () => <Panel value={{/* }}>"  # nosec B703
+                f" */ 1}}>{decoy}</Panel>;"
+            ),
+            "many-expressions.tsx": (
+                "export default () => <Panel>"
+                + "{value}" * 400
+                + decoy
+                + "</Panel>;"
+            ),
+        }
+        for name, source in inert.items():
+            with self.subTest(name=name):
+                self.assertEqual(
+                    "0",
+                    self.run_required_profile_analyzer({name: source}).stdout.strip(),
+                )
+
+        executable = {
+            "child.jsx": f"export default () => <Panel>{{{decoy}}}</Panel>;",
+            "handler.tsx": (
+                f"export default () => <Button onClick={{() => {decoy}}} />;"
+            ),
+            "spread.tsx": (
+                f"export default () => <Panel value={{{{run: () => {decoy}}}}} />;"
+            ),
+            "regex-brace.jsx": (
+                f"export default () => <Panel>{{/[}}]/.test(value) && {decoy}}}</Panel>;"
+            ),
+            "comment-brace.tsx": (
+                f"export default () => <Panel>{{/* }} is inert */ {decoy}}}</Panel>;"
+            ),
+            "after.jsx": (
+                "const view = <Panel>ordinary text</Panel>;\n"
+                f"fetch('{url}',{{method:'POST',body:JSON.stringify({{to:'+1'}})}});"
+            ),
+        }
+        for name, source in executable.items():
+            with self.subTest(name=name):
+                result = self.run_required_profile_analyzer({name: source})
+                self.assertTrue(
+                    any(name in row for row in result.stdout.splitlines()[1:]),
+                    result.stdout,
+                )
+
+    def test_ruby_slash_regex_literals_do_not_mask_following_sends(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        send = f"Net::HTTP.post(URI('{url}'), {{to: '+1'}}.to_json)"
+        prefixes = {
+            "apostrophe": "pattern = /don't/",
+            "escaped-slash": r"pattern = /a\/b's/",
+            "character-class": r"pattern = /[\/'a-z]+/i",
+            "argument": "value.match(/don't/)",
+            "command-argument": "warn /don't/",
+            "receiver-command-argument": "value.match /don't/",
+            "indexed-command-argument": "receivers[0].match /don't/",
+            "called-command-argument": "factory().match /don't/",
+            "constant-command-argument": "Foo::Bar.warn /don't/",
+            "block-command-argument": "consume /don't/ do |match|\nend",
+            "and-command-argument": "warn /don't/ and puts :ok",
+            "or-command-argument": "warn /don't/ or puts :ok",
+            "multiline": "pattern = /don't\nstop/",
+            "multiline-x": "pattern = /don't # prose\n stop/x",
+            "multiline-command": "warn /don't\nstop/",
+            "condition": "return unless /don't/.match?(value)",
+            "interpolation": r"pattern = /prefix#{helper('x')}don't/",
+            "division": "ratio = total / count",
+            "division-assignment": "total /= count",
+            "chained-division": (
+                "total / client.messages.sendNumberPool({to: '+1'}) / divisor"
+            ),
+            "division-before-url": (
+                "total / count\n"
+                f"Net::HTTP.post(URI('{url}'), {{to: '+1'}}.to_json)"
+            ),
+        }
+        for name, prefix in prefixes.items():
+            with self.subTest(name=name):
+                result = self.run_required_profile_analyzer(
+                    {f"{name}.rb": prefix + "\n" + send}
+                )
+                self.assertTrue(
+                    any(
+                        f"{name}.rb" in row
+                        for row in result.stdout.splitlines()[1:]
+                    ),
+                    result.stdout,
+                )
+
+        decoy = (
+            r"pattern = /client\.messages\.sendNumberPool\(\{to: 1\}\)/"
+            "\n"
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer({"decoy.rb": decoy}).stdout.strip(),
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer(
+                {
+                    "command-decoy.rb": (
+                        r"warn /client\.messages\.sendNumberPool\(\{to: 1\}\)/"
+                        "\n"
+                    )
+                }
+            ).stdout.strip(),
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer(
+                {
+                    "multiline-decoy.rb": (
+                        "pattern = /client.messages.\n"
+                        "sendNumberPool({to: 1})/x\n"
+                    )
+                }
+            ).stdout.strip(),
+        )
+
+        interpolated_send = (
+            f"pattern = /prefix#{{Net::HTTP.post(URI('{url}'), "
+            "{to: '+1'}.to_json)}}suffix/"
+        )
+        result = self.run_required_profile_analyzer(
+            {"interpolated-send.rb": interpolated_send}
+        )
+        self.assertTrue(
+            any(
+                "interpolated-send.rb" in row
+                for row in result.stdout.splitlines()[1:]
+            ),
+            result.stdout,
+        )
+
+    def test_jsx_and_ruby_regexp_reviews_hold_through_public_wrapper(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        self.assert_required_profile_passes(
+            {
+                "docs.tsx": (
+                    "export default () => <code>"
+                    "client.messages.sendNumberPool({to: '+1'})"
+                    "</code>;"
+                )
+            }
+        )
+
+        result, payload = self.run_messaging_linter(
+            {
+                "send.rb": (
+                    "pattern = /don't/\n"
+                    f"Net::HTTP.post(URI('{url}'), {{to: '+1'}}.to_json)"
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode, payload)
+        self.assert_required_profile_detected(payload, "send.rb")
+
     def test_export_default_regex_literals_preserve_following_sends(self) -> None:
         url = "https://api.telnyx.com/v2/messages/number_pool"
         send = (

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -2128,6 +2128,90 @@ class CorrectnessLinterContracts(unittest.TestCase):
             }
         )
 
+    def test_javascript_nonrelative_import_endpoints_fail_closed(self) -> None:
+        """Configured aliases and package imports retain URL provenance."""
+
+        forms = {
+            "named-at": "import { poolUrl } from '@/endpoints';\n",
+            "named-tilde": "import { poolUrl } from '~/endpoints';\n",
+            "named-hash": "import { poolUrl } from '#endpoints';\n",
+            "default": "import poolUrl from '#endpoints';\n",
+            "namespace": "import * as routes from '@/endpoints';\n",
+            "require-default": "const poolUrl = require('~/endpoints');\n",
+            "require-member": "const {poolUrl} = require('@/endpoints');\n",
+            "require-renamed": (
+                "const {poolUrl: endpoint} = require('#endpoints');\n"
+            ),
+        }
+        suffixes = (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts")
+        for suffix in suffixes:
+            for form, declaration in forms.items():
+                name = "routes.poolUrl" if form == "namespace" else (
+                    "endpoint" if form == "require-renamed" else "poolUrl"
+                )
+                source = declaration + (
+                    f"fetch({name}, {{method:'POST', "
+                    "body:JSON.stringify({to:'+1'})}});\n"
+                )
+                with self.subTest(suffix=suffix, form=form):
+                    result = self.run_required_profile_analyzer(
+                        {"send" + suffix: source}
+                    )
+                    rows = result.stdout.splitlines()
+                    self.assertEqual("1", rows[0], result.stdout)
+                    self.assertTrue(
+                        any(
+                            "could not resolve the imported endpoint" in row
+                            for row in rows[1:]
+                        ),
+                        result.stdout,
+                    )
+
+        # The provenance guard is method-aware: importing an identifier and
+        # merely reading it with fetch's default GET is not a message send.
+        result = self.run_required_profile_analyzer(
+            {
+                "read.ts": (
+                    "import { poolUrl } from '@/endpoints';\n"
+                    "fetch(poolUrl);\n"
+                )
+            }
+        )
+        self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+        configured = self.run_required_profile_analyzer(
+            {
+                "tsconfig.json": json.dumps(
+                    {
+                        "compilerOptions": {
+                            "paths": {"@app/*": ["src/*"]}
+                        }
+                    }
+                ),
+                "configured.ts": (
+                    "import { poolUrl } from '@app/endpoints';\n"
+                    "fetch(poolUrl,{method:'POST',"
+                    "body:JSON.stringify({to:'+1'})});\n"
+                ),
+            }
+        )
+        self.assertIn(
+            "could not resolve the imported endpoint", configured.stdout
+        )
+
+        non_object_config = self.run_required_profile_analyzer(
+            {
+                "tsconfig.json": "null\n",
+                "package.json": "[]\n",
+                "package.js": (
+                    "import endpoint from 'third-party-config';\n"
+                    "fetch(endpoint,{method:'POST',"
+                    "body:JSON.stringify({to:'+1'})});\n"
+                ),
+            }
+        )
+        self.assertEqual("0", non_object_config.stdout.strip(), non_object_config.stdout)
+
     def test_javascript_default_module_endpoint_provenance_matrix(self) -> None:
         pool = "https://api.telnyx.com/v2/messages/number_pool"
         normal = "https://api.telnyx.com/v2/messages"
@@ -2432,6 +2516,70 @@ class CorrectnessLinterContracts(unittest.TestCase):
         self.assertEqual(1, shell_result.returncode, payload)
         self.assertEqual(1, len(check["details"]["files"]), check)
         self.assertIn(r"odd\nname.js:1:", check["details"]["files"][0])
+
+        literal_backslash = self.run_required_profile_analyzer(
+            {
+                r"literal\nname.js": (
+                    "client.messages.sendNumberPool({to:'+1'});\n"
+                )
+            }
+        )
+        self.assertIn(r"literal\\nname.js:1:", literal_backslash.stdout)
+
+    def test_hybrid_migrated_paths_keep_structured_identity(self) -> None:
+        """Hybrid waivers never split or alias legal POSIX path bytes."""
+
+        for relative in (
+            "src/odd\nname.js",
+            "src/odd\rname.js",
+            r"src/literal\nname.js",
+        ):
+            with self.subTest(relative=repr(relative)):
+                with tempfile.TemporaryDirectory(
+                    prefix="telnyx-hybrid-structured-path-"
+                ) as directory:
+                    root = Path(directory)
+                    source = root / relative
+                    source.parent.mkdir(parents=True, exist_ok=True)
+                    source.write_text(
+                        "const twilio = require('twilio');\n",
+                        encoding="utf-8",
+                    )
+                    state = root / "migration-state.json"
+                    state.write_text(
+                        json.dumps(
+                            {
+                                "kept_on_twilio": {"conversations": True},
+                                "migrated_files": {"messaging": [relative]},
+                            }
+                        ),
+                        encoding="utf-8",
+                    )
+                    result = subprocess.run(
+                        [
+                            BASH,
+                            str(CORRECTNESS_LINTER),
+                            str(root),
+                            "--product",
+                            "all",
+                            "--state-file",
+                            str(state),
+                            "--json",
+                        ],
+                        cwd=ROOT,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        check=False,
+                    )
+                self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+                payload = json.loads(result.stdout)
+                residual = next(
+                    check
+                    for check in payload["checks"]
+                    if check["name"] == "residual_twilio_imports"
+                )
+                self.assertEqual("issue", residual["status"], residual)
 
     def test_url_constructor_base_is_combined_with_the_path(self) -> None:
         # new URL(path, base) resolves the path relative to the base, so

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -1181,6 +1181,41 @@ class CorrectnessLinterContracts(unittest.TestCase):
         )
         self.assertEqual("issue", check["status"], json.dumps(payload["checks"]))
 
+    def test_php_attributes_do_not_mask_required_sends(self) -> None:
+        missing = "$client->send_number_pool(['to' => '+1'%s]);"
+        wrappers = {
+            "same-line": "#[Route('/send')] function handler() { %s }\n",
+            "stacked": "#[Route('/send')]\n#[Audit('message')]\nfunction handler() { %s }\n",
+            "method": "class Sender { #[Route('/send')] public function run() { %s } }\n",
+            "parameter": "function handler(#[SensitiveParameter] $to) { %s }\n",
+        }
+        for label, wrapper in wrappers.items():
+            with self.subTest(shape=label, polarity="missing"):
+                _, payload = self.run_messaging_linter(
+                    {"send.php": "<?php\n" + wrapper % (missing % "")}
+                )
+                self.assert_required_profile_detected(payload, "send.php")
+            with self.subTest(shape=label, polarity="compliant"):
+                self.assert_required_profile_passes(
+                    {
+                        "send.php": "<?php\n"
+                        + wrapper
+                        % (missing % ", 'messaging_profile_id' => 'mp'")
+                    }
+                )
+
+        # Legacy PHP hash comments remain comments, and call-like text inside
+        # an attribute string remains data rather than an executable send.
+        self.assert_required_profile_passes(
+            {
+                "comments.php": (
+                    "<?php\n# $client->send_number_pool(['to' => '+1']);\n"
+                    "#[Example(\"send_number_pool(['to' => '+1'])\")]\n"
+                    "function handler() {}\n"
+                )
+            }
+        )
+
     def test_phtml_php_tag_family_preserves_only_executable_regions(self) -> None:
         missing = (
             '$client->post("https://api.telnyx.com/v2/messages/number_pool", '
@@ -1382,6 +1417,43 @@ class CorrectnessLinterContracts(unittest.TestCase):
             if item["name"] == "messaging_response_builder"
         )
         self.assertEqual(1, len(check["details"]["files"]))
+
+    def test_extensionless_shebang_paths_keep_structured_identity(self) -> None:
+        """Shebang discovery preserves every legal path byte except NUL."""
+
+        clean = "#!/usr/bin/env node\nconsole.log('ok');\n"
+        missing = (
+            "#!/usr/bin/env node\n"
+            "client.messages.sendNumberPool({to:'+1'});\n"
+        )
+        compliant = missing.replace("to:'+1'", "to:'+1',messaging_profile_id:'mp'")
+        for relative in (
+            "bin/send\nnow",
+            "bin/send\rnow",
+            r"bin/send\nnow",
+        ):
+            with self.subTest(path=repr(relative), polarity="clean"):
+                result, _ = self.run_messaging_linter({relative: clean})
+                self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            with self.subTest(path=repr(relative), polarity="missing"):
+                result, payload = self.run_messaging_linter({relative: missing})
+                self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+                check = next(
+                    item
+                    for item in payload["checks"]
+                    if item["name"] == "required_messaging_profile_id"
+                )
+                self.assertEqual("issue", check["status"], check)
+                self.assertEqual(1, len(check["details"]["files"]), check)
+                escaped_name = (
+                    Path(relative).name.replace("\\", r"\\")
+                    .replace("\r", r"\r")
+                    .replace("\n", r"\n")
+                )
+                self.assertIn(escaped_name, check["details"]["files"][0])
+            with self.subTest(path=repr(relative), polarity="compliant"):
+                result, _ = self.run_messaging_linter({relative: compliant})
+                self.assertEqual(0, result.returncode, result.stdout + result.stderr)
 
     def test_component_template_handlers_are_executable_javascript(self) -> None:
         violating = {

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -6664,6 +6664,141 @@ class CorrectnessLinterContracts(unittest.TestCase):
             {"example.rb": f"template = %q{{{call}}}\n"}
         )
 
+    def test_python_and_csharp_interpolation_preserve_only_expressions(
+        self,
+    ) -> None:
+        python_call = "client.messages.send_number_pool({'to': '+1'})"
+        python_live = {
+            "lower": f'f"{{{python_call}}}"',
+            "upper": f'F"{{{python_call}}}"',
+            "raw-first": f'rf"{{{python_call}}}"',
+            "format-first": f'fr"{{{python_call}}}"',
+            "triple": f'f"""{{{python_call}}}"""',
+            "nested-format": f'f"{{value:{{{python_call}}}}}"',
+        }
+        csharp_call = (
+            "client.Messages.SendNumberPool(new MessageSendNumberPoolParams "
+            '{ To = "+1" })'
+        )
+        csharp_live = {
+            "regular": f'$"{{{csharp_call}}}"',
+            "verbatim-dollar-first": f'$@"{{{csharp_call}}}"',
+            "verbatim-at-first": f'@$"{{{csharp_call}}}"',
+            "raw": f'$"""{{{csharp_call}}}"""',
+            "raw-two-dollar": f'$$"""{{{{{csharp_call}}}}}"""',
+            "alignment": f'$"{{{csharp_call},10}}"',
+        }
+        for language, suffix, forms in (
+            ("python", ".py", python_live),
+            ("csharp", ".cs", csharp_live),
+        ):
+            for label, literal in forms.items():
+                with self.subTest(language=language, shape=label):
+                    result = self.run_required_profile_analyzer(
+                        {f"live{suffix}": f"value = {literal}\n"}
+                    )
+                    rows = result.stdout.splitlines()
+                    self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+
+        inert = {
+            "python-escaped.py": f'f"{{{{{python_call}}}}}"',
+            "python-ordinary.py": f'"{{{python_call}}}"',
+            "python-format.py": (
+                f'f"{{value:{python_call}}}"'
+            ),
+            "csharp-escaped.cs": f'$"{{{{{csharp_call}}}}}"',
+            "csharp-ordinary.cs": f'"{{{csharp_call}}}"',
+            "csharp-format.cs": f'$"{{value:{csharp_call}}}"',
+            "csharp-raw.cs": f'"""{{{csharp_call}}}"""',
+        }
+        for fixture, source in inert.items():
+            with self.subTest(inert=fixture):
+                result = self.run_required_profile_analyzer(
+                    {fixture: f"value = {source};\n"}
+                )
+                self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+        # The public wrapper must block the reported missing-profile forms and
+        # accept their compliant twins in both languages.
+        for fixture, source, compliant in (
+            (
+                "live.py",
+                f'value = f"{{{python_call}}}"\n',
+                python_call.replace("'to': '+1'", "'to': '+1', 'messaging_profile_id': 'mp'"),
+            ),
+            (
+                "Live.cs",
+                f'value = $"{{{csharp_call}}}";\n',
+                csharp_call.replace('To = "+1"', 'To = "+1", MessagingProfileId = "mp"'),
+            ),
+        ):
+            with self.subTest(public=fixture, polarity="missing"):
+                _, payload = self.run_messaging_linter({fixture: source})
+                self.assert_required_profile_detected(payload, fixture)
+            with self.subTest(public=fixture, polarity="compliant"):
+                self.assert_required_profile_passes(
+                    {fixture: source.replace(python_call if fixture.endswith('.py') else csharp_call, compliant)}
+                )
+
+    def test_kotlin_and_scala_interpolation_preserve_only_expressions(
+        self,
+    ) -> None:
+        call = (
+            "client.messages.sendNumberPool(new MessageSendNumberPoolParams()"
+            '.setTo("+1"))'
+        )
+        live = {
+            "lower.kt": f'val value = "${{{call}}}"\n',
+            "script.kts": f'val value = "${{{call}}}"\n',
+            "raw.kt": f'val value = """${{{call}}}"""\n',
+            "s.scala": f'val value = s"${{{call}}}"\n',
+            "f.scala": f'val value = f"${{{call}}}%s"\n',
+            "raw.scala": f'val value = raw"""${{{call}}}"""\n',
+        }
+        for fixture, source in live.items():
+            with self.subTest(live=fixture):
+                result = self.run_required_profile_analyzer({fixture: source})
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+
+        inert = {
+            "escaped.kt": f'val value = "\\${{{call}}}"\n',
+            "ordinary.scala": f'val value = "${{{call}}}"\n',
+            "escaped.scala": f'val value = s"$${{{call}}}"\n',
+            "ordinary.java": f'String value = "${{{call}}}";\n',
+        }
+        for fixture, source in inert.items():
+            with self.subTest(inert=fixture):
+                result = self.run_required_profile_analyzer({fixture: source})
+                self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+    def test_shell_quoted_command_substitutions_remain_executable(
+        self,
+    ) -> None:
+        command = (
+            "curl -X POST https://api.telnyx.com/v2/messages/number_pool "
+            "-d '{\"to\":\"+1\"}'"
+        )
+        live = {
+            "dollar.sh": f'result="$({command})"\n',
+            "backtick.sh": f"result=`{command}`\n",
+            "nested.sh": f'result="$(printf %s "$({command})")"\n',
+        }
+        for fixture, source in live.items():
+            with self.subTest(live=fixture):
+                result = self.run_required_profile_analyzer({fixture: source})
+                rows = result.stdout.splitlines()
+                self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+
+        inert = {
+            "single.sh": f"result='$({command})'\n",
+            "escaped.sh": f'result="\\$({command})"\n',
+        }
+        for fixture, source in inert.items():
+            with self.subTest(inert=fixture):
+                result = self.run_required_profile_analyzer({fixture: source})
+                self.assertEqual("0", result.stdout.strip(), result.stdout)
+
     def test_profile_field_name_inside_message_text_does_not_satisfy_request(
         self,
     ) -> None:

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -754,12 +754,12 @@ class CorrectnessLinterContracts(unittest.TestCase):
             }
         )
         self.assertEqual(0, messaging_result.returncode, messaging_payload)
-        messaging_check = next(
+        messaging_checks = [
             check
             for check in messaging_payload["checks"]
             if check["name"] == "twilio_messages_create"
-        )
-        self.assertEqual("warn", messaging_check["status"])
+        ]
+        self.assertEqual([], messaging_checks)
 
         decoy_result, decoy_payload = self.run_messaging_linter(
             {
@@ -855,7 +855,7 @@ class CorrectnessLinterContracts(unittest.TestCase):
         )
         self.assertEqual("pass", check["status"], json.dumps(payload["checks"]))
 
-    def test_full_validation_forwards_discovery_webhook_context(self) -> None:
+    def test_full_validation_does_not_waive_unsigned_webhooks(self) -> None:
         with tempfile.TemporaryDirectory(prefix="telnyx-scan-context-") as directory:
             project = Path(directory)
             (project / "handler.js").write_text(
@@ -880,8 +880,9 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 check=False,
                 env={**os.environ, "TELNYX_API_KEY": ""},
             )
-        self.assertIn("original code did not validate webhooks either", result.stdout)
-        self.assertIn("Correctness checks passed", result.stdout)
+        self.assertNotIn("original code did not validate webhooks either", result.stdout)
+        self.assertIn("no Ed25519 signature verification", result.stdout)
+        self.assertIn("Correctness checks failed", result.stdout)
 
     def test_messaging_profile_linter_reads_every_js_module_extension(self) -> None:
         for suffix in self.JS_TS_FAMILY:
@@ -1050,7 +1051,7 @@ class CorrectnessLinterContracts(unittest.TestCase):
         check = next(
             item
             for item in payload["checks"]
-            if item["name"] == "gather_speech_model_attr"
+            if item["name"] == "speech_model_attr"
         )
         self.assertIn("ivr.xml:4", json.dumps(check), json.dumps(payload["checks"]))
 
@@ -1339,9 +1340,10 @@ class CorrectnessLinterContracts(unittest.TestCase):
         ]
         self.assertTrue(flagged, json.dumps(payload["checks"]))
 
-    def test_state_file_downgrades_residual_checks_to_warn(self) -> None:
-        # The linter had no hybrid mechanism at all: a kept-on-Twilio product
-        # the skill itself sanctioned hard-failed Phase 4 forever.
+    def test_state_file_does_not_cross_waive_selected_product(self) -> None:
+        # A retained TaskRouter product must not waive residual checks while
+        # validating Messaging. Hybrid state is scoped to the selected product;
+        # otherwise an unrelated retained product could hide live Twilio code.
         files = {
             "taskrouter_client.py": (
                 "from twilio.request_validator import RequestValidator\n"
@@ -1372,12 +1374,13 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 timeout=30,
                 check=False,
             )
-            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            self.assertEqual(1, result.returncode, result.stdout + result.stderr)
             payload = json.loads(result.stdout)
-            issues = [c for c in payload["checks"] if c["status"] == "issue"]
-            self.assertEqual([], issues, json.dumps(issues))
-            warns = [c for c in payload["checks"] if c["status"] == "warn"]
-            self.assertTrue(warns, "hybrid state produced no warns at all")
+            issues = {
+                c["name"] for c in payload["checks"] if c["status"] == "issue"
+            }
+            self.assertIn("twilio_webhook_middleware", issues)
+            self.assertIn("residual_twilio_imports", issues)
 
     def test_migration_comment_is_not_a_residual_import_in_linter(self) -> None:
         files = {
@@ -6792,7 +6795,7 @@ class AnalyzerConsistencyContracts(unittest.TestCase):
         self.assertIn("map to the corresponding TeXML element's `model`", skill)
         self.assertNotIn("non-Neural voices may fall back", skill)
         self.assertNotIn("non-Neural voices may fall back", verbs)
-        self.assertIn("Preserve a supported source voice verbatim", verbs)
+        self.assertIn("Preserve a documented provider-prefixed voice", verbs)
 
     def test_analyzer_and_shell_exclude_the_same_generated_directories(self) -> None:
         canonical = {

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -1,0 +1,6174 @@
+#!/usr/bin/env python3
+"""No-network contracts for the Twilio migration static analyzers."""
+
+from __future__ import annotations
+
+import json
+import os
+import pty
+import re
+import runpy
+import select
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BASH = shutil.which("bash") or "/bin/bash"
+MIGRATION_SCRIPTS = (
+    ROOT
+    / "skills"
+    / "telnyx-twilio-migration"
+    / "scripts"
+    / "test-migration"
+)
+CORRECTNESS_LINTER = MIGRATION_SCRIPTS.parent / "lint-telnyx-correctness.sh"
+MESSAGING_SOURCE_ANALYZER = (
+    MIGRATION_SCRIPTS.parent / "lint-required-messaging-profile.py"
+)
+PREFLIGHT_SCRIPT = MIGRATION_SCRIPTS.parent / "preflight-check.sh"
+TEXML_VALIDATOR = MIGRATION_SCRIPTS.parent / "validate-texml.sh"
+FILTER_SOURCE_SCRIPT = MIGRATION_SCRIPTS.parent / "filter-source-matches.py"
+SMOKE_SCRIPT = MIGRATION_SCRIPTS / "smoke-test.sh"
+WEBHOOK_FIXTURE_SCRIPT = MIGRATION_SCRIPTS / "test-webhooks-local.py"
+FAKE_DRIVER_ENV = "TELNYX_MIGRATION_FAKE_DRIVER"
+SCENARIO_ENV = "TELNYX_MIGRATION_FAKE_SCENARIO"
+LOG_ENV = "TELNYX_MIGRATION_FAKE_LOG"
+VALID_JWT = (
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJleHAiOjQxMDI0NDQ4MDB9.c2ln"
+)
+
+class CorrectnessLinterProductArgument(unittest.TestCase):
+    """--product must fail loudly. An unrecognised value matches no check's
+    product list, so every product-scoped check silently disappears and the
+    linter still exits 0 — a typo certifies the migration."""
+
+    maxDiff = None
+
+    def run_product(self, product: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory(prefix="telnyx-linter-product-") as directory:
+            (Path(directory) / "noop.txt").write_text("noop\n", encoding="utf-8")
+            return subprocess.run(
+                [BASH, str(CORRECTNESS_LINTER), directory, "--product", product],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+
+    def test_shell_endpoint_unknown_product_exits_two(self) -> None:
+        result = self.run_product("mesaging")
+        self.assertEqual(2, result.returncode, result.stdout + result.stderr)
+        self.assertIn("Unknown product 'mesaging'", result.stderr)
+
+    def test_shell_endpoint_known_products_are_accepted(self) -> None:
+        for product in (
+            "voice",
+            "messaging",
+            "verify",
+            "webrtc",
+            "sip",
+            "fax",
+            "video",
+            "iot",
+            "lookup",
+        ):
+            with self.subTest(product=product):
+                result = self.run_product(product)
+                self.assertEqual(
+                    0, result.returncode, result.stdout + result.stderr
+                )
+
+
+class CorrectnessLinterContracts(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if shutil.which("jq") is None:
+            raise RuntimeError("jq is required by the correctness-linter contract tests")
+
+    def run_messaging_linter(
+        self, files: dict[str, str], *, product: str = "messaging"
+    ) -> tuple[subprocess.CompletedProcess[str], dict[str, Any]]:
+        with tempfile.TemporaryDirectory(prefix="telnyx-linter-contracts-") as directory:
+            project_root = Path(directory)
+            for relative_path, contents in files.items():
+                fixture_path = project_root / relative_path
+                fixture_path.parent.mkdir(parents=True, exist_ok=True)
+                fixture_path.write_text(contents, encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    BASH,
+                    str(CORRECTNESS_LINTER),
+                    str(project_root),
+                    "--product",
+                    product,
+                    "--json",
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            self.assertIn(
+                result.returncode,
+                {0, 1},
+                f"linter execution failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            try:
+                payload = json.loads(result.stdout)
+            except json.JSONDecodeError as error:
+                self.fail(
+                    f"linter did not emit valid JSON: {error}\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+                )
+            return result, payload
+
+    def run_required_profile_analyzer(
+        self, files: dict[str, str]
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory(prefix="telnyx-source-analyzer-") as directory:
+            project_root = Path(directory)
+            for relative_path, contents in files.items():
+                fixture_path = project_root / relative_path
+                fixture_path.parent.mkdir(parents=True, exist_ok=True)
+                fixture_path.write_text(contents, encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, "-B", str(MESSAGING_SOURCE_ANALYZER), str(project_root)],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+
+    def test_documented_mapping_prose_is_not_residual_twilio(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                # Mixed casing matters on Linux even though macOS resolves it.
+                "Readme.md": (
+                    "A Messaging Profile is the Telnyx equivalent of a "
+                    "Twilio Messaging Service.\n"
+                    "Behavior change from the Twilio integration: national "
+                    "number normalization is no longer automatic.\n"
+                    "Badge: https://github.com/TwilioDevEd/example/actions/"
+                    "workflows/test.yml/badge.svg\n"
+                    "Clone: git@github.com:TwilioDevEd/example.git\n"
+                )
+            }
+        )
+        check = next(
+            item
+            for item in payload["checks"]
+            if item["name"] == "docs_still_twilio"
+        )
+        self.assertEqual("pass", check["status"], payload)
+        self.assertEqual(0, result.returncode, result.stdout)
+
+    def run_filter_source_matches(
+        self, filename: str, source: str, mode: str, pattern: str
+    ) -> str:
+        with tempfile.TemporaryDirectory(prefix="filter-source-") as directory:
+            path = Path(directory) / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(source, encoding="utf-8")
+            lines = source.splitlines()
+            grep_output = "".join(
+                f"{path}:{i + 1}:{line}\n"
+                for i, line in enumerate(lines)
+                if line.strip()
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-B",
+                    str(FILTER_SOURCE_SCRIPT),
+                    "--mode",
+                    mode,
+                    "--pattern",
+                    pattern,
+                    "--analyzer",
+                    str(MESSAGING_SOURCE_ANALYZER),
+                ],
+                input=grep_output,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            return result.stdout
+
+    def test_filter_source_matches_strips_comments_keeps_strings(self) -> None:
+        # A comment-only match is filtered; a string match is preserved.
+        output = self.run_filter_source_matches(
+            "app.js",
+            "// from twilio import Client\n"
+            'const msg = "from twilio removed";\n'
+            "from twilio.rest import Client\n",
+            "comments",
+            "from twilio",
+        )
+        kept_lines = [line for line in output.splitlines() if line.strip()]
+        # Line 1 (comment) should be stripped; lines 2 and 3 kept.
+        self.assertEqual(2, len(kept_lines), output)
+        self.assertNotIn(":1:", kept_lines[0])
+        self.assertIn(":2:", kept_lines[0])
+        self.assertIn(":3:", kept_lines[1])
+
+    def test_filter_source_matches_code_mode_masks_strings(self) -> None:
+        # In code mode, string content is masked so VoiceResponse in a
+        # string literal is not reported as live code.
+        output = self.run_filter_source_matches(
+            "app.js",
+            'const msg = "VoiceResponse() removed";\n'
+            "const x = VoiceResponse();\n",
+            "code",
+            "VoiceResponse",
+        )
+        kept_lines = [line for line in output.splitlines() if line.strip()]
+        # Only the live code line (2) should survive.
+        self.assertEqual(1, len(kept_lines), output)
+        self.assertIn(":2:", kept_lines[0])
+
+    def assert_required_profile_detected(
+        self, payload: dict[str, Any], fixture_name: str
+    ) -> None:
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertTrue(checks, "required-profile check was not emitted")
+        self.assertTrue(
+            any(check["status"] in {"warn", "issue"} for check in checks),
+            f"required-profile misuse was incorrectly reported as passing: {checks}",
+        )
+        self.assertIn(fixture_name, json.dumps(checks))
+
+    def test_dead_comments_and_quoted_prose_are_not_live_voice_code(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "app.js": (
+                    "// old endpoint: https://api.twilio.com/2010-04-01\n"
+                    "const active = true; // VoiceResponse() was removed\n"
+                    '"VoiceResponse() removed";\n'
+                )
+            },
+            product="voice",
+        )
+        statuses = {check["name"]: check["status"] for check in payload["checks"]}
+        self.assertEqual("pass", statuses.get("voice_response_builder"), statuses)
+        self.assertEqual(0, result.returncode, result.stdout)
+
+    def assert_required_profile_passes(self, files: dict[str, str]) -> None:
+        result, payload = self.run_messaging_linter(files)
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+        self.assertEqual(0, result.returncode)
+
+    def assert_required_profile_flagged(self, files: dict[str, str]) -> None:
+        result, payload = self.run_messaging_linter(files)
+        self.assertEqual(1, result.returncode, payload)
+        self.assert_required_profile_detected(payload, next(iter(files)))
+
+    def test_compact_control_flow_guards_are_language_complete(self) -> None:
+        fixtures = {
+            "compact.py": (
+                "import requests\npayload={'to': '+1', 'text': 'hi'}\n"
+                "if use_pool: payload['messaging_profile_id'] = profile\n"
+                "requests.post('https://api.telnyx.com/v2/messages/number_pool', json=payload)\n"
+            ),
+            "modifier.rb": (
+                "payload = {to: '+1', text: 'hi'}\n"
+                "payload[:messaging_profile_id] = profile if use_pool\n"
+                "client.post('https://api.telnyx.com/v2/messages/number_pool', payload)\n"
+            ),
+            "alternate.php": (
+                "<?php\n$payload = ['to' => '+1', 'text' => 'hi'];\n"
+                "if ($usePool):\n  $payload['messaging_profile_id'] = $profile;\nendif;\n"
+                "$client->post('https://api.telnyx.com/v2/messages/number_pool', $payload);\n"
+            ),
+            "compact.sh": (
+                "payload='{\"to\":\"+1\",\"text\":\"hi\"}'\n"
+                "enabled && payload='{\"to\":\"+1\",\"text\":\"hi\",\"messaging_profile_id\":\"MP\"}'\n"
+                "curl -X POST https://api.telnyx.com/v2/messages/number_pool -d \"$payload\"\n"
+            ),
+            "short-circuit.js": (
+                "const payload = {to: '+1', text: 'hi'};\n"
+                "usePool && (payload.messaging_profile_id = profile);\n"
+                "fetch('https://api.telnyx.com/v2/messages/number_pool', "
+                "{method: 'POST', body: JSON.stringify(payload)});\n"
+            ),
+            "ternary.ts": (
+                "const payload = {to: '+1', text: 'hi'};\n"
+                "usePool ? (payload.messaging_profile_id = profile) : null;\n"
+                "fetch('https://api.telnyx.com/v2/messages/number_pool', "
+                "{method: 'POST', body: JSON.stringify(payload)});\n"
+            ),
+        }
+        for filename, source in fixtures.items():
+            with self.subTest(filename=filename):
+                analyzer = self.run_required_profile_analyzer({filename: source})
+                lines = analyzer.stdout.splitlines()
+                self.assertEqual(0, analyzer.returncode, analyzer.stderr)
+                self.assertGreater(int(lines[0]), 0, analyzer.stdout)
+                self.assertGreater(len(lines), 1, analyzer.stdout)
+                self.assert_required_profile_flagged({filename: source})
+
+    def test_required_endpoint_builder_family_is_fail_safe(self) -> None:
+        fixtures = {
+            "urljoin.py": (
+                "from urllib.parse import urljoin\nimport requests\n"
+                "requests.post(urljoin('https://api.telnyx.com/v2/', 'messages/number_pool'), "
+                "json={'to': '+1', 'text': 'hi'})\n"
+            ),
+            "percent.py": (
+                "import requests\n"
+                "requests.post('%s/v2/messages/number_pool' % host, "
+                "json={'to': '+1', 'text': 'hi'})\n"
+            ),
+            "encode.js": (
+                "fetch(encodeURI('https://api.telnyx.com/v2/messages/number_pool'), "
+                "{method: 'POST', body: JSON.stringify({to: '+1', text: 'hi'})});\n"
+            ),
+            "concat.js": (
+                "const base = 'https://api.telnyx.com/v2';\n"
+                "fetch(base.concat('/messages/number_pool'), "
+                "{method: 'POST', body: JSON.stringify({to: '+1', text: 'hi'})});\n"
+            ),
+            "join.js": (
+                "fetch(['https://api.telnyx.com/v2/messages', 'number_pool'].join('/'), "
+                "{method: 'POST', body: JSON.stringify({to: '+1', text: 'hi'})});\n"
+            ),
+            "path-join-commonjs.js": (
+                "const {join} = require('path');\n"
+                "fetch(join('https://api.telnyx.com/v2', 'messages', 'number_pool'), "
+                "{method: 'POST', body: JSON.stringify({to: '+1', text: 'hi'})});\n"
+            ),
+            "path-join-posix.cjs": (
+                "const {join: pathJoin} = require('node:path').posix;\n"
+                "fetch(pathJoin('https://api.telnyx.com/v2', 'messages', 'number_pool'), "
+                "{method: 'POST', body: JSON.stringify({to: '+1', text: 'hi'})});\n"
+            ),
+            "path-join-esm.mjs": (
+                "import {join as pathJoin} from 'node:path';\n"
+                "fetch(pathJoin('https://api.telnyx.com/v2', 'messages', 'number_pool'), "
+                "{method: 'POST', body: JSON.stringify({to: '+1', text: 'hi'})});\n"
+            ),
+            "path-join-assigned.js": (
+                "const pathJoin = require('path').posix.join;\n"
+                "fetch(pathJoin('https://api.telnyx.com/v2', 'messages', 'number_pool'), "
+                "{method: 'POST', body: JSON.stringify({to: '+1', text: 'hi'})});\n"
+            ),
+            "sprintf.go": (
+                "package main\nimport (\"bytes\"; \"fmt\"; \"net/http\")\n"
+                "func send(host string) { http.Post(fmt.Sprintf(\"%s/v2/messages/number_pool\", host), "
+                "\"application/json\", bytes.NewBuffer([]byte(`{\"to\":\"+1\",\"text\":\"hi\"}`))) }\n"
+            ),
+            "format.java": (
+                "client.post(String.format(\"%s/v2/messages/number_pool\", host), payload);\n"
+            ),
+            "guzzle.php": (
+                "<?php\n$client = new Client(['base_uri' => 'https://api.telnyx.com/v2/messages/']);\n"
+                "$client->post('number_pool', ['json' => ['to' => '+1', 'text' => 'hi']]);\n"
+            ),
+            "faraday.rb": (
+                "client = Faraday.new(url: 'https://api.telnyx.com/v2/messages/')\n"
+                "client.post('number_pool', {to: '+1', text: 'hi'}.to_json)\n"
+            ),
+            "base-address.cs": (
+                "var client = new HttpClient();\n"
+                "client.BaseAddress = new Uri(\"https://api.telnyx.com/v2/messages/\");\n"
+                "client.PostAsync(\"number_pool\", new StringContent(\"{}\"));\n"
+            ),
+        }
+        for filename, source in fixtures.items():
+            with self.subTest(filename=filename):
+                analyzer = self.run_required_profile_analyzer({filename: source})
+                lines = analyzer.stdout.splitlines()
+                self.assertEqual(0, analyzer.returncode, analyzer.stderr)
+                self.assertGreater(int(lines[0]), 0, analyzer.stdout)
+                self.assertGreater(len(lines), 1, analyzer.stdout)
+                self.assert_required_profile_flagged({filename: source})
+
+    def test_node_path_join_aliases_respect_binding_identity(self) -> None:
+        endpoint_args = (
+            "'https://api.telnyx.com/v2', 'messages', 'number_pool'"
+        )
+        request = (
+            "fetch(join(%s), {method:'POST', "
+            "body:JSON.stringify({to:'+1'})});" % endpoint_args
+        )
+        # The imported/CommonJS binding is a URL builder.
+        self.assert_required_profile_flagged(
+            {"bound.js": "const {join}=require('path');\n" + request}
+        )
+        derived_bindings = {
+            "cjs-module.js": (
+                "const path=require('path'); const {join}=path;\n" + request
+            ),
+            "esm-module.mjs": (
+                "import path from 'node:path'; const {join}=path;\n" + request
+            ),
+            "copied.js": (
+                "const path=require('path'); const join=path.join;\n" + request
+            ),
+        }
+        for filename, source in derived_bindings.items():
+            with self.subTest(filename=filename):
+                self.assert_required_profile_flagged({filename: source})
+        # A parameter, local declaration, or later assignment with the same
+        # spelling is a different value and must not inherit path.join's
+        # identity merely because an earlier import exists in the file.
+        safe = {
+            "parameter.js": (
+                "const {join}=require('path');\n"
+                "function send(join) {" + request + "}\n"
+            ),
+            "local.js": (
+                "const {join}=require('path');\n"
+                "function send() { const join=customJoin; " + request + "}\n"
+            ),
+            "reassigned.js": (
+                "let {join}=require('path'); join=customJoin;\n" + request
+            ),
+            "unrelated.js": (
+                "const {join}=require('other-library');\n" + request
+            ),
+        }
+        for filename, source in safe.items():
+            with self.subTest(filename=filename):
+                self.assert_required_profile_passes({filename: source})
+
+        self.assert_required_profile_passes({
+            "unrelated-join.js": (
+                "const {join} = require('other-library');\n"
+                "fetch(join('/v2/messages', 'number_pool'), "
+                "{method: 'POST', body: JSON.stringify({to: '+1', text: 'hi'})});\n"
+            )
+        })
+
+    def test_profile_value_evidence_rejects_empty_expression_family(self) -> None:
+        values = ("'   '", "String()", "'' + ''", "process.env.MP || ''")
+        for value in values:
+            with self.subTest(value=value):
+                self.assert_required_profile_flagged({
+                    "send.js": (
+                        "fetch('https://api.telnyx.com/v2/messages/number_pool', {"
+                        "method: 'POST', body: JSON.stringify({to: '+1', text: 'hi', "
+                        f"messaging_profile_id: {value}" + "})});\n"
+                    )
+                })
+
+        self.assert_required_profile_flagged({
+            "send.py": (
+                "import os, requests\n"
+                "requests.post('https://api.telnyx.com/v2/messages/number_pool', "
+                "json={'to': '+1', 'text': 'hi', "
+                "'messaging_profile_id': os.environ.get('MP')})\n"
+            )
+        })
+        self.assert_required_profile_passes({
+            "send.py": (
+                "import os, requests\n"
+                "requests.post('https://api.telnyx.com/v2/messages/number_pool', "
+                "json={'to': '+1', 'text': 'hi', "
+                "'messaging_profile_id': os.environ.get('MP', 'MP_default')})\n"
+            )
+        })
+
+    def test_valid_guzzle_json_profile_is_not_reported_missing(self) -> None:
+        result, payload = self.run_messaging_linter({
+            "send.php": (
+                "<?php\n$client->post('https://api.telnyx.com/v2/messages/number_pool', "
+                "['json' => ['to' => '+1', 'text' => 'hi', "
+                "'messaging_profile_id' => 'MP_valid']]);\n"
+            )
+        })
+        self.assertEqual(0, result.returncode, payload)
+
+    # An extension is not a language. Node resolves .cjs/.mjs and TypeScript
+    # resolves .cts/.mts as the same source, and SKILL.md documents a CommonJS
+    # flow, so a check that globs only the bare extension silently approves a
+    # broken migration. Both linters must see every member of the family.
+    JS_TS_FAMILY = (
+        ".cjs",
+        ".cts",
+        ".js",
+        ".jsx",
+        ".mjs",
+        ".mts",
+        ".ts",
+        ".tsx",
+    )
+
+    def test_messaging_profile_linter_reads_every_js_module_extension(self) -> None:
+        for suffix in self.JS_TS_FAMILY:
+            with self.subTest(suffix=suffix):
+                name = f"send{suffix}"
+                files = {
+                    name: (
+                        "const telnyx = require('telnyx')(process.env.KEY);\n"
+                        "async function send(to, text) {\n"
+                        "  return await telnyx.messages.sendNumberPool("
+                        "{ to: to, text: text });\n"
+                        "}\n"
+                    )
+                }
+                _, payload = self.run_messaging_linter(files)
+                self.assert_required_profile_detected(payload, name)
+
+    def test_language_aliases_are_analysed_as_their_canonical_language(self) -> None:
+        # An extension is not a language. A .bash file is a shell script and a
+        # .phtml file is PHP, but every downstream check compares against the
+        # canonical suffix, so an alias was read as an unknown language and
+        # produced no findings at all — the migration passed while broken.
+        shell_body = (
+            "#!/usr/bin/env bash\n"
+            'curl -X POST "https://api.telnyx.com/v2/messages/number_pool" \\\n'
+            '  -H "Content-Type: application/json" \\\n'
+            "  -d '{\"to\":\"+15551234567\",\"text\":\"hi\"%s}'\n"
+        )
+        php_body = (
+            "<?php\n"
+            '$client->post("https://api.telnyx.com/v2/messages/number_pool", '
+            '["json" => ["to" => "+1", "text" => "hi"%s]]);\n'
+        )
+        families = (
+            (".sh", (".bash", ".ksh", ".zsh"), shell_body,
+             ',"messaging_profile_id":"abc"'),
+            (".php", (".phtml",), php_body,
+             ', "messaging_profile_id" => "abc"'),
+        )
+
+        def statuses(suffix: str, body: str) -> list:
+            _, payload = self.run_messaging_linter({f"send{suffix}": body})
+            return [
+                check["status"]
+                for check in payload["checks"]
+                if check["name"] == "required_messaging_profile_id"
+            ]
+
+        for canonical, aliases, template, profile in families:
+            violating = template % ""
+            compliant = template % profile
+            # Parity, not an absolute verdict. This linter is deliberately
+            # conservative and reports some compliant shapes it cannot prove;
+            # asserting "alias passes" would encode that conservatism as a
+            # requirement. What must hold is that an alias is analysed exactly
+            # as its canonical language — same verdict, same input.
+            for body, label in ((violating, "violating"), (compliant, "compliant")):
+                expected = statuses(canonical, body)
+                for alias in aliases:
+                    with self.subTest(alias=alias, body=label):
+                        self.assertEqual(
+                            expected,
+                            statuses(alias, body),
+                            f"{alias} is not analysed as {canonical}",
+                        )
+            # The violating case must genuinely be caught, or the parity above
+            # would be satisfied by both being silent.
+            self.assertTrue(
+                any(status in {"warn", "issue"} for status in statuses(canonical, violating)),
+                f"{canonical} did not flag a missing profile at all",
+            )
+
+    # Each entry: (label, filename, violating, compliant). Violating sends to
+    # /v2/messages/number_pool without messaging_profile_id and must be
+    # flagged; the compliant twin adds the profile and must pass. These are
+    # the stdlib HTTP clients of each ecosystem — no third-party SDK — which
+    # is exactly what hand-rolled migrated code uses.
+    STDLIB_CLIENT_SHAPES = (
+        (
+            "go_new_request",
+            "notify.go",
+            'package main\n\nfunc sendPoolSMS(to, text string) error {\n'
+            '\tpayload := map[string]string{"to": to, "text": text%s}\n'
+            "\tbody, _ := json.Marshal(payload)\n"
+            '\treq, err := http.NewRequest("POST", "https://api.telnyx.com/v2/messages/number_pool", bytes.NewBuffer(body))\n'
+            "\t_, err = http.DefaultClient.Do(req)\n\treturn err\n}\n",
+            ', "messaging_profile_id": os.Getenv("PROFILE")',
+        ),
+        (
+            "ruby_net_http_post",
+            "notify.rb",
+            "require 'net/http'\n\ndef send_pool_sms(to, text)\n"
+            "  Net::HTTP.post(\n"
+            "    URI('https://api.telnyx.com/v2/messages/number_pool'),\n"
+            "    { to: to, text: text%s }.to_json,\n"
+            "    'Content-Type' => 'application/json'\n  )\nend\n",
+            ", messaging_profile_id: ENV['PROFILE']",
+        ),
+        (
+            "ruby_post_form",
+            "notify.rb",
+            "require 'net/http'\n\ndef send_pool_sms(to, text)\n"
+            "  Net::HTTP.post_form(\n"
+            "    URI('https://api.telnyx.com/v2/messages/number_pool'),\n"
+            "    'to' => to, 'text' => text%s\n  )\nend\n",
+            ", 'messaging_profile_id' => ENV['PROFILE']",
+        ),
+        (
+            "java_builder",
+            "Notify.java",
+            "import java.net.URI;\nimport java.net.http.HttpRequest;\n\n"
+            "public class Notify {\n"
+            "    public void sendPoolSms(String to, String text) throws Exception {\n"
+            '        String json = "{\\"to\\": \\"+1\\", \\"text\\": \\"hi\\"%s}";\n'
+            "        HttpRequest request = HttpRequest.newBuilder()\n"
+            '            .uri(URI.create("https://api.telnyx.com/v2/messages/number_pool"))\n'
+            '            .header("Content-Type", "application/json")\n'
+            "            .POST(HttpRequest.BodyPublishers.ofString(json))\n"
+            "            .build();\n    }\n}\n",
+            ', \\"messaging_profile_id\\": \\"abc\\"',
+        ),
+        (
+            "php_curl",
+            "notify.php",
+            "<?php\nfunction send_pool_sms($to, $text) {\n"
+            '    $payload = ["to" => $to, "text" => $text%s];\n'
+            "    $ch = curl_init();\n"
+            '    curl_setopt($ch, CURLOPT_URL, "https://api.telnyx.com/v2/messages/number_pool");\n'
+            "    curl_setopt($ch, CURLOPT_POST, true);\n"
+            "    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));\n"
+            "    return curl_exec($ch);\n}\n",
+            ', "messaging_profile_id" => getenv("PROFILE")',
+        ),
+        (
+            "node_https_request",
+            "notify.js",
+            "const https = require('https');\n\nfunction sendPoolSms(to, text) {\n"
+            "  const payload = JSON.stringify({ to, text%s });\n"
+            "  const req = https.request({\n"
+            "    hostname: 'api.telnyx.com',\n"
+            "    path: '/v2/messages/number_pool',\n"
+            "    method: 'POST',\n"
+            "  });\n  req.write(payload);\n  req.end();\n}\n",
+            ", messaging_profile_id: process.env.PROFILE",
+        ),
+    )
+
+    def test_stdlib_http_clients_are_visible_to_the_profile_check(self) -> None:
+        for label, name, template, profile in self.STDLIB_CLIENT_SHAPES:
+            with self.subTest(shape=label, body="violating"):
+                _, payload = self.run_messaging_linter({name: template % ""})
+                self.assert_required_profile_detected(payload, name)
+            with self.subTest(shape=label, body="compliant"):
+                self.assert_required_profile_passes({name: template % profile})
+
+    def test_extensionless_shebang_send_is_analyzed(self) -> None:
+        # package.json "bin" entry points have no extension; the analyzer
+        # refused to open them while the Phase-1 scanner reported them.
+        body = (
+            "#!/usr/bin/env node\n"
+            "fetch('https://api.telnyx.com/v2/messages/number_pool', "
+            "{method: 'POST', body: JSON.stringify({to: '+1'%s})});\n"
+        )
+        _, payload = self.run_messaging_linter({"bin/send-pool": body % ""})
+        self.assert_required_profile_detected(payload, "send-pool")
+        self.assert_required_profile_passes(
+            {"bin/send-pool": body % ", messaging_profile_id: 'abc'"}
+        )
+
+    def test_uppercase_and_extensionless_python_sources_are_linted(self) -> None:
+        # SMSBOT.PY and an extensionless #!/usr/bin/env python3 executable are
+        # the same Python module as smsbot.py; both passed every check.
+        body = (
+            "from twilio.twiml.messaging_response import MessagingResponse\n"
+            "resp = MessagingResponse()\n"
+        )
+        for name, contents in (
+            ("SMSBOT.PY", body),
+            ("smsbot", "#!/usr/bin/env python3\n" + body),
+        ):
+            with self.subTest(file=name):
+                _, payload = self.run_messaging_linter({name: contents})
+                flagged = [
+                    c
+                    for c in payload["checks"]
+                    if c["status"] in {"warn", "issue"}
+                    and "messaging_response" in c["name"]
+                ]
+                self.assertTrue(
+                    flagged,
+                    f"{name} passed every check: {json.dumps(payload['checks'])}",
+                )
+
+    def test_embedded_texml_analyzer_skips_generated_output(self) -> None:
+        # The shell EXCLUDE_DIRS was aligned to the canonical list, but the
+        # embedded Python analyzer walks the tree itself with its own
+        # excluded_dirs — a stale .next bundle re-entered through that side
+        # door and failed a corrected project. Same one-layer-fixed class as
+        # the original finding.
+        gather = (
+            "export const x = `<Gather speechModel=\"phone_call\" "
+            'input="speech"></Gather>`;\n'
+        )
+        _, payload = self.run_messaging_linter(
+            {".next/server/pages/voice.js": gather}, product="voice"
+        )
+        flagged = [
+            c
+            for c in payload["checks"]
+            if c["status"] in {"warn", "issue"} and "speech_model" in c["name"]
+        ]
+        self.assertEqual([], flagged, json.dumps(flagged))
+
+        # Same content in source must still be flagged.
+        _, payload = self.run_messaging_linter(
+            {"src/voice.js": gather}, product="voice"
+        )
+        flagged = [
+            c
+            for c in payload["checks"]
+            if c["status"] in {"warn", "issue"} and "speech_model" in c["name"]
+        ]
+        self.assertTrue(flagged, json.dumps(payload["checks"]))
+
+    def test_state_file_downgrades_residual_checks_to_warn(self) -> None:
+        # The linter had no hybrid mechanism at all: a kept-on-Twilio product
+        # the skill itself sanctioned hard-failed Phase 4 forever.
+        files = {
+            "taskrouter_client.py": (
+                "from twilio.request_validator import RequestValidator\n"
+                "validator = RequestValidator(token)\n"
+            ),
+            "migration-state.json": json.dumps(
+                {"kept_on_twilio": {"taskrouter": "no equivalent"}}
+            ),
+        }
+        with tempfile.TemporaryDirectory(prefix="lint-hybrid-") as directory:
+            root = Path(directory)
+            for relative, contents in files.items():
+                (root / relative).write_text(contents, encoding="utf-8")
+            result = subprocess.run(
+                [
+                    BASH,
+                    str(CORRECTNESS_LINTER),
+                    str(root),
+                    "--product",
+                    "messaging",
+                    "--json",
+                    "--state-file",
+                    str(root / "migration-state.json"),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            payload = json.loads(result.stdout)
+            issues = [c for c in payload["checks"] if c["status"] == "issue"]
+            self.assertEqual([], issues, json.dumps(issues))
+            warns = [c for c in payload["checks"] if c["status"] == "warn"]
+            self.assertTrue(warns, "hybrid state produced no warns at all")
+
+    def test_migration_comment_is_not_a_residual_import_in_linter(self) -> None:
+        files = {
+            "app.py": (
+                "import telnyx\n"
+                "# NOTE: migrated from twilio to telnyx 2026-08\n"
+            )
+        }
+        _, payload = self.run_messaging_linter(files)
+        flagged = [
+            c
+            for c in payload["checks"]
+            if c["status"] in {"warn", "issue"}
+            and c["name"] == "residual_twilio_imports"
+        ]
+        self.assertEqual([], flagged, json.dumps(flagged))
+
+    def test_factory_created_rest_clients_are_scanned(self) -> None:
+        # requests.Session().post(...) and axios.create(...).post(...) have a
+        # factory-call receiver, so call_receiver() returns None and the
+        # anonymous-receiver guard dropped them before URL/payload analysis —
+        # a number-pool send through a very common client shape passed clean.
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        cases = {
+            "session.py": (
+                "import requests\n"
+                "def send(to, text):\n"
+                f"    return requests.Session().post('{url}', "
+                "json={'to': to, 'text': text%s})\n"
+            ),
+            # requests.session() is the documented lowercase alias.
+            "session_lower.py": (
+                "import requests\n"
+                "def send(to, text):\n"
+                f"    return requests.session().post('{url}', "
+                "json={'to': to, 'text': text%s})\n"
+            ),
+            "httpx_client.py": (
+                "import httpx\n"
+                "def send(to, text):\n"
+                f"    return httpx.Client().post('{url}', "
+                "json={'to': to, 'text': text%s})\n"
+            ),
+            "axios.js": (
+                "const axios = require('axios');\n"
+                "const api = axios.create({ baseURL: 'https://api.telnyx.com/v2' });\n"
+                "async function send(to, text) {\n"
+                "  return api.post('/messages/number_pool', "
+                "{ to, text%s });\n"
+                "}\n"
+            ),
+            "inline_axios.js": (
+                "const axios = require('axios');\n"
+                "async function send(to, text) {\n"
+                f"  return axios.create({{}}).post('{url}', "
+                "{ to, text%s });\n"
+                "}\n"
+            ),
+            "new_client.js": (
+                "async function send(to, text) {\n"
+                f"  return new Client().post('{url}', "
+                "{ to, text%s });\n"
+                "}\n"
+            ),
+        }
+        for name, template in cases.items():
+            with self.subTest(shape=name, body="violating"):
+                _, payload = self.run_messaging_linter({name: template % ""})
+                self.assert_required_profile_detected(payload, name)
+            with self.subTest(shape=name, body="compliant"):
+                profile = (
+                    ", 'messaging_profile_id': 'abc'"
+                    if name.endswith(".py")
+                    else ", messaging_profile_id: 'abc'"
+                )
+                self.assert_required_profile_passes({name: template % profile})
+
+    def test_statically_unusable_profile_values_are_rejected(self) -> None:
+        # messaging_profile_id present but falsy/empty (false, true, 0, [], {},
+        # '') is unusable — the Messages API receives an invalid profile — so
+        # it must be treated as missing (shape vs value).
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        for value in ("false", "true", "0", "[]", "{}", "''", '""'):
+            with self.subTest(js_value=value):
+                name = "send.js"
+                _, payload = self.run_messaging_linter(
+                    {
+                        name: (
+                            f"fetch('{url}', {{method:'POST', body: "
+                            f"JSON.stringify({{to:'+1', messaging_profile_id: {value}}})}});"
+                        )
+                    }
+                )
+                self.assert_required_profile_detected(payload, name)
+        for value in ("False", "[]", "{}", "0"):
+            with self.subTest(py_value=value):
+                name = "send.py"
+                _, payload = self.run_messaging_linter(
+                    {name: f"requests.post('{url}', json={{'to':'+1','messaging_profile_id': {value}}})"}
+                )
+                self.assert_required_profile_detected(payload, name)
+        # A usable value must still pass: string, non-zero number, env var.
+        for value in ("'abc'", "123", "process.env.MP"):
+            with self.subTest(valid=value):
+                self.assert_required_profile_passes(
+                    {
+                        "ok.js": (
+                            f"fetch('{url}', {{method:'POST', body: "
+                            f"JSON.stringify({{to:'+1', messaging_profile_id: {value}}})}});"
+                        )
+                    }
+                )
+
+    def test_url_constructor_base_is_combined_with_the_path(self) -> None:
+        # new URL(path, base) resolves the path relative to the base, so
+        # new URL('number_pool', 'https://.../messages/') targets number_pool.
+        # Unwrapping to the first arg alone classified the send as safe.
+        base = "https://api.telnyx.com/v2/messages/"
+        template = (
+            "fetch(new URL('number_pool', '%s'), {method:'POST', "
+            "body: JSON.stringify({to:'+1'%%s})});" % base
+        )
+        with self.subTest(body="violating"):
+            _, payload = self.run_messaging_linter({"send.js": template % ""})
+            self.assert_required_profile_detected(payload, "send.js")
+        with self.subTest(body="compliant"):
+            self.assert_required_profile_passes(
+                {"send.js": template % ", messaging_profile_id:'a'"}
+            )
+        # A base to /messages with a non-pool path is not a number-pool send.
+        self.assert_required_profile_passes(
+            {
+                "other.js": (
+                    "fetch(new URL('/', 'https://api.telnyx.com/v2/messages/'), "
+                    "{method:'POST', body: JSON.stringify({to:'+1'})});"
+                )
+            }
+        )
+        # RFC 3986: a base WITHOUT a trailing slash drops its last segment, so
+        # new URL('number_pool', '.../messages') resolves to .../number_pool —
+        # NOT a number-pool send. Naive concatenation would false-positive.
+        self.assert_required_profile_passes(
+            {
+                "noslash.js": (
+                    "fetch(new URL('number_pool', 'https://api.telnyx.com/v2/messages'), "
+                    "{method:'POST', body: JSON.stringify({to:'+1'})});"
+                )
+            }
+        )
+        # Java's new URI(scheme, ssp) is not (path, base); combining its
+        # arguments must not misclassify it.
+        self.assert_required_profile_passes(
+            {
+                "Send.java": (
+                    'HttpRequest.newBuilder().uri(new URI("number_pool", '
+                    '"https://api.telnyx.com/v2/messages/")).POST('
+                    'HttpRequest.BodyPublishers.ofString("{}")).build();'
+                )
+            }
+        )
+
+    def test_client_base_url_is_combined_with_the_request_path(self) -> None:
+        # A client base URL makes the request path relative. The effective
+        # endpoint is base + path, so a base ending in /messages with a
+        # /number_pool path is a number-pool send. Both the inline and the
+        # idiomatic variable form must resolve.
+        base = "https://api.telnyx.com/v2/messages"
+        forms = {
+            "inline.js": f"axios.create({{baseURL:'{base}'}}).post('/number_pool', {{to:'+1'%s}});",
+            "variable.js": (
+                f"const api = axios.create({{baseURL:'{base}'}});\n"
+                "api.post('/number_pool', {to:'+1'%s});\n"
+            ),
+            "httpx.py": (
+                f"httpx.Client(base_url='{base}')"
+                ".post('/number_pool', json={'to':'+1'%s})"
+            ),
+        }
+        for name, template in forms.items():
+            with self.subTest(shape=name, body="violating"):
+                _, payload = self.run_messaging_linter({name: template % ""})
+                self.assert_required_profile_detected(payload, name)
+            with self.subTest(shape=name, body="compliant"):
+                profile = (
+                    ", 'messaging_profile_id': 'a'"
+                    if name.endswith(".py")
+                    else ", messaging_profile_id: 'a'"
+                )
+                self.assert_required_profile_passes({name: template % profile})
+
+    def test_base_url_to_a_different_endpoint_is_not_flagged(self) -> None:
+        # The base-URL combination must not over-fire: a base ending in
+        # /messages with a non-pool path is not a number-pool send.
+        self.assert_required_profile_passes(
+            {
+                "other.js": (
+                    "axios.create({baseURL:'https://api.telnyx.com/v2/messages'})"
+                    ".post('/', {to: '+1'});"
+                )
+            }
+        )
+
+    def test_mock_factory_post_is_not_treated_as_a_send(self) -> None:
+        # The factory discrimination must keep mocking/assertion libraries out
+        # of scope: nock(...).post(url) sets up an expectation, it does not
+        # send. Analysing it would false-positive on test files.
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        for name, code in (
+            ("nock.spec.js", f"nock(API).post('{url}').reply(200);\n"),
+            ("sinon.spec.js", f"sinon.stub().post('{url}');\n"),
+        ):
+            with self.subTest(mock=name):
+                self.assert_required_profile_passes({name: code})
+
+    def test_unbraced_conditional_profile_write_is_guarded(self) -> None:
+        # `if (flag) payload.messaging_profile_id = pid;` sets the profile
+        # only conditionally, so a number-pool send below it can run without
+        # the profile. The control-flow index skipped unbraced bodies, so the
+        # write looked unconditional and the send passed. It must be flagged.
+        js = (
+            "async function send(to, text, usePool) {\n"
+            "  const payload = { to, text };\n"
+            "  if (usePool) payload.messaging_profile_id = 'abc';\n"
+            "  return fetch('https://api.telnyx.com/v2/messages/number_pool', "
+            "{ method: 'POST', body: JSON.stringify(payload) });\n"
+            "}\n"
+        )
+        _, payload = self.run_messaging_linter({"send.js": js})
+        self.assert_required_profile_detected(payload, "send.js")
+
+    def test_every_unbraced_control_body_guards_a_profile_write(self) -> None:
+        # The whole unbraced-body class, not just the `if` that was reported
+        # first. In each case the profile is set only inside an unbraced
+        # control body that may not run (or runs only on one branch), so the
+        # number-pool send below can execute without the profile and must be
+        # flagged. Bodies: if, else, else-if, for, while, foreach.
+        send = (
+            "  return fetch('https://api.telnyx.com/v2/messages/number_pool', "
+            "{ method: 'POST', body: JSON.stringify(payload) });\n"
+        )
+        bodies = {
+            "unbraced_if":
+                "  if (opt) payload.messaging_profile_id = 'p';\n",
+            "unbraced_else":
+                "  if (skip) { doThing(); } else payload.messaging_profile_id = 'p';\n",
+            "unbraced_else_if":
+                "  if (a) doA(); else if (b) payload.messaging_profile_id = 'p';\n",
+            "unbraced_for":
+                "  for (const x of items) payload.messaging_profile_id = x.id;\n",
+            "unbraced_while":
+                "  while (more()) payload.messaging_profile_id = next();\n",
+            "unbraced_foreach_java":
+                "  for (Item x : items) payload.messaging_profile_id = x.id;\n",
+        }
+        for label, body in bodies.items():
+            suffix = ".java" if "java" in label else ".js"
+            name = f"send{suffix}"
+            source = (
+                "function send(items, opt, skip) {\n"
+                "  const payload = { to, text };\n"
+                + body + send + "}\n"
+            )
+            with self.subTest(shape=label):
+                _, payload = self.run_messaging_linter({name: source})
+                self.assert_required_profile_detected(payload, name)
+
+    def test_braced_exhaustive_if_else_still_passes(self) -> None:
+        # Both branches set the profile: the send is guaranteed compliant and
+        # must NOT be flagged. Guards against the fix over-firing on exhaustive
+        # if/else, including an unbraced else.
+        compliant = (
+            "function send(opt) {\n"
+            "  const payload = { to, text };\n"
+            "  if (opt) payload.messaging_profile_id = 'a';"
+            " else payload.messaging_profile_id = 'b';\n"
+            "  return fetch('https://api.telnyx.com/v2/messages/number_pool', "
+            "{ method: 'POST', body: JSON.stringify(payload) });\n"
+            "}\n"
+        )
+        self.assert_required_profile_passes({"send.js": compliant})
+
+    def test_do_while_body_runs_and_is_not_a_guard(self) -> None:
+        # A do-while body always executes at least once, so a profile write
+        # there IS guaranteed and the send must pass. Confirms _body_arm does
+        # not spuriously guard the trailing `while (cond);`.
+        compliant = (
+            "function send() {\n"
+            "  const payload = { to, text };\n"
+            "  do payload.messaging_profile_id = 'p'; while (retry());\n"
+            "  return fetch('https://api.telnyx.com/v2/messages/number_pool', "
+            "{ method: 'POST', body: JSON.stringify(payload) });\n"
+            "}\n"
+        )
+        self.assert_required_profile_passes({"send.js": compliant})
+
+    def test_unconditional_profile_write_still_passes(self) -> None:
+        # The guard must not over-fire: an unconditional write is compliant.
+        js = (
+            "async function send(to, text) {\n"
+            "  const payload = { to, text };\n"
+            "  payload.messaging_profile_id = 'abc';\n"
+            "  return fetch('https://api.telnyx.com/v2/messages/number_pool', "
+            "{ method: 'POST', body: JSON.stringify(payload) });\n"
+            "}\n"
+        )
+        self.assert_required_profile_passes({"send.js": js})
+
+    def test_request_style_config_object_urls_are_resolved(self) -> None:
+        """post({url: ..., json: {...}}) must be seen as a number-pool send.
+
+        The URL lives in an object member rather than a named argument, so the
+        resolver evaluated the whole object and the call was not recognised as
+        targeting the endpoint at all — a send missing messaging_profile_id
+        passed. Both halves are covered here: the URL side must find the call,
+        and the payload side must be able to prove a compliant body, or fixing
+        the miss would just convert it into a false report.
+        """
+
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        shapes = {
+            "inline": "request.post({{{key}: '%s', json: {{{body}}}}});" % url,
+            "inline_with_callback":
+                "request.post({{{key}: '%s', json: {{{body}}}}}, cb);" % url,
+            "variable": (
+                "const cfg = {{{key}: '%s', json: {{{body}}}}};\n"
+                "request.post(cfg);" % url
+            ),
+            "variable_with_callback": (
+                "const cfg = {{{key}: '%s', json: {{{body}}}}};\n"
+                "request.post(cfg, cb);" % url
+            ),
+        }
+        violating_body = "to: '+1', text: 'hi'"
+        compliant_body = violating_body + ", messaging_profile_id: 'abc'"
+
+        for label, template in shapes.items():
+            # Every spelling the named-argument path already accepted. `uri`
+            # worked as a named argument but not as an object member, which is
+            # how the two paths drifted apart.
+            for key in ("url", "uri", "requestUri"):
+                with self.subTest(shape=label, key=key, body="violating"):
+                    name = "send.js"
+                    _, payload = self.run_messaging_linter(
+                        {name: template.format(key=key, body=violating_body)}
+                    )
+                    self.assert_required_profile_detected(payload, name)
+
+                with self.subTest(shape=label, key=key, body="compliant"):
+                    self.assert_required_profile_passes(
+                        {"send.js": template.format(key=key, body=compliant_body)}
+                    )
+
+    def test_config_object_url_does_not_displace_a_positional_endpoint(self) -> None:
+        # A url-shaped key inside the BODY must not be mistaken for the
+        # endpoint. post(url, {callback_url: ...}) still resolves the
+        # positional string, and a base-URL client passing only a body keeps
+        # its previous treatment rather than being newly misread.
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        _, payload = self.run_messaging_linter(
+            {
+                "send.js": (
+                    f"client.post('{url}', "
+                    "{to: '+1', callback_url: 'https://example.test/cb'});"
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, "send.js")
+
+        self.assert_required_profile_passes(
+            {
+                "send.js": (
+                    f"client.post('{url}', {{to: '+1', "
+                    "messaging_profile_id: 'abc', "
+                    "callback_url: 'https://example.test/cb'});"
+                )
+            }
+        )
+
+    def test_go_client_post_body_is_read_from_the_third_argument(self) -> None:
+        # (*http.Client).Post has the same (url, contentType, body) signature
+        # as net/http.Post, but the branch handling it was gated on the
+        # receiver being literally "http". Every client.Post /
+        # http.DefaultClient.Post call fell through to the generic
+        # post(url, body, config) rule, which inspected "application/json" as
+        # the payload and reported a compliant send as missing the profile.
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        for receiver in ("http", "client", "http.DefaultClient", "httpClient"):
+            with self.subTest(receiver=receiver):
+                compliant = {
+                    "send.go": (
+                        "package main\n\nfunc send() {\n"
+                        f'\t{receiver}.Post("{url}", "application/json", '
+                        'strings.NewReader(`{"to":"+1",'
+                        '"messaging_profile_id":"abc"}`))\n}\n'
+                    )
+                }
+                self.assert_required_profile_passes(compliant)
+
+                violating = {
+                    "send.go": (
+                        "package main\n\nfunc send() {\n"
+                        f'\t{receiver}.Post("{url}", "application/json", '
+                        'strings.NewReader(`{"to":"+1"}`))\n}\n'
+                    )
+                }
+                _, payload = self.run_messaging_linter(violating)
+                self.assert_required_profile_detected(payload, "send.go")
+
+    def test_correctness_linter_scans_every_js_module_extension(self) -> None:
+        for suffix in self.JS_TS_FAMILY:
+            with self.subTest(suffix=suffix):
+                name = f"voice{suffix}"
+                files = {
+                    name: (
+                        "const twilio = require('twilio');\n"
+                        "const VoiceResponse = twilio.twiml.VoiceResponse;\n"
+                        "const response = new VoiceResponse();\n"
+                    )
+                }
+                _, payload = self.run_messaging_linter(files, product="voice")
+                leftovers = [
+                    check
+                    for check in payload["checks"]
+                    if check["status"] in {"warn", "issue"}
+                    and "voice" in json.dumps(check).lower()
+                ]
+                self.assertTrue(
+                    leftovers,
+                    f"TwiML leftover in {name} was reported as clean: "
+                    f"{json.dumps(payload['checks'])}",
+                )
+
+    # The member-net contract: a required path the call-centric resolver never
+    # evaluates stays reported unless PROVABLY unused. Each flow below was a
+    # reproduced silent miss before member_net_contexts existed. A miss is
+    # worse than an extra report — none of these may ever pass again.
+    def test_member_net_reports_flows_the_resolver_cannot_see(self) -> None:
+        pool = '"/v2/messages/number_pool"'
+        flows = {
+            "spread-benign-ref.js": (
+                f"var endpoints = {{ pool: {pool},"
+                " normal: '/v2/messages' };\n"
+                "fetch(endpoints.normal, {method: 'POST'});\n"
+                "const urls = { ...endpoints };\n"
+                "fetch(urls.pool, {method: 'POST'});"
+            ),
+            "helper-param.ts": (
+                f"const endpoints = {{ pool: {pool} }};\n"
+                "function send(url, payload) { return post(url, payload); }\n"
+                'send(endpoints.pool, { to: "+1" });'
+            ),
+            "later-definition.ts": (
+                'function go() { return post(endpoints.pool,'
+                ' { to: "+1" }); }\n'
+                f"const endpoints = {{ pool: {pool} }};"
+            ),
+            "same-member-unmodelled.ts": (
+                f"const endpoints = {{ pool: {pool},"
+                " normal: '/v2/messages' };\n"
+                'myClient.send(endpoints.pool, { to: "+1" });\n'
+                'axios.post(endpoints.normal, { to: "+1" });'
+            ),
+            "globalthis-dotted.js": (
+                f"var endpoints = {{ pool: {pool},"
+                " normal: '/v2/messages' };\n"
+                "fetch(endpoints.normal, {method: 'POST'});\n"
+                "fetch(globalThis.endpoints.pool, {method: 'POST'});"
+            ),
+            "ancestor-handoff.js": (
+                f"const endpoints = {{ grp: {{ pool: {pool},"
+                " normal: '/v2/messages' } };\n"
+                "function sendIt(g) { return fetch(g.pool,"
+                " {method: 'POST'}); }\n"
+                "sendIt(endpoints.grp);"
+            ),
+            "export-equals.ts": (
+                f"const endpoints = {{ pool: {pool},"
+                " normal: '/v2/messages' };\n"
+                "fetch(endpoints.normal, {method: 'POST'});\n"
+                "export = endpoints;"
+            ),
+            "class-attribute.py": (
+                "class Config:\n"
+                f"    endpoints = {{ 'pool': {pool},"
+                " 'normal': '/v2/messages' }\n"
+                "    default = endpoints['normal']\n"
+                "def send_pool(p):\n"
+                "    requests.post(Config.endpoints['pool'], json=p)"
+            ),
+            "destructured-required.ts": (
+                f"const endpoints = {{ pool: {pool} }};\n"
+                "const { pool } = endpoints;\n"
+                'await post(pool, { to: "+1" });'
+            ),
+            "renamed-into-other.ts": (
+                f"const endpoints = {{ poolUrl: {pool},"
+                " normal: '/v2/messages' };\n"
+                "const alt = { normal: endpoints.poolUrl };\n"
+                'await post(alt.normal, { to: "+1" });'
+            ),
+            "relative-in-container.ts": (
+                "const endpoints = { pool: 'messages/number_pool' };\n"
+                "myClient.send(endpoints.pool, { to: '+1' });"
+            ),
+        }
+        for name, source in flows.items():
+            with self.subTest(flow=name):
+                self.assert_required_profile_flagged({name: source})
+
+    def test_member_net_reports_cross_file_definition(self) -> None:
+        self.assert_required_profile_flagged(
+            {
+                "endpoints.js": (
+                    "export const ENDPOINTS = { pool:"
+                    ' "https://api.telnyx.com/v2/messages/number_pool" };'
+                ),
+                "send.js": (
+                    'import { ENDPOINTS } from "./endpoints.js";\n'
+                    'await post(ENDPOINTS.pool, { to: "+1" });'
+                ),
+            }
+        )
+
+    def test_member_net_defers_to_the_resolver_where_it_is_proven(
+        self,
+    ) -> None:
+        # The resolver's corpus pins these as its domain; the net must not
+        # duplicate or contradict it.
+        pool = '"/v2/messages/number_pool"'
+        clears = {
+            "member-divergent.ts": (
+                f"const endpoints = {{ pool: {pool},"
+                " normal: '/v2/messages' };\n"
+                "axios.post(endpoints.normal, {from, to, text});"
+            ),
+            "exported-divergent.ts": (
+                f"export const endpoints = {{ pool: {pool},"
+                " normal: '/v2/messages' };\n"
+                "axios.post(endpoints.normal, {from, to, text});"
+            ),
+            "toplevel-divergent.py": (
+                f"endpoints = {{ 'pool': {pool},"
+                " 'normal': '/v2/messages' }\n"
+                "requests.post(endpoints['normal'], json={'from': 1})"
+            ),
+            "dynamic-key.ts": (
+                f"const endpoints = {{ pool: {pool},"
+                " normal: '/v2/messages' };\n"
+                "axios.post(endpoints[whichever], {from, to});"
+            ),
+        }
+        for name, source in clears.items():
+            with self.subTest(flow=name):
+                self.assert_required_profile_passes({name: source})
+
+    def test_relative_base_url_paths_are_required(self) -> None:
+        self.assert_required_profile_flagged(
+            {
+                "base-url.ts": (
+                    "const api = axios.create({ baseURL:"
+                    " 'https://api.telnyx.com/v2/' });\n"
+                    "api.post('messages/number_pool',"
+                    " { to: '+1', text: 'hi' });"
+                )
+            }
+        )
+        self.assert_required_profile_passes(
+            {
+                "base-url-ok.ts": (
+                    "const api = axios.create({ baseURL:"
+                    " 'https://api.telnyx.com/v2/' });\n"
+                    "api.post('messages/number_pool', { to: '+1',"
+                    " text: 'hi', messaging_profile_id: 'mp-1' });"
+                )
+            }
+        )
+        self.assert_required_profile_passes(
+            {
+                "base-url-ordinary.ts": (
+                    "const api = axios.create({ baseURL:"
+                    " 'https://api.telnyx.com/v2/' });\n"
+                    "api.post('messages', { to: '+1', text: 'hi' });"
+                )
+            }
+        )
+
+    def test_telnyx_messages_create_with_text_is_not_classified_as_twilio(
+        self,
+    ) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "telnyx-client.js": "\n".join(
+                    (
+                        "await client.messages.create({",
+                        "  from: sender,",
+                        "  to: recipient,",
+                        "  text: 'hello from Telnyx',",
+                        "});",
+                    )
+                ),
+                "telnyx-client.rb": "\n".join(
+                    (
+                        "client.messages.create(",
+                        "  from: sender,",
+                        "  to: recipient,",
+                        "  text: 'hello from Telnyx'",
+                        ")",
+                    )
+                ),
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "twilio_messages_create"
+        ]
+        self.assertEqual(
+            [{"name": "twilio_messages_create", "status": "pass"}], checks
+        )
+        self.assertEqual(0, result.returncode)
+
+    def test_twilio_body_field_detection_is_quote_and_comment_aware(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "valid-text.js": "\n".join(
+                    (
+                        "await client.messages.create({",
+                        "  text: 'The body: hello // still message text',",
+                        "  webhookUrl: 'https://example.test/status',",
+                        "  metadata: {body: 'not message content'},",
+                        "});",
+                    )
+                ),
+                "valid-same-line.js": (
+                    "await client.messages.create({text: "
+                    "'The body: hello // still message text'});"
+                ),
+                "valid-nested-shorthand.js": (
+                    "const body = 'metadata'; "
+                    "await client.messages.create({text, metadata: {body}});"
+                ),
+                "valid-payload-variable.js": (
+                    "const body = {text: 'hello'}; "
+                    "await client.messages.create(body);"
+                ),
+                "real-body-after-url.js": (
+                    "await client.messages.create({webhookUrl: "
+                    "'https://example.test/status', body: 'legacy'});"
+                ),
+                "quoted-body.ts": (
+                    'await client.messages.create({"body": "legacy"});'
+                ),
+                "shorthand-create.js": (
+                    "await client.messages.create({from, to, body});"
+                ),
+                "shorthand-send.ts": "await client.messages.send({body});",
+                "send-body.py": "client.messages.send(to=to, body='legacy')",
+            }
+        )
+        check = next(
+            item
+            for item in payload["checks"]
+            if item["name"] == "twilio_messages_create"
+        )
+        self.assertEqual("issue", check["status"])
+        details = json.dumps(check["details"])
+        self.assertNotIn("valid-text.js", details)
+        self.assertNotIn("valid-same-line.js", details)
+        self.assertNotIn("valid-nested-shorthand.js", details)
+        self.assertNotIn("valid-payload-variable.js", details)
+        self.assertIn("real-body-after-url.js", details)
+        self.assertIn("quoted-body.ts", details)
+        self.assertIn("shorthand-create.js", details)
+        body_check = next(
+            item for item in payload["checks"] if item["name"] == "body_not_text"
+        )
+        body_details = json.dumps(body_check["details"])
+        self.assertNotIn("valid-text.js", body_details)
+        self.assertNotIn("valid-same-line.js", body_details)
+        self.assertNotIn("valid-nested-shorthand.js", body_details)
+        self.assertNotIn("valid-payload-variable.js", body_details)
+        self.assertIn("shorthand-send.ts", body_details)
+        self.assertIn("send-body.py", body_details)
+        self.assertEqual(1, result.returncode)
+
+    def test_javascript_body_detector_resolves_static_payload_forms(self) -> None:
+        positive = {
+            "computed-double.js": (
+                'client.messages.create({["body"]: legacy});'
+            ),
+            "computed-single.ts": (
+                "client.messages.send({['body']: legacy});"
+            ),
+            "computed-template.tsx": (
+                "client.messages.send({[`body`]: legacy});"
+            ),
+            "optional-member.jsx": (
+                "client.messages?.create({body});"
+            ),
+            "optional-call.ts": "client.messages.send?.({body});",
+            "payload-explicit.js": (
+                "const payload = {body: legacy};\n"
+                "client.messages.create(payload);"
+            ),
+            "payload-shorthand.ts": (
+                "const payload = {body};\nclient.messages.send(payload);"
+            ),
+            "payload-computed.tsx": (
+                'const payload = {["body"]: legacy};\n'
+                "client.messages.send(payload);"
+            ),
+            "payload-alias.js": (
+                "const original = {body};\nconst payload = original;\n"
+                "client.messages.create(payload);"
+            ),
+            "payload-spread.jsx": (
+                "const payload = {body};\n"
+                "client.messages.create({...payload, text});"
+            ),
+            "payload-dot-mutation.ts": (
+                "const payload = {text};\npayload.body = legacy;\n"
+                "client.messages.send(payload);"
+            ),
+            "payload-computed-mutation.js": (
+                'const payload = {text};\npayload["body"] = legacy;\n'
+                "client.messages.create(payload);"
+            ),
+            "payload-second-spread.js": (
+                "const metadata = {source};\nconst payload = {body};\n"
+                "client.messages.create({...metadata, ...payload});"
+            ),
+            "outer-payload-in-closure.js": (
+                "const payload = {body};\n"
+                "function send() { client.messages.create(payload); }"
+            ),
+            "outer-mutation-after-shadow.js": (
+                "const payload = {text};\n"
+                "function unrelated() { const payload = {body}; }\n"
+                "payload.body = legacy;\n"
+                "client.messages.create(payload);"
+            ),
+        }
+        negative = {
+            "nested-shorthand.js": (
+                "client.messages.create({text, metadata: {body}});"
+            ),
+            "nested-computed.ts": (
+                'client.messages.send({text, metadata: {["body"]: legacy}});'
+            ),
+            "payload-variable-named-body.js": (
+                "const body = {text};\nclient.messages.create(body);"
+            ),
+            "body-as-text-value.ts": (
+                "client.messages.send({text: body});"
+            ),
+            "body-computed-value.jsx": (
+                'client.messages.create({text: source["body"]});'
+            ),
+            "mutation-after-call.tsx": (
+                "const payload = {text};\nclient.messages.send(payload);\n"
+                "payload.body = legacy;"
+            ),
+            "stale-payload-assignment.js": (
+                "let payload = {body};\npayload = {text};\n"
+                "client.messages.create(payload);"
+            ),
+            "mutation-string-decoy.js": (
+                "const payload = {text};\n"
+                "console.log('payload[\"body\"] = legacy');\n"
+                "client.messages.create(payload);"
+            ),
+            "nested-scope-mutation-decoy.js": (
+                "const payload = {text};\n"
+                "function unrelated() {\n"
+                "  const payload = {text};\n"
+                "  payload.body = legacy;\n"
+                "}\n"
+                "client.messages.create(payload);"
+            ),
+            "sibling-scope-assignment-decoy.js": (
+                "function unrelated() { const payload = {body}; }\n"
+                "function send() {\n"
+                "  const payload = {text};\n"
+                "  client.messages.create(payload);\n"
+                "}"
+            ),
+        }
+        _, payload = self.run_messaging_linter({**positive, **negative})
+        check = next(
+            item for item in payload["checks"] if item["name"] == "body_not_text"
+        )
+        details = {
+            Path(detail.split(":", 1)[0]).name
+            for detail in check["details"]["files"]
+        }
+        self.assertEqual(set(positive), details)
+
+    def test_javascript_body_detector_exhaustive_finite_grammar(self) -> None:
+        """Exhaust every production in the declared direct-call grammar.
+
+        Whitespace and comments are unbounded languages, so the grammar uses
+        four lexer-equivalence classes. Assignment, alias, spread, and mutation
+        productions are covered separately by the static-payload-form oracle.
+        """
+
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_messaging_source_analyzer_contract",
+        )
+        detect = namespace["message_body_fields"]
+        all_calls = namespace["MESSAGE_BODY_CALL_RE"]
+        create_calls = namespace["TWILIO_MESSAGE_CREATE_RE"]
+
+        key_forms = (
+            "body",
+            "body: legacy",
+            "'body': legacy",
+            '"body": legacy',
+            "['body']: legacy",
+            '["body"]: legacy',
+            "[`body`]: legacy",
+        )
+        positions = {
+            "sole": lambda key: [key],
+            "first": lambda key: [key, "text"],
+            "middle": lambda key: ["from", key, "text"],
+            "last": lambda key: ["from", "text", key],
+        }
+        layouts = {
+            "compact": lambda members: "{" + ",".join(members) + "}",
+            "spaced": lambda members: "{ " + ", ".join(members) + " }",
+            "multiline": lambda members: "{\n  "
+            + ",\n  ".join(members)
+            + "\n}",
+            "comments": lambda members: "{/* gap */ "
+            + " /* member */ , /* gap */ ".join(members)
+            + " /* end */}",
+        }
+        decoys = (
+            "{text: body}",
+            "{text, metadata: {body}}",
+            "{text, metadata: {'body': legacy}}",
+            '{text, metadata: {["body"]: legacy}}',
+            '{text: source["body"]}',
+            "body",
+            "body, requestOptions",
+            "{somebody: legacy}",
+            "{bodyText: legacy}",
+            "{text: 'body: legacy'}",
+            "{text /* body */}",
+        )
+
+        with tempfile.TemporaryDirectory(
+            prefix="telnyx-body-grammar-"
+        ) as temp_dir:
+            temp_root = Path(temp_dir)
+            for extension in ("js", "jsx", "ts", "tsx"):
+                lines: list[str] = []
+                expected_all: set[int] = set()
+                expected_create: set[int] = set()
+                next_line = 1
+
+                def append_call(
+                    method: str,
+                    root_optional: bool,
+                    member_optional: bool,
+                    call_optional: bool,
+                    arguments: str,
+                    *,
+                    expected: bool,
+                ) -> None:
+                    nonlocal next_line
+                    root = "?." if root_optional else "."
+                    member = "?." if member_optional else "."
+                    invocation = "?." if call_optional else ""
+                    statement = (
+                        f"client{root}messages{member}{method}{invocation}"
+                        f"({arguments});"
+                    )
+                    statement_line = next_line
+                    lines.append(statement)
+                    next_line += statement.count("\n") + 1
+                    if expected:
+                        expected_all.add(statement_line)
+                        if method == "create":
+                            expected_create.add(statement_line)
+
+                for method in ("create", "send"):
+                    for root_optional in (False, True):
+                        for member_optional in (False, True):
+                            for call_optional in (False, True):
+                                for key in key_forms:
+                                    for make_members in positions.values():
+                                        members = make_members(key)
+                                        for render in layouts.values():
+                                            append_call(
+                                                method,
+                                                root_optional,
+                                                member_optional,
+                                                call_optional,
+                                                render(members),
+                                                expected=True,
+                                            )
+                                for decoy in decoys:
+                                    append_call(
+                                        method,
+                                        root_optional,
+                                        member_optional,
+                                        call_optional,
+                                        decoy,
+                                        expected=False,
+                                    )
+                                append_call(
+                                    method,
+                                    root_optional,
+                                    member_optional,
+                                    call_optional,
+                                    "{text}, {body: transportOption}",
+                                    expected=False,
+                                )
+
+                access_forms = 2 * 2 * 2
+                positive_count = (
+                    2
+                    * access_forms
+                    * len(key_forms)
+                    * len(positions)
+                    * len(layouts)
+                )
+                negative_count = 2 * access_forms * (len(decoys) + 1)
+                self.assertEqual(
+                    positive_count + negative_count, len(lines)
+                )
+                self.assertEqual(positive_count, len(expected_all))
+                self.assertEqual(positive_count // 2, len(expected_create))
+                fixture = temp_root / f"matrix.{extension}"
+                fixture.write_text("\n".join(lines) + "\n", encoding="utf-8")
+                prefix = f"{fixture}:"
+
+                def finding_lines(pattern: re.Pattern[str]) -> set[int]:
+                    return {
+                        int(detail[len(prefix) :].split(":", 1)[0])
+                        for detail in detect(fixture, pattern)
+                    }
+
+                self.assertEqual(expected_all, finding_lines(all_calls))
+                self.assertEqual(
+                    expected_create, finding_lines(create_calls)
+                )
+
+    def test_python_ruby_body_detector_static_payload_grammar(self) -> None:
+        positive = {
+            "python-keyword.py": (
+                "client.messages.create(to=recipient, body=legacy)"
+            ),
+            "python-dict.py": (
+                'client.messages.send({"to": recipient, "body": legacy})'
+            ),
+            "python-payload.py": (
+                'payload = {"body": legacy}\n'
+                "client.messages.create(**payload)"
+            ),
+            "python-mutation.py": (
+                'payload = {"text": text}\npayload["body"] = legacy\n'
+                "client.messages.send(**payload)"
+            ),
+            "ruby-keyword.rb": (
+                "client.messages.create(to: recipient, body: legacy)"
+            ),
+            "ruby-hash-rocket.rb": (
+                'client.messages.send({"to" => recipient, "body" => legacy})'
+            ),
+            "ruby-payload.rb": (
+                "payload = { body: legacy }\n"
+                "client.messages.create(**payload)"
+            ),
+            "ruby-symbol-mutation.rb": (
+                "payload = { text: text }\npayload[:body] = legacy\n"
+                "client.messages.send(**payload)"
+            ),
+        }
+        negative = {
+            "python-text-value.py": (
+                "client.messages.create(text=body)"
+            ),
+            "python-nested.py": (
+                'client.messages.send({"text": text, "metadata": {"body": legacy}})'
+            ),
+            "python-stale.py": (
+                'payload = {"body": legacy}\npayload = {"text": text}\n'
+                "client.messages.create(**payload)"
+            ),
+            "python-variable-named-body.py": (
+                'body = {"text": text}\nclient.messages.send(**body)'
+            ),
+            "ruby-text-value.rb": (
+                "client.messages.create(text: body)"
+            ),
+            "ruby-nested.rb": (
+                "client.messages.send(text: text, metadata: {body: legacy})"
+            ),
+            "ruby-stale.rb": (
+                "payload = {body: legacy}\npayload = {text: text}\n"
+                "client.messages.create(**payload)"
+            ),
+            "ruby-variable-named-body.rb": (
+                "body = {text: text}\nclient.messages.send(**body)"
+            ),
+        }
+        _, payload = self.run_messaging_linter({**positive, **negative})
+        check = next(
+            item for item in payload["checks"] if item["name"] == "body_not_text"
+        )
+        details = {
+            Path(detail.split(":", 1)[0]).name
+            for detail in check["details"]["files"]
+        }
+        self.assertEqual(set(positive), details)
+
+    def test_supported_non_neural_polly_voice_is_preserved_without_warning(
+        self,
+    ) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "voice.xml": (
+                    '<Response><Say voice="Polly.Mizuki">Hello</Say></Response>'
+                )
+            },
+            product="voice",
+        )
+        check = next(
+            item for item in payload["checks"] if item["name"] == "polly_non_neural"
+        )
+        self.assertEqual("pass", check["status"])
+        self.assertNotIn("woman", json.dumps(payload))
+        self.assertEqual(0, result.returncode)
+
+    def test_twilio_messages_create_with_body_is_still_an_issue(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "twilio-client.js": "\n".join(
+                    (
+                        "await client.messages.create({",
+                        "  from: sender,",
+                        "  to: recipient,",
+                        "  body: 'legacy Twilio field',",
+                        "});",
+                    )
+                ),
+                "twilio-client.rb": "\n".join(
+                    (
+                        "client.messages.create(",
+                        "  from: sender,",
+                        "  to: recipient,",
+                        "  body: 'legacy Twilio field'",
+                        ")",
+                    )
+                ),
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "twilio_messages_create"
+        ]
+        self.assertEqual(1, len(checks))
+        self.assertEqual("issue", checks[0]["status"])
+        details = json.dumps(checks[0]["details"])
+        self.assertIn("twilio-client.js", details)
+        self.assertIn("twilio-client.rb", details)
+        self.assertEqual(1, result.returncode)
+
+    def test_generated_alphanumeric_sender_path_is_detected_in_js_and_ts_variants(
+        self,
+    ) -> None:
+        for extension in ("js", "jsx", "ts", "tsx"):
+            fixture_name = f"sender.{extension}"
+            with self.subTest(extension=extension):
+                _, payload = self.run_messaging_linter(
+                    {
+                        fixture_name: "\n".join(
+                            (
+                                'const endpoint = "/v2/messages/alphanumeric_sender_id";',
+                                "export const send = () => fetch(endpoint, { method: \"POST\" });",
+                            )
+                        )
+                    }
+                )
+                self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_composed_rest_endpoint_alias_is_checked_at_request(self) -> None:
+        fixture_name = "composed-endpoint.ts"
+        _, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        'const path = "/v2/messages/number_pool";',
+                        "const url = API_BASE + path;",
+                        "axios.post(url, {from, to, text});",
+                    )
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_composed_rest_endpoint_alias_with_profile_passes(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "valid-composed-endpoint.ts": "\n".join(
+                    (
+                        'const path = "/v2/messages/number_pool";',
+                        "const url = API_BASE + path;",
+                        "axios.post(url, {from, to, text, messaging_profile_id: profileId});",
+                    )
+                )
+            }
+        )
+
+    def test_rest_endpoint_object_members_keep_distinct_identity(self) -> None:
+        fixtures = {
+            "dot-member.ts": "\n".join(
+                (
+                    "const endpoints = {",
+                    '  pool: "/v2/messages/number_pool",',
+                    '  normal: "/v2/messages",',
+                    "};",
+                    "axios.post(endpoints.normal, {from, to, text});",
+                )
+            ),
+            "bracket-member.js": "\n".join(
+                (
+                    "const endpoints = {",
+                    '  "pool": "/v2/messages/number_pool",',
+                    '  "normal": "/v2/messages",',
+                    "};",
+                    'fetch(endpoints["normal"], {method: "POST", body: JSON.stringify({from, to, text})});',
+                )
+            ),
+            "nested-member.tsx": "\n".join(
+                (
+                    "const routes = {messages: {",
+                    '  pool: "/v2/messages/number_pool",',
+                    '  normal: "/v2/messages",',
+                    "}};",
+                    "axios.post(routes.messages.normal, {from, to, text});",
+                )
+            ),
+            "destructured-member.ts": "\n".join(
+                (
+                    "const endpoints = {",
+                    '  pool: "/v2/messages/number_pool",',
+                    '  normal: "/v2/messages",',
+                    "};",
+                    "const {normal: endpoint} = endpoints;",
+                    "axios.post(endpoint, {from, to, text});",
+                )
+            ),
+            "shadowed-member.ts": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    "function send() {",
+                    '  const endpoints = {pool: "/v2/messages"};',
+                    "  axios.post(endpoints.pool, {from, to, text});",
+                    "}",
+                )
+            ),
+            "reassigned-member.ts": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    'endpoints.pool = "/v2/messages";',
+                    "axios.post(endpoints.pool, {from, to, text});",
+                )
+            ),
+            "reassigned-bracket-member.js": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    'endpoints["pool"] = "/v2/messages";',
+                    'fetch(endpoints["pool"], {method: "POST", body: payload});',
+                )
+            ),
+        }
+        self.assert_required_profile_passes(fixtures)
+
+    def test_rest_endpoint_object_member_aliases_preserve_required_path(self) -> None:
+        fixtures = {
+            "dot-member.ts": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    "axios.post(endpoints.pool, {from, to, text});",
+                )
+            ),
+            "bracket-member.js": "\n".join(
+                (
+                    'const endpoints = {"pool": "/v2/messages/number_pool"};',
+                    'fetch(endpoints["pool"], {method: "POST", body: JSON.stringify({from, to, text})});',
+                )
+            ),
+            "nested-member.tsx": "\n".join(
+                (
+                    "const routes = {messages: {",
+                    '  pool: "/v2/messages/number_pool",',
+                    "}};",
+                    "const endpoint = routes.messages.pool;",
+                    "axios.post(endpoint, {from, to, text});",
+                )
+            ),
+            "destructured-member.ts": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    "const {pool: endpoint} = endpoints;",
+                    "axios.post(endpoint, {from, to, text});",
+                )
+            ),
+            "requests-method-first.py": "\n".join(
+                (
+                    'endpoints = {"pool": "/v2/messages/number_pool"}',
+                    'requests.request("POST", endpoints["pool"], json={"text": text})',
+                )
+            ),
+            "request-method-first.ts": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    'request("POST", endpoints.pool, {text});',
+                )
+            ),
+            "ky-member.ts": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    'ky.post(endpoints.pool, {json: {text}});',
+                )
+            ),
+            "axios-request-member.ts": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    'axios.request({method: "post", url: endpoints.pool, data: {text}});',
+                )
+            ),
+            "assigned-member.ts": "\n".join(
+                (
+                    "const endpoints = {};",
+                    'endpoints.pool = "/v2/messages/number_pool";',
+                    "axios.post(endpoints.pool, {text});",
+                )
+            ),
+            "assigned-bracket-member.js": "\n".join(
+                (
+                    "const endpoints = {};",
+                    'endpoints["pool"] = "/v2/messages/number_pool";',
+                    'fetch(endpoints["pool"], {method: "POST", body: payload});',
+                )
+            ),
+            "sibling-scope-does-not-shadow.ts": "\n".join(
+                (
+                    'const endpoints = {pool: "/v2/messages/number_pool"};',
+                    "function unrelated() {",
+                    '  const endpoints = {pool: "/v2/messages"};',
+                    "  return endpoints.pool;",
+                    "}",
+                    "axios.post(endpoints.pool, {text});",
+                )
+            ),
+        }
+        _, payload = self.run_messaging_linter(fixtures)
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_rest_endpoint_resolution_exhaustive_finite_grammar(self) -> None:
+        """Exhaust the declared bounded endpoint-reference grammar.
+
+        The oracle covers static map/array identity, aliases and request
+        signatures in every supported suffix, lexical shadowing, JS/TS
+        destructuring and template aliases, and fail-closed dynamic keys.
+        It intentionally excludes computed expressions and interprocedural
+        data flow: those remain outside this non-parser's finite grammar.
+        """
+
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_endpoint_resolution_contract",
+        )
+        analyze_file = namespace["analyze_file"]
+        suffixes = (
+            ".cjs",
+            ".cs",
+            ".cts",
+            ".go",
+            ".java",
+            ".js",
+            ".jsx",
+            ".mjs",
+            ".mts",
+            ".php",
+            ".py",
+            ".rb",
+            ".sh",
+            ".ts",
+            ".tsx",
+        )
+        javascript_suffixes = (
+            ".cjs",
+            ".cts",
+            ".js",
+            ".jsx",
+            ".mjs",
+            ".mts",
+            ".ts",
+            ".tsx",
+        )
+        inline_suffixes = tuple(
+            suffix for suffix in suffixes if suffix != ".sh"
+        )
+        routes = ("number_pool", "alphanumeric_sender_id")
+        normal_url = "https://api.telnyx.com/v2/messages"
+        counts = {
+            "static": 0,
+            "container_source": 0,
+            "inline": 0,
+            "scope": 0,
+            "mutation_scope": 0,
+            "destructuring": 0,
+            "dynamic": 0,
+            "template": 0,
+        }
+
+        def quoted(value: str, quote: str = '"') -> str:
+            return f"{quote}{value}{quote}"
+
+        def static_container(
+            suffix: str,
+            name: str,
+            shape: str,
+            values: tuple[str, str],
+            selected: int,
+            alternate: bool,
+        ) -> tuple[str, str]:
+            rendered = tuple(quoted(value) for value in values)
+            key = ("first", "second")[selected]
+            if suffix in javascript_suffixes:
+                if shape == "keyed" and alternate:
+                    literal = (
+                        f'{{["first"]: {rendered[0]}, '
+                        f'["second"]: {rendered[1]}}}'
+                    )
+                    member = f'{name}?.["{key}"]'
+                elif shape == "keyed":
+                    literal = (
+                        f"{{first: {rendered[0]}, second: {rendered[1]}}}"
+                    )
+                    member = f"{name}.{key}"
+                else:
+                    literal = f"[{rendered[0]}, {rendered[1]}]"
+                    member = f"{name}[{selected}]"
+                return f"const {name} = {literal};", member
+            if suffix == ".py":
+                quote = '"' if alternate else "'"
+                rendered = tuple(quoted(value, quote) for value in values)
+                if shape == "keyed":
+                    literal = (
+                        f"{{{quote}first{quote}: {rendered[0]}, "
+                        f"{quote}second{quote}: {rendered[1]}}}"
+                    )
+                    member = f"{name}[{quote}{key}{quote}]"
+                else:
+                    literal = f"[{rendered[0]}, {rendered[1]}]"
+                    member = f"{name}[{selected}]"
+                return f"{name} = {literal}", member
+            if suffix == ".rb":
+                if shape == "keyed" and alternate:
+                    literal = (
+                        f'{{"first" => {rendered[0]}, '
+                        f'"second" => {rendered[1]}}}'
+                    )
+                    member = f'{name}["{key}"]'
+                elif shape == "keyed":
+                    literal = (
+                        f"{{first: {rendered[0]}, second: {rendered[1]}}}"
+                    )
+                    member = f"{name}[:{key}]"
+                else:
+                    literal = f"[{rendered[0]}, {rendered[1]}]"
+                    member = f"{name}[{selected}]"
+                return f"{name} = {literal}", member
+            if suffix == ".php":
+                items = (
+                    f'"first" => {rendered[0]}, '
+                    f'"second" => {rendered[1]}'
+                    if shape == "keyed"
+                    else f"{rendered[0]}, {rendered[1]}"
+                )
+                literal = f"array({items})" if alternate else f"[{items}]"
+                member = (
+                    f'${name}["{key}"]'
+                    if shape == "keyed"
+                    else f"${name}[{selected}]"
+                )
+                return f"${name} = {literal};", member
+            if suffix == ".java":
+                if shape == "keyed":
+                    literal = (
+                        f'Map.of("first", {rendered[0]}, '
+                        f'"second", {rendered[1]})'
+                    )
+                    member = f'{name}.get("{key}")'
+                elif alternate:
+                    literal = f"List.of({rendered[0]}, {rendered[1]})"
+                    member = f"{name}.get({selected})"
+                else:
+                    literal = (
+                        f"new String[] {{{rendered[0]}, {rendered[1]}}}"
+                    )
+                    member = f"{name}[{selected}]"
+                return f"var {name} = {literal};", member
+            if suffix == ".cs":
+                if shape == "keyed":
+                    literal = (
+                        "new Dictionary<string, string> "
+                        f'{{["first"] = {rendered[0]}, '
+                        f'["second"] = {rendered[1]}}}'
+                    )
+                    member = f'{name}["{key}"]'
+                elif alternate:
+                    literal = (
+                        f"new List<string> {{{rendered[0]}, {rendered[1]}}}"
+                    )
+                    member = f"{name}[{selected}]"
+                else:
+                    literal = f"new[] {{{rendered[0]}, {rendered[1]}}}"
+                    member = f"{name}[{selected}]"
+                return f"var {name} = {literal};", member
+            if suffix == ".go":
+                quote = "`" if alternate else '"'
+                rendered = tuple(quoted(value, quote) for value in values)
+                if shape == "keyed":
+                    literal = (
+                        f"map[string]string{{{quote}first{quote}: {rendered[0]}, "
+                        f"{quote}second{quote}: {rendered[1]}}}"
+                    )
+                    member = f"{name}[{quote}{key}{quote}]"
+                else:
+                    kind = "[2]string" if alternate else "[]string"
+                    literal = f"{kind}{{{rendered[0]}, {rendered[1]}}}"
+                    member = f"{name}[{selected}]"
+                return f"{name} := {literal}", member
+            if suffix == ".sh":
+                if shape == "keyed":
+                    first_key = '["first"]' if alternate else "[first]"
+                    second_key = '["second"]' if alternate else "[second]"
+                    literal = (
+                        f"declare -A {name}=({first_key}={rendered[0]} "
+                        f"{second_key}={rendered[1]})"
+                    )
+                    access_key = f'"{key}"' if alternate else key
+                    member = f'"${{{name}[{access_key}]}}"'
+                else:
+                    prefix = "declare -a " if alternate else ""
+                    literal = (
+                        f"{prefix}{name}=({rendered[0]} {rendered[1]})"
+                    )
+                    member = f'"${{{name}[{selected}]}}"'
+                return literal, member
+            raise AssertionError(f"unsupported suffix: {suffix}")
+
+        def alias_assignment(
+            suffix: str, name: str, expression: str
+        ) -> tuple[str, str]:
+            if suffix in javascript_suffixes:
+                return f"const {name} = {expression};", name
+            if suffix in {".java", ".cs"}:
+                return f"var {name} = {expression};", name
+            if suffix == ".go":
+                return f"{name} := {expression}", name
+            if suffix == ".php":
+                return f"${name} = {expression};", f"${name}"
+            if suffix == ".sh":
+                return f'{name}={expression}', f'"${name}"'
+            return f"{name} = {expression}", name
+
+        def scalar_endpoint_source(
+            suffix: str, name: str, value: str
+        ) -> tuple[str, str]:
+            if suffix in javascript_suffixes:
+                return f'const {name} = "{value}";', name
+            if suffix in {".java", ".cs"}:
+                return f'var {name} = "{value}";', name
+            if suffix == ".go":
+                return f'{name} := "{value}"', name
+            if suffix == ".php":
+                return f'${name} = "{value}";', f"${name}"
+            if suffix == ".sh":
+                return f'{name}="{value}"', f'"${name}"'
+            return f'{name} = "{value}"', name
+
+        def member_source_assignment(
+            suffix: str,
+            root: str,
+            shape: str,
+            slot: int,
+            source: str,
+        ) -> str:
+            key = ("first", "second")[slot]
+            if suffix in javascript_suffixes:
+                target = f"{root}.{key}" if shape == "keyed" else f"{root}[{slot}]"
+                return f"{target} = {source};"
+            if suffix == ".py":
+                target = f'{root}["{key}"]' if shape == "keyed" else f"{root}[{slot}]"
+                return f"{target} = {source}"
+            if suffix == ".rb":
+                target = f"{root}[:{key}]" if shape == "keyed" else f"{root}[{slot}]"
+                return f"{target} = {source}"
+            if suffix == ".php":
+                target = f'${root}["{key}"]' if shape == "keyed" else f"${root}[{slot}]"
+                return f"{target} = {source};"
+            if suffix == ".java" and shape == "keyed":
+                return f'{root}.put("{key}", {source});'
+            if suffix == ".sh":
+                target = f"{root}[{key}]" if shape == "keyed" else f"{root}[{slot}]"
+                return f"{target}={source}"
+            target = f'{root}["{key}"]' if shape == "keyed" else f"{root}[{slot}]"
+            terminator = ";" if suffix in {".cs", ".java"} else ""
+            return f"{target} = {source}{terminator}"
+
+        def bare_root_mutation(suffix: str, declaration: str) -> str:
+            if suffix in javascript_suffixes:
+                return re.sub(r"^(?:const|let|var)\s+", "", declaration)
+            if suffix in {".java", ".cs"}:
+                return re.sub(r"^var\s+", "", declaration)
+            if suffix == ".go":
+                return declaration.replace(":=", "=", 1)
+            raise AssertionError(f"unsupported mutation suffix: {suffix}")
+
+        def inline_container_expression(
+            suffix: str,
+            root: str,
+            assignment: str,
+            member: str,
+        ) -> str:
+            separator = ":=" if suffix == ".go" else "="
+            literal = assignment.split(separator, 1)[1].strip()
+            if literal.endswith(";"):
+                literal = literal[:-1]
+            marker = f"${root}" if suffix == ".php" else root
+            self.assertTrue(member.startswith(marker))
+            return f"({literal}){member[len(marker):]}"
+
+        def request_call(
+            suffix: str, expression: str, signature: str
+        ) -> str:
+            if signature == "method_first":
+                if suffix == ".sh":
+                    return f"curl --request POST {expression} -d '{{}}'"
+                return f'request("POST", {expression}, {{}});'
+            if suffix in javascript_suffixes:
+                return f"fetch({expression}, {{method: \"POST\", body: \"{{}}\"}});"
+            if suffix == ".py":
+                return f"requests.post({expression}, json={{}})"
+            if suffix == ".rb":
+                return f"client.post({expression}, {{}})"
+            if suffix == ".php":
+                return f"$client->post({expression}, []);"
+            if suffix == ".java":
+                return f"client.post({expression}, payload);"
+            if suffix == ".cs":
+                return f"client.PostAsync({expression}, payload);"
+            if suffix == ".go":
+                return f'http.Post({expression}, "application/json", body)'
+            if suffix == ".sh":
+                return f"curl {expression} -d '{{}}'"
+            raise AssertionError(f"unsupported suffix: {suffix}")
+
+        def scoped_function(
+            suffix: str, name: str, body: list[tuple[str, bool]]
+        ) -> list[tuple[str, bool]]:
+            if suffix == ".py":
+                return [(f"def {name}():", False)] + [
+                    (f"    {line}", expected) for line, expected in body
+                ]
+            if suffix == ".rb":
+                return [(f"def {name}", False)] + [
+                    (f"  {line}", expected) for line, expected in body
+                ] + [("end", False)]
+            opener = (
+                f"func {name}() {{"
+                if suffix == ".go"
+                else f"function {name}() {{"
+                if suffix in javascript_suffixes or suffix in {".php", ".sh"}
+                else f"void {name}() {{"
+            )
+            return [(opener, False)] + [
+                (f"  {line}", expected) for line, expected in body
+            ] + [("}", False)]
+
+        def run_batch(
+            temp_root: Path,
+            category: str,
+            suffix: str,
+            cases: list[list[tuple[str, bool]]],
+        ) -> None:
+            # Small batches keep this binding-aware lexical oracle fast: the
+            # analyzer intentionally compares every required literal with
+            # later request calls in the same file.
+            batch_size = 8
+            for batch_start in range(0, len(cases), batch_size):
+                lines: list[str] = []
+                expected_lines: set[int] = set()
+                batch = cases[batch_start:batch_start + batch_size]
+                for case in batch:
+                    counts[category] += 1
+                    for line, expected in case:
+                        lines.append(line)
+                        if expected:
+                            expected_lines.add(len(lines))
+                    lines.append("")
+                fixture = temp_root / (
+                    f"{category}-matrix-{batch_start // batch_size}{suffix}"
+                )
+                fixture.write_text("\n".join(lines), encoding="utf-8")
+                count, details = analyze_file(fixture, temp_root)
+                prefix = f"{fixture}:"
+                actual_lines = {
+                    int(detail[len(prefix):].split(":", 1)[0])
+                    for detail in details
+                    if detail.startswith(prefix)
+                }
+                self.assertEqual(
+                    expected_lines,
+                    actual_lines,
+                    f"{category}{suffix} endpoint-oracle mismatch",
+                )
+                self.assertEqual(len(actual_lines), count)
+                self.assertEqual(len(actual_lines), len(details))
+
+        with tempfile.TemporaryDirectory(
+            prefix="telnyx-endpoint-grammar-"
+        ) as temp_dir:
+            temp_root = Path(temp_dir)
+
+            for suffix in suffixes:
+                cases = []
+                case_id = 0
+                for route in routes:
+                    required_url = (
+                        f"https://api.telnyx.com/v2/messages/{route}"
+                    )
+                    for shape in ("keyed", "indexed"):
+                        for required_slot in (0, 1):
+                            values = [normal_url, normal_url]
+                            values[required_slot] = required_url
+                            for selected_required in (False, True):
+                                selected = (
+                                    required_slot
+                                    if selected_required
+                                    else 1 - required_slot
+                                )
+                                for access in ("direct", "alias"):
+                                    for signature in ("native", "method_first"):
+                                        case_id += 1
+                                        root = f"routes_static_{case_id}"
+                                        assignment, expression = static_container(
+                                            suffix,
+                                            root,
+                                            shape,
+                                            tuple(values),
+                                            selected,
+                                            access == "alias",
+                                        )
+                                        rendered = [(assignment, False)]
+                                        if access == "alias":
+                                            alias, expression = alias_assignment(
+                                                suffix,
+                                                f"url_static_{case_id}",
+                                                expression,
+                                            )
+                                            rendered.append((alias, False))
+                                        rendered.append(
+                                            (
+                                                request_call(
+                                                    suffix, expression, signature
+                                                ),
+                                                selected_required,
+                                            )
+                                        )
+                                        cases.append(rendered)
+                run_batch(temp_root, "static", suffix, cases)
+
+            for suffix in suffixes:
+                cases = []
+                case_id = 0
+                for route in routes:
+                    required_url = (
+                        f"https://api.telnyx.com/v2/messages/{route}"
+                    )
+                    for shape in ("keyed", "indexed"):
+                        for required_slot in (0, 1):
+                            for selected_required in (False, True):
+                                selected = (
+                                    required_slot
+                                    if selected_required
+                                    else 1 - required_slot
+                                )
+                                for source_style in ("literal", "member"):
+                                    for signature in ("native", "method_first"):
+                                        case_id += 1
+                                        root = f"routes_source_{case_id}"
+                                        source_name = f"required_source_{case_id}"
+                                        source_line, source_ref = scalar_endpoint_source(
+                                            suffix, source_name, required_url
+                                        )
+                                        if source_style == "literal":
+                                            values = [normal_url, normal_url]
+                                            values[required_slot] = required_url
+                                            assignment, expression = static_container(
+                                                suffix,
+                                                root,
+                                                shape,
+                                                tuple(values),
+                                                selected,
+                                                False,
+                                            )
+                                            assignment = re.sub(
+                                                rf'(["\'`]){re.escape(required_url)}\1',
+                                                source_ref,
+                                                assignment,
+                                                count=1,
+                                            )
+                                            rendered = [
+                                                (source_line, False),
+                                                (assignment, False),
+                                            ]
+                                        else:
+                                            assignment, expression = static_container(
+                                                suffix,
+                                                root,
+                                                shape,
+                                                (normal_url, normal_url),
+                                                selected,
+                                                False,
+                                            )
+                                            rendered = [
+                                                (source_line, False),
+                                                (assignment, False),
+                                                (
+                                                    member_source_assignment(
+                                                        suffix,
+                                                        root,
+                                                        shape,
+                                                        required_slot,
+                                                        source_ref,
+                                                    ),
+                                                    False,
+                                                ),
+                                            ]
+                                        rendered.append(
+                                            (
+                                                request_call(
+                                                    suffix, expression, signature
+                                                ),
+                                                selected_required,
+                                            )
+                                        )
+                                        cases.append(rendered)
+                run_batch(
+                    temp_root, "container_source", suffix, cases
+                )
+
+            for suffix in inline_suffixes:
+                cases = []
+                case_id = 0
+                for route in routes:
+                    required_url = (
+                        f"https://api.telnyx.com/v2/messages/{route}"
+                    )
+                    for shape in ("keyed", "indexed"):
+                        for selected_required in (False, True):
+                            for alternate in (False, True):
+                                for signature in ("native", "method_first"):
+                                    case_id += 1
+                                    root = f"routes_inline_{case_id}"
+                                    selected = 0 if selected_required else 1
+                                    assignment, member = static_container(
+                                        suffix,
+                                        root,
+                                        shape,
+                                        (required_url, normal_url),
+                                        selected,
+                                        alternate,
+                                    )
+                                    expression = inline_container_expression(
+                                        suffix, root, assignment, member
+                                    )
+                                    cases.append(
+                                        [
+                                            (
+                                                request_call(
+                                                    suffix, expression, signature
+                                                ),
+                                                selected_required,
+                                            )
+                                        ]
+                                    )
+                run_batch(temp_root, "inline", suffix, cases)
+
+            scope_states = (
+                "sibling_shadow",
+                "active_shadow",
+                "inner_required",
+                "same_scope_reassignment",
+            )
+            for suffix in suffixes:
+                cases = []
+                case_id = 0
+                for route in routes:
+                    required_url = (
+                        f"https://api.telnyx.com/v2/messages/{route}"
+                    )
+                    for shape in ("keyed", "indexed"):
+                        for state in scope_states:
+                            case_id += 1
+                            root = f"routes_scope_{case_id}"
+                            outer_required, outer_expression = static_container(
+                                suffix,
+                                root,
+                                shape,
+                                (required_url, normal_url),
+                                0,
+                                False,
+                            )
+                            outer_normal, _ = static_container(
+                                suffix,
+                                root,
+                                shape,
+                                (normal_url, normal_url),
+                                0,
+                                False,
+                            )
+                            inner_required, inner_expression = static_container(
+                                suffix,
+                                root,
+                                shape,
+                                (required_url, normal_url),
+                                0,
+                                False,
+                            )
+                            inner_normal, _ = static_container(
+                                suffix,
+                                root,
+                                shape,
+                                (normal_url, normal_url),
+                                0,
+                                False,
+                            )
+                            call = request_call(
+                                suffix, outer_expression, "native"
+                            )
+                            function_name = f"scope_case_{case_id}"
+                            if state == "sibling_shadow":
+                                rendered = [(outer_required, False)]
+                                rendered.extend(
+                                    scoped_function(
+                                        suffix,
+                                        function_name,
+                                        [(inner_normal, False), (call, False)],
+                                    )
+                                )
+                                rendered.append((call, True))
+                            elif state == "active_shadow":
+                                rendered = [(outer_required, False)]
+                                rendered.extend(
+                                    scoped_function(
+                                        suffix,
+                                        function_name,
+                                        [(inner_normal, False), (call, False)],
+                                    )
+                                )
+                            elif state == "inner_required":
+                                rendered = [(outer_normal, False)]
+                                rendered.extend(
+                                    scoped_function(
+                                        suffix,
+                                        function_name,
+                                        [
+                                            (inner_required, False),
+                                            (
+                                                request_call(
+                                                    suffix,
+                                                    inner_expression,
+                                                    "native",
+                                                ),
+                                                True,
+                                            ),
+                                        ],
+                                    )
+                                )
+                            else:
+                                rendered = [
+                                    (outer_required, False),
+                                    (outer_normal, False),
+                                    (call, False),
+                                ]
+                            cases.append(rendered)
+                run_batch(temp_root, "scope", suffix, cases)
+
+            for suffix in (".js", ".java", ".go"):
+                cases = []
+                case_id = 0
+                for route in routes:
+                    required_url = (
+                        f"https://api.telnyx.com/v2/messages/{route}"
+                    )
+                    for shape in ("keyed", "indexed"):
+                        for inner_required in (False, True):
+                            for mutation_kind in ("root", "member"):
+                                case_id += 1
+                                root = f"routes_mutation_{case_id}"
+                                outer_url = (
+                                    normal_url if inner_required else required_url
+                                )
+                                inner_url = (
+                                    required_url if inner_required else normal_url
+                                )
+                                outer, expression = static_container(
+                                    suffix,
+                                    root,
+                                    shape,
+                                    (outer_url, normal_url),
+                                    0,
+                                    False,
+                                )
+                                rendered = [(outer, False)]
+                                if mutation_kind == "root":
+                                    inner, _ = static_container(
+                                        suffix,
+                                        root,
+                                        shape,
+                                        (inner_url, normal_url),
+                                        0,
+                                        False,
+                                    )
+                                    mutation = bare_root_mutation(suffix, inner)
+                                else:
+                                    source_line, source_ref = scalar_endpoint_source(
+                                        suffix,
+                                        f"inner_source_{case_id}",
+                                        inner_url,
+                                    )
+                                    rendered.append((source_line, False))
+                                    mutation = member_source_assignment(
+                                        suffix,
+                                        root,
+                                        shape,
+                                        0,
+                                        source_ref,
+                                    )
+                                rendered.append((f"{{ {mutation} }}", False))
+                                rendered.append(
+                                    (
+                                        request_call(
+                                            suffix, expression, "native"
+                                        ),
+                                        inner_required,
+                                    )
+                                )
+                                cases.append(rendered)
+                run_batch(
+                    temp_root, "mutation_scope", suffix, cases
+                )
+
+            for suffix in javascript_suffixes:
+                cases = []
+                case_id = 0
+                for route in routes:
+                    required_url = (
+                        f"https://api.telnyx.com/v2/messages/{route}"
+                    )
+                    for shape in ("object", "array"):
+                        for nested in (False, True):
+                            for binding_style in ("direct", "renamed"):
+                                for selected_required in (False, True):
+                                    for signature in ("native", "method_first"):
+                                        case_id += 1
+                                        root = f"routes_destructure_{case_id}"
+                                        endpoint = f"endpoint_{case_id}"
+                                        required_key = f"required_{case_id}"
+                                        normal_key = f"normal_{case_id}"
+                                        selected_key = (
+                                            required_key
+                                            if selected_required
+                                            else normal_key
+                                        )
+                                        if shape == "object":
+                                            members = (
+                                                f"{required_key}: "
+                                                f'"{required_url}", '
+                                                f"{normal_key}: "
+                                                f'"{normal_url}"'
+                                            )
+                                            literal = (
+                                                f"{{nested: {{{members}}}}}"
+                                                if nested
+                                                else f"{{{members}}}"
+                                            )
+                                            if binding_style == "direct":
+                                                leaf = selected_key
+                                                expression = selected_key
+                                            else:
+                                                leaf = (
+                                                    f"{selected_key}: {endpoint}"
+                                                )
+                                                expression = endpoint
+                                            pattern = (
+                                                f"{{nested: {{{leaf}}}}}"
+                                                if nested
+                                                else f"{{{leaf}}}"
+                                            )
+                                            rendered = [
+                                                (
+                                                    f"const {root} = {literal};",
+                                                    False,
+                                                ),
+                                                (
+                                                    f"const {pattern} = {root};",
+                                                    False,
+                                                ),
+                                            ]
+                                        else:
+                                            literal = (
+                                                f'[["{required_url}"], '
+                                                f'["{normal_url}"]]'
+                                                if nested
+                                                else (
+                                                    f'["{required_url}", '
+                                                    f'"{normal_url}"]'
+                                                )
+                                            )
+                                            selected = 0 if selected_required else 1
+                                            chosen = (
+                                                endpoint
+                                                if binding_style == "direct"
+                                                else f"selected_{case_id}"
+                                            )
+                                            other = f"unused_{case_id}"
+                                            leaves = [other, other]
+                                            leaves[selected] = chosen
+                                            pattern = (
+                                                f"[[{leaves[0]}], [{leaves[1]}]]"
+                                                if nested
+                                                else f"[{leaves[0]}, {leaves[1]}]"
+                                            )
+                                            rendered = [
+                                                (
+                                                    f"const {root} = {literal};",
+                                                    False,
+                                                ),
+                                                (
+                                                    f"const {pattern} = {root};",
+                                                    False,
+                                                ),
+                                            ]
+                                            expression = chosen
+                                            if binding_style == "renamed":
+                                                alias, expression = alias_assignment(
+                                                    suffix, endpoint, chosen
+                                                )
+                                                rendered.append((alias, False))
+                                        rendered.append(
+                                            (
+                                                request_call(
+                                                    suffix, expression, signature
+                                                ),
+                                                selected_required,
+                                            )
+                                        )
+                                        cases.append(rendered)
+                run_batch(temp_root, "destructuring", suffix, cases)
+
+            for suffix in suffixes:
+                cases = []
+                case_id = 0
+                for route in routes:
+                    required_url = (
+                        f"https://api.telnyx.com/v2/messages/{route}"
+                    )
+                    for shape in ("keyed", "indexed"):
+                        for signature in ("native", "method_first"):
+                            case_id += 1
+                            root = f"routes_dynamic_{case_id}"
+                            key = f"dynamic_key_{case_id}"
+                            assignment, static_member = static_container(
+                                suffix,
+                                root,
+                                shape,
+                                (required_url, normal_url),
+                                0,
+                                False,
+                            )
+                            if suffix == ".php":
+                                key_assignment = f"${key} = $runtime_key;"
+                                expression = f"${root}[${key}]"
+                            elif suffix == ".sh":
+                                key_assignment = f'{key}="$RUNTIME_KEY"'
+                                expression = f'"${{{root}[${key}]}}"'
+                            elif suffix == ".java" and shape == "keyed":
+                                key_assignment = f"var {key} = runtimeKey;"
+                                expression = f"{root}.get({key})"
+                            elif suffix in {".java", ".cs"}:
+                                key_assignment = f"var {key} = runtimeKey;"
+                                expression = f"{root}[{key}]"
+                            elif suffix == ".go":
+                                key_assignment = f"{key} := runtimeKey"
+                                expression = f"{root}[{key}]"
+                            else:
+                                prefix = "const " if suffix in javascript_suffixes else ""
+                                key_assignment = f"{prefix}{key} = runtime_key"
+                                key_assignment += ";" if prefix else ""
+                                expression = f"{root}[{key}]"
+                            cases.append(
+                                [
+                                    (assignment, False),
+                                    (key_assignment, False),
+                                    (
+                                        request_call(
+                                            suffix, expression, signature
+                                        ),
+                                        False,
+                                    ),
+                                ]
+                            )
+                            if suffix != ".sh":
+                                inline_expression = inline_container_expression(
+                                    suffix, root, assignment, static_member
+                                )
+                                dynamic_key = (
+                                    f"${key}" if suffix == ".php" else key
+                                )
+                                if suffix == ".java" and shape == "keyed":
+                                    inline_expression = re.sub(
+                                        r"\.get\([^)]*\)$",
+                                        f".get({dynamic_key})",
+                                        inline_expression,
+                                    )
+                                else:
+                                    inline_expression, replacements = re.subn(
+                                        r"\[[^][]+\]$",
+                                        f"[{dynamic_key}]",
+                                        inline_expression,
+                                    )
+                                    if replacements == 0:
+                                        inline_expression = re.sub(
+                                            r"\.[A-Za-z_]\w*$",
+                                            f"[{dynamic_key}]",
+                                            inline_expression,
+                                        )
+                                cases.append(
+                                    [
+                                        (key_assignment, False),
+                                        (
+                                            request_call(
+                                                suffix,
+                                                inline_expression,
+                                                signature,
+                                            ),
+                                            False,
+                                        ),
+                                    ]
+                                )
+                run_batch(temp_root, "dynamic", suffix, cases)
+
+            for suffix in javascript_suffixes:
+                cases = []
+                case_id = 0
+                for route in routes:
+                    required_url = (
+                        f"https://api.telnyx.com/v2/messages/{route}"
+                    )
+                    for shape in ("keyed", "indexed"):
+                        for signature in ("native", "method_first"):
+                            case_id += 1
+                            root = f"routes_template_{case_id}"
+                            url = f"url_template_{case_id}"
+                            assignment, expression = static_container(
+                                suffix,
+                                root,
+                                shape,
+                                (required_url, normal_url),
+                                0,
+                                False,
+                            )
+                            cases.append(
+                                [
+                                    (assignment, False),
+                                    (f"const {url} = `${{{expression}}}`;", False),
+                                    (
+                                        request_call(suffix, url, signature),
+                                        True,
+                                    ),
+                                ]
+                            )
+                run_batch(temp_root, "template", suffix, cases)
+
+        # Derived from the suffix tuples rather than written as literals: the
+        # leading factor is "how many languages this category enumerates", so
+        # hardcoding it meant widening a tuple failed here for arithmetic
+        # reasons and hid whether coverage had actually grown. mutation_scope
+        # keeps its own literal because it enumerates its own three suffixes.
+        all_suffixes = len(suffixes)
+        inline_only = len(inline_suffixes)
+        js_only = len(javascript_suffixes)
+        self.assertEqual(
+            {
+                "static": all_suffixes * 2 * 2 * 2 * 2 * 2 * 2,
+                "container_source": all_suffixes * 2 * 2 * 2 * 2 * 2 * 2,
+                "inline": inline_only * 2 * 2 * 2 * 2 * 2,
+                "scope": all_suffixes * 2 * 2 * 4,
+                "mutation_scope": 3 * 2 * 2 * 2 * 2,
+                "destructuring": js_only * 2 * 2 * 2 * 2 * 2 * 2,
+                "dynamic": (all_suffixes * 2 * 2 * 2) + (inline_only * 2 * 2 * 2),
+                "template": js_only * 2 * 2 * 2,
+            },
+            counts,
+        )
+        # Grew from 2,408 when the JS module extensions joined the matrix.
+        self.assertEqual(3_464, sum(counts.values()))
+
+    def test_c_function_header_index_is_declaration_first(self) -> None:
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_function_header_contract",
+        )
+        lex_source = namespace["lex_source"]
+        c_function_headers = namespace["c_function_headers"]
+
+        rejected = {
+            ".java": [
+                "Object x = new Runnable(callback()) { };",
+                "synchronized(lock) { work(); }",
+                "try(resource) { work(); }",
+                "if ready(path) { work(); }",
+            ],
+            ".cs": [
+                "var x = new Widget(callback()) { Value = 1 };",
+                "using(resource) { Work(); }",
+                "lock(gate) { Work(); }",
+            ],
+            ".js": ["class X extends mixin(Base) { }"],
+        }
+        for suffix, sources in rejected.items():
+            for source in sources:
+                with self.subTest(suffix=suffix, source=source):
+                    lexed = lex_source(source, suffix)
+                    self.assertEqual({}, c_function_headers(lexed, suffix))
+
+        accepted = {
+            (".cs", "class C { C(string path) { } }"): ["string path"],
+            (
+                ".cs",
+                "class C { C(string path) : base(transform(path)) { } }",
+            ): ["string path"],
+            (
+                ".php",
+                "$fn = function($path) use ($client) { return $path; };",
+            ): ["$path"],
+            (".js", "foo(); path => { use(path); };"): ["path"],
+            (
+                ".go",
+                "func send(path string) error { return nil }",
+            ): ["path string"],
+            (
+                ".go",
+                "func send(path string) (error, int) { return nil, 0 }",
+            ): ["path string"],
+            (
+                ".java",
+                "void send(String path) throws IOException { use(path); }",
+            ): ["String path"],
+            (
+                ".ts",
+                "send(path: string): Promise<void> { use(path); }",
+            ): ["path: string"],
+            (
+                ".js",
+                "const handlers = { send(path) { use(path); } };",
+            ): ["path"],
+            (
+                ".java",
+                "Object x = new Runnable(callback()) { public void run() { } };",
+            ): [""],
+        }
+        for (suffix, source), expected in accepted.items():
+            with self.subTest(suffix=suffix, source=source):
+                lexed = lex_source(source, suffix)
+                headers = c_function_headers(lexed, suffix)
+                parameters = [
+                    source[start:end].strip()
+                    for start, end in headers.values()
+                ]
+                self.assertEqual(expected, parameters)
+
+    def test_indexed_endpoint_resolver_closes_cross_dimension_regressions(
+        self,
+    ) -> None:
+        required = "/v2/messages/number_pool"
+        detected = {
+            "container-source.js": (
+                f'const required = "{required}";\n'
+                "const routes = {pool: required};\n"
+                "axios.post(routes.pool, {});"
+            ),
+            "array-source.ts": (
+                f'const required = "{required}";\n'
+                "const routes = [required];\n"
+                "fetch(routes[0], {method: \"POST\", body: \"{}\"});"
+            ),
+            "member-source.java": (
+                f'var required = "{required}";\n'
+                "var routes = new HashMap<String, String>();\n"
+                "routes.put(\"pool\", required);\n"
+                "client.post(routes.get(\"pool\"), payload);"
+            ),
+            "inline-source.tsx": (
+                f'const required = "{required}";\n'
+                "axios.post(({pool: required, normal: \"/v2/messages\"}).pool, {});"
+            ),
+            "live-alias-mutation.js": (
+                'const routes = {pool: "/v2/messages"};\n'
+                "const alias = routes;\n"
+                f'routes.pool = "{required}";\n'
+                "axios.post(alias.pool, {});"
+            ),
+            "reverse-alias-mutation.js": (
+                'const routes = {pool: "/v2/messages"};\n'
+                "const alias = routes;\n"
+                f'alias.pool = "{required}";\n'
+                "axios.post(routes.pool, {});"
+            ),
+            "axios-config.js": (
+                f'const endpoint = "{required}";\n'
+                "const config = {url: endpoint, method: \"post\", data: {}};\n"
+                "axios.request(config);"
+            ),
+            "keyword-request.py": (
+                f'endpoint = "{required}"\n'
+                'requests.request(method="POST", url=endpoint, json={})'
+            ),
+            "session-request.py": (
+                f'endpoint = "{required}"\n'
+                'session.request("POST", endpoint, json={})'
+            ),
+            "ruby-request.rb": (
+                f'endpoint = "{required}"\n'
+                "client.request(:post, endpoint, {})"
+            ),
+            "php-request.php": (
+                f'$endpoint = "{required}";\n'
+                '$client->request("POST", $endpoint, []);'
+            ),
+            "typed-destructure.ts": (
+                f'const routes = {{pool: "{required}"}};\n'
+                "const {pool: endpoint}: Routes = routes;\n"
+                "axios.post(endpoint, {});"
+            ),
+            "default-destructure.js": (
+                f'const fallback = "{required}";\n'
+                f'const routes = {{pool: "{required}"}};\n'
+                "const {pool: endpoint = fallback} = routes;\n"
+                "axios.post(endpoint, {});"
+            ),
+            "block-mutation.js": (
+                'let endpoint = "/v2/messages";\n'
+                f'{{ endpoint = "{required}"; }}\n'
+                "axios.post(endpoint, {});"
+            ),
+            "block-mutation.java": (
+                'String endpoint = "/v2/messages";\n'
+                f'{{ endpoint = "{required}"; }}\n'
+                "client.post(endpoint, payload);"
+            ),
+            "block-mutation.go": (
+                'endpoint := "/v2/messages"\n'
+                f'{{ endpoint = "{required}" }}\n'
+                'http.Post(endpoint, "application/json", body)'
+            ),
+            "var-function-scope.js": (
+                'var endpoint = "/v2/messages";\n'
+                f'{{ var endpoint = "{required}"; }}\n'
+                "axios.post(endpoint, {});"
+            ),
+            "python-class.py": (
+                f'endpoint = "{required}"\n'
+                "class Routes:\n"
+                '    endpoint = "/v2/messages"\n'
+                "    def send(self):\n"
+                "        requests.post(endpoint, json={})"
+            ),
+            "java-anonymous-capture.java": (
+                f'String endpoint = "{required}";\n'
+                "Object worker = new Runnable(callback()) {\n"
+                "  public void run() { client.post(endpoint, payload); }\n"
+                "};"
+            ),
+            "js-mixin-class-capture.js": (
+                f'const endpoint = "{required}";\n'
+                "class Sender extends mixin(Base) {\n"
+                "  send() { axios.post(endpoint, {}); }\n"
+                "}"
+            ),
+            "python-interpolation.py": (
+                f'path = "{required}"\n'
+                'url = f"https://api.telnyx.com{path}"\n'
+                "requests.post(url, json={})"
+            ),
+            "ruby-interpolation.rb": (
+                f'path = "{required}"\n'
+                'url = "https://api.telnyx.com#{path}"\n'
+                "client.post(url, {})"
+            ),
+            "shell-container.sh": (
+                f'required="{required}"\n'
+                'declare -A routes=([pool]="$required")\n'
+                'curl "${routes[pool]}" -d \'{}\''
+            ),
+            "shell-indexed-unquoted.sh": (
+                f'required="{required}"\n'
+                "routes=($required)\n"
+                'curl "${routes[0]}" -d \'{}\''
+            ),
+        }
+        detected_items = list(detected.items())
+        for batch_start in range(0, len(detected_items), 12):
+            batch = dict(detected_items[batch_start:batch_start + 12])
+            _, payload = self.run_messaging_linter(batch)
+            for fixture_name in batch:
+                with self.subTest(fixture=fixture_name):
+                    self.assert_required_profile_detected(
+                        payload, fixture_name
+                    )
+
+        self.assert_required_profile_passes(
+            {
+                "dynamic-key.js": (
+                    f'const pool = "{required}";\n'
+                    'const routes = {[pool]: "/v2/messages", normal: "/v2/messages"};\n'
+                    "const key = runtimeKey;\n"
+                    "axios.post(routes[key], {});"
+                ),
+                "inline-normal.js": (
+                    f'const required = "{required}";\n'
+                    'axios.post(({pool: required, normal: "/v2/messages"}).normal, {});'
+                ),
+                "live-alias-kill.js": (
+                    f'const routes = {{pool: "{required}"}};\n'
+                    "const alias = routes;\n"
+                    'routes.pool = "/v2/messages";\n'
+                    "axios.post(alias.pool, {});"
+                ),
+                "reverse-alias-kill.js": (
+                    f'const routes = {{pool: "{required}"}};\n'
+                    "const alias = routes;\n"
+                    'alias.pool = "/v2/messages";\n'
+                    "axios.post(routes.pool, {});"
+                ),
+                "unsupported-transform.js": (
+                    f'const required = "{required}";\n'
+                    "const endpoint = chooseEndpoint(required);\n"
+                    "axios.post(endpoint, {});"
+                ),
+                "parameter-shadow.js": (
+                    f'const endpoint = "{required}";\n'
+                    "function send(endpoint) { axios.post(endpoint, {}); }"
+                ),
+                "parameter-shadow.py": (
+                    f'endpoint = "{required}"\n'
+                    "def send(endpoint):\n"
+                    "    requests.post(endpoint, json={})"
+                ),
+                "parameter-shadow.java": (
+                    f'var endpoint = "{required}";\n'
+                    "void send(String endpoint) { client.post(endpoint, payload); }"
+                ),
+                "parameter-shadow.cs": (
+                    f'var endpoint = "{required}";\n'
+                    "void Send(string endpoint) { client.PostAsync(endpoint, payload); }"
+                ),
+                "parameter-shadow.go": (
+                    f'endpoint := "{required}"\n'
+                    'func send(endpoint string) { http.Post(endpoint, "application/json", body) }'
+                ),
+                "parameter-shadow.php": (
+                    f'$endpoint = "{required}";\n'
+                    "function send($endpoint) { $client->post($endpoint, []); }"
+                ),
+                "php-closure-capture.php": (
+                    f'$endpoint = "{required}";\n'
+                    "$fn = function($endpoint) use ($client) {\n"
+                    "  $client->post($endpoint, []);\n"
+                    "};"
+                ),
+                "csharp-constructor-base.cs": (
+                    f'var endpoint = "{required}";\n'
+                    "class Sender {\n"
+                    "  Sender(string endpoint) : base(transform(endpoint)) {\n"
+                    "    client.PostAsync(endpoint, payload);\n"
+                    "  }\n"
+                    "}"
+                ),
+                "go-tuple-return-parameter.go": (
+                    f'endpoint := "{required}"\n'
+                    "func send(endpoint string) (error, int) {\n"
+                    '  http.Post(endpoint, "application/json", body)\n'
+                    "  return nil, 0\n"
+                    "}"
+                ),
+                "single-arrow-parameter.js": (
+                    f'const endpoint = "{required}";\n'
+                    "prepare();\n"
+                    "const send = endpoint => { axios.post(endpoint, {}); };"
+                ),
+                "parameter-shadow.rb": (
+                    f'endpoint = "{required}"\n'
+                    "def send(endpoint)\n"
+                    "  client.post(endpoint, {})\n"
+                    "end"
+                ),
+                "block-parameter-shadow.rb": (
+                    f'endpoint = "{required}"\n'
+                    "items.each do |endpoint|\n"
+                    "  client.post(endpoint, {})\n"
+                    "end"
+                ),
+                "catch-parameter-shadow.js": (
+                    f'const endpoint = "{required}";\n'
+                    "try { work(); } catch (endpoint) { axios.post(endpoint, {}); }"
+                ),
+                "loop-binding-shadow.js": (
+                    f'const endpoint = "{required}";\n'
+                    "for (const endpoint of endpoints) { axios.post(endpoint, {}); }"
+                ),
+                "block-kill.js": (
+                    f'let endpoint = "{required}";\n'
+                    '{ endpoint = "/v2/messages"; }\n'
+                    "axios.post(endpoint, {});"
+                ),
+                "mixed-default.js": (
+                    f'const fallback = "{required}";\n'
+                    'const routes = {pool: "/v2/messages"};\n'
+                    "const {pool: endpoint = fallback} = routes;\n"
+                    "axios.post(endpoint, {});"
+                ),
+                "python-class-safe.py": (
+                    'endpoint = "/v2/messages"\n'
+                    "class Routes:\n"
+                    f'    endpoint = "{required}"\n'
+                    "    def send(self):\n"
+                    "        requests.post(endpoint, json={})"
+                ),
+            }
+        )
+
+    def test_endpoint_resolver_common_static_syntax_corpus(self) -> None:
+        required = "/v2/messages/number_pool"
+        safe = "/v2/messages"
+        detected = {
+            "default-existing.js": (
+                f'const r = {{pool: "{required}"}};\n'
+                f'const {{pool: url = "{safe}"}} = r;\n'
+                "axios.post(url, {});"
+            ),
+            "default-missing.js": (
+                "const r = {};\n"
+                f'const {{pool: url = "{required}"}} = r;\n'
+                "axios.post(url, {});"
+            ),
+            "array-default.js": (
+                f'const r = ["{required}"];\n'
+                f'const [url = "{safe}"] = r;\n'
+                "axios.post(url, {});"
+            ),
+            "nested-default.js": (
+                f'const r = {{messages: {{pool: "{required}"}}}};\n'
+                f'const {{messages: {{pool: url = "{safe}"}}}} = r;\n'
+                "axios.post(url, {});"
+            ),
+            "ts-inline-type.ts": (
+                f'const r = {{pool: "{required}"}};\n'
+                "const {pool}: {pool: string} = r;\n"
+                "axios.post(pool, {});"
+            ),
+            "ts-rhs-as.ts": (
+                f'const r = {{pool: "{required}"}};\n'
+                "const {pool} = (r as Routes);\n"
+                "axios.post(pool, {});"
+            ),
+            "ts-as-const.ts": (
+                f'const r = {{pool: "{required}"}} as const;\n'
+                "const {pool} = r;\n"
+                "axios.post(pool, {});"
+            ),
+            "destructuring-assignment.js": (
+                f'const r = {{pool: "{required}"}};\n'
+                "let url;\n"
+                "({pool: url} = r);\n"
+                "axios.post(url, {});"
+            ),
+            "wrapper-parentheses.js": (
+                f'const r = {{pool: "{required}"}};\n'
+                "axios.post((r).pool, {});"
+            ),
+            "wrapper-nonnull.ts": (
+                f'const r = {{pool: "{required}"}};\n'
+                "axios.post(r!.pool, {});"
+            ),
+            "wrapper-as.ts": (
+                f'const r = {{pool: "{required}"}};\n'
+                "axios.post((r as Routes).pool, {});"
+            ),
+            "computed-key.js": (
+                f'const r = {{pool: "{required}"}};\n'
+                'const key = "pool";\n'
+                "axios.post(r[key], {});"
+            ),
+            "computed-key.py": (
+                f'r = {{"pool": "{required}"}}\n'
+                'key = "pool"\n'
+                "requests.post(r[key], json={})"
+            ),
+            "computed-key.rb": (
+                f'r = {{pool: "{required}"}}\n'
+                "key = :pool\n"
+                "client.post(r[key], {})"
+            ),
+            "computed-key.sh": (
+                f'declare -A r=([pool]="{required}")\n'
+                "key=pool\n"
+                'curl "${r[$key]}" -d \'{}\''
+            ),
+            "named-requests.py": (
+                f'endpoint = "{required}"\n'
+                "requests.post(url=endpoint, json={})"
+            ),
+            "named-session.py": (
+                f'endpoint = "{required}"\n'
+                "session.post(url=endpoint, json={})"
+            ),
+            "named-csharp.cs": (
+                f'var endpoint = "{required}";\n'
+                "client.PostAsync(requestUri: endpoint, content: payload);"
+            ),
+            "named-php.php": (
+                f'$endpoint = "{required}";\n'
+                "$client->post(uri: $endpoint, options: []);"
+            ),
+            "lookup-python.py": (
+                f'r = {{"pool": "{required}"}}\n'
+                f'requests.post(r.get("pool", "{safe}"), json={{}})'
+            ),
+            "lookup-ruby.rb": (
+                f'r = {{pool: "{required}"}}\n'
+                f'client.post(r.fetch(:pool, "{safe}"), {{}})'
+            ),
+            "lookup-java.java": (
+                f'var r = Map.of("pool", "{required}");\n'
+                f'client.post(r.getOrDefault("pool", "{safe}"), payload);'
+            ),
+            "lookup-csharp.cs": (
+                f'var r = new Dictionary<string, string> '
+                f'{{ ["pool"] = "{required}" }};\n'
+                f'client.PostAsync(r.GetValueOrDefault("pool", "{safe}"), payload);'
+            ),
+            "lookup-missing.py": (
+                "r = {}\n"
+                f'requests.post(r.get("pool", "{required}"), json={{}})'
+            ),
+            "dig-ruby.rb": (
+                f'r = {{messages: {{pool: "{required}"}}}}\n'
+                "client.post(r.dig(:messages, :pool), {})"
+            ),
+            "interpolation-php.php": (
+                '$BASE = "https://api.telnyx.com";\n'
+                f'$endpoint = "{required}";\n'
+                '$url = "{$BASE}{$endpoint}";\n'
+                "$client->post($url, []);"
+            ),
+            "interpolation-csharp.cs": (
+                'var BASE = "https://api.telnyx.com";\n'
+                f'var endpoint = "{required}";\n'
+                'var url = $"{BASE}{endpoint}";\n'
+                "client.PostAsync(url, payload);"
+            ),
+            "interpolation-format.py": (
+                'BASE = "https://api.telnyx.com"\n'
+                f'endpoint = "{required}"\n'
+                'url = "{}{}".format(BASE, endpoint)\n'
+                "requests.post(url, json={})"
+            ),
+        }
+        split_literals = {
+            ".js": "axios.post(PATH, {});",
+            ".ts": "axios.post(PATH, {});",
+            ".py": "requests.post(PATH, json={})",
+            ".rb": "client.post(PATH, {})",
+            ".java": "client.post(PATH, payload);",
+            ".cs": "client.PostAsync(PATH, payload);",
+            ".go": 'http.Post(PATH, "application/json", body)',
+        }
+        for suffix, call in split_literals.items():
+            detected[f"split-literal{suffix}"] = call.replace(
+                "PATH", '"/v2/messages/" + "number_pool"'
+            )
+
+        safe_cases = {
+            "lambda-shadow.js": (
+                f'const endpoint = "{required}";\n'
+                f'["{safe}"].forEach(endpoint => axios.post(endpoint, {{}}));'
+            ),
+            "lambda-shadow.java": (
+                f'String endpoint = "{required}";\n'
+                "items.forEach(endpoint -> client.post(endpoint, payload));"
+            ),
+            "lambda-shadow.cs": (
+                f'var endpoint = "{required}";\n'
+                "items.ForEach(endpoint => client.PostAsync(endpoint, payload));"
+            ),
+            "runtime-key.js": (
+                f'const r = {{pool: "{required}"}};\n'
+                "const key = runtimeKey();\n"
+                "axios.post(r[key], {});"
+            ),
+            "runtime-key.py": (
+                f'r = {{"pool": "{required}"}}\n'
+                "key = runtime_key()\n"
+                "requests.post(r[key], json={})"
+            ),
+            "runtime-key.rb": (
+                f'r = {{pool: "{required}"}}\n'
+                "key = runtime_key()\n"
+                "client.post(r[key], {})"
+            ),
+            "runtime-key.sh": (
+                f'declare -A r=([pool]="{required}")\n'
+                'key="$RUNTIME_KEY"\n'
+                'curl "${r[$key]}" -d \'{}\''
+            ),
+            "bash-bare-shorthand.sh": (
+                f'r=("{required}")\n'
+                'curl "$r" -d \'{}\''
+            ),
+            "negative-index.js": (
+                f'const r = ["{required}"];\n'
+                "axios.post(r[-1], {});"
+            ),
+            "spread-only.js": (
+                "const r = {...runtimeRoutes};\n"
+                "axios.post(r.pool, {});"
+            ),
+            "loop-result.js": (
+                "let endpoint;\n"
+                "for (endpoint of endpoints) { consume(endpoint); }\n"
+                "axios.post(endpoint, {});"
+            ),
+            "uri-builder.js": (
+                f'const endpoint = new URL("{required}", base);\n'
+                "axios.post(endpoint, {});"
+            ),
+            "runtime-concat.js": (
+                'const endpoint = "/v2/messages/" + runtimeSuffix;\n'
+                "axios.post(endpoint, {});"
+            ),
+            "runtime-primary-default.js": (
+                "const r = runtimeRoutes;\n"
+                f'const {{pool: endpoint = "{required}"}} = r;\n'
+                "axios.post(endpoint, {});"
+            ),
+        }
+
+        detected_items = list(detected.items())
+        for batch_start in range(0, len(detected_items), 12):
+            batch = dict(detected_items[batch_start:batch_start + 12])
+            _, payload = self.run_messaging_linter(batch)
+            for fixture_name in batch:
+                with self.subTest(fixture=fixture_name):
+                    self.assert_required_profile_detected(
+                        payload, fixture_name
+                    )
+        self.assert_required_profile_passes(safe_cases)
+        self.assertEqual(49, len(detected) + len(safe_cases))
+
+    def test_indexed_endpoint_resolver_is_iterative_and_call_linear(self) -> None:
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_endpoint_scaling_contract",
+        )
+        analyze_file = namespace["analyze_file"]
+        with tempfile.TemporaryDirectory(
+            prefix="telnyx-endpoint-scaling-"
+        ) as temp_dir:
+            temp_root = Path(temp_dir)
+            chain = temp_root / "chain.js"
+            chain_lines = [
+                'const endpoint_0 = "/v2/messages/number_pool";'
+            ]
+            chain_lines.extend(
+                f"const endpoint_{index} = endpoint_{index - 1};"
+                for index in range(1, 2_001)
+            )
+            chain_lines.append("axios.post(endpoint_2000, {});")
+            chain.write_text("\n".join(chain_lines), encoding="utf-8")
+            self.assertEqual(1, analyze_file(chain, temp_root)[0])
+
+            cycle = temp_root / "cycle.js"
+            cycle.write_text(
+                "\n".join(
+                    (
+                        'let required = "/v2/messages/number_pool";',
+                        "let first = required;",
+                        "let second = first;",
+                        "first = second;",
+                        "axios.post(first, {});",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(1, analyze_file(cycle, temp_root)[0])
+
+            scaling = temp_root / "scaling.js"
+            scaling.write_text(
+                "\n".join(
+                    [
+                        f'const unused_{index} = "/v2/messages/number_pool";'
+                        for index in range(200)
+                    ]
+                    + [
+                        f'axios.post("/v2/messages", {{id: {index}}});'
+                        for index in range(200)
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            started = time.perf_counter()
+            self.assertEqual(0, analyze_file(scaling, temp_root)[0])
+            self.assertLess(time.perf_counter() - started, 2.0)
+
+    def test_required_rest_path_must_derive_from_the_request_url(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "axios-data-decoy.ts": (
+                    'axios({method: "post", url: "/v2/messages", '
+                    'data: {audit: "/v2/messages/number_pool"}});'
+                ),
+                "axios-post-data-decoy.ts": (
+                    'axios.post("/v2/messages", '
+                    '{audit: "/v2/messages/number_pool"});'
+                ),
+                "fetch-header-decoy.ts": (
+                    'fetch("/v2/messages", {method: "POST", headers: '
+                    '{audit: "/v2/messages/number_pool"}, body: payload});'
+                ),
+                "method-first-data-decoy.py": (
+                    'requests.request("POST", "/v2/messages", '
+                    'json={"audit": "/v2/messages/number_pool"})'
+                ),
+                "inline-normal-member.ts": (
+                    'axios.post(({pool: "/v2/messages/number_pool", '
+                    'normal: "/v2/messages"}).normal, {text});'
+                ),
+                "expect-decoy.ts": (
+                    'expect(endpoint).toBe("/v2/messages/number_pool");'
+                ),
+                "assert-decoy.py": (
+                    'assert endpoint == "/v2/messages/number_pool"'
+                ),
+                "return-decoy.ts": (
+                    'function endpoint() { return "/v2/messages/number_pool"; }'
+                ),
+                "router-decoy.ts": (
+                    'router.post("/v2/messages/number_pool", handler);'
+                ),
+                "express-decoy.ts": (
+                    'app.post("/v2/messages/number_pool", handler);'
+                ),
+                "nock-decoy.ts": (
+                    'nock(API).post("/v2/messages/number_pool").reply(200);'
+                ),
+                "console-decoy.ts": (
+                    'console.log("/v2/messages/number_pool");'
+                ),
+                "curl-header-decoy.sh": (
+                    "curl https://example.invalid/audit -H "
+                    "'X-Endpoint: https://api.telnyx.com/v2/messages/number_pool'"
+                ),
+                "curl-body-decoy.sh": (
+                    "curl https://example.invalid/audit --data "
+                    "'https://api.telnyx.com/v2/messages/number_pool'"
+                ),
+                "curl-write-out-decoy.sh": (
+                    "curl https://example.invalid/audit --write-out "
+                    "'https://api.telnyx.com/v2/messages/number_pool'"
+                ),
+            }
+        )
+        fixture_name = "inline-pool-member.ts"
+        _, payload = self.run_messaging_linter(
+            {
+                fixture_name: (
+                    'axios.post(({pool: "/v2/messages/number_pool", '
+                    'normal: "/v2/messages"}).pool, {text});'
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_rest_profile_must_be_in_request_body_not_query_or_config(self) -> None:
+        fixtures = {
+            "axios-config.ts": "\n".join(
+                (
+                    'const path = "/v2/messages/number_pool";',
+                    "axios.post(path, {from, to, text}, {params: {messaging_profile_id: profile}});",
+                )
+            ),
+            "fetch-query.ts": (
+                'fetch("/v2/messages/alphanumeric_sender_id", '
+                '{method: "POST", body: JSON.stringify({from, to, text}), '
+                'params: {messaging_profile_id: profile}});'
+            ),
+            "requests-query.py": (
+                'requests.post("/v2/messages/number_pool", '
+                'json={"from": sender, "to": recipient, "text": text}, '
+                'params={"messaging_profile_id": profile})'
+            ),
+        }
+        result, payload = self.run_messaging_linter(fixtures)
+        self.assertEqual(1, result.returncode)
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_javascript_profile_shorthand_is_accepted_only_in_payloads(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "axios-shorthand.ts": "\n".join(
+                    (
+                        'const url = "/v2/messages/number_pool";',
+                        "axios.post(url, {from, to, text, messaging_profile_id});",
+                    )
+                ),
+                "fetch-shorthand.js": (
+                    'fetch("/v2/messages/alphanumeric_sender_id", '
+                    '{method: "POST", body: JSON.stringify({from, to, text, messagingProfileId})});'
+                ),
+                "variable-shorthand.tsx": "\n".join(
+                    (
+                        "const payload = {from, to, text, messagingProfileID};",
+                        'axios.post("/v2/messages/number_pool", payload);',
+                    )
+                ),
+            }
+        )
+        fixture_name = "config-shorthand.ts"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: (
+                    'axios.post("/v2/messages/number_pool", {from, to, text}, '
+                    "{params: {messaging_profile_id}});"
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_javascript_options_object_payload_shorthand_is_resolved(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "fetch-inline-options.ts": "\n".join(
+                    (
+                        'const url = "/v2/messages/number_pool";',
+                        "const body = JSON.stringify({from, to, text, messaging_profile_id});",
+                        "fetch(url, {method: 'POST', body});",
+                    )
+                ),
+                "fetch-assigned-options.js": "\n".join(
+                    (
+                        'const url = "/v2/messages/alphanumeric_sender_id";',
+                        "const body = JSON.stringify({from, to, text, messagingProfileId});",
+                        "const options = {method: 'POST', body};",
+                        "fetch(url, options);",
+                    )
+                ),
+                "axios-inline-options.tsx": "\n".join(
+                    (
+                        'const url = "/v2/messages/number_pool";',
+                        "const data = {from, to, text, messagingProfileID};",
+                        "axios({url, method: 'POST', data});",
+                    )
+                ),
+            }
+        )
+
+    def test_shell_profile_must_be_in_curl_body_and_accepts_inline_json(self) -> None:
+        fixture_name = "query-only.sh"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: (
+                    "curl -X POST "
+                    "https://api.telnyx.com/v2/messages/number_pool?messaging_profile_id=mp-query"
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        self.assert_required_profile_detected(payload, fixture_name)
+        self.assert_required_profile_passes(
+            {
+                "inline-json.sh": (
+                    "curl -X POST --json "
+                    "'{\"from\":\"pool\",\"to\":\"+12025550123\","
+                    "\"messaging_profile_id\":\"mp-body\"}' "
+                    "https://api.telnyx.com/v2/messages/number_pool"
+                )
+            }
+        )
+
+    def test_shell_jq_built_profile_is_resolved_from_the_output_filter(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "jq-payload.sh": "\n".join(
+                    (
+                        "url='https://api.telnyx.com/v2/messages/number_pool'",
+                        "payload=$(jq -cn \\",
+                        "  --arg p \"$PROFILE\" \\",
+                        "  '{from:$ENV.FROM,to:$ENV.TO,text:\"hello\",messaging_profile_id:$p}')",
+                        'curl --json "$payload" "$url"',
+                    )
+                )
+            }
+        )
+
+        fixtures = {
+            "jq-arg-name-decoy.sh": "\n".join(
+                (
+                    "url='https://api.telnyx.com/v2/messages/number_pool'",
+                    'payload=$(jq -cn --arg messaging_profile_id "$PROFILE" '
+                    "'{from:$ENV.FROM,to:$ENV.TO,text:\"hello\"}')",
+                    'curl --json "$payload" "$url"',
+                )
+            ),
+            "jq-nested-decoy.sh": "\n".join(
+                (
+                    "url='https://api.telnyx.com/v2/messages/alphanumeric_sender_id'",
+                    'payload=$(jq -cn --arg p "$PROFILE" '
+                    "'{text:\"hello\",metadata:{messaging_profile_id:$p}}')",
+                    'curl --json "$payload" "$url"',
+                )
+            ),
+        }
+        result, payload = self.run_messaging_linter(fixtures)
+        self.assertEqual(1, result.returncode)
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_shell_get_data_is_not_a_message_send(self) -> None:
+        fixtures = {
+            "get-long.sh": (
+                "curl --get --data-urlencode messaging_profile_id=mp-query "
+                "https://api.telnyx.com/v2/messages/number_pool"
+            ),
+            "get-short-cluster.sh": "\n".join(
+                (
+                    "url='https://api.telnyx.com/v2/messages/alphanumeric_sender_id'",
+                    "curl -sG \"$url\" --json "
+                    "'{\"messaging_profile_id\":\"mp-query\"}'",
+                )
+            ),
+        }
+        fixtures.update(
+            {
+                "get-disabled.sh": (
+                    "curl -G --no-get --json "
+                    "'{\"messaging_profile_id\":\"mp-body\"}' "
+                    "https://api.telnyx.com/v2/messages/number_pool"
+                )
+            }
+        )
+        self.assert_required_profile_passes(fixtures)
+
+    def test_shell_endpoint_variables_resolve_to_their_curl_calls(self) -> None:
+        fixture_name = "endpoint-variable.sh"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "url='https://api.telnyx.com/v2/messages/number_pool'",
+                        "curl -X POST \"$url\" -d '{\"text\":\"missing\"}'",
+                    )
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        self.assert_required_profile_detected(payload, fixture_name)
+        self.assert_required_profile_passes(
+            {
+                "endpoint-alias.sh": "\n".join(
+                    (
+                        "endpoint='https://api.telnyx.com/v2/messages/number_pool'",
+                        "url=$endpoint",
+                        "curl -X POST \"${url}\" --json "
+                        "'{\"messaging_profile_id\":\"mp-1\"}'",
+                    )
+                )
+            }
+        )
+
+    def test_shell_endpoint_aliases_cover_common_command_forms(self) -> None:
+        fixtures = {
+            "quoted-command-substitution.sh": "\n".join(
+                (
+                    "endpoint='https://api.telnyx.com/v2/messages/number_pool'",
+                    'url="$endpoint"',
+                    "response=$(curl -X POST \"${url}\" --json "
+                    "'{\"text\":\"missing\"}')",
+                )
+            ),
+            "if-command.sh": "\n".join(
+                (
+                    "url='https://api.telnyx.com/v2/messages/alphanumeric_sender_id'",
+                    "if curl -X POST \"$url\" -d '{\"text\":\"missing\"}'; then",
+                    "  echo sent",
+                    "fi",
+                )
+            ),
+        }
+        result, payload = self.run_messaging_linter(fixtures)
+        self.assertEqual(1, result.returncode)
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_shell_curl_payloads_do_not_bleed_across_commands(self) -> None:
+        fixture_name = "two-curls.sh"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "url='https://api.telnyx.com/v2/messages/number_pool'",
+                        "curl -X POST \"$url\" -d '{\"text\":\"missing\"}'; "
+                        "curl https://example.invalid/audit --json "
+                        "'{\"messaging_profile_id\":\"decoy\"}'",
+                    )
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_single_quoted_shell_alias_is_not_treated_as_an_endpoint(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "literal-alias.sh": "\n".join(
+                    (
+                        "url='https://api.telnyx.com/v2/messages/number_pool'",
+                        "curl -X POST '$url' -d '{\"text\":\"not a Telnyx send\"}'",
+                    )
+                )
+            }
+        )
+        self.assertEqual(0, result.returncode)
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+
+    def test_shell_endpoint_alias_must_be_the_curl_url(self) -> None:
+        files = {
+            "payload-only.sh": "\n".join(
+                (
+                    "url='https://api.telnyx.com/v2/messages/number_pool'",
+                    "curl https://example.invalid/audit -d \"$url\"",
+                )
+            ),
+            "header-only.sh": "\n".join(
+                (
+                    "url='https://api.telnyx.com/v2/messages/alphanumeric_sender_id'",
+                    "curl -H \"X-Decoy: $url\" https://example.invalid/audit",
+                )
+            ),
+            "prose-only.sh": "\n".join(
+                (
+                    "url='https://api.telnyx.com/v2/messages/number_pool'",
+                    "echo curl \"$url\"",
+                )
+            ),
+        }
+        result, payload = self.run_messaging_linter(files)
+        self.assertEqual(0, result.returncode)
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+
+    def test_profile_must_be_a_top_level_payload_member(self) -> None:
+        fixtures = {
+            "nested-axios.ts": (
+                'axios.post("/v2/messages/number_pool", '
+                "{from, to, text, metadata: {messaging_profile_id: profile}});"
+            ),
+            "nested-fetch.js": (
+                'fetch("/v2/messages/alphanumeric_sender_id", '
+                "{method: 'POST', body: JSON.stringify({from, to, text, metadata: "
+                "{messagingProfileId: profile}})});"
+            ),
+            "nested-sdk.ts": (
+                "client.messages.sendNumberPool({from, to, text, metadata: "
+                "{messagingProfileID: profile}});"
+            ),
+            "nested-python.py": (
+                "client.messages.send_number_pool(to=recipient, "
+                'metadata={"messaging_profile_id": profile})'
+            ),
+            "nested-request.py": (
+                'requests.post("/v2/messages/number_pool", '
+                'json={"from": sender, "metadata": '
+                '{"messaging_profile_id": profile}})'
+            ),
+            "nested-go.go": (
+                "client.Messages.SendNumberPool(ctx, Params{Metadata: "
+                'map[string]any{"messaging_profile_id": profile}})'
+            ),
+            "nested-csharp.cs": (
+                "client.Messages.SendNumberPool(new Params { Metadata = "
+                "new { MessagingProfileId = profile } });"
+            ),
+            "nested-php.php": (
+                "<?php\n$client->messages()->sendNumberPool("
+                "['metadata' => ['messaging_profile_id' => $profile]]);"
+            ),
+            "nested-ruby.rb": (
+                "client.messages.send_number_pool(metadata: "
+                "{ messaging_profile_id: profile })"
+            ),
+            "nested-java.java": (
+                "client.messages().sendNumberPool(Params.builder().metadata("
+                "new Metadata().messagingProfileId(profile)).build());"
+            ),
+        }
+        result, payload = self.run_messaging_linter(fixtures)
+        self.assertEqual(1, result.returncode)
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_fetch_options_variable_resolves_only_its_body(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "options-body.ts": "\n".join(
+                    (
+                        'const endpoint = "/v2/messages/number_pool";',
+                        "const payload = {from, to, text, messaging_profile_id};",
+                        "const options = {method: 'POST', body: JSON.stringify(payload)};",
+                        "fetch(endpoint, options);",
+                    )
+                ),
+                "aliased-options-body.ts": "\n".join(
+                    (
+                        'const endpoint = "/v2/messages/number_pool";',
+                        "const payload = {from, to, text, messaging_profile_id};",
+                        "const baseOptions = {method: 'POST', body: JSON.stringify(payload)};",
+                        "const options = baseOptions;",
+                        "fetch(endpoint, options);",
+                    )
+                ),
+                "mutated-options-body.ts": "\n".join(
+                    (
+                        'const endpoint = "/v2/messages/number_pool";',
+                        "const payload = {from, to, text, messaging_profile_id};",
+                        "const options = {method: 'POST'};",
+                        "options.body = JSON.stringify(payload);",
+                        "fetch(endpoint, options);",
+                    )
+                ),
+            }
+        )
+        fixture_name = "options-query.ts"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        'const endpoint = "/v2/messages/number_pool";',
+                        "const options = {method: 'POST', params: {messaging_profile_id}};",
+                        "fetch(endpoint, options);",
+                    )
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        self.assert_required_profile_detected(payload, fixture_name)
+
+        stale_fixture = "options-stale-body.ts"
+        result, payload = self.run_messaging_linter(
+            {
+                stale_fixture: "\n".join(
+                    (
+                        'const endpoint = "/v2/messages/number_pool";',
+                        "const options = {method: 'POST', body: JSON.stringify("
+                        "{messaging_profile_id})};",
+                        "options.body = JSON.stringify({to, text});",
+                        "fetch(endpoint, options);",
+                    )
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        self.assert_required_profile_detected(payload, stale_fixture)
+
+    def test_javascript_payload_spreads_resolve_only_at_payload_root(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "spread-sdk.ts": "\n".join(
+                    (
+                        "const base = {messaging_profile_id};",
+                        "client.messages.sendNumberPool({...base, to, text});",
+                    )
+                ),
+                "spread-rest.ts": "\n".join(
+                    (
+                        "const base = {messagingProfileId};",
+                        'axios.post("/v2/messages/number_pool", {...base, to, text});',
+                    )
+                ),
+                "spread-fetch.ts": "\n".join(
+                    (
+                        "const base = {messagingProfileID};",
+                        'fetch("/v2/messages/alphanumeric_sender_id", '
+                        "{method: 'POST', body: JSON.stringify({...base, to, text})});",
+                    )
+                ),
+            }
+        )
+        fixture_name = "nested-spread.ts"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "const base = {messaging_profile_id};",
+                        'axios.post("/v2/messages/number_pool", '
+                        "{to, text, metadata: {...base}});",
+                    )
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_serialized_payload_must_be_the_body_not_json_looking_text(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "serialized-body.js": "\n".join(
+                    (
+                        'const payload = \'{"messaging_profile_id":"mp-real"}\';',
+                        'fetch("/v2/messages/number_pool", {method: "POST", body: payload});',
+                    )
+                ),
+                "escaped-serialized-body.js": "\n".join(
+                    (
+                        'const payload = "{\\"messaging_profile_id\\":'
+                        '\\"mp-real\\"}";',
+                        'fetch("/v2/messages/number_pool", {method: "POST", body: payload});',
+                    )
+                ),
+            }
+        )
+        fixture_name = "json-looking-text.js"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "const payload = {text: "
+                        "'{\"messaging_profile_id\":\"mp-fake\"}'};",
+                        "client.messages.sendNumberPool(payload);",
+                    )
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_axios_config_object_selects_only_its_request_body(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "axios-config-body.ts": (
+                    'axios({method: "post", url: "/v2/messages/number_pool", '
+                    "data: {to, text, messaging_profile_id}});"
+                ),
+                "axios-config-variable.ts": "\n".join(
+                    (
+                        "const config = {",
+                        '  url: "/v2/messages/alphanumeric_sender_id",',
+                        '  method: "post",',
+                        "  data: {to, text, messaging_profile_id},",
+                        "};",
+                        "axios(config);",
+                    )
+                ),
+                "axios-config-alias.ts": "\n".join(
+                    (
+                        "const baseConfig = {",
+                        '  url: "/v2/messages/number_pool",',
+                        '  method: "post",',
+                        "  data: {to, text, messaging_profile_id},",
+                        "};",
+                        "const config = baseConfig;",
+                        "axios(config);",
+                    )
+                ),
+            }
+        )
+        fixtures = {
+            "axios-config-params.ts": (
+                'axios({method: "post", url: '
+                '"/v2/messages/alphanumeric_sender_id", data: {to, text}, '
+                "params: {messaging_profile_id}});"
+            ),
+            "axios-config-variable-params.ts": "\n".join(
+                (
+                    "const config = {",
+                    '  url: "/v2/messages/number_pool",',
+                    '  method: "post",',
+                    "  data: {to, text},",
+                    "  params: {messaging_profile_id},",
+                    "};",
+                    "axios(config);",
+                )
+            ),
+        }
+        result, payload = self.run_messaging_linter(
+            fixtures
+        )
+        self.assertEqual(1, result.returncode)
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_axios_config_combines_base_url_and_honors_method(self) -> None:
+        """One-shot Axios configs use both URL fields and default to GET."""
+
+        forms = {
+            "inline.js": (
+                "axios({method:'post', "
+                "baseURL:'https://api.telnyx.com/v2/messages/', "
+                "url:'./number_pool', data:{to:'+1'%s}});"
+            ),
+            "variable.js": (
+                "const cfg={method:'post', "
+                "baseURL:'https://api.telnyx.com/v2/messages/', "
+                "url:'./number_pool', data:{to:'+1'%s}}; axios(cfg);"
+            ),
+            "request-inline.js": (
+                "axios.request({method:'post', "
+                "baseURL:'https://api.telnyx.com/v2/messages/', "
+                "url:'./number_pool', data:{to:'+1'%s}});"
+            ),
+            "request-variable.js": (
+                "const cfg={method:'post', "
+                "baseURL:'https://api.telnyx.com/v2/messages/', "
+                "url:'./number_pool', data:{to:'+1'%s}}; "
+                "axios.request(cfg);"
+            ),
+        }
+        for filename, template in forms.items():
+            with self.subTest(filename=filename, body="violating"):
+                self.assert_required_profile_flagged({filename: template % ""})
+            with self.subTest(filename=filename, body="compliant"):
+                self.assert_required_profile_passes(
+                    {
+                        filename: template
+                        % ", messaging_profile_id:'MP_valid'"
+                    }
+                )
+
+        # Axios defaults to GET; a static GET is not a message send and does
+        # not acquire a request-body profile requirement merely because its
+        # URL names the collection. A dynamic method remains fail-safe.
+        self.assert_required_profile_passes(
+            {
+                "get.js": (
+                    "axios({method:'get', "
+                    "url:'/v2/messages/number_pool'});"
+                ),
+                "default-get.js": (
+                    "axios({url:'/v2/messages/number_pool'});"
+                ),
+            }
+        )
+        self.assert_required_profile_flagged(
+            {
+                "dynamic.js": (
+                    "axios({method:verb, "
+                    "url:'/v2/messages/number_pool', data:{to:'+1'}});"
+                )
+            }
+        )
+        self.assert_required_profile_flagged(
+            {
+                "shorthand.js": (
+                    "const method='POST'; "
+                    "const baseURL='https://api.telnyx.com/v2/messages/'; "
+                    "axios({method, baseURL, url:'number_pool', "
+                    "data:{to:'+1'}});"
+                )
+            }
+        )
+
+    def test_http_method_gate_is_consistent_across_transports(self) -> None:
+        """GET-like reads stay safe; mutating or unknown methods are checked."""
+
+        required = "https://api.telnyx.com/v2/messages/number_pool"
+        safe = {
+            "fetch-default.js": f"fetch('{required}');",
+            "fetch-empty.js": f"fetch('{required}', {{}});",
+            "fetch-get.js": f"fetch('{required}', {{method:'GET'}});",
+            "fetch-alias.js": (
+                f"const method='GET'; fetch('{required}', {{method}});"
+            ),
+            "fetch-options.js": (
+                f"const options={{}}; fetch('{required}', options);"
+            ),
+            "fetch-undefined.js": (
+                f"fetch('{required}', {{method:undefined}});"
+            ),
+            "request-get.js": f"request('GET', '{required}', {{}});",
+            "request-config-get.js": (
+                f"request({{method:'GET', url:'{required}'}});"
+            ),
+            "request-config-callback.js": (
+                f"request({{url:'{required}'}}, callback);"
+            ),
+            "request-url-options.js": (
+                f"request('{required}', {{}}, callback);"
+            ),
+            "request-mutated-get.js": (
+                f"const options={{url:'{required}'}}; "
+                "options.method='GET'; request(options);"
+            ),
+            "fetch-dynamic-compliant.js": (
+                f"fetch('{required}', {{method:verb, body:JSON.stringify("
+                "{messaging_profile_id})}});"
+            ),
+            "request-dynamic-compliant.js": (
+                f"request(verb, '{required}', {{messaging_profile_id}});"
+            ),
+            "curl-dynamic-compliant.sh": (
+                f"curl -X \"$METHOD\" -d '{{\"messaging_profile_id\":\"mp\"}}' "
+                f"'{required}'\n"
+            ),
+            "curl-dynamic-compliant.php": (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);\n"
+                "curl_setopt($ch, CURLOPT_POSTFIELDS, "
+                "'{\"messaging_profile_id\":\"mp\"}');\n"
+                "curl_exec($ch);\n"
+            ),
+            "go-method-get.go": (
+                "package main\nimport \"net/http\"\n"
+                f"func read() {{ http.NewRequest(http.MethodGet, \"{required}\", nil) }}\n"
+            ),
+            "curl-default.sh": f"curl '{required}'\n",
+            "curl-get.sh": f"curl -X GET '{required}'\n",
+            "curl-data-as-query.sh": f"curl -G -d 'to=+1' '{required}'\n",
+            "curl-default.php": (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_exec($ch);\n"
+            ),
+            "curl-httpget.php": (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_setopt($ch, CURLOPT_HTTPGET, true);\n"
+                "curl_exec($ch);\n"
+            ),
+        }
+        for method in ("GET", "HEAD", "OPTIONS", "DELETE"):
+            safe[f"fetch-{method.lower()}.mjs"] = (
+                f"fetch('{required}', {{method:'{method}'}});"
+            )
+            safe[f"request-{method.lower()}.cjs"] = (
+                f"request('{method}', '{required}', {{}});"
+            )
+            safe[f"curl-{method.lower()}.bash"] = (
+                f"curl -X {method} '{required}'\n"
+            )
+            safe[f"curl-{method.lower()}.phtml"] = (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                f"curl_setopt($ch, CURLOPT_CUSTOMREQUEST, '{method}');\n"
+                "curl_exec($ch);\n"
+            )
+        self.assert_required_profile_passes(safe)
+
+        sends = {
+            "fetch-post.js": (
+                f"fetch('{required}', {{method:'POST', body:'{{}}'}});"
+            ),
+            "fetch-put.js": (
+                f"fetch('{required}', {{method:'PUT', body:'{{}}'}});"
+            ),
+            "fetch-mutated-options.js": (
+                "const options={}; options.method='POST'; options.body='{}'; "
+                f"fetch('{required}', options);"
+            ),
+            "fetch-dynamic.js": (
+                f"fetch('{required}', {{method:verb, body:'{{}}'}});"
+            ),
+            "request-dynamic.js": (
+                f"request(verb, '{required}', {{}});"
+            ),
+            "go-method-post.go": (
+                "package main\nimport \"net/http\"\n"
+                f"func send() {{ http.NewRequest(http.MethodPost, \"{required}\", nil) }}\n"
+            ),
+            "request-config-mutated.js": (
+                f"const options={{url:'{required}'}}; "
+                "options.method='POST'; request(options, callback);"
+            ),
+            "request-url-options-post.js": (
+                f"request('{required}', {{method:'POST'}}, callback);"
+            ),
+            "axios-config-mutated.js": (
+                f"const options={{url:'{required}'}}; "
+                "options.method='POST'; axios(options);"
+            ),
+            "curl-data.sh": f"curl -d '{{}}' '{required}'\n",
+            "curl-attached-data.sh": f"curl -d'{{}}' '{required}'\n",
+            "curl-form.sh": f"curl -F 'text=hello' '{required}'\n",
+            "curl-upload.sh": f"curl -T payload.json '{required}'\n",
+            "curl-post.sh": f"curl -X POST '{required}'\n",
+            "curl-dynamic.sh": f"curl -X \"$METHOD\" '{required}'\n",
+            "curl-post.php": (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_setopt($ch, CURLOPT_POST, true);\n"
+                "curl_setopt($ch, CURLOPT_POSTFIELDS, '{}');\n"
+                "curl_exec($ch);\n"
+            ),
+            "curl-custom.php": (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');\n"
+                "curl_exec($ch);\n"
+            ),
+            "curl-upload.php": (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_setopt($ch, CURLOPT_UPLOAD, true);\n"
+                "curl_exec($ch);\n"
+            ),
+            "curl-dynamic.php": (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);\n"
+                "curl_exec($ch);\n"
+            ),
+            "curl-reused-handle.php": (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_setopt($ch, CURLOPT_POST, true);\n"
+                "curl_setopt($ch, CURLOPT_POSTFIELDS, '{}');\n"
+                "curl_exec($ch);\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                "curl_setopt($ch, CURLOPT_POSTFIELDS, "
+                "'{\"messaging_profile_id\":\"mp\"}');\n"
+                "curl_exec($ch);\n"
+            ),
+        }
+        for method in ("POST", "PUT", "PATCH"):
+            sends[f"fetch-{method.lower()}.mjs"] = (
+                f"fetch('{required}', {{method:'{method}', body:'{{}}'}});"
+            )
+            sends[f"request-{method.lower()}.cjs"] = (
+                f"request('{method}', '{required}', {{}});"
+            )
+            sends[f"curl-{method.lower()}.bash"] = (
+                f"curl -X {method} '{required}'\n"
+            )
+            sends[f"curl-{method.lower()}.phtml"] = (
+                "<?php\n$ch = curl_init();\n"
+                f"curl_setopt($ch, CURLOPT_URL, '{required}');\n"
+                f"curl_setopt($ch, CURLOPT_CUSTOMREQUEST, '{method}');\n"
+                "curl_exec($ch);\n"
+            )
+        for filename, source in sends.items():
+            with self.subTest(filename=filename):
+                self.assert_required_profile_flagged({filename: source})
+
+    def test_rest_client_signatures_select_the_request_body_argument(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "requests.py": (
+                    'requests.post("/v2/messages/number_pool", '
+                    'json={"messaging_profile_id": profile})'
+                ),
+                "request.py": (
+                    'requests.request("POST", "/v2/messages/number_pool", '
+                    'json={"messaging_profile_id": profile})'
+                ),
+                "request-positional.js": (
+                    'request("POST", "/v2/messages/number_pool", '
+                    "{messaging_profile_id});"
+                ),
+                "post.ts": (
+                    'post("/v2/messages/number_pool", {messaging_profile_id});'
+                ),
+                "ky.ts": (
+                    'ky.post("/v2/messages/number_pool", '
+                    "{json: {messaging_profile_id}});"
+                ),
+                "axios-request.ts": (
+                    'axios.request({url: "/v2/messages/number_pool", '
+                    "data: {messaging_profile_id}});"
+                ),
+            }
+        )
+
+    def test_curl_body_option_matrix_rejects_header_and_nested_decoys(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "json-equals.sh": (
+                    "curl --json='{\"messaging_profile_id\":\"mp\"}' "
+                    "https://api.telnyx.com/v2/messages/number_pool"
+                ),
+                "data-raw-equals.sh": (
+                    "curl --data-raw='{\"messaging_profile_id\":\"mp\"}' "
+                    "https://api.telnyx.com/v2/messages/number_pool"
+                ),
+                "data-binary-equals.sh": (
+                    "curl --data-binary='{\"messaging_profile_id\":\"mp\"}' "
+                    "https://api.telnyx.com/v2/messages/number_pool"
+                ),
+                "short-attached.sh": (
+                    "curl -d'{\"messaging_profile_id\":\"mp\"}' "
+                    "https://api.telnyx.com/v2/messages/number_pool"
+                ),
+            }
+        )
+        fixtures = {
+            "header-decoy.sh": (
+                "curl -H 'messaging_profile_id: mp' -d '{\"text\":\"x\"}' "
+                "https://api.telnyx.com/v2/messages/number_pool"
+            ),
+            "nested-inline.sh": (
+                "curl --json '{\"metadata\":{\"messaging_profile_id\":\"mp\"}}' "
+                "https://api.telnyx.com/v2/messages/number_pool"
+            ),
+            "nested-file.sh": (
+                "curl --data-binary @nested.json "
+                "https://api.telnyx.com/v2/messages/number_pool"
+            ),
+            "nested.json": '{"metadata":{"messaging_profile_id":"mp"}}',
+        }
+        result, payload = self.run_messaging_linter(fixtures)
+        self.assertEqual(1, result.returncode)
+        for fixture_name in ("header-decoy.sh", "nested-inline.sh", "nested-file.sh"):
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_profile_on_one_send_does_not_mask_second_missing_profile(self) -> None:
+        fixture_name = "two-sends.tsx"
+        _, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "async function sendBoth() {",
+                        '  await fetch("/v2/messages/alphanumeric_sender_id", {method: "POST", body: JSON.stringify({from: "GOOD", to, text, messaging_profile_id: "mp-1"})});',
+                        '  await fetch("/v2/messages/alphanumeric_sender_id", {method: "POST", body: JSON.stringify({from: "MISSING", to, text})});',
+                        "}",
+                    )
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_unrelated_requests_comments_and_strings_do_not_mask_missing_profile(
+        self,
+    ) -> None:
+        fixtures = {
+            "next-curl.sh": "\n".join(
+                (
+                    "curl -X POST -d '{\"text\":\"missing\"}' https://api.telnyx.com/v2/messages/alphanumeric_sender_id",
+                    "curl -X POST -d '{\"messaging_profile_id\":\"mp-unrelated\"}' https://example.com/unrelated",
+                )
+            ),
+            "next-statement.ts": "\n".join(
+                (
+                    "fetch('/v2/messages/alphanumeric_sender_id', {method: 'POST', body: JSON.stringify({text})});",
+                    "const unrelated = {messaging_profile_id: 'mp-unrelated'};",
+                )
+            ),
+            "comment-mask.ts": "\n".join(
+                (
+                    "fetch('/v2/messages/alphanumeric_sender_id', {method: 'POST', body: JSON.stringify({text})});",
+                    "// TODO: add messaging_profile_id",
+                    "const debug = 'messaging_profile_id';",
+                )
+            ),
+            "block-comment-mask.ts": "\n".join(
+                (
+                    "fetch('/v2/messages/alphanumeric_sender_id', {",
+                    "  method: 'POST',",
+                    "  /* this example is intentionally disabled:",
+                    "     messaging_profile_id: 'mp-comment-only',",
+                    "  */",
+                    "  body: JSON.stringify({text}),",
+                    "});",
+                )
+            ),
+        }
+        result, payload = self.run_messaging_linter(fixtures)
+        self.assertEqual(1, result.returncode)
+        self.assertNotEqual("clean", payload["result"])
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_valid_multiline_required_profile_sends_pass(self) -> None:
+        _, payload = self.run_messaging_linter(
+            {
+                "valid-sdk.tsx": "\n".join(
+                    (
+                        "export async function send() {",
+                        "  return client.messages.sendWithAlphanumericSender({",
+                        '    from: "TELNYX",',
+                        "    to,",
+                        "    text,",
+                        '    messagingProfileId: "mp-1",',
+                        "  });",
+                        "}",
+                    )
+                ),
+                "valid-curl.sh": "\n".join(
+                    (
+                        "curl -X POST \\",
+                        "  -H 'Content-Type: application/json' \\",
+                        "  -d '{\"from\":\"TELNYX\",\"to\":\"+31201234567\",\"text\":\"hi\",\"messaging_profile_id\":\"mp-1\"}' \\",
+                        "  https://api.telnyx.com/v2/messages/alphanumeric_sender_id",
+                    )
+                ),
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+
+    def test_shell_curl_payload_variables_and_files_resolve_before_send(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "payload-variable.sh": "\n".join(
+                    (
+                        "payload='{\"to\":\"+12025550123\",\"messaging_profile_id\":\"mp-1\"}'",
+                        'curl -X POST --data "$payload" https://api.telnyx.com/v2/messages/number_pool',
+                    )
+                ),
+                "braced-alias.sh": "\n".join(
+                    (
+                        "payload='{\"messaging_profile_id\":\"mp-2\"}'",
+                        "request_body=$payload",
+                        'curl --json "${request_body}" https://api.telnyx.com/v2/messages/alphanumeric_sender_id',
+                    )
+                ),
+                "file-payload.sh": (
+                    "curl --data-binary @payload.json "
+                    "https://api.telnyx.com/v2/messages/number_pool"
+                ),
+                "payload.json": '{"messaging_profile_id":"mp-3"}',
+            }
+        )
+
+    def test_shell_curl_payload_resolution_does_not_accept_stale_or_decoy_data(
+        self,
+    ) -> None:
+        fixtures = {
+            "reassigned-payload.sh": "\n".join(
+                (
+                    "payload='{\"messaging_profile_id\":\"mp-stale\"}'",
+                    "payload='{\"text\":\"missing\"}'",
+                    'curl -d "$payload" https://api.telnyx.com/v2/messages/number_pool',
+                )
+            ),
+            "missing-file.sh": (
+                "curl --data @missing.json "
+                "https://api.telnyx.com/v2/messages/alphanumeric_sender_id"
+            ),
+            "decoy-text.sh": "\n".join(
+                (
+                    "payload='remember messaging_profile_id before shipping'",
+                    'curl --json "$payload" https://api.telnyx.com/v2/messages/number_pool',
+                )
+            ),
+        }
+        result, payload = self.run_messaging_linter(fixtures)
+        self.assertEqual(1, result.returncode)
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
+    def test_required_profile_lexer_preserves_source_boundaries(self) -> None:
+        cases = {
+            "absolute-url.ts": (
+                'fetch("https://api.telnyx.com/v2/messages/alphanumeric_sender_id", '
+                '{method: "POST", body: JSON.stringify({messaging_profile_id: "mp-1"})});'
+            ),
+            "endpoint-variable.ts": (
+                'const endpoint = "/v2/messages/alphanumeric_sender_id";\n'
+                "fetch(endpoint, {method: 'POST', body: JSON.stringify({messaging_profile_id: "
+                '"mp-1"})});'
+            ),
+            "reassigned-endpoint.ts": (
+                'let endpoint = "/v2/messages/alphanumeric_sender_id";\n'
+                'endpoint = "/v2/messages";\nfetch(endpoint, {method: "POST"});'
+            ),
+            "metadata-only-endpoint.ts": (
+                'const endpoint = "/v2/messages/alphanumeric_sender_id";\n'
+                'fetch("/v2/other", {method: "POST", metadata: endpoint});'
+            ),
+            "curl-url-first.sh": (
+                "curl https://api.telnyx.com/v2/messages/number_pool "
+                "-d '{\"messaging_profile_id\":\"mp-1\"}'"
+            ),
+            "hash-in-text.py": (
+                'client.messages.send_number_pool(text="ticket #42", '
+                'messaging_profile_id="mp-1")'
+            ),
+            "java-decoys.java": "\n".join(
+                (
+                    "MessageSendNumberPoolParams params = MessageSendNumberPoolParams.builder()",
+                    '    .messagingProfileId("mp-real").build();',
+                    'String note = "params = MessageSendNumberPoolParams.builder().build();";',
+                    "// params = MessageSendNumberPoolParams.builder().build();",
+                    "holder.params = MessageSendNumberPoolParams.builder().build();",
+                    "client.messages().sendNumberPool(params);",
+                )
+            ),
+            "semicolons-in-text.js": (
+                'client.messages.sendNumberPool({text: "first; message", '
+                'messagingProfileId: "mp-1"}); '
+                'client.messages.sendNumberPool({text: "second; message", '
+                'messagingProfileId: "mp-2"});'
+            ),
+        }
+        for fixture_name, source in cases.items():
+            with self.subTest(fixture=fixture_name):
+                self.assert_required_profile_passes({fixture_name: source})
+
+    def test_profile_field_name_inside_message_text_does_not_satisfy_request(
+        self,
+    ) -> None:
+        cases = {
+            "profile-name-in-text.js": (
+                'client.messages.sendNumberPool({text: '
+                '"remember messaging_profile_id: before shipping"});'
+            ),
+            "json-looking-text.js": (
+                "client.messages.sendNumberPool({text: "
+                "'{\"messaging_profile_id\":\"fake\"}'});"
+            ),
+            "go-context-mask.go": (
+                'ctx := Context{MessagingProfileID: "mp-not-payload"}\n'
+                "params := MessageSendNumberPoolParams{}\n"
+                "client.Messages.SendNumberPool(ctx, params)"
+            ),
+            "go-inline-context-mask.go": (
+                'client.Messages.SendNumberPool(Context{MessagingProfileID: "mp-not-payload"}, '
+                "MessageSendNumberPoolParams{})"
+            ),
+            "cli-name-in-text.sh": (
+                "curl -d '{\"text\":\"--messaging-profile-id fake\"}' "
+                "https://api.telnyx.com/v2/messages/number_pool"
+            ),
+        }
+        for fixture_name, source in cases.items():
+            with self.subTest(fixture=fixture_name):
+                result, payload = self.run_messaging_linter(
+                    {fixture_name: source}
+                )
+                self.assert_required_profile_detected(payload, fixture_name)
+                self.assertEqual(1, result.returncode)
+
+    def test_variable_payloads_resolve_in_supported_sdk_languages(self) -> None:
+        fixtures = {
+            "variable.js": (
+                'const payload = {messagingProfileId: "mp-js"};\n'
+                "client.messages.sendNumberPool(payload);"
+            ),
+            "variable.py": (
+                'payload = {"messaging_profile_id": "mp-py"}\n'
+                "client.messages.send_number_pool(**payload)"
+            ),
+            "variable.rb": (
+                'payload = { messaging_profile_id: "mp-rb" }\n'
+                "client.messages.send_number_pool(**payload)"
+            ),
+            "variable.go": (
+                'params := MessageSendNumberPoolParams{MessagingProfileID: "mp-go"}\n'
+                "client.Messages.SendNumberPool(ctx, params)"
+            ),
+            "variable.php": (
+                "<?php\n$payload = ['messaging_profile_id' => 'mp-php'];\n"
+                "$client->messages()->sendNumberPool($payload);"
+            ),
+            "variable.cs": (
+                'var payload = new MessageSendNumberPoolParams { MessagingProfileId = "mp-cs" };\n'
+                "client.Messages.SendNumberPool(payload);"
+            ),
+            "rest-variable.py": (
+                'payload = {"messaging_profile_id": "mp-rest"}\n'
+                'requests.post("/v2/messages/number_pool", json=payload)'
+            ),
+        }
+        self.assert_required_profile_passes(fixtures)
+
+    def test_profile_fields_added_to_payload_variables_before_send_pass(self) -> None:
+        fixtures = {
+            "mutated-subscript.py": (
+                'payload = {"to": recipient, "text": "hello"}\n'
+                'payload["messaging_profile_id"] = profile_id\n'
+                "client.messages.send_number_pool(**payload)"
+            ),
+            "mutated-property.js": (
+                'const payload = {to: recipient, text: "hello"};\n'
+                'payload.messagingProfileId = "mp-js";\n'
+                "client.messages.sendNumberPool(payload);"
+            ),
+            "mutated-symbol.rb": (
+                'payload = { to: recipient, text: "hello" }\n'
+                'payload[:messaging_profile_id] = "mp-rb"\n'
+                "client.messages.send_number_pool(**payload)"
+            ),
+        }
+        self.assert_required_profile_passes(fixtures)
+
+    def test_profile_mutation_after_send_does_not_mask_missing_profile(self) -> None:
+        fixture_name = "late-mutation.py"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: (
+                    'payload = {"to": recipient, "text": "hello"}\n'
+                    "client.messages.send_number_pool(**payload)\n"
+                    'payload["messaging_profile_id"] = profile_id'
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, fixture_name)
+        self.assertEqual(1, result.returncode)
+
+    def test_profile_mutation_decoys_do_not_mask_missing_profile(self) -> None:
+        fixtures = {
+            "other-object.py": (
+                'payload = {"to": recipient, "text": "hello"}\n'
+                'metadata["messaging_profile_id"] = profile_id\n'
+                "client.messages.send_number_pool(**payload)"
+            ),
+            "before-reassignment.js": (
+                "let payload = {};\n"
+                'payload.messagingProfileId = "mp-stale";\n'
+                'payload = {to: recipient, text: "hello"};\n'
+                "client.messages.sendNumberPool(payload);"
+            ),
+            "comment-and-comparison.rb": (
+                "payload = { to: recipient, text: 'hello' }\n"
+                "# payload[:messaging_profile_id] = 'mp-comment'\n"
+                "if payload[:messaging_profile_id] == 'mp-decoy'\n"
+                "  warn 'missing'\n"
+                "end\n"
+                "client.messages.send_number_pool(**payload)"
+            ),
+        }
+        for fixture_name, source in fixtures.items():
+            with self.subTest(fixture=fixture_name):
+                result, payload = self.run_messaging_linter(
+                    {fixture_name: source}
+                )
+                self.assert_required_profile_detected(payload, fixture_name)
+                self.assertEqual(1, result.returncode)
+
+    def test_php_required_sender_invocation_without_profile_is_detected(
+        self,
+    ) -> None:
+        fixture_name = "missing-number-pool.php"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "<?php",
+                        "$client->messages()->sendNumberPool(",
+                        '  to: "+12025550123",',
+                        ");",
+                    )
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, fixture_name)
+        self.assertEqual(1, result.returncode)
+
+    def test_php_required_sender_invocation_with_profile_passes(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "valid-alphanumeric-sender.php": "\n".join(
+                    (
+                        "<?php",
+                        "$client->messages()->sendWithAlphanumericSender(",
+                        '  to: "+12025550123",',
+                        '  messagingProfileID: "mp-1",',
+                        ");",
+                    )
+                )
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+        self.assertEqual(0, result.returncode)
+
+    def test_same_line_javascript_sends_are_checked_per_invocation(self) -> None:
+        fixture_name = "same-line-number-pools.js"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: (
+                    'client.messages.sendNumberPool({to: "+12025550123"}); '
+                    'client.messages.sendNumberPool({to: "+12025550124", '
+                    'messagingProfileId: "mp-1"});'
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, fixture_name)
+        details = next(
+            check["details"]["files"]
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        )
+        self.assertEqual(1, len(details), details)
+        self.assertIn('+12025550123', details[0])
+        self.assertNotIn('+12025550124', details[0])
+        self.assertEqual(1, result.returncode)
+
+    def test_same_line_javascript_sends_all_pass_with_profiles(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "valid-same-line-number-pools.js": (
+                    'client.messages.sendNumberPool({to: "+12025550123", '
+                    'messagingProfileId: "mp-1"}); '
+                    'client.messages.sendNumberPool({to: "+12025550124", '
+                    'messagingProfileId: "mp-2"});'
+                )
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+        self.assertEqual(0, result.returncode)
+
+    def test_same_line_go_sends_are_checked_per_invocation(self) -> None:
+        fixture_name = "same-line-number-pools.go"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: (
+                    'client.Messages.SendNumberPool(ctx, Params{To: "+12025550123"}); '
+                    'client.Messages.SendNumberPool(ctx, Params{To: "+12025550124", '
+                    'MessagingProfileID: "mp-1"})'
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, fixture_name)
+        details = next(
+            check["details"]["files"]
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        )
+        self.assertEqual(1, len(details), details)
+        self.assertIn('+12025550123', details[0])
+        self.assertNotIn('+12025550124', details[0])
+        self.assertEqual(1, result.returncode)
+
+    def test_same_line_go_sends_all_pass_with_profiles(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "valid-same-line-number-pools.go": (
+                    'client.Messages.SendNumberPool(ctx, Params{MessagingProfileID: "mp-1"}); '
+                    'client.Messages.SendNumberPool(ctx, Params{MessagingProfileID: "mp-2"})'
+                )
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+        self.assertEqual(0, result.returncode)
+
+    def test_go_request_options_do_not_replace_or_satisfy_request_body(
+        self,
+    ) -> None:
+        self.assert_required_profile_passes(
+            {
+                "go-request-option.go": (
+                    "client.Messages.SendNumberPool(ctx, "
+                    'MessageSendNumberPoolParams{MessagingProfileID: "mp-1"}, '
+                    'option.WithHeader("X-Request-ID", requestID))'
+                ),
+                "go-alphanumeric-request-option.go": (
+                    "client.Messages.SendWithAlphanumericSender(ctx, "
+                    'MessageSendWithAlphanumericSenderParams{MessagingProfileID: "mp-2"}, '
+                    'option.WithHeader("X-Request-ID", requestID))'
+                )
+            }
+        )
+        fixture_name = "go-request-option-decoy.go"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: (
+                    "client.Messages.SendNumberPool(ctx, "
+                    "MessageSendNumberPoolParams{}, "
+                    "customOption(OptionMetadata{MessagingProfileID: profile}))"
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, fixture_name)
+        self.assertEqual(1, result.returncode)
+
+    def test_same_line_python_and_ruby_sends_are_checked_per_invocation(
+        self,
+    ) -> None:
+        fixtures = {
+            "same-line.py": (
+                'client.messages.send_number_pool(to="+12025550123"); '
+                'client.messages.send_number_pool(to="+12025550124", '
+                'messaging_profile_id="mp-1")'
+            ),
+            "same-line.rb": (
+                'client.messages.send_number_pool(to: "+12025550123"); '
+                'client.messages.send_number_pool(to: "+12025550124", '
+                'messaging_profile_id: "mp-1")'
+            ),
+        }
+        for fixture_name, source in fixtures.items():
+            with self.subTest(fixture=fixture_name):
+                result, payload = self.run_messaging_linter({fixture_name: source})
+                self.assert_required_profile_detected(payload, fixture_name)
+                details = next(
+                    check["details"]["files"]
+                    for check in payload["checks"]
+                    if check["name"] == "required_messaging_profile_id"
+                )
+                self.assertEqual(1, len(details), details)
+                self.assertIn('+12025550123', details[0])
+                self.assertNotIn('+12025550124', details[0])
+                self.assertEqual(1, result.returncode)
+
+    def test_same_line_python_and_ruby_sends_all_pass_with_profiles(self) -> None:
+        fixtures = {
+            "valid-same-line.py": (
+                'client.messages.send_number_pool(messaging_profile_id="mp-1"); '
+                'client.messages.send_number_pool(messaging_profile_id="mp-2")'
+            ),
+            "valid-same-line.rb": (
+                'client.messages.send_number_pool(messaging_profile_id: "mp-1"); '
+                'client.messages.send_number_pool(messaging_profile_id: "mp-2")'
+            ),
+        }
+        for fixture_name, source in fixtures.items():
+            with self.subTest(fixture=fixture_name):
+                result, payload = self.run_messaging_linter({fixture_name: source})
+                checks = [
+                    check
+                    for check in payload["checks"]
+                    if check["name"] == "required_messaging_profile_id"
+                ]
+                self.assertEqual(
+                    [{"name": "required_messaging_profile_id", "status": "pass"}],
+                    checks,
+                )
+                self.assertEqual(0, result.returncode)
+
+    def test_java_number_pool_builder_profile_is_resolved_from_call_variable(
+        self,
+    ) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "valid-number-pool.java": "\n".join(
+                    (
+                        "import com.telnyx.sdk.models.messages.MessageSendNumberPoolParams;",
+                        "",
+                        "MessageSendNumberPoolParams params = MessageSendNumberPoolParams.builder()",
+                        '    .from("pool-1")',
+                        '    .to("+12025550123")',
+                        '    .text("hello")',
+                        '    .messagingProfileId("mp-1")',
+                        "    .build();",
+                        "client.messages().sendNumberPool(params);",
+                    )
+                )
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+        self.assertEqual(0, result.returncode)
+
+    def test_java_number_pool_builder_without_profile_is_detected_at_call(
+        self,
+    ) -> None:
+        fixture_name = "missing-number-pool.java"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "import com.telnyx.sdk.models.messages.MessageSendNumberPoolParams;",
+                        "",
+                        "MessageSendNumberPoolParams params = MessageSendNumberPoolParams.builder()",
+                        '    .from("pool-1")',
+                        '    .to("+12025550123")',
+                        '    .text("hello")',
+                        "    .build();",
+                        "client.messages().sendNumberPool(params);",
+                    )
+                )
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(1, len(checks))
+        self.assertEqual("issue", checks[0]["status"])
+        matches = checks[0]["details"]["files"]
+        self.assertEqual(1, len(matches), matches)
+        self.assertIn(
+            "client.messages().sendNumberPool(params);",
+            matches[0],
+        )
+        self.assertEqual(1, result.returncode)
+
+    def test_java_number_pool_builders_are_isolated_by_invocation_variable(
+        self,
+    ) -> None:
+        fixture_name = "two-number-pools.java"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "import com.telnyx.sdk.models.messages.MessageSendNumberPoolParams;",
+                        "",
+                        "MessageSendNumberPoolParams missingParams = MessageSendNumberPoolParams.builder()",
+                        '    .from("pool-missing")',
+                        '    .to("+12025550123")',
+                        '    .text("missing")',
+                        "    .build();",
+                        "MessageSendNumberPoolParams validParams = MessageSendNumberPoolParams.builder()",
+                        '    .from("pool-valid")',
+                        '    .to("+12025550124")',
+                        '    .text("valid")',
+                        '    .messagingProfileId("mp-1")',
+                        "    .build();",
+                        "client.messages().sendNumberPool(missingParams);",
+                        "client.messages().sendNumberPool(validParams);",
+                    )
+                )
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(1, len(checks))
+        self.assertEqual("issue", checks[0]["status"])
+        matches = checks[0]["details"]["files"]
+        self.assertEqual(1, len(matches), matches)
+        self.assertIn(
+            "client.messages().sendNumberPool(missingParams);",
+            matches[0],
+        )
+        self.assertNotIn("validParams", matches[0])
+        self.assertEqual(1, result.returncode)
+
+    def test_java_same_line_sends_are_checked_per_invocation(self) -> None:
+        fixture_name = "same-line-number-pools.java"
+        result, payload = self.run_messaging_linter(
+            {
+                fixture_name: "\n".join(
+                    (
+                        "MessageSendNumberPoolParams missingParams = MessageSendNumberPoolParams.builder()",
+                        '    .to("+12025550123")',
+                        '    .text("missing")',
+                        "    .build();",
+                        "MessageSendNumberPoolParams validParams = MessageSendNumberPoolParams.builder()",
+                        '    .to("+12025550124")',
+                        '    .text("valid")',
+                        '    .messagingProfileId("mp-1")',
+                        "    .build();",
+                        "client.messages().sendNumberPool(missingParams); client.messages().sendNumberPool(validParams);",
+                    )
+                )
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(1, len(checks))
+        self.assertEqual("issue", checks[0]["status"])
+        matches = checks[0]["details"]["files"]
+        self.assertEqual(1, len(matches), matches)
+        self.assertIn("sendNumberPool(missingParams)", matches[0])
+        self.assertNotIn("validParams", matches[0])
+        self.assertEqual(1, result.returncode)
+
+    def test_java_same_line_sends_all_pass_when_each_builder_has_profile(
+        self,
+    ) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "valid-same-line-number-pools.java": "\n".join(
+                    (
+                        "MessageSendNumberPoolParams firstParams = MessageSendNumberPoolParams.builder()",
+                        '    .messagingProfileId("mp-1")',
+                        "    .build();",
+                        "MessageSendNumberPoolParams secondParams = MessageSendNumberPoolParams.builder()",
+                        '    .messagingProfileId("mp-2")',
+                        "    .build();",
+                        "client.messages().sendNumberPool(firstParams); client.messages().sendNumberPool(secondParams);",
+                    )
+                )
+            }
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        ]
+        self.assertEqual(
+            [{"name": "required_messaging_profile_id", "status": "pass"}],
+            checks,
+        )
+        self.assertEqual(0, result.returncode)
+
+
+    def test_payload_state_official_sdk_shapes_and_body_keys(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "official.js": (
+                    "client.messages.sendNumberPool({messagingProfileId: profile});"
+                ),
+                "official.py": (
+                    "client.messages.send_number_pool("
+                    "messaging_profile_id=profile)"
+                ),
+                "official.rb": (
+                    "client.messages.send_with_alphanumeric_sender("
+                    "messaging_profile_id: profile)"
+                ),
+                "official.java": (
+                    "client.messages().sendNumberPool(Params.builder()"
+                    ".messagingProfileId(profile).build());"
+                ),
+                "official.go": (
+                    "client.Messages.SendNumberPool(ctx, "
+                    "Params{MessagingProfileID: profile})"
+                ),
+            }
+        )
+        positive = {
+            "body.js": "client.messages.send({body: legacy});",
+            "body.py": "client.messages.send(body=legacy)",
+            "body.rb": "client.messages.send_(body: legacy)",
+            "body.java": (
+                "Params p = Params.builder().body(legacy).build();\n"
+                "client.messages().send(p);"
+            ),
+            "body.go": (
+                "p := Params{Body: legacy}\nclient.Messages.Send(ctx, p)"
+            ),
+        }
+        negative = {
+            "text.js": "client.messages.send({text: body});",
+            "nested.py": (
+                'client.messages.send(metadata={"body": legacy}, text=text)'
+            ),
+            "nested.java": (
+                "client.messages().send(Params.builder().metadata("
+                "new Metadata().body(legacy)).build());"
+            ),
+            "text.go": (
+                "p := Params{Text: body}\nclient.Messages.Send(ctx, p)"
+            ),
+        }
+        _, payload = self.run_messaging_linter({**positive, **negative})
+        check = next(
+            item for item in payload["checks"]
+            if item["name"] == "body_not_text"
+        )
+        details = json.dumps(check.get("details", {}))
+        for fixture in positive:
+            self.assertIn(fixture, details)
+        for fixture in negative:
+            self.assertNotIn(fixture, details)
+
+    def test_payload_state_alias_copy_branch_and_merge_semantics(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "shared-alias.js": "\n".join(
+                    (
+                        "const source = {};",
+                        "const sent = source;",
+                        "source.messagingProfileId = profile;",
+                        "client.messages.sendNumberPool(sent);",
+                    )
+                ),
+                "alias-survives-rebind.js": "\n".join(
+                    (
+                        "let source = {messagingProfileId: profile};",
+                        "const sent = source;",
+                        "source = {};",
+                        "client.messages.sendNumberPool(sent);",
+                    )
+                ),
+                "spread-snapshot.js": "\n".join(
+                    (
+                        "const source = {messagingProfileId: profile};",
+                        "const sent = {...source};",
+                        "delete source.messagingProfileId;",
+                        "client.messages.sendNumberPool(sent);",
+                    )
+                ),
+                "exhaustive-branches.js": "\n".join(
+                    (
+                        "const sent = {};",
+                        "if (flag) { sent.messagingProfileId = 'a'; }",
+                        "else { sent.messagingProfileId = 'b'; }",
+                        "client.messages.sendNumberPool(sent);",
+                    )
+                ),
+                "finally-write.js": "\n".join(
+                    (
+                        "const sent = {};",
+                        "try { work(); } finally {",
+                        "  sent.messagingProfileId = profile;",
+                        "}",
+                        "client.messages.sendNumberPool(sent);",
+                    )
+                ),
+                "object-assign.js": "\n".join(
+                    (
+                        "const sent = {};",
+                        "Object.assign(sent, {messagingProfileId: profile});",
+                        "client.messages.sendNumberPool(sent);",
+                    )
+                ),
+                "dict-update.py": "\n".join(
+                    (
+                        "sent = {}",
+                        'sent.update({"messaging_profile_id": profile})',
+                        "client.messages.send_number_pool(**sent)",
+                    )
+                ),
+                "ruby-merge.rb": "\n".join(
+                    (
+                        "sent = {}",
+                        "sent.merge!({messaging_profile_id: profile})",
+                        "client.messages.send_number_pool(**sent)",
+                    )
+                ),
+            }
+        )
+        warnings = {
+            "may-alias.js": "\n".join(
+                (
+                    "const left = {};",
+                    "const right = {};",
+                    "const selected = flag ? left : right;",
+                    "selected.messagingProfileId = profile;",
+                    "client.messages.sendNumberPool(left);",
+                )
+            ),
+            "nonexhaustive.js": "\n".join(
+                (
+                    "const sent = {};",
+                    "if (flag) { sent.messagingProfileId = profile; }",
+                    "client.messages.sendNumberPool(sent);",
+                )
+            ),
+            "conditional-delete.py": "\n".join(
+                (
+                    'sent = {"messaging_profile_id": profile}',
+                    "if flag:",
+                    '    del sent["messaging_profile_id"]',
+                    "client.messages.send_number_pool(**sent)",
+                )
+            ),
+        }
+        _, payload = self.run_messaging_linter(warnings)
+        for fixture in warnings:
+            self.assert_required_profile_detected(payload, fixture)
+
+    def test_payload_state_body_deletes_aliases_and_snapshots(self) -> None:
+        positive = {
+            "conditional-delete.js": "\n".join(
+                (
+                    "const payload = {body: legacy};",
+                    "if (flag) { delete payload.body; }",
+                    "client.messages.send(payload);",
+                )
+            ),
+            "alias-source-add.js": "\n".join(
+                (
+                    "const source = {};",
+                    "const payload = source;",
+                    "source.body = legacy;",
+                    "client.messages.send(payload);",
+                )
+            ),
+            "copy-survives-delete.js": "\n".join(
+                (
+                    "const source = {body: legacy};",
+                    "const payload = {...source};",
+                    "delete source.body;",
+                    "client.messages.send(payload);",
+                )
+            ),
+            "delete-after.py": "\n".join(
+                (
+                    'payload = {"body": legacy}',
+                    "client.messages.send(**payload)",
+                    'del payload["body"]',
+                )
+            ),
+        }
+        negative = {
+            "dominating-delete.js": "\n".join(
+                (
+                    "const payload = {body: legacy};",
+                    "delete payload.body;",
+                    "client.messages.send(payload);",
+                )
+            ),
+            "nested-callable.rb": "\n".join(
+                (
+                    "payload = {text: text}",
+                    "def unrelated(payload)",
+                    "  payload[:body] = legacy",
+                    "end",
+                    "client.messages.send_(**payload)",
+                )
+            ),
+        }
+        _, payload = self.run_messaging_linter({**positive, **negative})
+        check = next(
+            item for item in payload["checks"]
+            if item["name"] == "body_not_text"
+        )
+        details = json.dumps(check.get("details", {}))
+        for fixture in positive:
+            self.assertIn(fixture, details)
+        for fixture in negative:
+            self.assertNotIn(fixture, details)
+
+    def test_payload_state_optional_values_fail_closed_without_body_noise(self) -> None:
+        warnings = {
+            "conditional.js": (
+                "client.messages.sendNumberPool({messagingProfileId: "
+                "flag ? profile : null});"
+            ),
+            "null.py": (
+                "client.messages.send_number_pool(messaging_profile_id=None)"
+            ),
+            "empty.rb": (
+                "client.messages.send_number_pool(messaging_profile_id: '')"
+            ),
+            "optional-call.ts": (
+                "client?.messages?.sendNumberPool?.({"
+                "messagingProfileId: maybeProfile ?? null});"
+            ),
+        }
+        _, payload = self.run_messaging_linter(warnings)
+        for fixture in warnings:
+            self.assert_required_profile_detected(payload, fixture)
+        _, body_payload = self.run_messaging_linter(
+            {"opaque.js": "client.messages.send(runtimePayload);"}
+        )
+        body_check = next(
+            item for item in body_payload["checks"]
+            if item["name"] == "body_not_text"
+        )
+        self.assertEqual("pass", body_check["status"])
+
+    def test_payload_state_cross_language_matrix_regressions(self) -> None:
+        self.assert_required_profile_passes(
+            {
+                "go-net-http.go": "\n".join(
+                    (
+                        "payload := map[string]any{}",
+                        'payload["messaging_profile_id"] = profileID',
+                        'http.Post("/v2/messages/number_pool", '
+                        '"application/json", payload)',
+                    )
+                ),
+                "go-uninvoked-delete.go": "\n".join(
+                    (
+                        "payload := map[string]any{",
+                        '  "messaging_profile_id": profileID,',
+                        "}",
+                        "mutate := func() {",
+                        '  delete(payload, "messaging_profile_id")',
+                        "}",
+                        'http.Post("/v2/messages/number_pool", '
+                        '"application/json", payload)',
+                    )
+                ),
+                "shell-uninvoked-delete.sh": "\n".join(
+                    (
+                        "payload='{\"messaging_profile_id\":\"mp-1\"}'",
+                        "mutate() {",
+                        "  payload='{}'",
+                        "}",
+                        'curl --json "${payload}" '
+                        '"/v2/messages/number_pool"',
+                    )
+                ),
+            }
+        )
+        warnings = {
+            "ruby-loop.rb": "\n".join(
+                (
+                    "payload = {}",
+                    "items.each do |item|",
+                    "  payload[:messaging_profile_id] = profile_id",
+                    "end",
+                    'client.post("/v2/messages/number_pool", json: payload)',
+                )
+            ),
+            "go-if.go": "\n".join(
+                (
+                    "payload := map[string]any{}",
+                    "if flag {",
+                    '  payload["messaging_profile_id"] = profileID',
+                    "}",
+                    'http.Post("/v2/messages/number_pool", '
+                    '"application/json", payload)',
+                )
+            ),
+            "go-range.go": "\n".join(
+                (
+                    "payload := map[string]any{}",
+                    "for _, item := range items {",
+                    '  payload["messaging_profile_id"] = profileID',
+                    "}",
+                    'http.Post("/v2/messages/number_pool", '
+                    '"application/json", payload)',
+                )
+            ),
+            "java-remove.java": "\n".join(
+                (
+                    "var payload = new HashMap<String, Object>();",
+                    'payload.put("messaging_profile_id", profileId);',
+                    'payload.remove("messaging_profile_id");',
+                    'client.post("/v2/messages/number_pool", payload);',
+                )
+            ),
+            "csharp-remove.cs": "\n".join(
+                (
+                    "var payload = new Dictionary<string, object>();",
+                    'payload["MessagingProfileId"] = profileId;',
+                    'payload.Remove("MessagingProfileId");',
+                    'client.PostAsync("/v2/messages/number_pool", payload);',
+                )
+            ),
+            "shell-uninvoked-add.sh": "\n".join(
+                (
+                    "payload='{}'",
+                    "mutate() {",
+                    "  payload='{\"messaging_profile_id\":\"mp-1\"}'",
+                    "}",
+                    'curl --json "${payload}" '
+                    '"/v2/messages/number_pool"',
+                )
+            ),
+        }
+        _, payload = self.run_messaging_linter(warnings)
+        for fixture in warnings:
+            self.assert_required_profile_detected(payload, fixture)
+
+        positive_body = {
+            "ruby-dup.rb": "\n".join(
+                (
+                    "source = {body: legacy}",
+                    "payload = source.dup",
+                    "source.delete(:body)",
+                    "client.messages.send_(**payload)",
+                )
+            ),
+            "csharp-copy.cs": "\n".join(
+                (
+                    "var source = new Dictionary<string, object>();",
+                    'source["Body"] = legacy;',
+                    "var payload = new Dictionary<string, object>(source);",
+                    'source.Remove("Body");',
+                    "client.Messages.Send(payload);",
+                )
+            ),
+            "go-copy.go": "\n".join(
+                (
+                    'source := map[string]any{"Body": legacy}',
+                    "payload := maps.Clone(source)",
+                    'delete(source, "Body")',
+                    "client.Messages.Send(ctx, payload)",
+                )
+            ),
+            "java-copy.java": "\n".join(
+                (
+                    "var source = new HashMap<String, Object>();",
+                    'source.put("body", legacy);',
+                    "var payload = new HashMap<String, Object>(source);",
+                    'source.remove("body");',
+                    "client.messages().send(payload);",
+                )
+            ),
+            "go-conditional-delete.go": "\n".join(
+                (
+                    'payload := map[string]any{"Body": legacy}',
+                    "if flag {",
+                    '  delete(payload, "Body")',
+                    "}",
+                    "client.Messages.Send(ctx, payload)",
+                )
+            ),
+        }
+        negative_body = {
+            "csharp-delete.cs": "\n".join(
+                (
+                    "var payload = new Dictionary<string, object>();",
+                    'payload["Body"] = legacy;',
+                    'payload.Remove("Body");',
+                    "client.Messages.Send(payload);",
+                )
+            ),
+            "go-alias-delete.go": "\n".join(
+                (
+                    'source := map[string]any{"Body": legacy}',
+                    "payload := source",
+                    'delete(source, "Body")',
+                    "client.Messages.Send(ctx, payload)",
+                )
+            ),
+            "java-alias-delete.java": "\n".join(
+                (
+                    "var source = new HashMap<String, Object>();",
+                    'source.put("body", legacy);',
+                    "var payload = source;",
+                    'source.remove("body");',
+                    "client.messages().send(payload);",
+                )
+            ),
+        }
+        _, body_payload = self.run_messaging_linter(
+            {**positive_body, **negative_body}
+        )
+        body_check = next(
+            item for item in body_payload["checks"]
+            if item["name"] == "body_not_text"
+        )
+        body_details = json.dumps(body_check.get("details", {}))
+        for fixture in positive_body:
+            self.assertIn(fixture, body_details)
+        for fixture in negative_body:
+            self.assertNotIn(fixture, body_details)
+
+    def test_payload_state_index_scaling_and_json_no_crash(self) -> None:
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_payload_state_scaling_contract",
+        )
+        analyze = namespace["analyze_file"]
+        body_fields = namespace["message_body_fields"]
+        body_calls = namespace["MESSAGE_BODY_CALL_RE"]
+        with tempfile.TemporaryDirectory(
+            prefix="telnyx-payload-state-"
+        ) as temp_dir:
+            root = Path(temp_dir)
+
+            def elapsed(count: int) -> float:
+                fixture = root / f"scale-{count}.js"
+                fixture.write_text(
+                    "const payload = {};\n"
+                    + "\n".join(
+                        f"payload.value_{index} = {index};"
+                        for index in range(count)
+                    )
+                    + "\npayload.messagingProfileId = profile;\n"
+                    + "client.messages.sendNumberPool(payload);\n",
+                    encoding="utf-8",
+                )
+                started = time.perf_counter()
+                self.assertEqual((1, []), analyze(fixture, root))
+                return time.perf_counter() - started
+
+            small = min(elapsed(64) for _ in range(2))
+            medium = min(elapsed(128) for _ in range(2))
+            self.assertLess(medium, max(0.05, small * 3))
+            self.assertLess(elapsed(512), 3.0)
+
+            crash = root / "json-shapes.js"
+            crash.write_text(
+                "client.messages.sendNumberPool([null, {}, [], "
+                "{messagingProfileId: null}]);\n"
+                "const listPayload = '{\"messagingProfileId\":[]}';\n"
+                "client.messages.sendNumberPool(listPayload);\n"
+                "const dictPayload = '{\"messagingProfileId\":{}}';\n"
+                "client.messages.sendNumberPool(dictPayload);\n"
+                "client.messages.send({items: [null, {}, []]});\n",
+                encoding="utf-8",
+            )
+            total, missing = analyze(crash, root)
+            self.assertEqual(3, total)
+            self.assertEqual(3, len(missing))
+            self.assertEqual([], body_fields(crash, body_calls))
+
+    def test_required_endpoint_normalizes_interior_dot_segments(self) -> None:
+        # axios combineURLs does not normalize dot segments: a trailing-slash
+        # baseURL joined with a relative path leaves interior "." / ".."
+        # segments that the HTTP layer resolves before the request is sent.
+        # required_endpoint() only stripped a LEADING "./", so a number-pool
+        # send reached through such a join was silently treated as safe.
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_required_endpoint_dot_segments_contract",
+        )
+        required_endpoint = namespace["required_endpoint"]
+        # Interior "." and ".." that resolve back to the required path.
+        self.assertTrue(required_endpoint("/v2/messages/./number_pool"))
+        self.assertTrue(required_endpoint("/v2/messages/foo/../number_pool"))
+        self.assertTrue(
+            required_endpoint(
+                "https://api.telnyx.com/v2/messages/./alphanumeric_sender_id"
+            )
+        )
+        # The plain and base-URL-relative forms still match.
+        self.assertTrue(required_endpoint("/v2/messages/number_pool"))
+        self.assertTrue(required_endpoint("messages/number_pool"))
+        # A ".." that resolves to a DIFFERENT path must not match.
+        self.assertFalse(
+            required_endpoint("/v2/messages/../calls/number_pool")
+        )
+        self.assertFalse(required_endpoint("/v2/messages/number_pool_export"))
+
+    def test_empty_constant_alias_profile_is_treated_as_absent(self) -> None:
+        # A messaging_profile_id assigned through a local constant that holds an
+        # empty string is present in shape but unusable. The direct empty
+        # literal was already caught; the aliased form passed because the
+        # identifier text is non-empty. Resolving the nearest single static
+        # assignment (and any alias chain) closes that gap WITHOUT flagging a
+        # genuinely populated or reassigned alias.
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_static_alias_profile_contract",
+        )
+        analyze = namespace["analyze_file"]
+        base = (
+            "import axios from 'axios';\n"
+            "const api = axios.create({ baseURL: 'https://api.telnyx.com/v2' });\n"
+        )
+        send = (
+            "export const send = (mp) => api.post('/messages/number_pool', "
+            "{ messaging_profile_id: mp, to: '+1', from: '+1' });\n"
+        )
+
+        def run(source: str) -> tuple[int, int]:
+            with tempfile.TemporaryDirectory(
+                prefix="telnyx-static-alias-"
+            ) as temp_dir:
+                root = Path(temp_dir)
+                fixture = root / "index.js"
+                fixture.write_text(source, encoding="utf-8")
+                total, missing = analyze(fixture, root)
+                return total, len(missing)
+
+        # Empty constant alias -> flagged as missing.
+        self.assertEqual(
+            (1, 1),
+            run(base + "const mp = '';\n" + send.replace("(mp)", "()")),
+        )
+        # Alias chain to an empty constant -> flagged.
+        self.assertEqual(
+            (1, 1),
+            run(base + "const a = ''; const b = a;\n"
+                + send.replace("(mp)", "()").replace("mp", "b")),
+        )
+        # A genuinely populated constant alias -> NOT flagged.
+        self.assertEqual(
+            (1, 0),
+            run(base + "const mp = 'MP_abc123';\n" + send.replace("(mp)", "()")),
+        )
+        # Reassigned to a non-empty value before use -> NOT flagged.
+        self.assertEqual(
+            (1, 0),
+            run(base + "let mp = ''; mp = 'MP_real';\n"
+                + send.replace("(mp)", "()")),
+        )
+
+    def _analyze_source(self, filename: str, source: str) -> tuple[int, int]:
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_send_shape_contract",
+        )
+        analyze = namespace["analyze_file"]
+        with tempfile.TemporaryDirectory(prefix="telnyx-send-shape-") as tmp:
+            root = Path(tmp)
+            fixture = root / filename
+            fixture.write_text(source, encoding="utf-8")
+            total, missing = analyze(fixture, root)
+            return total, len(missing)
+
+    def test_axios_method_helper_per_request_baseurl_is_combined(self) -> None:
+        # axios.post(url, data, {baseURL}) sets the effective base and OVERRIDES
+        # the instance one. Only the one-shot axios(config) form was read, so
+        # this shape resolved to the bare path and passed with zero required
+        # sends even though the effective POST is /v2/messages/number_pool.
+        head = "const axios=require('axios');\n"
+        cfg = "{baseURL:'https://api.telnyx.com/v2/messages/'}"
+        # Missing profile through the helper config -> counted AND flagged.
+        self.assertEqual(
+            (1, 1),
+            self._analyze_source(
+                "a.js",
+                head + f"module.exports=()=>axios.post('/number_pool',{{to:'+1'}},{cfg});\n",
+            ),
+        )
+        # Same shape WITH a usable profile -> counted, not flagged.
+        self.assertEqual(
+            (1, 0),
+            self._analyze_source(
+                "b.js",
+                head
+                + "module.exports=()=>axios.post('/number_pool',"
+                + f"{{messaging_profile_id:'MP_x',to:'+1'}},{cfg});\n",
+            ),
+        )
+        # A non-required path through the same shape stays safe.
+        self.assertEqual(
+            (0, 0),
+            self._analyze_source(
+                "c.js",
+                head + f"module.exports=()=>axios.post('/other',{{to:'+1'}},{cfg});\n",
+            ),
+        )
+
+    def test_required_send_contract_matrix(self) -> None:
+        """Cross-product contract matrix over the SUPPORTED SURFACE.
+
+        Built from the code's own inventory (FETCH_CALL_RE call forms, the
+        base-URL/payload resolution branches, JS_TS_SUFFIXES and
+        SUFFIX_LANGUAGE_ALIASES) rather than from cases we happened to imagine,
+        so every client signature is exercised in both polarities. Earlier
+        suites were exhaustive only over the branches already implemented, which
+        is why array/per-request-config/handle-reuse forms went missing.
+        """
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        other = "https://api.telnyx.com/v2/messages/other"
+        base = "https://api.telnyx.com/v2/messages/"
+        forms = {
+            ("js.fetch", ".js"): lambda p: f"fetch('{url}',{{method:'POST',body:JSON.stringify({{{p}to:'+1'}})}});",
+            ("js.axios.abs", ".js"): lambda p: f"const axios=require('axios');axios.post('{url}',{{{p}to:'+1'}});",
+            ("js.axios.cfg", ".js"): lambda p: f"const axios=require('axios');axios({{method:'post',baseURL:'{base}',url:'./number_pool',data:{{{p}to:'+1'}}}});",
+            ("js.axios.helper", ".js"): lambda p: f"const axios=require('axios');axios.post('/number_pool',{{{p}to:'+1'}},{{baseURL:'{base}'}});",
+            ("js.axios.factory", ".js"): lambda p: f"const axios=require('axios');const api=axios.create({{baseURL:'{base}'}});api.post('/number_pool',{{{p}to:'+1'}});",
+            ("py.requests", ".py"): lambda p: f"import requests\nrequests.post('{url}', json={{{p}'to':'+1'}})",
+            ("php.guzzle.abs", ".php"): lambda p: f'<?php\n$c=new GuzzleHttp\\Client();\n$c->post("{url}",["json"=>[{p}"to"=>"+1"]]);',
+            ("php.curl.setopt", ".php"): lambda p: f'<?php\n$ch=curl_init();\ncurl_setopt($ch,CURLOPT_URL,"{url}");\ncurl_setopt($ch,CURLOPT_POST,true);\ncurl_setopt($ch,CURLOPT_POSTFIELDS,json_encode([{p}"to"=>"+1"]));\ncurl_exec($ch);',
+            ("php.curl.array", ".php"): lambda p: f'<?php\n$ch=curl_init();\ncurl_setopt_array($ch,[CURLOPT_URL=>"{url}",CURLOPT_POST=>true,CURLOPT_POSTFIELDS=>json_encode([{p}"to"=>"+1"])]);\ncurl_exec($ch);',
+            ("php.curl.reuse", ".php"): lambda p: f'<?php\n$ch=curl_init();\ncurl_setopt($ch,CURLOPT_URL,"{other}");\ncurl_setopt($ch,CURLOPT_POST,true);\ncurl_setopt($ch,CURLOPT_POSTFIELDS,json_encode([{p}"to"=>"+1"]));\ncurl_exec($ch);\ncurl_setopt($ch,CURLOPT_URL,"{url}");\ncurl_exec($ch);',
+            ("rb.nethttp", ".rb"): lambda p: f'Net::HTTP.post(URI("{url}"), {{{p}to: "+1"}}.to_json)',
+            ("rb.faraday", ".rb"): lambda p: f'conn = Faraday.new(url: "{base}")\nconn.post("number_pool", {{{p}to: "+1"}}.to_json)',
+            ("go.post", ".go"): lambda p: f'body := []byte(`{{{p}"to":"+1"}}`)\nhttp.Post("{url}","application/json",bytes.NewBuffer(body))',
+            # NewRequest builds; client.Do(req) sends. The execution link is
+            # required or a request that is merely constructed is reported.
+            ("go.newrequest", ".go"): lambda p: f'body := []byte(`{{{p}"to":"+1"}}`)\nreq, _ := http.NewRequest("POST","{url}", bytes.NewBuffer(body))\nclient.Do(req)',
+            ("java.httpclient", ".java"): lambda p: f'String json = "{{{p}\\"to\\":\\"+1\\"}}";\nHttpRequest.newBuilder().uri(URI.create("{url}")).POST(HttpRequest.BodyPublishers.ofString(json)).build();',
+            ("cs.postasync", ".cs"): lambda p: f'var content = new StringContent("{{{p}\\"to\\":\\"+1\\"}}");\nawait client.PostAsync("{url}", content);',
+        }
+        profiles = {
+            ".js": 'messaging_profile_id:"MP_x",',
+            ".py": "'messaging_profile_id':'MP_x',",
+            ".php": '"messaging_profile_id"=>"MP_x",',
+            ".rb": 'messaging_profile_id: "MP_x", ',
+            ".go": '"messaging_profile_id":"MP_x",',
+            ".java": '\\"messaging_profile_id\\":\\"MP_x\\",',
+            ".cs": '\\"messaging_profile_id\\":\\"MP_x\\",',
+        }
+        for (form_id, ext), build in forms.items():
+            with self.subTest(form=form_id, profile=False):
+                total, missing = self._analyze_source("x" + ext, build(""))
+                self.assertGreaterEqual(total, 1, form_id)
+                self.assertGreaterEqual(missing, 1, form_id)
+            with self.subTest(form=form_id, profile=True):
+                total, missing = self._analyze_source(
+                    "x" + ext, build(profiles[ext])
+                )
+                self.assertGreaterEqual(total, 1, form_id)
+                self.assertEqual(0, missing, form_id)
+
+        # Non-mutating and non-required shapes must not be counted at all.
+        zero = {
+            ("get.js.method", ".js"): f"fetch('{url}',{{method:'GET'}});",
+            ("get.js.default", ".js"): f"fetch('{url}');",
+            ("get.py", ".py"): f"import requests\nrequests.get('{url}')",
+            ("get.php.curlarray", ".php"): f'<?php\n$ch=curl_init();\ncurl_setopt_array($ch,[CURLOPT_URL=>"{url}",CURLOPT_HTTPGET=>true]);\ncurl_exec($ch);',
+            ("get.php.reuse_reset", ".php"): f'<?php\n$ch=curl_init();\ncurl_setopt($ch,CURLOPT_URL,"{other}");\ncurl_setopt($ch,CURLOPT_POST,true);\ncurl_setopt($ch,CURLOPT_POSTFIELDS,"{{}}");\ncurl_exec($ch);\ncurl_reset($ch);\ncurl_setopt($ch,CURLOPT_URL,"{url}");\ncurl_exec($ch);',
+            ("get.go", ".go"): f'http.Get("{url}")',
+            ("nonreq.js", ".js"): f"fetch('{other}',{{method:'POST',body:'{{}}'}});",
+        }
+        for (form_id, ext), source in zero.items():
+            with self.subTest(form=form_id):
+                total, _ = self._analyze_source("x" + ext, source)
+                self.assertEqual(0, total, form_id)
+
+    def test_try_body_is_a_guard_in_every_language(self) -> None:
+        # A `try` body is not unconditional: when a sibling handler swallows the
+        # error, execution continues past the statement with the profile write
+        # skipped, so a send AFTER the statement can go out without it. Ruby's
+        # begin/rescue was already treated as an arm; Python `try:` and the
+        # braced `try { }` of PHP/JS/Java/C# were not — the same defect class in
+        # every other supported language.
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        guarded = {
+            "a.py": (
+                "import requests\npl={\"to\":\"+1\"}\ntry:\n"
+                "    pl[\"messaging_profile_id\"]=mp\nexcept Exception:\n    pass\n"
+                f"requests.post(\"{url}\", json=pl)\n"
+            ),
+            "b.js": (
+                "const p={to:'+1'};\ntry { p.messaging_profile_id=mp; } catch(e) {}\n"
+                f"fetch('{url}',{{method:'POST',body:JSON.stringify(p)}});\n"
+            ),
+            "c.php": (
+                '<?php\n$p=["to"=>"+1"];\n'
+                'try { $p["messaging_profile_id"]=$mp; } catch (Exception $e) {}\n'
+                '$c=new GuzzleHttp\\Client();\n'
+                f'$c->post("{url}",["json"=>$p]);\n'
+            ),
+        }
+        for name, source in guarded.items():
+            self.assertEqual(
+                (1, 1), self._analyze_source(name, source), name
+            )
+
+        # A send INSIDE the same try body shares the arm — not a guard, and must
+        # not be reported (the write cannot be skipped while the send happens).
+        self.assertEqual(
+            (1, 0),
+            self._analyze_source(
+                "d.js",
+                "try {\n const p={messaging_profile_id:mp,to:'+1'};\n"
+                f" fetch('{url}',{{method:'POST',body:JSON.stringify(p)}});\n"
+                "} catch(e) {}\n",
+            ),
+        )
+        # `finally` always runs, so a write there is still unconditional.
+        self.assertEqual(
+            (1, 0),
+            self._analyze_source(
+                "e.py",
+                "import requests\npl={\"to\":\"+1\"}\ntry:\n    pass\nfinally:\n"
+                "    pl[\"messaging_profile_id\"]=mp\n"
+                f"requests.post(\"{url}\", json=pl)\n",
+            ),
+        )
+
+    def test_reraising_handler_leaves_the_try_body_unconditional(self) -> None:
+        # A handler that RE-RAISES does not swallow the error, so execution can
+        # never continue past the statement with the profile write skipped — a
+        # later send is unreachable without it. Log-and-rethrow
+        # (`catch (e) { log(e); throw e; }` / `except: log(e); raise`) is the
+        # standard idiom, and treating it as a guard reported compliant
+        # migrations as missing the profile.
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        unconditional = {
+            "a.py": (
+                "import requests\npl={\"to\":\"+1\"}\ntry:\n"
+                "    pl[\"messaging_profile_id\"]=mp\nexcept Exception as e:\n"
+                "    log(e)\n    raise\n"
+                f"requests.post(\"{url}\", json=pl)\n"
+            ),
+            "b.js": (
+                "const p={to:'+1'};\n"
+                "try { p.messaging_profile_id=mp; } catch(e) { log(e); throw e; }\n"
+                f"fetch('{url}',{{method:'POST',body:JSON.stringify(p)}});\n"
+            ),
+            "c.php": (
+                '<?php\n$p=["to"=>"+1"];\n'
+                'try { $p["messaging_profile_id"]=$mp; }'
+                ' catch (Exception $e) { log($e); throw $e; }\n'
+                '$c=new GuzzleHttp\\Client();\n'
+                f'$c->post("{url}",["json"=>$p]);\n'
+            ),
+        }
+        for name, source in unconditional.items():
+            self.assertEqual((1, 0), self._analyze_source(name, source), name)
+
+        # ONE swallowing handler is enough to make the body conditional again,
+        # so a mixed handler list stays flagged.
+        self.assertEqual(
+            (1, 1),
+            self._analyze_source(
+                "d.py",
+                "import requests\npl={\"to\":\"+1\"}\ntry:\n"
+                "    pl[\"messaging_profile_id\"]=mp\nexcept ValueError:\n"
+                "    raise\nexcept Exception:\n    pass\n"
+                f"requests.post(\"{url}\", json=pl)\n",
+            ),
+        )
+        # A re-raise nested under a condition can be skipped, so it swallows.
+        self.assertEqual(
+            (1, 1),
+            self._analyze_source(
+                "e.py",
+                "import requests\npl={\"to\":\"+1\"}\ntry:\n"
+                "    pl[\"messaging_profile_id\"]=mp\nexcept Exception:\n"
+                "    if fatal:\n        raise\n"
+                f"requests.post(\"{url}\", json=pl)\n",
+            ),
+        )
+
+    def test_php_curl_setopt_array_and_carried_handle_state(self) -> None:
+        # (1) curl_setopt_array is as idiomatic as repeated curl_setopt calls,
+        # but the array form was never visited, so a number-pool send configured
+        # this way escaped the requirement entirely.
+        array_post = (
+            '<?php\n$ch=curl_init();\n'
+            'curl_setopt_array($ch,[CURLOPT_URL=>'
+            '"https://api.telnyx.com/v2/messages/number_pool",'
+            'CURLOPT_POST=>true,CURLOPT_POSTFIELDS=>"{}"]);\ncurl_exec($ch);\n'
+        )
+        self.assertEqual((1, 1), self._analyze_source("a.php", array_post))
+        # The array form carrying a usable profile is not flagged.
+        self.assertEqual(
+            (1, 0),
+            self._analyze_source(
+                "b.php",
+                array_post.replace(
+                    'CURLOPT_POSTFIELDS=>"{}"',
+                    'CURLOPT_POSTFIELDS=>'
+                    'json_encode(["messaging_profile_id"=>"MP_x"])',
+                ),
+            ),
+        )
+        # An array that configures a GET is not a send at all.
+        self.assertEqual(
+            (0, 0),
+            self._analyze_source(
+                "c.php",
+                '<?php\n$ch=curl_init();\n'
+                'curl_setopt_array($ch,[CURLOPT_URL=>'
+                '"https://api.telnyx.com/v2/messages/number_pool",'
+                'CURLOPT_HTTPGET=>true]);\ncurl_exec($ch);\n',
+            ),
+        )
+        # (2) ext-curl options PERSIST across curl_exec until overwritten or
+        # reset. A handle that posts, then changes only CURLOPT_URL, is still
+        # POSTing — starting state after the previous exec made it look like a
+        # fresh GET and the required send was reported clean.
+        reused = (
+            '<?php\n$ch=curl_init();\n'
+            'curl_setopt($ch,CURLOPT_URL,"https://api.telnyx.com/v2/other");\n'
+            'curl_setopt($ch,CURLOPT_POST,true);\n'
+            'curl_setopt($ch,CURLOPT_POSTFIELDS,"{}");\ncurl_exec($ch);\n'
+            'curl_setopt($ch,CURLOPT_URL,'
+            '"https://api.telnyx.com/v2/messages/number_pool");\n'
+            'curl_exec($ch);\n'
+        )
+        self.assertEqual((1, 1), self._analyze_source("d.php", reused))
+        # curl_reset clears the carried state -> the second call is a GET.
+        self.assertEqual(
+            (0, 0),
+            self._analyze_source(
+                "e.php", reused.replace("curl_exec($ch);\ncurl_setopt($ch,CURLOPT_URL,"
+                                        '"https://api.telnyx.com/v2/messages/number_pool");',
+                                        "curl_exec($ch);\ncurl_reset($ch);\n"
+                                        'curl_setopt($ch,CURLOPT_URL,'
+                                        '"https://api.telnyx.com/v2/messages/number_pool");',
+                                        1)
+            ),
+        )
+        # Explicitly switching the reused handle back to GET is also clean.
+        self.assertEqual(
+            (0, 0),
+            self._analyze_source(
+                "f.php",
+                reused.replace(
+                    'curl_setopt($ch,CURLOPT_URL,'
+                    '"https://api.telnyx.com/v2/messages/number_pool");',
+                    'curl_setopt($ch,CURLOPT_HTTPGET,true);\n'
+                    'curl_setopt($ch,CURLOPT_URL,'
+                    '"https://api.telnyx.com/v2/messages/number_pool");',
+                    1,
+                ),
+            ),
+        )
+
+    def test_inline_language_speech_model_requires_conversation_relay_parent(
+        self,
+    ) -> None:
+        _, payload = self.run_messaging_linter(
+            {
+                "valid-language.js": (
+                    "const texml = `<tw:Response><tw:Connect>"
+                    "<tw:ConversationRelay><tw:Language "
+                    "speechModel=\"phone_call\"/></tw:ConversationRelay>"
+                    "</tw:Connect></tw:Response>`;"
+                ),
+                "invalid-language.js": (
+                    "const texml = `<Response><Language "
+                    "speechModel=\"phone_call\"/></Response>`;"
+                ),
+            },
+            product="voice",
+        )
+        checks = [
+            check
+            for check in payload["checks"]
+            if check["name"] == "speech_model_attr"
+        ]
+        self.assertEqual(1, len(checks))
+        finding_files = checks[0]["details"]["files"]
+        self.assertTrue(
+            any("/invalid-language.js:" in finding for finding in finding_files)
+        )
+        self.assertFalse(
+            any("/valid-language.js:" in finding for finding in finding_files)
+        )
+
+
+class AnalyzerConsistencyContracts(unittest.TestCase):
+    def test_analyzer_and_shell_exclude_the_same_generated_directories(self) -> None:
+        canonical = {
+            ".next", ".nuxt", "coverage", ".tox", "node_modules", "dist", "build"
+        }
+        shell = CORRECTNESS_LINTER.read_text(encoding="utf-8")
+        declared = re.search(
+            r'^EXCLUDE_DIRS="([^"]*)"', shell, re.MULTILINE
+        )
+        self.assertIsNotNone(declared, "shell linter has no EXCLUDE_DIRS")
+        self.assertEqual(set(), canonical - set(declared.group(1).split()))
+
+        analyzer = MESSAGING_SOURCE_ANALYZER.read_text(encoding="utf-8")
+        block = analyzer.split("EXCLUDED_DIRS = {", 1)[1]
+        analyzer_dirs = set(
+            re.findall(r'"([^"]+)"', block[: block.index("}")])
+        )
+        self.assertEqual(set(), canonical - analyzer_dirs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -1210,6 +1210,49 @@ class CorrectnessLinterContracts(unittest.TestCase):
             }
         )
 
+    def test_mixed_php_tag_family_preserves_only_executable_regions(self) -> None:
+        missing = (
+            "$client->post('https://api.telnyx.com/v2/messages/number_pool', "
+            "['json' => ['to' => '+1', 'text' => 'hi']]);"
+        )
+        valid = missing.replace(
+            "'text' => 'hi'",
+            "'text' => 'hi', 'messaging_profile_id' => 'mp'",
+        )
+        wrappers = {
+            "normal": ("<?php ", " ?>"),
+            "short": ("<? ", " ?>"),
+            "echo": ("<?= ", " ?>"),
+            "unclosed": ("<?php ", ""),
+            "multiple-blocks": ("<?php $title = 'ready'; ?>\n<?php ", " ?>"),
+        }
+        for tag, (opening, closing) in wrappers.items():
+            for polarity, body in (("missing", missing), ("valid", valid)):
+                with self.subTest(tag=tag, polarity=polarity):
+                    files = {
+                        "send.php": (
+                            "<p>It's ready</p>\n"
+                            + opening
+                            + body
+                            + closing
+                            + "\n"
+                        )
+                    }
+                    if polarity == "missing":
+                        _, payload = self.run_messaging_linter(files)
+                        self.assert_required_profile_detected(payload, "send.php")
+                    else:
+                        self.assert_required_profile_passes(files)
+
+        # Markup examples outside PHP tags are prose, while raw tagless PHP is
+        # retained for generated snippets and the analyzer's documented input
+        # convention.
+        self.assert_required_profile_passes(
+            {"example.php": "<code>" + missing + "</code>\n"}
+        )
+        _, payload = self.run_messaging_linter({"raw.php": missing + "\n"})
+        self.assert_required_profile_detected(payload, "raw.php")
+
     def test_multiline_template_comments_preserve_speech_model_line(self) -> None:
         source = (
             "<!-- comment\n"

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -36,6 +36,9 @@ MESSAGING_SOURCE_ANALYZER = (
     MIGRATION_SCRIPTS.parent / "lint-required-messaging-profile.py"
 )
 PREFLIGHT_SCRIPT = MIGRATION_SCRIPTS.parent / "preflight-check.sh"
+SCAN_USAGE_SCRIPT = MIGRATION_SCRIPTS.parent / "scan-twilio-usage.sh"
+DEEP_SCAN_SCRIPT = MIGRATION_SCRIPTS.parent / "scan-twilio-deep.py"
+VALIDATE_MIGRATION_SCRIPT = MIGRATION_SCRIPTS.parent / "validate-migration.sh"
 TEXML_VALIDATOR = MIGRATION_SCRIPTS.parent / "validate-texml.sh"
 FILTER_SOURCE_SCRIPT = MIGRATION_SCRIPTS.parent / "filter-source-matches.py"
 SMOKE_SCRIPT = MIGRATION_SCRIPTS / "smoke-test.sh"
@@ -158,6 +161,72 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 timeout=15,
                 check=False,
             )
+
+    def test_csharp_twilio_message_send_and_client_init_are_actionable(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "Program.cs": (
+                    "using Twilio;\n"
+                    "using Twilio.Rest.Api.V2010.Account;\n"
+                    "TwilioClient.Init(accountSid, authToken);\n"
+                    "var message = MessageResource.Create(\n"
+                    "  from: new PhoneNumber(from),\n"
+                    "  to: new PhoneNumber(to),\n"
+                    "  body: \"Ahoy from Twilio!\"\n"
+                    ");\n"
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode)
+        statuses = {item["name"]: item["status"] for item in payload["checks"]}
+        self.assertEqual("issue", statuses["twilio_messages_create"])
+        self.assertEqual("issue", statuses["body_not_text"])
+        self.assertEqual("issue", statuses["twilio_client_instantiation"])
+
+    def test_csharp_body_checks_require_sdk_ownership(self) -> None:
+        sources = (
+            ('class MessageResource { public static void Create(string body) {} }\n'
+             'class Queue { void Send() { MessageResource.Create(body: "data"); } }', False),
+            ('using Twilio.Rest.Api.V2010.Account;\n'
+             'class MessageResource { public static void Create(string body) {} }\n'
+             'MessageResource.Create(body: "data");', False),
+            ('using MessageResource = Example.Queue;\n'
+             'using Twilio.Rest.Api.V2010.Account;\nMessageResource.Create(body: "data");', False),
+            ('using Sms = Twilio.Rest.Api.V2010.Account.MessageResource;\nSms.Create(body: "data");', True),
+            ('using Api = Twilio.Rest.Api.V2010.Account;\nApi.MessageResource.Create(body: "data");', True),
+            ('global::Twilio.Rest.Api.V2010.Account.MessageResource.Create(body: "data");', True),
+            ('using static Twilio.Rest.Api.V2010.Account.MessageResource;\nCreate(body: "data");', True),
+            ('namespace A { using Twilio.Rest.Api.V2010.Account; }\n'
+             'namespace B { class Queue { void Send() { MessageResource.Create(body: "data"); } } }', False),
+            ('using Sms = Twilio.Rest.Api.V2010.Account.MessageResource;\n'
+             'class X { void Go() { var Sms = new Queue(); Sms.Create(body: "data"); } }', False),
+            ('using Api = Twilio.Rest.Api.V2010.Account;\n'
+             'class X { void Go() { var Api = new Queue(); Api.MessageResource.Create(body: "data"); } }', False),
+            ('using Sms = Twilio.Rest.Api.V2010.Account.MessageResource;\n'
+             'class X { void Go(Queue Sms) { Sms.Create(body: "data"); } }', False),
+            ('using Sms = Twilio.Rest.Api.V2010.Account.MessageResource;\n'
+             'class X { void Other() { var Sms = new Queue(); }\n'
+             'void Go() { Sms.Create(body: "data"); } }', True),
+            ('using Sms = Twilio.Rest.Api.V2010.Account.MessageResource;\n'
+             'class X { void Go() { { var Sms = new Queue(); } Sms.Create(body: "data"); } }', True),
+        )
+        for source, expected in sources:
+            with self.subTest(source=source):
+                _, payload = self.run_messaging_linter({"Program.cs": source})
+                statuses = {item["name"]: item["status"] for item in payload["checks"]}
+                for check in ("twilio_messages_create", "body_not_text"):
+                    self.assertEqual("issue" if expected else "pass", statuses[check])
+
+    def test_csharp_generic_body_calls_are_preserved(self) -> None:
+        for field, expected in (("Body", "issue"), ("Text", "pass")):
+            with self.subTest(field=field):
+                _, payload = self.run_messaging_linter({"Program.cs": (
+                    'client.Messages.Send(new MessageCreateOptions { '
+                    f'{field} = "hello", To = "+1"' + ' });'
+                )})
+                statuses = {item["name"]: item["status"] for item in payload["checks"]}
+                self.assertEqual(expected, statuses["body_not_text"])
+                self.assertEqual("pass", statuses["twilio_messages_create"])
 
     def test_documented_mapping_prose_is_not_residual_twilio(self) -> None:
         result, payload = self.run_messaging_linter(
@@ -1789,6 +1858,19 @@ class CorrectnessLinterContracts(unittest.TestCase):
         _, payload = self.run_messaging_linter({"Frontmatter.astro": astro_frontmatter})
         self.assert_required_profile_detected(payload, "Frontmatter.astro")
 
+        comment_string_frontmatter = "\n".join(
+            (
+                "---",
+                'const marker = "<!--";',
+                'fetch("/v2/messages/number_pool", {method: "POST", body: JSON.stringify({to: "+1"})});',
+                "---",
+            )
+        )
+        _, payload = self.run_messaging_linter(
+            {"CommentString.astro": comment_string_frontmatter}
+        )
+        self.assert_required_profile_detected(payload, "CommentString.astro")
+
     def test_ejs_client_script_blocks_are_executable(self) -> None:
         name = "send.ejs"
         _, payload = self.run_messaging_linter(
@@ -1800,6 +1882,220 @@ class CorrectnessLinterContracts(unittest.TestCase):
             }
         )
         self.assert_required_profile_detected(payload, name)
+
+    def test_ejs_script_type_controls_client_execution(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        missing = (
+            f'fetch("{url}", '
+            '{method: "POST", body: JSON.stringify({to: "+1"})});'
+        )
+        valid = missing.replace(
+            '{to: "+1"}',
+            '{to: "+1", messaging_profile_id: "mp"}',
+        )
+        executable_openers = {
+            "absent": "<script>",
+            "empty": '<script type="">',
+            "boolean-empty": "<script type>",
+            "module": '<script type="module">',
+            "classic": '<script type="text/javascript">',
+            "legacy": "<script TYPE=application/x-javascript>",
+            "data-type-only": '<script data-type="application/json">',
+            "dynamic-type": '<script type="<%= scriptType %>">',
+            "language-javascript": '<script language="javascript">',
+        }
+        inert_openers = {
+            "json": '<script type="application/json">',
+            "json-case": "<SCRIPT TYPE='Application/JSON'>",
+            "json-entity": '<script type="application&#x2f;json">',
+            "json-ld": "<script type=application/ld+json>",
+            "plain": '<script type = "text/plain">',
+            "import-map": '<script type="importmap">',
+            "speculation-rules": '<script type="speculationrules">',
+            "language-non-js": '<script language="vbscript">',
+            "duplicate-first": (
+                '<script type="application/json" type="text/javascript">'
+            ),
+            "module-with-parameters": '<script type="module;foo">',
+            "empty-essence-with-parameters": (
+                '<script type="; charset=utf-8">'
+            ),
+            "javascript-with-parameters": (
+                '<script type="Application/JavaScript; charset=utf-8">'
+            ),
+        }
+
+        for label, opener in executable_openers.items():
+            for polarity, request, should_detect in (
+                ("missing", missing, True),
+                ("valid", valid, False),
+            ):
+                name = f"executable-{label}-{polarity}.ejs"
+                with self.subTest(label=label, polarity=polarity):
+                    result, payload = self.run_messaging_linter(
+                        {name: f"{opener}{request}</script>"}
+                    )
+                    if should_detect:
+                        self.assert_required_profile_detected(payload, name)
+                    else:
+                        checks = [
+                            check
+                            for check in payload["checks"]
+                            if check["name"] == "required_messaging_profile_id"
+                        ]
+                        self.assertEqual(
+                            [
+                                {
+                                    "name": "required_messaging_profile_id",
+                                    "status": "pass",
+                                }
+                            ],
+                            checks,
+                        )
+                        self.assertEqual(0, result.returncode, result.stdout)
+
+        for label, opener in inert_openers.items():
+            name = f"inert-{label}.ejs"
+            with self.subTest(label=label):
+                self.assert_required_profile_passes(
+                    {name: f"{opener}{missing}</script>"}
+                )
+
+        self.assert_required_profile_passes(
+            {
+                "mixed.ejs": (
+                    f'<script type="application/json">{missing}</script>'
+                    f'<script type="module">{valid}</script>'
+                )
+            }
+        )
+        self.assert_required_profile_passes(
+            {
+                "quoted-angle.ejs": (
+                    '<script data-note="1 > 0" type="application/json">'
+                    f"{missing}</script>"
+                ),
+                "commented.ejs": f"<!-- <script>{missing}</script> -->",
+                "boundary.ejs": f"<scripture>{missing}</scripture>",
+            }
+        )
+        _, payload = self.run_messaging_linter(
+            {"unclosed.ejs": f"<script>{missing}"}
+        )
+        self.assert_required_profile_detected(payload, "unclosed.ejs")
+        _, payload = self.run_messaging_linter(
+            {
+                "closing-boundary.ejs": (
+                    f"<script>const inert = 1;</scripture>{missing}</script>"
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, "closing-boundary.ejs")
+
+        # Tag discovery must preserve original Unicode offsets and follow HTML
+        # tag-name/end-tag boundaries.  Inert custom/data/comment regions must
+        # not become requests, nor may they consume a later real script.
+        _, payload = self.run_messaging_linter(
+            {"unicode-offset.ejs": f"İ<script>{missing}</script>"}
+        )
+        self.assert_required_profile_detected(payload, "unicode-offset.ejs")
+        for name, source in {
+            "script-dot.ejs": f"<script.foo>{missing}</script.foo>",
+            "slash-close.ejs": (
+                "<script>const okay = true;</script/>"
+                f'<script type="application/json">{missing}</script>'
+            ),
+            "unterminated-comment.ejs": f"<!--\n<script>{missing}</script>",
+            "textarea.ejs": f"<textarea><script>{missing}</script></textarea>",
+            "title.ejs": f"<title><script>{missing}</script></title>",
+            "style.ejs": f"<style><script>{missing}</script></style>",
+            "plaintext.ejs": f"<plaintext><script>{missing}</script>",
+            "non-ascii-empty-type.ejs": (
+                f'<script type="&nbsp;">{missing}</script>'
+            ),
+            "attribute.ejs": f'<div data-example="<script>{missing}</script>">x</div>',
+            "nested-template.ejs": (
+                "<template><template></template>"
+                f"<script>{missing}</script></template>"
+            ),
+        }.items():
+            with self.subTest(inert_boundary=name):
+                self.assert_required_profile_passes({name: source})
+
+        for name, source in {
+            "after-custom.ejs": (
+                f"<script.foo>{missing}</script.foo><script>{missing}</script>"
+            ),
+            "after-comment.ejs": (
+                f"<!-- <script>{missing}</script> --><script>{missing}</script>"
+            ),
+            "after-bang-comment.ejs": (
+                f"<!-- inert --!><script>{missing}</script>"
+            ),
+            "after-abrupt-comment.ejs": f"<!--><script>{missing}</script>",
+            "legacy-script-comment.ejs": (
+                f"<script><!--\n{missing}\n//--></script>"
+            ),
+            "comment-text-in-script.ejs": (
+                f'<script>const marker = "<!--";\n{missing}</script>'
+            ),
+            "comment-text-in-attribute.ejs": (
+                f'<div data-marker="<!--"></div><script>{missing}</script>'
+            ),
+            "ascii-end-tag.ejs": (
+                f'<script>const marker = "</ſcript>";\n{missing}</script>'
+            ),
+            "non-ascii-attribute-separator.ejs": (
+                f'<script type\u00a0="application/json">{missing}</script>'
+            ),
+            "slash-close-live.ejs": (
+                f"<script>{missing}</script/><p>ordinary</p>"
+            ),
+        }.items():
+            with self.subTest(executable_boundary=name):
+                _, payload = self.run_messaging_linter({name: source})
+                self.assert_required_profile_detected(payload, name)
+
+        for suffix in (".vue", ".svelte", ".astro"):
+            with self.subTest(suffix=suffix, script_type="json"):
+                self.assert_required_profile_passes(
+                    {
+                        f"data{suffix}": (
+                            '<script type="application/json">'
+                            f"{missing}</script>"
+                        )
+                    }
+                )
+            with self.subTest(suffix=suffix, script_type="module"):
+                _, payload = self.run_messaging_linter(
+                    {
+                        f"module{suffix}": (
+                            f'<script type="module">{missing}</script>'
+                        )
+                    }
+                )
+                self.assert_required_profile_detected(payload, f"module{suffix}")
+
+    def test_template_comment_and_script_scans_are_linear(self) -> None:
+        namespace = runpy.run_path(str(MESSAGING_SOURCE_ANALYZER))
+        without_comments = namespace["_without_html_comments"]
+        script_ranges = namespace["_script_element_body_ranges"]
+
+        # These inputs made the former non-anchored DOTALL regex retry at every
+        # opener.  Large bounded fixtures make the regression deterministic:
+        # the linear scanners complete comfortably below this generous limit.
+        for label, operation, source in (
+            ("comments", without_comments, "<!--" * 20_000),
+            (
+                "script-tags",
+                script_ranges,
+                "İ" * 20_000 + "<script>const x = 1;</script>" * 2_000,
+            ),
+        ):
+            with self.subTest(label=label):
+                started = time.perf_counter()
+                operation(source)
+                self.assertLess(time.perf_counter() - started, 1.0)
 
     def test_component_style_blocks_are_not_executable_requests(self) -> None:
         for suffix in (".svelte", ".astro"):
@@ -3160,6 +3456,274 @@ class CorrectnessLinterContracts(unittest.TestCase):
             any("after-heredoc.rb" in row for row in result.stdout.splitlines()[1:]),
             result.stdout,
         )
+
+    def test_ruby_multiple_heredocs_preserve_each_body_interpolation_mode(
+        self,
+    ) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+
+        def request(profile: bool) -> str:
+            field = ", messaging_profile_id: 'mp'" if profile else ""
+            return (
+                f"Net::HTTP.post(URI('{url}'), "
+                f"{{to: '+1'{field}}}.to_json)"
+            )
+
+        opener_modes = {
+            "plain": lambda tag: f"<<{tag}",
+            "indented": lambda tag: f"<<~{tag}",
+            "double": lambda tag: f'<<"{tag}"',
+            "single": lambda tag: f"<<'{tag}'",
+            "command": lambda tag: f"<<`{tag}`",
+        }
+        for first_mode, first_opener in opener_modes.items():
+            for second_mode, second_opener in opener_modes.items():
+                for active_body in (0, 1):
+                    for polarity, profile in (
+                        ("missing", False),
+                        ("valid", True),
+                    ):
+                        modes = (first_mode, second_mode)
+                        bodies = ["ordinary first", "ordinary second"]
+                        bodies[active_body] = f"#{{{request(profile)}}}"
+                        source = "\n".join(
+                            (
+                                f"puts {first_opener('FIRST')}, {second_opener('SECOND')}",
+                                bodies[0],
+                                "FIRST",
+                                bodies[1],
+                                "SECOND",
+                                "",
+                            )
+                        )
+                        should_execute = modes[active_body] != "single"
+                        name = (
+                            f"multi-{first_mode}-{second_mode}-{active_body}-"
+                            f"{polarity}.rb"
+                        )
+                        with self.subTest(
+                            first=first_mode,
+                            second=second_mode,
+                            active_body=active_body,
+                            polarity=polarity,
+                        ):
+                            result = self.run_required_profile_analyzer(
+                                {name: source}
+                            )
+                            detected = any(
+                                name in row for row in result.stdout.splitlines()[1:]
+                            )
+                            self.assertEqual(
+                                should_execute and not profile,
+                                detected,
+                                result.stdout,
+                            )
+
+        triple = "\n".join(
+            (
+                "render <<'ONE', <<~TWO, <<\"THREE\"",
+                f"#{{{request(False)}}}",
+                "ONE",
+                "ordinary second",
+                "TWO",
+                f"#{{{request(False)}}}",
+                "THREE",
+                "",
+            )
+        )
+        result = self.run_required_profile_analyzer({"triple.rb": triple})
+        self.assertTrue(
+            any("triple.rb" in row for row in result.stdout.splitlines()[1:]),
+            result.stdout,
+        )
+
+    def test_ruby_heredoc_grammar_boundaries(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        send = f"Net::HTTP.post(URI('{url}'), {{to: '+1'}}.to_json)"
+
+        # Ripper classifies these completed operands as shifts rather than
+        # heredoc openers.  None may mask the live request that follows.
+        shifts = {
+            "decimal": "mask = 1 <<OFFSET",
+            "hex": "mask = 0x1 <<OFFSET",
+            "parenthesized": "mask = value() <<OFFSET",
+            "string": 'mask = "x" <<OFFSET',
+            "instance": "mask = @value <<OFFSET",
+            "class-variable": "mask = @@value <<OFFSET",
+            "global": "mask = $value <<OFFSET",
+            "nil": "mask = nil <<OFFSET",
+            "true": "mask = true <<OFFSET",
+            "false": "mask = false <<OFFSET",
+            "self": "mask = self <<OFFSET",
+            "file-keyword": "mask = __FILE__ <<OFFSET",
+            "symbol": "mask = :value <<OFFSET",
+            "regexp": "mask = /value/ <<OFFSET",
+            "adjacent-local": "buffer<<OFFSET",
+            "adjacent-constant": "Buffer<<OFFSET",
+            "bound-local": "value = 1; mask = value <<OFFSET",
+            "bound-parameter": "def shift(value); mask = value <<OFFSET; end",
+            "bound-brace-parameter": "[1].each { |value| mask = value <<OFFSET }",
+            "bound-destructured-parameter": (
+                "[[1, 2]].each { |(value, other)| mask = value <<OFFSET }"
+            ),
+            "bound-do-parameter": (
+                "[1].each do |value|\n  mask = value <<OFFSET\nend"
+            ),
+            "multiple-assignment": "value, other = 1, 2; mask = value <<OFFSET",
+            "two-bound-shifts": (
+                "def first(value); value <<BITS; end\n"
+                "def second(other); other <<MASK; end"
+            ),
+            "multiline-parameter": (
+                "def shift(\n  value\n)\n  value <<OFFSET\nend"
+            ),
+        }
+        for label, shift in shifts.items():
+            name = f"shift-{label}.rb"
+            with self.subTest(shift=label):
+                result = self.run_required_profile_analyzer(
+                    {name: f"OFFSET = 1\n{shift}\n{send}\n"}
+                )
+                self.assertTrue(
+                    any(name in row for row in result.stdout.splitlines()[1:]),
+                    result.stdout,
+                )
+
+        # Names mentioned only in parameter defaults or introduced as block
+        # parameters are not locals in the surrounding scope. Their `<<DOC`
+        # forms remain real heredocs, so requests inside the bodies are inert.
+        for label, source in {
+            "default-expression": (
+                "def render(value = fallback)\n"
+                f"  fallback <<DOC\n  {send}\nDOC\nend\n"
+            ),
+            "block-shadow": (
+                "[1].each { |value| value = 1 }\n"
+                f"value <<DOC\n{send}\nDOC\n"
+            ),
+            "block-default": (
+                "[1].each { |value = fallback| value }\n"
+                f"fallback <<DOC\n{send}\nDOC\n"
+            ),
+            "nested-block-shadow": (
+                "[1].each do |value|\n"
+                "  if true\n    :ok\n  end\n"
+                "  value = 1\nend\n"
+                f"value <<DOC\n{send}\nDOC\n"
+            ),
+        }.items():
+            with self.subTest(binding_scope=label):
+                self.assertEqual(
+                    "0",
+                    self.run_required_profile_analyzer(
+                        {f"binding-{label}.rb": source}
+                    ).stdout.strip(),
+                )
+
+        # Quoted identifiers accept delimiters beyond bare Ruby identifiers.
+        # Their bodies remain inert for every quote mode.
+        for label, opener, terminator in (
+            ("hyphen", '<<"END-HTML"', "END-HTML"),
+            ("space", '<<"1 END"', "1 END"),
+            ("punctuation", "<<'END/HTML!'", "END/HTML!"),
+            ("command", "<<`END-HTML`", "END-HTML"),
+            ("backslash", r'<<"END\q"', r"END\q"),
+            ("unicode-bare", "<<ÉND", "ÉND"),
+        ):
+            with self.subTest(delimiter=label):
+                self.assertEqual(
+                    "0",
+                    self.run_required_profile_analyzer(
+                        {
+                            f"delimiter-{label}.rb": (
+                                f"doc = {opener}\n{send}\n{terminator}\n"
+                            )
+                        }
+                    ).stdout.strip(),
+                )
+
+        # Plain heredocs terminate only at column zero and only on an exact
+        # delimiter line.  Flexible variants accept indentation but still not
+        # suffix text.
+        for premature in ("  DOC", "DOC.anything", "DOC # comment", "DOC ", "DOC\t"):
+            with self.subTest(plain_premature=premature):
+                self.assertEqual(
+                    "0",
+                    self.run_required_profile_analyzer(
+                        {"plain-terminator.rb": f"doc = <<DOC\n{premature}\n{send}\nDOC\n"}
+                    ).stdout.strip(),
+                )
+        for opener in ("<<-DOC", "<<~DOC"):
+            for trailing in (" ", "\t"):
+                with self.subTest(opener=opener, trailing=trailing):
+                    self.assertEqual("0", self.run_required_profile_analyzer({
+                        "trailing.rb": f"doc = {opener}\n  DOC{trailing}\n{send}\nDOC\n"
+                    }).stdout.strip())
+            with self.subTest(indented_terminator=opener):
+                result = self.run_required_profile_analyzer(
+                    {"indented-terminator.rb": f"doc = {opener}\n  DOC\n{send}\n"}
+                )
+                self.assertTrue(
+                    any(
+                        "indented-terminator.rb" in row
+                        for row in result.stdout.splitlines()[1:]
+                    ),
+                    result.stdout,
+                )
+
+        modified = (
+            "puts <<FIRST.upcase, <<'SECOND'\n"
+            f"#{{{send}}}\nFIRST\nordinary\nSECOND\n"
+        )
+        result = self.run_required_profile_analyzer({"modified.rb": modified})
+        self.assertTrue(
+            any("modified.rb" in row for row in result.stdout.splitlines()[1:]),
+            result.stdout,
+        )
+
+        # Text that resembles an opener inside a declaration-line string is
+        # not a second heredoc and cannot steal a later live send.
+        quoted_decoy = f'puts <<FIRST, "not <<SECOND"\nordinary\nFIRST\n{send}\n'
+        result = self.run_required_profile_analyzer(
+            {"quoted-decoy.rb": quoted_decoy}
+        )
+        self.assertTrue(
+            any("quoted-decoy.rb" in row for row in result.stdout.splitlines()[1:]),
+            result.stdout,
+        )
+        regex_decoy = f"puts <<FIRST, /not <<SECOND/\nordinary\nFIRST\n{send}\n"
+        result = self.run_required_profile_analyzer(
+            {"regexp-opener-decoy.rb": regex_decoy}
+        )
+        self.assertTrue(
+            any(
+                "regexp-opener-decoy.rb" in row
+                for row in result.stdout.splitlines()[1:]
+            ),
+            result.stdout,
+        )
+
+    def test_ruby_multiple_heredoc_discovery_is_linear(self) -> None:
+        namespace = runpy.run_path(str(MESSAGING_SOURCE_ANALYZER))
+        openers_at = namespace["_ruby_heredoc_openers_at"]
+        source = ", ".join(f"<<H{index}" for index in range(30_000)) + "\n"
+        started = time.perf_counter()
+        matches = openers_at(source, 0)
+        self.assertEqual(30_000, len(matches))
+        self.assertLess(time.perf_counter() - started, 1.0)
+
+        # Guard the complete binding-sensitive second pass too. Its owner
+        # lookup once scanned every method span for every assignment, making a
+        # large but ordinary Ruby file quadratic even without any heredocs.
+        lex_source = namespace["lex_source"]
+        methods = "".join(
+            f"def method_{index}(value); local = {index}; end\n"
+            for index in range(8_000)
+        )
+        started = time.perf_counter()
+        lexed = lex_source(methods, ".rb")
+        self.assertEqual(len(methods), len(lexed.code))
+        self.assertLess(time.perf_counter() - started, 4.0)
 
     def test_ruby_interpolation_balancing_ignores_literal_braces(self) -> None:
         url = "https://api.telnyx.com/v2/messages/number_pool"
@@ -9766,6 +10330,841 @@ class CorrectnessLinterContracts(unittest.TestCase):
         )
 
 
+CSHARP_DISCOVERY_RESOURCES = (
+    ("Twilio.Rest.Api.V2010.Account.MessageResource", "messaging"),
+    ("Twilio.Rest.Api.V2010.Account.CallResource", "voice"),
+    ("Twilio.Rest.Verify.V2.Service.VerificationResource", "verify"),
+    ("Twilio.Rest.Fax.V1.FaxResource", "fax"),
+    ("Twilio.Rest.Supersim.V1.SimResource", "iot"),
+    ("Twilio.Rest.Wireless.V1.SimResource", "iot"),
+    ("Twilio.Rest.Conversations.V1.ConversationResource", "conversations"),
+    ("Twilio.Rest.Conversations.V1.Service.ConversationResource", "conversations"),
+    ("Twilio.Rest.Notify.V1.Service.NotificationResource", "notify"),
+    ("Twilio.Rest.Taskrouter.V1.Workspace.WorkflowResource", "taskrouter"),
+)
+
+
+class CsharpResourceOwnershipSiblings(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.calls = staticmethod(runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("sdk-source-ownership.py")))["contextual_calls"])
+
+    def products(self, source: str) -> set[str]:
+        return {product for _, product in self.calls(source, ".cs")}
+
+    def test_imported_and_fully_qualified_resources_are_owned(self) -> None:
+        for target, product in CSHARP_DISCOVERY_RESOURCES:
+            namespace, resource = target.rsplit(".", 1)
+            for source in (
+                f"using {namespace}; class App {{ void Run() {{ {resource}.CreateAsync(); }} }}",
+                f"class App {{ void Run() {{ global::{target}.Fetch(); }} }}",
+            ):
+                with self.subTest(target=target, source=source):
+                    self.assertEqual({product}, self.products(source))
+
+    def test_alias_is_owned(self) -> None:
+        source = (
+            "using Verify = Twilio.Rest.Verify.V2.Service.VerificationResource; "
+            "class App { void Run() { Verify.Create(); } }"
+        )
+        self.assertEqual({"verify"}, self.products(source))
+
+    def test_namespace_import_does_not_cross_boundary(self) -> None:
+        source = (
+            "namespace One { using Twilio.Rest.Fax.V1; } "
+            "namespace Two { class FaxResource { public static void Create() {} } "
+            "class App { void Run() { FaxResource.Create(); } } }"
+        )
+        self.assertEqual(set(), self.products(source))
+
+    def test_alias_and_resource_are_shadowed_locally(self) -> None:
+        fixtures = (
+            "using Verify = Twilio.Rest.Verify.V2.Service.VerificationResource; "
+            "class App { void Run(Queue Verify) { Verify.Create(); } }",
+            "using Twilio.Rest.Conversations.V1; "
+            "class ConversationResource { public static void Create() {} } "
+            "class App { void Run() { ConversationResource.Create(); } }",
+        )
+        for source in fixtures:
+            with self.subTest(source=source):
+                self.assertEqual(set(), self.products(source))
+
+    def test_shallow_scanner_rejects_unowned_bare_resources(self) -> None:
+        declarations = "\n".join(
+            f"class {target.rsplit('.', 1)[-1]} {{ public static void Create() {{}} }}"
+            for target, _ in dict(CSHARP_DISCOVERY_RESOURCES).items()
+        )
+        calls = "\n".join(
+            f"{target.rsplit('.', 1)[-1]}.Create();" for target, _ in CSHARP_DISCOVERY_RESOURCES
+        )
+        with tempfile.TemporaryDirectory(prefix="csharp-resource-ownership-") as directory:
+            (Path(directory) / "App.cs").write_text(
+                declarations + "\nclass App { void Run() {\n" + calls + "\n} }\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [BASH, str(SCAN_USAGE_SCRIPT), directory], cwd=ROOT,
+                capture_output=True, text=True, timeout=30, check=False,
+            )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual([], json.loads(result.stdout)["products_used"])
+
+
+
+class GradleMapDependencySiblings(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.helper = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("inspect-sdk-dependencies.py")))
+
+    def inspect(self, source: str) -> tuple[bool, bool]:
+        with tempfile.TemporaryDirectory(prefix="gradle-map-dependency-") as directory:
+            root = Path(directory)
+            (root / "build.gradle").write_text(source, encoding="utf-8")
+            dependencies = self.helper["gradle_dependencies"](root)
+            declared = any(
+                group == "com.telnyx.sdk" and artifact == "telnyx"
+                for group, artifact, _ in dependencies
+            )
+            return declared, self.helper["gradle_pinned"](root)
+
+    def test_named_map_notation_is_declared_and_pinned(self) -> None:
+        sources = (
+            "dependencies { implementation group: 'com.telnyx.sdk', "
+            "name: 'telnyx', version: '6.89.0' }",
+            "dependencies { implementation(version: '6.89.0', "
+            "name: 'telnyx', group: 'com.telnyx.sdk') }",
+            "dependencies { api name: \"telnyx\", version: \"6.89.0\", "
+            "group: \"com.telnyx.sdk\" }",
+        )
+        for source in sources:
+            with self.subTest(source=source):
+                self.assertEqual((True, True), self.inspect(source))
+
+    def test_missing_or_dynamic_version_is_declared_but_not_pinned(self) -> None:
+        sources = (
+            "implementation group: 'com.telnyx.sdk', name: 'telnyx'",
+            "implementation group: 'com.telnyx.sdk', name: 'telnyx', "
+            "version: sdkVersion",
+            "implementation(group: 'com.telnyx.sdk', name: 'telnyx', "
+            "version: 'latest.release')",
+        )
+        for source in sources:
+            with self.subTest(source=source):
+                self.assertEqual((True, False), self.inspect(source))
+
+    def test_unrelated_coordinates_are_not_telnyx(self) -> None:
+        sources = (
+            "implementation group: 'com.example', name: 'telnyx', version: '6.89.0'",
+            "implementation group: 'com.telnyx.sdk', name: 'other', version: '6.89.0'",
+        )
+        for source in sources:
+            with self.subTest(source=source):
+                self.assertEqual((False, False), self.inspect(source))
+
+    def test_map_fields_do_not_cross_statement_boundaries(self) -> None:
+        source = (
+            "implementation group: 'com.telnyx.sdk'; "
+            "implementation name: 'telnyx', version: '6.89.0'"
+        )
+        self.assertEqual((False, False), self.inspect(source))
+
+    def test_comma_newline_continues_named_map(self) -> None:
+        source = (
+            "implementation group: 'com.telnyx.sdk',\n"
+            "  name: 'telnyx',\n"
+            "  version: '6.89.0'"
+        )
+        self.assertEqual((True, True), self.inspect(source))
+
+    def test_later_dynamic_duplicate_invalidates_literal_version(self) -> None:
+        source = (
+            "implementation group: 'com.telnyx.sdk', name: 'telnyx', "
+            "version: '6.89.0', version: sdkVersion"
+        )
+        self.assertEqual((True, False), self.inspect(source))
+
+    def test_comments_and_prose_do_not_establish_map_dependency(self) -> None:
+        sources = (
+            "// implementation group: 'com.telnyx.sdk', name: 'telnyx', version: '6.89.0'",
+            "def help = \"implementation group: 'com.telnyx.sdk', name: 'telnyx', "
+            "version: '6.89.0'\"",
+            "dependencies { /* implementation group: 'com.telnyx.sdk', "
+            "name: 'telnyx', version: '6.89.0' */ }",
+        )
+        for source in sources:
+            with self.subTest(source=source):
+                self.assertEqual((False, False), self.inspect(source))
+
+    def test_validator_accepts_declared_pinned_map_dependency(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gradle-map-validator-") as directory:
+            (Path(directory) / "build.gradle").write_text(
+                "dependencies { implementation group: 'com.telnyx.sdk', "
+                "name: 'telnyx', version: '6.89.0' }",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [BASH, str(VALIDATE_MIGRATION_SCRIPT), directory, "--json"],
+                cwd=ROOT, capture_output=True, text=True, timeout=30,
+                check=False,
+            )
+        checks = {
+            check["name"]: check["status"]
+            for check in json.loads(result.stdout)["checks"]
+        }
+        self.assertEqual("pass", checks["telnyx_sdk_dependency"])
+        self.assertEqual("pass", checks["telnyx_sdk_version_pinned"])
+
+
+
+class DiscoveryAndValidationRegressionContracts(unittest.TestCase):
+    maxDiff = None
+
+    def test_discovery_pipeline_does_not_certify_failed_or_empty_scans(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            wrapper = scripts / "run-discovery.sh"
+            wrapper.write_text(SCAN_USAGE_SCRIPT.with_name("run-discovery.sh").read_text(), encoding="utf-8")
+            project = root / "project"
+            project.mkdir()
+            environment = dict(os.environ)
+            environment.pop("TELNYX_API_KEY", None)
+            for scan, expected in (
+                ('echo "Python 3 is required" >&2; exit 127', 2),
+                ('echo "partial output"; echo "cannot read source" >&2; exit 2', 2),
+                ('exit 0', 2),
+                ('echo \'{"products_used": [], "files": [], "languages_detected": []}\'', 0),
+            ):
+                with self.subTest(scan=scan):
+                    (scripts / "scan-twilio-usage.sh").write_text(scan, encoding="utf-8")
+                    result = subprocess.run([BASH, str(wrapper), str(project)],
+                        capture_output=True, text=True, timeout=45, env=environment)
+                    self.assertEqual(expected, result.returncode, result.stdout + result.stderr)
+                    if expected:
+                        self.assertIn("Discovery incomplete", result.stderr)
+                        self.assertNotIn("Phase 1 Complete", result.stdout)
+                        self.assertNotIn("PASS", result.stdout)
+                    else:
+                        self.assertIn("Phase 1 Complete", result.stdout)
+                    if "Python 3" in scan:
+                        self.assertIn("Python 3 is required", result.stderr)
+                    if "cannot read" in scan:
+                        self.assertIn("cannot read source", result.stderr)
+
+    def test_hidden_source_directories_are_not_generated_directories(self) -> None:
+        scanner = runpy.run_path(str(DEEP_SCAN_SCRIPT))
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = "using Twilio.Rest.Api.V2010.Account;\nMessageResource.Create(args);"
+            for folder in (".github/scripts", ".tools", ".git", ".venv", "node_modules"):
+                path = root / folder / "Send.cs"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source, encoding="utf-8")
+            report = scanner["run_scan"](root)
+            self.assertEqual({".github/scripts/Send.cs", ".tools/Send.cs"},
+                {item["path"] for item in report["files"]})
+            result = subprocess.run([BASH, str(SCAN_USAGE_SCRIPT), str(root)],
+                capture_output=True, text=True, timeout=45)
+            self.assertEqual(0, result.returncode, result.stderr)
+            shallow = json.loads(result.stdout)
+            self.assertIn("messaging", shallow["products_used"])
+
+    def test_csharp_resource_discovery_uses_shared_ownership(self) -> None:
+        scanner = runpy.run_path(str(DEEP_SCAN_SCRIPT))
+        for resource, product in (("MessageResource", "messaging"), ("CallResource", "voice"),
+                                  ("IncomingPhoneNumberResource", "phone-numbers")):
+            for method in ("Create", "Read", "Update", "Fetch"):
+                for source, expected in (
+                    (f'class {resource} {{}}\n{resource}.{method}(args);', set()),
+                    (f'using Twilio.Rest.Api.V2010.Account;\n{resource}.{method}(args);', {product}),
+                    (f'using Resource = Twilio.Rest.Api.V2010.Account.{resource};\nResource.{method}(args);', {product}),
+                ):
+                    with self.subTest(resource=resource, method=method, source=source):
+                        found = scanner["scan_csharp_file"](Path("app.cs"), source.split("\n"))
+                        self.assertEqual(expected, {d.product for d in found if d.product != "general"})
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = root / "app.cs"
+            for source, expected in (("class MessageResource {}\nMessageResource.Create(args);", []),
+                ('using Twilio.Rest.Api.V2010.Account;\nMessageResource.Create(args);', ["messaging"])):
+                path.write_text(source, encoding="utf-8")
+                result = subprocess.run([BASH, str(SCAN_USAGE_SCRIPT), str(root)],
+                    capture_output=True, text=True, timeout=45)
+                self.assertEqual(0, result.returncode, result.stderr)
+                self.assertEqual(expected, json.loads(result.stdout)["products_used"])
+
+    def test_discovery_read_errors_are_not_successful_empty_scans(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "app.php"
+            source.write_text("<?php use Twilio\\Rest\\Client;", encoding="utf-8")
+            source.chmod(0)
+            try:
+                result = subprocess.run([BASH, str(SCAN_USAGE_SCRIPT), str(root)],
+                    capture_output=True, text=True, timeout=45)
+                self.assertEqual(2, result.returncode, result.stdout + result.stderr)
+                self.assertIn("scan is incomplete", result.stderr)
+                self.assertNotIn('"products_used"', result.stdout)
+            finally:
+                source.chmod(0o644)
+
+    def test_rake_language_and_sip_product_are_unambiguous(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "send.rake").write_text('require "twilio-ruby"\nSipGrant\n', encoding="utf-8")
+            result = subprocess.run([BASH, str(SCAN_USAGE_SCRIPT), str(root)],
+                capture_output=True, text=True, timeout=45)
+            report = json.loads(result.stdout)
+            self.assertEqual(["ruby"], report["languages_detected"])
+            self.assertEqual(["sip"], report["products_used"])
+
+    def test_go_sdk_product_ownership_siblings(self) -> None:
+        helper = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("sdk-source-ownership.py")))
+        calls = helper["contextual_calls"]
+        for service, resource, product in (("Api", "Message", "messaging"), ("Api", "Call", "voice"),
+                ("VerifyV2", "Verification", "verify"), ("LookupsV2", "PhoneNumber", "lookup"),
+                ("VideoV1", "Room", "video")):
+            method = "Fetch" if service == "LookupsV2" else "Create"
+            for imported, factory in (("import \"github.com/twilio/twilio-go\"", "twilio"),
+                    ('import (\n sms "github.com/twilio/twilio-go"\n)', "sms")):
+                prefix = f'package main\n{imported}\nfunc main() {{ c := {factory}.NewRestClient(); '
+                for code, expected in (
+                    (f'c.{service}.{method}{resource}(p)', {product}),
+                    (f'alias := c; alias.{service}.{method}{resource}(p)', {product}),
+                    (f'c = queue.New(); c.{service}.{method}{resource}(p)', set()),
+                    (f'// c.{service}.{method}{resource}(p)\n', set()),
+                    (f'example := "c.{service}.{method}{resource}(p)"', set()),
+                ):
+                    with self.subTest(service=service, code=code, imported=imported):
+                        self.assertEqual(expected, {p for _, p in calls(prefix + code + " }", ".go")})
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "main.go").write_text('package main\nimport "github.com/twilio/twilio-go"\n'
+                'func main(){ c := twilio.NewRestClient(); c.Api.CreateMessage(p) }\n', encoding="utf-8")
+            result = subprocess.run([BASH, str(SCAN_USAGE_SCRIPT), str(root)],
+                capture_output=True, text=True, timeout=45)
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("messaging", json.loads(result.stdout)["products_used"])
+
+    def test_generic_product_names_do_not_establish_sdk_ownership(self) -> None:
+        scanner = runpy.run_path(str(DEEP_SCAN_SCRIPT))
+        for name, suffix in (("scan_java_file", ".java"), ("scan_php_file", ".php"), ("scan_go_file", ".go")):
+            with self.subTest(suffix=suffix):
+                found = scanner[name](Path("sample" + suffix), ["verifyToken();", "conversations = [];", "lookups();"])
+                self.assertEqual([], found)
+
+    def test_residual_import_extension_siblings(self) -> None:
+        # The correctness wrapper already expands families; the migration
+        # validator must not silently narrow those same families.
+        families = (
+            ((".py", ".pyw"), "from twilio.rest import Client", "twilio_python_imports"),
+            ((".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".jsx", ".tsx"),
+             'import Twilio from "twilio";', "twilio_js_imports"),
+            ((".rb", ".rake"), 'require "twilio-ruby"', "twilio_ruby_imports"),
+            ((".java", ".kt", ".kts", ".scala"),
+             "import com.twilio.rest.api.v2010.account.Message;", "twilio_java_imports"),
+            ((".php", ".phtml"), "<?php use Twilio\\Rest\\Client;", "twilio_php_imports"),
+            ((".cs", ".cshtml"), "using Twilio;", "twilio_csharp_imports"),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for suffixes, statement, check in families:
+                for suffix in suffixes:
+                    with self.subTest(suffix=suffix):
+                        path = root / ("app" + suffix)
+                        for source, expected in ((statement, "fail"), ("", "pass")):
+                            path.write_text(source + "\n", encoding="utf-8")
+                            result = subprocess.run([BASH, str(VALIDATE_MIGRATION_SCRIPT), str(root), "--json"],
+                                capture_output=True, text=True, timeout=30)
+                            checks = {item["name"]: item["status"].lower()
+                                      for item in json.loads(result.stdout)["checks"]}
+                            self.assertEqual(expected, checks[check], result.stdout)
+                        path.unlink()
+
+    def test_sdk_ownership_binding_siblings(self) -> None:
+        helper = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("sdk-source-ownership.py")))
+        calls = helper["contextual_calls"]
+        for source, suffix, expected in (
+            ("import com.twilio.rest.api.v2010.account.*;\nMessage.creator(a,b,c);", ".java", "messaging"),
+            ("import com.twilio.rest.api.v2010.account.Message as Sms\nSms.creator(a,b,c)", ".kt", "messaging"),
+            ("com.twilio.rest.api.v2010.account.Call.creator(a,b,c);", ".java", "voice"),
+            ('String text = "import com.twilio.rest.api.v2010.account.Message";\nMessage.creator();', ".java", None),
+            ("<?php use Twilio\\Rest\\Client as Sms;\n$c = new Sms($sid,$token);\n$alias = $c;\n$alias->messages->create($to,[]);", ".php", "messaging"),
+            ("<?php $c = new \\Twilio\\Rest\\Client($sid,$token);\n$c->calls->create($to,[]);", ".phtml", "voice"),
+            ("<?php use Twilio\\Rest\\Client;\n$c = new Client($sid,$token);\n$c = new Queue();\n$c->messages->create($to,[]);", ".php", None),
+            ("<?php use Twilio\\Rest\\Client;\nfunction one(Client $c) {$c->calls->read();}\nfunction two($c) {$c->messages->create($to,[]);}", ".php", "voice"),
+            ("import com.twilio.rest.api.v2010.account.*;\nimport com.example.Message;\nMessage.creator();", ".java", None),
+            ("import com.example.Message;\nimport com.twilio.rest.api.v2010.account.*;\nMessage.creator();", ".java", None),
+            ("import com.twilio.rest.api.v2010.account.Message;\nclass X { void send(Queue Message) { Message.creator(); } }", ".java", None),
+            ("import com.twilio.rest.api.v2010.account.Message;\nclass X { void send() { var Message = new Queue(); Message.creator(); } }", ".java", None),
+            ("import com.twilio.rest.api.v2010.account.Message as Sms\nfun send() { val Sms = Queue(); Sms.creator() }", ".kt", None),
+            ("import com.twilio.rest.api.v2010.account.Message as Sms\nfun send(Sms: Queue) { Sms.creator() }", ".kt", None),
+            ("import com.twilio.rest.api.v2010.account.Message\nobject X { def send(Message: Queue) = { Message.creator() } }", ".scala", None),
+            ("import com.twilio.rest.api.v2010.account.Message as Sms\nfun other(Sms: Queue) {}\nfun send() { Sms.creator() }", ".kt", "messaging"),
+            ("import com.twilio.rest.api.v2010.account.Message\nobject X { def other(Message: Queue) = {}\ndef send() = { Message.creator() } }", ".scala", "messaging"),
+            ("<?php use Twilio\\Rest\\Client; class A { function send() {$this->client->messages->create($to, []);} function __construct() {$this->client = new Client($sid, $token);} }", ".php", "messaging"),
+            ("<?php use Twilio\\Rest\\Client; class A { function send() {$this->client->messages->create($to, []);} private Client $client; }", ".php", "messaging"),
+            ("<?php namespace A { use Twilio\\Rest\\Client; } namespace B { class Client {} $c = new Client(); $c->messages->create($to, []); }", ".php", None),
+            ("<?php namespace A; use Twilio\\Rest\\Client; namespace B; $c = new Client(); $c->messages->create($to, []);", ".php", None),
+            ("<?php namespace B { $c = new \\Twilio\\Rest\\Client(); $c->messages->create($to, []); }", ".php", "messaging"),
+            ("<?php namespace { $c = new Twilio\\Rest\\Client(); $c->messages->create($to, []); }", ".php", "messaging"),
+            ("<?php use Twilio\\Rest\\Client; function send(Client $client) { return $client->messages->create($to, []); }", ".php", "messaging"),
+            ("<?php use Twilio\\Rest\\Client; function send(Client $client, bool $dryRun) { if ($dryRun) return $client; $client->messages->create($to, []); }", ".php", "messaging"),
+        ):
+            with self.subTest(source=source):
+                found = {product for _, product in calls(source, suffix)}
+                self.assertEqual({expected} if expected else set(), found)
+
+    def test_structured_dependency_pin_siblings(self) -> None:
+        helper = runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("inspect-sdk-dependencies.py")))
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "gradle").mkdir()
+            catalogs = (
+                '[libraries]\ntelnyx = "com.telnyx.sdk:telnyx:6.89.0"\n',
+                '[versions]\nsdk = "6.89.0"\n[libraries]\ntelnyx = { module = "com.telnyx.sdk:telnyx", version.ref = "sdk" }\n',
+                '[libraries]\ntelnyx = { group = "com.telnyx.sdk", name = "telnyx", version = "6.89.0" }\n',
+            )
+            for catalog in catalogs:
+                (root / "gradle/libs.versions.toml").write_text(catalog, encoding="utf-8")
+                for declaration, expected in (
+                    ("dependencies { implementation(libs.telnyx) }", True),
+                    ("dependencies { implementation(libs.unrelated) }", False),
+                    ("// implementation(libs.telnyx)", False),
+                    ("dependencies { // implementation(libs.telnyx)\n}", False),
+                    ('val help = """implementation(libs.telnyx)"""', False),
+                ):
+                    with self.subTest(catalog=catalog, declaration=declaration):
+                        (root / "build.gradle.kts").write_text(declaration, encoding="utf-8")
+                        self.assertEqual(expected and helper["tomllib"] is not None,
+                                         helper["gradle_pinned"](root))
+            for version, expected in (("6.89.0", True), ("6.+", False), ("latest.release", False)):
+                (root / "build.gradle.kts").write_text(
+                    f'dependencies {{ implementation("com.telnyx.sdk:telnyx:{version}") }}', encoding="utf-8")
+                self.assertEqual(expected, helper["gradle_pinned"](root))
+            for source in ('dependencies { // implementation("com.telnyx.sdk:telnyx:6.89.0")\n}',
+                           'val help = """implementation("com.telnyx.sdk:telnyx:6.89.0")"""'):
+                (root / "build.gradle.kts").write_text(source, encoding="utf-8")
+                self.assertFalse(helper["gradle_pinned"](root))
+            (root / "build.gradle.kts").write_text("", encoding="utf-8")
+            for delimiter, terminator in (("/", "/"), ("$/", "/$")):
+                (root / "build.gradle").write_text(
+                    f'def help = {delimiter}implementation("com.telnyx.sdk:telnyx:6.89.0"){terminator}', encoding="utf-8")
+                self.assertFalse(helper["gradle_pinned"](root))
+            (root / "build.gradle").write_text("dependencies { implementation 'com.telnyx.sdk:telnyx:6.89.0' }", encoding="utf-8")
+            self.assertTrue(helper["gradle_pinned"](root))
+            (root / "build.gradle").write_text("", encoding="utf-8")
+            dependency = "<dependency><groupId>com.telnyx.sdk</groupId><artifactId>telnyx</artifactId>{}</dependency>"
+            for managed_version, expected in (("6.89.0", True), ("${unknown}", False)):
+                (root / "pom.xml").write_text("<project><dependencyManagement><dependencies>"
+                    + dependency.format("<version>" + managed_version + "</version>")
+                    + "</dependencies></dependencyManagement><dependencies>"
+                    + dependency.format("") + "</dependencies></project>", encoding="utf-8")
+                self.assertEqual(expected, helper["maven_pinned"](root / "pom.xml"))
+            for contents in ("<project><!-- com.telnyx.sdk:telnyx --></project>",
+                             "<project><dependencies><dependency><groupId>com.telnyx.sdk</groupId><artifactId>unrelated</artifactId><version>1.0.0</version></dependency></dependencies></project>"):
+                (root / "pom.xml").write_text(contents, encoding="utf-8")
+                self.assertFalse(helper["jvm_declared"](root, "telnyx"))
+
+    def test_sdk_ownership_ignores_comments_and_unrelated_receivers(self) -> None:
+        for suffix in ("java", "kt", "kts", "scala"):
+            with self.subTest(suffix=suffix):
+                shallow, deep = self._scan({f"Queue.{suffix}": (
+                    "import com.example.queue.Message;\n"
+                    "import com.twilio.Twilio;\n"
+                    "// com.twilio.rest.api.v2010.account.Message\n"
+                    "class Queue { Object send() { return Message.creator(); } }\n"
+                )})
+                self.assertNotIn("messaging", shallow["products_used"])
+                self.assertNotIn("messaging", deep["products_used"])
+        for suffix in ("php", "phtml"):
+            for context in ("// Twilio\\Rest\\Client", "use Twilio\\Rest\\Client;"):
+                with self.subTest(suffix=suffix, context=context):
+                    shallow, deep = self._scan({f"Queue.{suffix}": (
+                        "<?php\n" + context + "\n"
+                        "$client = new \\Example\\Queue();\n"
+                        "$client->messages->create($to, $payload);\n"
+                    )})
+                    self.assertNotIn("messaging", shallow["products_used"])
+                    self.assertNotIn("messaging", deep["products_used"])
+
+    def test_maven_pin_belongs_to_dependency(self) -> None:
+        dependency = ("<dependency><groupId>com.telnyx.sdk</groupId>"
+                      "<artifactId>telnyx</artifactId>{}</dependency>")
+        for header, version, expected in (
+            ("<version>1.2.3</version>", "", "warn"),
+            ("<parent><version>1.2.3</version></parent>", "", "warn"),
+            ("", "<version>6.89.0</version>", "pass"),
+            ("<properties><sdk.version>6.89.0</sdk.version></properties>",
+             "<version>${sdk.version}</version>", "pass"),
+            ("", "<version>${missing}</version>", "warn"),
+        ):
+            with self.subTest(header=header, version=version):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    (root / "pom.xml").write_text(
+                        '<project xmlns="http://maven.apache.org/POM/4.0.0">'
+                        + header + "<dependencies>" + dependency.format(version)
+                        + "</dependencies></project>", encoding="utf-8")
+                    result = subprocess.run(
+                        [BASH, str(VALIDATE_MIGRATION_SCRIPT), directory, "--json"],
+                        capture_output=True, text=True, timeout=30, check=False)
+                    checks = {item["name"]: item["status"]
+                              for item in json.loads(result.stdout)["checks"]}
+                    self.assertEqual(expected, checks["telnyx_sdk_version_pinned"])
+
+    def test_php_preflight_uses_dependency_sections(self) -> None:
+        for section, expected in (("require", True), ("require-dev", True),
+                                  ("extra", False)):
+            with self.subTest(section=section), tempfile.TemporaryDirectory() as directory:
+                (Path(directory) / "composer.json").write_text(
+                    json.dumps({section: {"telnyx/telnyx-php": "^7.0"}}),
+                    encoding="utf-8")
+                result = subprocess.run(
+                    [BASH, str(PREFLIGHT_SCRIPT), directory, "--quick"],
+                    env={**os.environ, "TELNYX_API_KEY": "KEYlocal-test-only"},
+                    capture_output=True, text=True, timeout=30, check=False)
+                self.assertEqual(expected, "PHP: telnyx/telnyx-php" in result.stdout)
+
+    def _write_fixture(self, root: Path, files: dict[str, str | bytes]) -> None:
+        for relative, contents in files.items():
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(contents, bytes):
+                path.write_bytes(contents)
+            else:
+                path.write_text(contents, encoding="utf-8")
+
+    def _scan(
+        self, files: dict[str, str]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        with tempfile.TemporaryDirectory(prefix="twilio-discovery-") as directory:
+            root = Path(directory)
+            self._write_fixture(root, files)
+            shallow = subprocess.run(
+                [BASH, str(SCAN_USAGE_SCRIPT), str(root)],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(0, shallow.returncode, shallow.stderr)
+            deep = subprocess.run(
+                [sys.executable, "-B", str(DEEP_SCAN_SCRIPT), str(root)],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(0, deep.returncode, deep.stderr)
+            return json.loads(shallow.stdout), json.loads(deep.stdout)
+
+    def test_public_repo_messaging_shapes_are_discovered_consistently(self) -> None:
+        fixtures = {
+            "php": {
+                "Observer/Send.php": (
+                    "<?php\nuse Twilio\\Rest\\ClientFactory;\n"
+                    "class Sender { private $clientFactory;\n"
+                    "function __construct(ClientFactory $factory) {\n"
+                    "$this->clientFactory = $factory; }\n"
+                    "function send() { $client = $this->clientFactory->create([]);\n"
+                    "$client->messages->create($to, ['body' => $text]); } }\n"
+                )
+            },
+            "go-rest": {
+                "main.go": (
+                    'package main\nvar endpoint = "https://api.twilio.com/'
+                    '2010-04-01/Accounts/AC123/Messages.json"\n'
+                )
+            },
+            "typescript-rest": {
+                "src/component/utils.ts": (
+                    "export const endpoint = `https://api.twilio.com/"
+                    "2010-04-01/Accounts/${sid}/Messages.json`;\n"
+                )
+            },
+            "kotlin-sdk": {
+                "src/SmsService.kt": (
+                    "import com.twilio.rest.api.v2010.account.Message\n"
+                    "import com.twilio.type.PhoneNumber\n"
+                    "val creator = Message.creator(to, from, message)\n"
+                ),
+                "pom.xml": (
+                    "<dependency><groupId>com.twilio.sdk</groupId>"
+                    "<artifactId>twilio</artifactId></dependency>\n"
+                ),
+            },
+        }
+        for label, files in fixtures.items():
+            with self.subTest(label=label):
+                shallow, deep = self._scan(files)
+                self.assertIn("messaging", shallow["products_used"])
+                self.assertIn("messaging", deep["products_used"])
+                self.assertNotIn("voice-android:webrtc", shallow["products_used"])
+
+    def test_direct_rest_product_siblings_are_classified(self) -> None:
+        cases = {
+            "voice": "https://api.twilio.com/2010-04-01/Accounts/AC/Calls.json",
+            "verify": "https://verify.twilio.com/v2/Services/VA/Verifications",
+            "lookup": "https://lookups.twilio.com/v2/PhoneNumbers/+12025550123",
+            "video": "https://video.twilio.com/v1/Rooms",
+            "fax": "https://fax.twilio.com/v1/Faxes",
+            "phone-numbers": (
+                "https://api.twilio.com/2010-04-01/Accounts/AC/"
+                "IncomingPhoneNumbers.json"
+            ),
+        }
+        for product, endpoint in cases.items():
+            with self.subTest(product=product):
+                shallow, deep = self._scan(
+                    {"client.ts": f"export const endpoint = '{endpoint}';\n"}
+                )
+                self.assertIn(product, shallow["products_used"])
+                self.assertIn(product, deep["products_used"])
+
+    def test_generic_message_method_names_require_twilio_context(self) -> None:
+        fixtures = {
+            "java": {
+                "src/Queue.java": (
+                    "import com.example.queue.Message;\n"
+                    "class Queue { Object create() { return Message.creator(); } }\n"
+                )
+            },
+            "php": {
+                "src/Mailer.php": (
+                    "<?php\n$client->messages->create($recipient, $payload);\n"
+                )
+            },
+        }
+        for label, files in fixtures.items():
+            with self.subTest(label=label):
+                shallow, deep = self._scan(files)
+                self.assertNotIn("messaging", shallow["products_used"])
+                self.assertNotIn("messaging", deep["products_used"])
+
+    def test_mobile_dependency_delimiter_and_binary_exclusion(self) -> None:
+        shallow, _ = self._scan(
+            {
+                "build.gradle": (
+                    "implementation 'com.twilio:voice-android:6.6.0'\n"
+                )
+            }
+        )
+        self.assertIn("webrtc", shallow["products_used"])
+        self.assertNotIn("voice-android:webrtc", shallow["products_used"])
+
+        with tempfile.TemporaryDirectory(prefix="twilio-binary-scan-") as directory:
+            root = Path(directory)
+            (root / "compiled-app").write_bytes(
+                b"\x7fELF\x00https://api.twilio.com/2010-04-01/"
+                b"Accounts/AC/Messages.json\x00"
+            )
+            result = subprocess.run(
+                [BASH, str(SCAN_USAGE_SCRIPT), str(root)],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual([], payload["products_used"])
+            self.assertEqual([], payload["files"])
+
+    def test_validator_ignores_binary_build_artifacts_and_recognizes_pins(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="migration-validation-") as directory:
+            root = Path(directory)
+            self._write_fixture(
+                root,
+                {
+                    "go.mod": (
+                        "module example.test/migration\n\n"
+                        "go 1.24\n\n"
+                        "require github.com/team-telnyx/telnyx-go/v4 v4.98.0\n"
+                    ),
+                    "src/App.kt": (
+                        "import com.telnyx.sdk.client.TelnyxClient\n"
+                        "class App(val client: TelnyxClient)\n"
+                    ),
+                    "build-output": (
+                        b"\x7fELF\x00https://api.twilio.com/2010-04-01/"
+                        b"\x00X-Twilio-Signature\x00HmacSHA1\x00"
+                    ),
+                },
+            )
+            result = subprocess.run(
+                [BASH, str(VALIDATE_MIGRATION_SCRIPT), str(root), "--json"],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            checks = {
+                item["name"]: item["status"]
+                for item in json.loads(result.stdout)["checks"]
+            }
+            self.assertEqual("pass", checks["twilio_api_urls"])
+            self.assertEqual("pass", checks["twilio_signature_validation"])
+            self.assertEqual("pass", checks["telnyx_sdk_version_pinned"])
+            self.assertEqual("pass", checks["telnyx_source_imports"])
+
+    def test_validator_recognizes_kotlin_telnyx_imports(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="kotlin-validation-") as directory:
+            root = Path(directory)
+            self._write_fixture(
+                root,
+                {
+                    "pom.xml": (
+                        "<project><dependencies><dependency>"
+                        "<groupId>com.telnyx.sdk</groupId>"
+                        "<artifactId>telnyx</artifactId><version>6.89.0</version>"
+                        "</dependency></dependencies></project>\n"
+                    ),
+                    "src/App.kt": (
+                        "import com.telnyx.sdk.client.TelnyxClient\n"
+                        "class App(val client: TelnyxClient)\n"
+                    ),
+                },
+            )
+            result = subprocess.run(
+                [BASH, str(VALIDATE_MIGRATION_SCRIPT), str(root), "--json"],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            checks = {
+                item["name"]: item["status"]
+                for item in json.loads(result.stdout)["checks"]
+            }
+            self.assertEqual("pass", checks["telnyx_source_imports"])
+            self.assertEqual("pass", checks["telnyx_sdk_version_pinned"])
+
+    def test_validator_does_not_infer_maven_pin_from_unrelated_version(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="maven-validation-") as directory:
+            root = Path(directory)
+            (root / "pom.xml").write_text(
+                "<project><name>telnyx migration helper</name>"
+                "<version>1.2.3</version>"
+                "<dependencies><dependency><groupId>com.example</groupId>"
+                "<artifactId>example</artifactId><version>4.5.6</version>"
+                "</dependency></dependencies></project>\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [BASH, str(VALIDATE_MIGRATION_SCRIPT), str(root), "--json"],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+            checks = {
+                item["name"]: item["status"]
+                for item in json.loads(result.stdout)["checks"]
+            }
+            self.assertEqual("fail", checks["telnyx_sdk_dependency"])
+            self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
+
+    def test_project_preflight_does_not_report_host_ruby_gems(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="migration-preflight-") as directory:
+            root = Path(directory)
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            gem = fake_bin / "gem"
+            gem.write_text(
+                "#!/bin/sh\n"
+                "case \"$*\" in\n"
+                "  *twilio-ruby*) echo 'twilio-ruby (7.8.4)' ;;\n"
+                "  *telnyx*) echo 'telnyx (5.1.0)' ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            gem.chmod(gem.stat().st_mode | stat.S_IXUSR)
+            project = root / "project"
+            project.mkdir()
+            (project / "package.json").write_text(
+                '{"dependencies":{"twilio":"^5.0.0","telnyx":"^6.0.0"}}\n',
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment["PATH"] = f"{fake_bin}{os.pathsep}{environment['PATH']}"
+            environment["TELNYX_API_KEY"] = "KEYlocal-test-only"
+            result = subprocess.run(
+                [BASH, str(PREFLIGHT_SCRIPT), str(project), "--quick"],
+                cwd=ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            self.assertNotIn("Ruby: twilio-ruby", result.stdout)
+            self.assertNotIn("Ruby: telnyx", result.stdout)
+            self.assertIn("Node.js: twilio ^5.0.0 (declared in project)", result.stdout)
+            self.assertIn("Node.js: telnyx ^6.0.0 (declared in project)", result.stdout)
+
+    def test_project_preflight_detects_jvm_project_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="jvm-migration-preflight-") as directory:
+            project = Path(directory)
+            (project / "pom.xml").write_text(
+                "<project><dependencies>"
+                "<dependency><groupId>com.twilio.sdk</groupId>"
+                "<artifactId>twilio</artifactId><version>7.34.0</version>"
+                "</dependency>"
+                "<dependency><groupId>com.telnyx.sdk</groupId>"
+                "<artifactId>telnyx</artifactId><version>6.89.0</version>"
+                "</dependency>"
+                "</dependencies></project>\n",
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment["TELNYX_API_KEY"] = "KEYlocal-test-only"
+            result = subprocess.run(
+                [BASH, str(PREFLIGHT_SCRIPT), str(project), "--quick"],
+                cwd=ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            self.assertIn("Java/Kotlin: Twilio SDK (declared in project)", result.stdout)
+            self.assertIn("Java/Kotlin: Telnyx SDK (declared in project)", result.stdout)
+
+    def test_host_preflight_go_module_major_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            go = fake_bin / "go"
+            go.write_text('#!/bin/sh\nif [ "$*" = "list -m all" ]; then\n'
+                'printf "%s\\n" "$TEST_GO_MODULE"\nelse exit 1; fi\n', encoding="utf-8")
+            go.chmod(0o755)
+            for module, expected in (("github.com/team-telnyx/telnyx-go/v4 v4.0.0", True),
+                    ("github.com/team-telnyx/telnyx-go v1.0.0", True),
+                    ("github.com/example/telnyx-go v4.0.0", False),
+                    ("github.com/team-telnyx/telnyx-go-tools v1.0.0", False)):
+                with self.subTest(module=module):
+                    environment = {**os.environ, "PATH": str(fake_bin) + os.pathsep + os.environ["PATH"],
+                        "TELNYX_API_KEY": "KEYlocal-test-only", "TEST_GO_MODULE": module}
+                    result = subprocess.run([BASH, str(PREFLIGHT_SCRIPT), "--quick"],
+                        cwd=root, capture_output=True, text=True, timeout=45, env=environment)
+                    self.assertEqual(0, result.returncode, result.stderr + result.stdout)
+                    self.assertEqual(expected, "Go: telnyx-go (found in go.mod)" in result.stdout)
+
+
 class AnalyzerConsistencyContracts(unittest.TestCase):
     def test_texml_runtime_guidance_matches_analyzer_contracts(self) -> None:
         skill = (ROOT / "skills/telnyx-twilio-migration/SKILL.md").read_text(
@@ -9809,6 +11208,227 @@ class AnalyzerConsistencyContracts(unittest.TestCase):
             re.findall(r'"([^"]+)"', block[: block.index("}")])
         )
         self.assertEqual(shell_dirs, analyzer_dirs)
+
+
+class PhpSdkOwnershipRegression(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.calls = staticmethod(runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("sdk-source-ownership.py")))["contextual_calls"])
+
+    def products(self, source: str) -> set[str]:
+        return {product for _, product in self.calls(source, ".php")}
+
+    def test_grouped_import_alias_owns_client(self) -> None:
+        source = (
+            "<?php namespace App;\n"
+            "use Twilio\\Rest\\{Client as SmsClient, ClientFactory};\n"
+            "$client = new SmsClient($sid, $token);\n"
+            "$client->messages->create($to, []);\n"
+        )
+        self.assertEqual({"messaging"}, self.products(source))
+
+    def test_unrelated_group_member_does_not_own_client(self) -> None:
+        source = (
+            "<?php namespace App;\n"
+            "use Twilio\\Rest\\{Queue, ClientFactory};\n"
+            "$client = new Queue();\n"
+            "$client->messages->create($to, []);\n"
+        )
+        self.assertEqual(set(), self.products(source))
+
+    def test_grouped_alias_does_not_cross_namespace_boundary(self) -> None:
+        source = (
+            "<?php namespace One { use Twilio\\Rest\\{Client as SmsClient}; }\n"
+            "namespace Two { class SmsClient {} $client = new SmsClient(); "
+            "$client->messages->create($to, []); }\n"
+        )
+        self.assertEqual(set(), self.products(source))
+
+    def test_promoted_client_properties_own_receiver(self) -> None:
+        for modifier in (
+            "private",
+            "protected",
+            "public",
+            "private readonly",
+            "protected readonly",
+            "public readonly",
+        ):
+            with self.subTest(modifier=modifier):
+                source = (
+                    "<?php namespace App; use Twilio\\Rest\\Client;\n"
+                    f"class Sender {{ function __construct({modifier} Client $client) {{}} "
+                    "function send() { $this->client->messages->create($to, []); } }\n"
+                )
+                self.assertEqual({"messaging"}, self.products(source))
+
+    def test_unrelated_promoted_type_does_not_own_receiver(self) -> None:
+        source = (
+            "<?php namespace App; use Twilio\\Rest\\Client;\n"
+            "class Sender { function __construct(private Queue $client) {} "
+            "function send() { $this->client->messages->create($to, []); } }\n"
+        )
+        self.assertEqual(set(), self.products(source))
+
+    def test_promoted_property_does_not_cross_class_boundary(self) -> None:
+        source = (
+            "<?php namespace App; use Twilio\\Rest\\Client;\n"
+            "class TwilioSender { function __construct(private Client $client) {} }\n"
+            "class QueueSender { private $client; function send() { "
+            "$this->client->messages->create($to, []); } }\n"
+        )
+        self.assertEqual(set(), self.products(source))
+
+
+
+class ValidatorCorpusRegression(unittest.TestCase):
+    def run_fixture(self, files, *args, unreadable=None):
+        with tempfile.TemporaryDirectory(prefix="validator-corpus-") as directory:
+            root = Path(directory)
+            for name, text in files.items():
+                path = root / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(text, encoding="utf-8")
+            if unreadable:
+                (root / unreadable).chmod(0)
+            try:
+                return subprocess.run(
+                    [shutil.which("bash") or "/bin/bash", str(VALIDATE_MIGRATION_SCRIPT), str(root), *args],
+                    capture_output=True, text=True, timeout=45,
+                )
+            finally:
+                if unreadable:
+                    (root / unreadable).chmod(0o644)
+
+    def status(self, result, name):
+        return next((check["status"] for check in json.loads(result.stdout)["checks"]
+                     if check["name"] == name), None)
+
+    def test_twimlets_is_residual(self):
+        result = self.run_fixture({"app.py": 'url = "http://twimlets.com/forward?PhoneNumber=123"\n'}, "--json")
+        self.assertEqual(self.status(result, "twilio_api_urls"), "fail")
+
+    def test_unreadable_file_blocks_unless_excluded(self):
+        files = {"skipme/bad.py": "x = 1\n"}
+        result = self.run_fixture(files, "--json", unreadable="skipme/bad.py")
+        self.assertEqual(self.status(result, "source_readability"), "fail")
+        result = self.run_fixture(files, "--json", "--exclude-dir", "skipme", unreadable="skipme/bad.py")
+        self.assertIsNone(self.status(result, "source_readability"))
+        result = self.run_fixture({"package-lock.json": "{}"}, "--json", unreadable="package-lock.json")
+        self.assertIsNone(self.status(result, "source_readability"))
+
+    def test_rust_twilio_is_not_hidden_by_node_telnyx(self):
+        files = {"src/main.rs": "use twilio::{Client, OutboundMessage};\n",
+                 "Cargo.toml": '[dependencies]\ntwilio = "1.1"\n',
+                 "package.json": '{"dependencies":{"telnyx":"^6.0.0"}}',
+                 "app.js": "const Telnyx = require('telnyx');\n"}
+        result = self.run_fixture(files, "--json")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertEqual(self.status(result, "unsupported_twilio_source"), "fail")
+        files["src/main.rs"] = "fn main() {}\n"
+        files["Cargo.toml"] = '[dependencies]\nreqwest = "0.12"\n'
+        result = self.run_fixture(files, "--json")
+        self.assertIsNone(self.status(result, "unsupported_twilio_source"))
+
+    def test_unreadable_path_identity_is_structured(self):
+        name = "bad:line\nnext\r.py"
+        result = self.run_fixture({name: "x = 1"}, "--json", unreadable=name)
+        check = next(item for item in json.loads(result.stdout)["checks"]
+                     if item["name"] == "source_readability")
+        self.assertEqual(1, len(check["details"]["files"]))
+        self.assertTrue(check["details"]["files"][0].endswith("/" + name))
+
+    def test_unrelated_security_names_do_not_certify_telnyx(self):
+        result = self.run_fixture({
+            "crypto.go": 'package crypto\nimport "crypto/ed25519"\nfunc key() { _ = ed25519.GenerateKey }\n',
+            "auth.go": 'package auth\nfunc Auth(t string) string { return "Authorization: Bearer " + t }\n',
+            "package.json": '{"dependencies":{"telnyx":"^6.0.0"}}',
+        })
+        self.assertNotIn("webhook verification pattern found", result.stdout)
+        self.assertNotIn("Ed25519 webhook signature validation found", result.stdout)
+        self.assertNotIn("Bearer auth pattern found", result.stdout)
+
+    def test_real_telnyx_auth_patterns_remain_visible_without_certification(self):
+        result = self.run_fixture({
+            "app.py": 'from telnyx import Telnyx\nclient = Telnyx()\nclient.webhooks.unwrap(body, headers=headers)\n',
+            "send.sh": 'curl https://api.telnyx.com/v2/messages -H "Authorization: Bearer $TELNYX_API_KEY"\n',
+            "requirements.txt": "telnyx>=4.0,<5.0\n",
+        })
+        self.assertIn("Telnyx webhook verification pattern found", result.stdout)
+        self.assertIn("Bearer auth pattern found", result.stdout)
+        self.assertIn("static evidence only", result.stdout)
+
+
+
+class GoSdkOwnershipSiblings(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.calls = staticmethod(runpy.run_path(str(DEEP_SCAN_SCRIPT.with_name("sdk-source-ownership.py")))["contextual_calls"])
+
+    def products(self, source: str) -> set[str]:
+        return {product for _, product in self.calls(source, ".go")}
+
+    def test_import_package_is_shadowed_by_parameter(self) -> None:
+        source = 'package app\nimport "github.com/twilio/twilio-go"\n' + (
+            "func send(twilio Other) {\n"
+            " client := twilio.NewRestClient()\n"
+            " client.Api.CreateMessage(params)\n"
+            "}\n"
+        )
+        self.assertEqual(set(), self.products(source))
+
+    def test_outer_sdk_client_is_shadowed_by_parameter(self) -> None:
+        source = 'package app\nimport "github.com/twilio/twilio-go"\n' + (
+            "var client = twilio.NewRestClient()\n"
+            "func send(client Other) { client.Api.CreateMessage(params) }\n"
+        )
+        self.assertEqual(set(), self.products(source))
+
+    def test_uninitialized_locals_shadow_package_and_client(self) -> None:
+        fixtures = (
+            'package app\nimport "github.com/twilio/twilio-go"\n' + (
+                "func send() { var twilio Other; client := twilio.NewRestClient(); "
+                "client.Api.CreateMessage(params) }\n"
+            ),
+            'package app\nimport "github.com/twilio/twilio-go"\n' + (
+                "var client = twilio.NewRestClient()\n"
+                "func send() { var client Other; client.Api.CreateMessage(params) }\n"
+            ),
+        )
+        for source in fixtures:
+            with self.subTest(source=source):
+                self.assertEqual(set(), self.products(source))
+
+    def test_selector_assignment_does_not_rebind_sdk_client(self) -> None:
+        source = 'package app\nimport "github.com/twilio/twilio-go"\n' + (
+            "func send(holder *Holder) {\n"
+            " client := twilio.NewRestClient()\n"
+            " holder.client = other\n"
+            " client.Api.CreateMessage(params)\n"
+            "}\n"
+        )
+        self.assertEqual({"messaging"}, self.products(source))
+
+    def test_true_assignment_rebinds_sdk_client(self) -> None:
+        source = 'package app\nimport "github.com/twilio/twilio-go"\n' + (
+            "func send() {\n"
+            " client := twilio.NewRestClient()\n"
+            " client = queue.New()\n"
+            " client.Api.CreateMessage(params)\n"
+            "}\n"
+        )
+        self.assertEqual(set(), self.products(source))
+
+    def test_bindings_in_unrelated_scopes_do_not_hide_sdk_client(self) -> None:
+        source = 'package app\nimport "github.com/twilio/twilio-go"\n' + (
+            "func unrelated(twilio Other) { _ = twilio }\n"
+            "func send() {\n"
+            " client := twilio.NewRestClient()\n"
+            " { client := queue.New(); _ = client }\n"
+            " client.Api.CreateMessage(params)\n"
+            "}\n"
+        )
+        self.assertEqual({"messaging"}, self.products(source))
+
 
 
 if __name__ == "__main__":

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -3038,6 +3038,9 @@ class CorrectnessLinterContracts(unittest.TestCase):
         url = "https://api.telnyx.com/v2/messages/number_pool"
         decoy = "client.messages.sendNumberPool({to: '+1'})"
         inert = {
+            "text.js": f"export default () => <code>{decoy}</code>;",
+            "text.mjs": f"export default () => <code>{decoy}</code>;",
+            "text.cjs": f"module.exports = () => <code>{decoy}</code>;",
             "text.jsx": f"export default () => <code>{decoy}</code>;",
             "nested.tsx": (
                 f"export default () => <Panel><span>{decoy}</span></Panel>;"
@@ -3084,6 +3087,14 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 )
 
         executable = {
+            "child.js": f"export default () => <Panel>{{{decoy}}}</Panel>;",
+            "handler.mjs": (
+                f"export default () => <Button onClick={{() => {decoy}}} />;"
+            ),
+            "after.cjs": (
+                "const view = <Panel>ordinary text</Panel>;\n"
+                f"fetch('{url}',{{method:'POST',body:JSON.stringify({{to:'+1'}})}});"
+            ),
             "child.jsx": f"export default () => <Panel>{{{decoy}}}</Panel>;",
             "handler.tsx": (
                 f"export default () => <Button onClick={{() => {decoy}}} />;"
@@ -3109,6 +3120,97 @@ class CorrectnessLinterContracts(unittest.TestCase):
                     any(name in row for row in result.stdout.splitlines()[1:]),
                     result.stdout,
                 )
+
+    def test_ruby_heredoc_literal_text_is_inert_but_interpolation_executes(
+        self,
+    ) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        send = f"Net::HTTP.post(URI('{url}'), {{to: '+1'}}.to_json)"
+        inert = {
+            "plain.rb": f"doc = <<DOC\n{send}\nDOC\n",
+            "indented.rb": f"doc = <<~DOC\n  {send}\nDOC\n",
+            "double-quoted.rb": f'doc = <<"DOC"\n{send}\nDOC\n',
+            "single-quoted.rb": f"doc = <<'DOC'\n#{{{send}}}\nDOC\n",
+            "escaped.rb": f"doc = <<DOC\n\\#{{{send}}}\nDOC\n",
+        }
+        for name, source in inert.items():
+            with self.subTest(name=name):
+                self.assertEqual(
+                    "0",
+                    self.run_required_profile_analyzer({name: source}).stdout.strip(),
+                )
+
+        for opener in ("<<DOC", "<<-DOC", "<<~DOC", '<<"DOC"'):
+            with self.subTest(opener=opener):
+                source = f"doc = {opener}\n#{{{send}}}\nDOC\n"
+                result = self.run_required_profile_analyzer(
+                    {"interpolated-heredoc.rb": source}
+                )
+                self.assertTrue(
+                    any(
+                        "interpolated-heredoc.rb" in row
+                        for row in result.stdout.splitlines()[1:]
+                    ),
+                    result.stdout,
+                )
+
+        after = f"doc = <<~DOC\nordinary text\nDOC\n{send}\n"
+        result = self.run_required_profile_analyzer({"after-heredoc.rb": after})
+        self.assertTrue(
+            any("after-heredoc.rb" in row for row in result.stdout.splitlines()[1:]),
+            result.stdout,
+        )
+
+    def test_ruby_interpolation_balancing_ignores_literal_braces(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        literals = {
+            "percent-q": "%q[hello}]",
+            "percent-Q": "%Q(hello})",
+            "regexp": "/hello}/",
+            "regexp-class": "/[}]/",
+            "quoted": '"hello}"',
+        }
+        for container in ("heredoc", "string"):
+            for literal_name, literal in literals.items():
+                for polarity, profile in (
+                    ("missing", ""),
+                    ("valid", ", messaging_profile_id: 'mp'"),
+                ):
+                    with self.subTest(
+                        container=container,
+                        literal=literal_name,
+                        polarity=polarity,
+                    ):
+                        send = (
+                            f"Net::HTTP.post(URI('{url}'), "
+                            f"{{to: '+1'{profile}}}.to_json)"
+                        )
+                        expression = f"#{{ {literal} + ({send}).to_s }}"
+                        source = (
+                            f"doc = <<DOC\n{expression}\nDOC\n"
+                            if container == "heredoc"
+                            else f'doc = "{expression}"\n'
+                        )
+                        result = self.run_required_profile_analyzer(
+                            {f"{container}-{literal_name}.rb": source}
+                        )
+                        findings = [
+                            row for row in result.stdout.splitlines()[1:] if row
+                        ]
+                        if polarity == "missing":
+                            self.assertTrue(findings, result.stdout)
+                        else:
+                            self.assertEqual([], findings, result.stdout)
+
+    def test_deep_jsx_expression_nesting_is_stack_safe(self) -> None:
+        decoy = "client.messages.sendNumberPool({to: '+1'})"
+        source = f"<code>{decoy}</code>"
+        for _ in range(1100):
+            source = f"<Panel>{{{source}}}</Panel>"
+        result = self.run_required_profile_analyzer(
+            {"deep-expression.js": f"export default () => {source};"}
+        )
+        self.assertEqual("0", result.stdout.strip(), result.stdout)
 
     def test_ruby_slash_regex_literals_do_not_mask_following_sends(self) -> None:
         url = "https://api.telnyx.com/v2/messages/number_pool"

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -613,6 +613,43 @@ class CorrectnessLinterContracts(unittest.TestCase):
         )
         self.assertEqual("issue", check["status"], json.dumps(payload["checks"]))
 
+    def test_script_end_tag_variants_preserve_executable_boundaries(self) -> None:
+        # HTML parsers tolerate whitespace and ignored junk after an end-tag
+        # name. The template extractor must therefore recognize the same
+        # boundary: code before it remains executable, while markup after it
+        # must not be scanned as host-language source.
+        closing_tags = (
+            "</script>",
+            "</SCRIPT   >",
+            "</script\t\n data-ignored>",
+            "</ScRiPt ignored=value>",
+        )
+        for suffix in (*self.JS_COMPONENT_FAMILY, ".ejs"):
+            for closing_tag in closing_tags:
+                with self.subTest(suffix=suffix, closing_tag=closing_tag):
+                    source = (
+                        "<script>\n"
+                        "client.messages.sendNumberPool({to, text});\n"
+                        f"{closing_tag}\n"
+                        "<p>client.messages.sendNumberPool({to, text});</p>\n"
+                    )
+                    _, payload = self.run_messaging_linter(
+                        {f"Component{suffix}": source}
+                    )
+                    check = next(
+                        item
+                        for item in payload["checks"]
+                        if item["name"] == "required_messaging_profile_id"
+                    )
+                    self.assertEqual(
+                        "issue", check["status"], json.dumps(payload["checks"])
+                    )
+                    self.assertEqual(
+                        1,
+                        len(check["details"]["files"]),
+                        json.dumps(check),
+                    )
+
     def test_body_field_modes_continue_after_one_unreadable_file(self) -> None:
         with tempfile.TemporaryDirectory(
             prefix="telnyx-body-field-fail-safe-"

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -3034,6 +3034,160 @@ class CorrectnessLinterContracts(unittest.TestCase):
                     else:
                         self.assertEqual([], findings, result.stdout)
 
+    def test_export_default_regex_literals_preserve_following_sends(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        send = (
+            f"fetch('{url}',{{method:'POST',body:JSON.stringify("
+            "{to:'+1'PROFILE})});"
+        )
+        for declaration in (
+            "export default /[/*]/;",
+            "export /* comment */ default /[//]/gu;",
+            "export default\n/[/*]/;",
+        ):
+            for polarity, profile in (
+                ("missing", ""),
+                ("valid", ",messaging_profile_id:'mp'"),
+            ):
+                with self.subTest(declaration=declaration, polarity=polarity):
+                    result = self.run_required_profile_analyzer(
+                        {"send.js": declaration + "\n" + send.replace("PROFILE", profile)}
+                    )
+                    rows = result.stdout.splitlines()
+                    self.assertGreaterEqual(int(rows[0]), 1, result.stdout)
+                    findings = [row for row in rows[1:] if "send.js" in row]
+                    self.assertEqual(polarity == "missing", bool(findings), result.stdout)
+
+        # A member named `default` is an operand, not the export keyword.
+        result = self.run_required_profile_analyzer(
+            {"division.js": "const ratio = config.default / divisor;\n" + send.replace("PROFILE", "")}
+        )
+        self.assertTrue(any("division.js" in row for row in result.stdout.splitlines()[1:]))
+
+    def test_shell_heredocs_accept_trailing_redirections(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        redirections = (
+            ">sample.txt",
+            ">> sample.txt 2>&1",
+            "2>/dev/null >'sample file.txt'",
+            "3>&1 1>sample.txt",
+            "&>sample.txt",
+            "&>> sample.txt # generated fixture",
+            ">sample.txt # generated fixture",
+        )
+        for redirection in redirections:
+            with self.subTest(redirection=redirection):
+                inert = (
+                    f"cat <<'DOC' {redirection}\n"
+                    "client.messages.sendNumberPool({to:'+1'})\n"
+                    "DOC\n"
+                )
+                result = self.run_required_profile_analyzer({"example.sh": inert})
+                self.assertEqual("0", result.stdout.strip(), result.stdout)
+
+                live = inert + f"curl -X POST '{url}' -d '{{\"to\":\"+1\"}}'\n"
+                result = self.run_required_profile_analyzer({"send.sh": live})
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertTrue(any("send.sh" in row for row in rows[1:]), result.stdout)
+
+    def test_ruby_request_constructors_require_an_execution_link(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        for verb in ("Post", "Put", "Patch"):
+            prefix = (
+                f"uri = URI('{url}')\n"
+                f"req = Net::HTTP::{verb}.new(uri)\n"
+                "req.body = {to:'+1'PROFILE}.to_json\n"
+            )
+            with self.subTest(verb=verb, execution="absent"):
+                result = self.run_required_profile_analyzer(
+                    {"request.rb": prefix.replace("PROFILE", "")}
+                )
+                self.assertEqual("0", result.stdout.strip(), result.stdout)
+            for execution in ("http.request(req)", "http.request req"):
+                for polarity, profile in (
+                    ("missing", ""),
+                    ("valid", ",messaging_profile_id:mp"),
+                ):
+                    with self.subTest(
+                        verb=verb, execution=execution, polarity=polarity
+                    ):
+                        result = self.run_required_profile_analyzer(
+                            {
+                                "request.rb": prefix.replace("PROFILE", profile)
+                                + execution
+                                + "\n"
+                            }
+                        )
+                        rows = result.stdout.splitlines()
+                        self.assertEqual("1", rows[0], result.stdout)
+                        findings = [row for row in rows[1:] if "request.rb" in row]
+                        self.assertEqual(
+                            polarity == "missing", bool(findings), result.stdout
+                        )
+
+        for binding in ("@req", "@@req", "$req"):
+            with self.subTest(binding=binding):
+                source = (
+                    f"uri = URI('{url}')\n"
+                    f"{binding} = Net::HTTP::Post.new(uri)\n"
+                    f"{binding}.body = {{to:'+1'}}.to_json\n"
+                    f"http.request({binding})\n"
+                )
+                result = self.run_required_profile_analyzer({"request.rb": source})
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertTrue(any("request.rb" in row for row in rows[1:]), result.stdout)
+
+        # A later reaching definition or an execution in another method cannot
+        # execute the discarded POST constructor.
+        rebound = (
+            f"pool = URI('{url}')\nother = URI('/health')\n"
+            "req = Net::HTTP::Post.new(pool)\n"
+            "req.body = {to:'+1'}.to_json\n"
+            "req = Net::HTTP::Get.new(other)\nhttp.request(req)\n"
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer({"rebound.rb": rebound}).stdout.strip(),
+        )
+        cross_scope = (
+            f"uri = URI('{url}')\nreq = Net::HTTP::Post.new(uri)\n"
+            "req.body = {to:'+1'}.to_json\n"
+            "def later\n  http.request(req)\nend\n"
+        )
+        self.assertEqual(
+            "0",
+            self.run_required_profile_analyzer(
+                {"cross-scope.rb": cross_scope}
+            ).stdout.strip(),
+        )
+
+    def test_review_regressions_hold_through_public_wrapper(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        missing = {
+            "send.js": (
+                "export default /[/*]/;\n"
+                f"fetch('{url}',{{method:'POST',body:JSON.stringify({{to:'+1'}})}});"
+            )
+        }
+        result, payload = self.run_messaging_linter(missing)
+        self.assertEqual(1, result.returncode, payload)
+        self.assert_required_profile_detected(payload, "send.js")
+
+        self.assert_required_profile_passes(
+            {
+                "example.sh": (
+                    "cat <<DOC &>sample.txt # generated\n"
+                    "client.messages.sendNumberPool({to:'+1'})\nDOC\n"
+                ),
+                "request.rb": (
+                    f"uri=URI('{url}')\nreq=Net::HTTP::Post.new(uri)\n"
+                    "req.body={to:'+1'}.to_json\n"
+                ),
+            }
+        )
+
     def test_javascript_division_and_comments_remain_distinct_from_regex(
         self,
     ) -> None:

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -10539,6 +10539,19 @@ class DeclaredSdkVersionContracts(unittest.TestCase):
         self.assertEqual("pass" if declared else "fail", checks["telnyx_sdk_dependency"])
         self.assertEqual("pass" if pinned else "warn", checks["telnyx_sdk_version_pinned"])
 
+    def test_source_import_fallback_respects_file_filters(self) -> None:
+        # Run under GNU grep in CI and BSD grep on macOS: excluded files and
+        # non-source manifests must not supply evidence of an SDK import.
+        for name, expected in (
+            ("app.py", "warn"), ("app.js", "warn"),
+            ("notes.txt", "fail"), ("metadata.json", "fail"),
+            ("go.mod", "fail"), ("libs.versions.toml", "fail"),
+            ("node_modules/app.js", "fail"), (".git/app.py", "fail"),
+        ):
+            with self.subTest(name=name):
+                checks = self.checks({name: "import telnyx\n"})
+                self.assertEqual(expected, checks["telnyx_sdk_dependency"])
+
     def test_node_exact_and_declared_dependency_sections(self) -> None:
         for section in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies"):
             with self.subTest(section=section):

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -189,10 +189,16 @@ class CorrectnessLinterContracts(unittest.TestCase):
             path = Path(directory) / filename
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(source, encoding="utf-8")
-            lines = source.splitlines()
-            grep_output = "".join(
-                f"{path}:{i + 1}:{line}\n"
-                for i, line in enumerate(lines)
+            # Match the producer contract exactly: grep --null terminates the
+            # filename with NUL and counts only LF as a source-line boundary.
+            grep_output = b"".join(
+                os.fsencode(path)
+                + b"\0"
+                + str(i + 1).encode("ascii")
+                + b":"
+                + line.encode("utf-8")
+                + b"\n"
+                for i, line in enumerate(source.split("\n"))
                 if line.strip()
             )
             result = subprocess.run(
@@ -209,11 +215,11 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 ],
                 input=grep_output,
                 capture_output=True,
-                text=True,
                 timeout=15,
                 check=False,
             )
-            return result.stdout
+            self.assertEqual(0, result.returncode, result.stderr.decode())
+            return result.stdout.decode()
 
     def test_filter_source_matches_strips_comments_keeps_strings(self) -> None:
         # A comment-only match is filtered; a string match is preserved.
@@ -246,6 +252,113 @@ class CorrectnessLinterContracts(unittest.TestCase):
         # Only the live code line (2) should survive.
         self.assertEqual(1, len(kept_lines), output)
         self.assertIn(":2:", kept_lines[0])
+
+    def test_filter_source_matches_uses_grep_lf_line_boundaries(self) -> None:
+        # str.splitlines() also splits form-feed and vertical-tab characters,
+        # while grep -n does not. That disagreement used to index the wrong
+        # lexed line and silently discard the live match after either byte.
+        for separator in ("\f", "\v"):
+            with self.subTest(separator=repr(separator)):
+                output = self.run_filter_source_matches(
+                    "app.js",
+                    f"const marker = 1;{separator}\nconst x = VoiceResponse();\n",
+                    "code",
+                    "VoiceResponse",
+                )
+                self.assertIn(":2:", output)
+                self.assertIn("VoiceResponse", output)
+
+    def test_filter_source_matches_preserves_numeric_colons_in_paths(self) -> None:
+        # The old `<path>:<line>:<text>` regex treated `:123:` inside a valid
+        # path as the locator, then fell back to filtering the raw comment.
+        output = self.run_filter_source_matches(
+            "root:123:part/app.js",
+            "// VoiceResponse() removed\nconst x = VoiceResponse();\n",
+            "code",
+            "VoiceResponse",
+        )
+        kept_lines = [line for line in output.splitlines() if line.strip()]
+        self.assertEqual(1, len(kept_lines), output)
+        self.assertIn("root:123:part/app.js:2:", kept_lines[0])
+
+    def test_filter_source_matches_keeps_numeric_colons_in_match_text(self) -> None:
+        output = self.run_filter_source_matches(
+            "app.js",
+            "const x = VoiceResponse({code:123:value});\n",
+            "code",
+            "VoiceResponse",
+        )
+        self.assertIn("code:123:value", output)
+
+    def test_filter_source_matches_rejects_legacy_ambiguous_records(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-B",
+                str(FILTER_SOURCE_SCRIPT),
+                "--mode",
+                "code",
+                "--pattern",
+                "VoiceResponse",
+                "--analyzer",
+                str(MESSAGING_SOURCE_ANALYZER),
+            ],
+            input=b"/tmp/app.js:1:VoiceResponse()\n",
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        self.assertEqual(2, result.returncode, result.stderr.decode())
+        self.assertIn("malformed NUL-delimited grep input", result.stderr.decode())
+
+    def test_filter_source_matches_fails_closed_for_missing_source(self) -> None:
+        missing = Path(tempfile.gettempdir()) / "missing-filter-source.js"
+        missing.unlink(missing_ok=True)
+        record = os.fsencode(missing) + b"\0" + b"1:VoiceResponse()\n"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-B",
+                str(FILTER_SOURCE_SCRIPT),
+                "--mode",
+                "code",
+                "--pattern",
+                "VoiceResponse",
+                "--analyzer",
+                str(MESSAGING_SOURCE_ANALYZER),
+            ],
+            input=record,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        self.assertEqual(2, result.returncode, result.stderr.decode())
+        self.assertIn("could not filter", result.stderr.decode())
+
+    def test_filter_source_matches_fails_closed_for_invalid_pattern(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="filter-pattern-") as directory:
+            path = Path(directory) / "app.js"
+            path.write_text("VoiceResponse()\n", encoding="utf-8")
+            record = os.fsencode(path) + b"\0" + b"1:VoiceResponse()\n"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-B",
+                    str(FILTER_SOURCE_SCRIPT),
+                    "--mode",
+                    "code",
+                    "--pattern",
+                    "[",
+                    "--analyzer",
+                    str(MESSAGING_SOURCE_ANALYZER),
+                ],
+                input=record,
+                capture_output=True,
+                timeout=15,
+                check=False,
+            )
+        self.assertEqual(2, result.returncode, result.stderr.decode())
+        self.assertIn("could not evaluate", result.stderr.decode())
 
     def assert_required_profile_detected(
         self, payload: dict[str, Any], fixture_name: str
@@ -967,6 +1080,25 @@ class CorrectnessLinterContracts(unittest.TestCase):
         ]
         self.assertEqual(1, len(findings), json.dumps(payload["checks"]))
 
+        # Exclusions apply to the source suffix, never to matching text. The
+        # old formatted-output regex discarded this real server handler merely
+        # because its route happened to contain a component-like locator.
+        _, payload = self.run_messaging_linter(
+            {
+                "server.js": (
+                    'app.post("/callback.vue:123:test", '
+                    "() => data.payload);\n"
+                )
+            }
+        )
+        findings = [
+            item
+            for item in payload["checks"]
+            if item["name"] == "webhook_ed25519_missing"
+            and item["status"] in {"warn", "issue"}
+        ]
+        self.assertEqual(1, len(findings), json.dumps(payload["checks"]))
+
     def test_language_aliases_are_analysed_as_their_canonical_language(self) -> None:
         # An extension is not a language. A .bash file is a shell script and a
         # .phtml file is PHP, but every downstream check compares against the
@@ -1397,6 +1529,40 @@ class CorrectnessLinterContracts(unittest.TestCase):
             and c["name"] == "residual_twilio_imports"
         ]
         self.assertEqual([], flagged, json.dumps(flagged))
+
+    def test_residual_import_filter_protocol_handles_path_and_line_boundaries(
+        self,
+    ) -> None:
+        # Exercise the real grep -> NUL-record -> lexer pipeline, not just the
+        # parser helper. Numeric colons in paths and non-LF control bytes in a
+        # prior physical line must neither invent nor hide a residual import.
+        _, comment_payload = self.run_messaging_linter(
+            {"root:123:part/app.py": "# from twilio.rest import Client\n"}
+        )
+        comment_check = next(
+            c
+            for c in comment_payload["checks"]
+            if c["name"] == "residual_twilio_imports"
+        )
+        self.assertEqual("pass", comment_check["status"], comment_payload)
+
+        for marker in ("\f", "\v", "\0"):
+            with self.subTest(marker=repr(marker)):
+                result, payload = self.run_messaging_linter(
+                    {
+                        "root:123:part/app.py": (
+                            f"sentinel = 1{marker}\n"
+                            "from twilio.rest import Client\n"
+                        )
+                    }
+                )
+                check = next(
+                    c
+                    for c in payload["checks"]
+                    if c["name"] == "residual_twilio_imports"
+                )
+                self.assertEqual("issue", check["status"], payload)
+                self.assertEqual(1, result.returncode, result.stdout)
 
     def test_factory_created_rest_clients_are_scanned(self) -> None:
         # requests.Session().post(...) and axios.create(...).post(...) have a

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -3074,6 +3074,7 @@ class CorrectnessLinterContracts(unittest.TestCase):
             "&>sample.txt",
             "&>> sample.txt # generated fixture",
             ">sample.txt # generated fixture",
+            r">sample\ file.txt",
         )
         for redirection in redirections:
             with self.subTest(redirection=redirection):

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -10517,12 +10517,15 @@ class GradleMapDependencySiblings(unittest.TestCase):
 
 
 class DeclaredSdkVersionContracts(unittest.TestCase):
-    def checks(self, files: dict[str, str]) -> dict[str, str]:
+    def checks(self, files: dict[str, str | bytes]) -> dict[str, str]:
         with tempfile.TemporaryDirectory(prefix="declared-sdk-version-") as directory:
             for name, content in files.items():
                 path = Path(directory) / name
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(content, encoding="utf-8")
+                if isinstance(content, bytes):
+                    path.write_bytes(content)
+                else:
+                    path.write_text(content, encoding="utf-8")
             result = subprocess.run(
                 [BASH, str(VALIDATE_MIGRATION_SCRIPT), directory, "--json"],
                 cwd=ROOT, capture_output=True, text=True, timeout=30, check=False,
@@ -10601,6 +10604,135 @@ class DeclaredSdkVersionContracts(unittest.TestCase):
         ):
             with self.subTest(source=source):
                 self.assert_manifest({"setup.py": "from setuptools import setup\n" + source}, True, True)
+
+    def test_setup_import_identity_and_alias_siblings(self) -> None:
+        for prefix, callee in (
+            ("from setuptools import setup as package_setup", "package_setup"),
+            ("from setuptools import (find_packages, setup as package_setup)", "package_setup"),
+            ("import setuptools as packaging", "packaging.setup"),
+            ("import setuptools\npackaging = setuptools", "packaging.setup"),
+            ("from setuptools import setup\npackage_setup = setup", "package_setup"),
+            ("import setuptools as packaging\npackage_setup = packaging.setup", "package_setup"),
+            ("from distutils.core import setup as package_setup", "package_setup"),
+        ):
+            with self.subTest(prefix=prefix):
+                self.assert_manifest({"setup.py": prefix + f'\n{callee}(install_requires=["telnyx>=4.0"])\n'}, True, True)
+
+    def test_setup_equivalent_import_branches_preserve_ownership(self) -> None:
+        for prefix, callee in (
+            ("try:\n    from setuptools import setup\nexcept ImportError:\n    from distutils.core import setup", "setup"),
+            ("if sys.version_info >= (3, 0):\n    from setuptools import setup\nelse:\n    from distutils.core import setup", "setup"),
+            ("try:\n    from setuptools import setup as configure\nexcept (ImportError, ModuleNotFoundError):\n    from distutils.core import setup as configure", "configure"),
+            ("if version:\n    import setuptools as packaging\nelse:\n    import setuptools as packaging", "packaging.setup"),
+            ("try:\n    from setuptools import setup\nexcept ImportError:\n    from distutils.core import setup\nelse:\n    pass\nfinally:\n    pass", "setup"),
+            ("if version:\n    try:\n        from setuptools import setup\n    except ImportError:\n        from distutils.core import setup\nelse:\n    from setuptools import setup", "setup"),
+            ("if version:\n    from setuptools import setup\n    REQS = ['other']\nelse:\n    from distutils.core import setup\n    REQS = []", "setup"),
+        ):
+            with self.subTest(prefix=prefix):
+                self.assert_manifest({"setup.py": prefix + f'\n{callee}(install_requires=["telnyx>=4.0"])\n'}, True, True)
+
+    def test_setup_submodule_and_public_star_imports(self) -> None:
+        for prefix, callee in (
+            ("import setuptools.command.sdist", "setuptools.setup"),
+            ("import os, setuptools.command.sdist", "setuptools.setup"),
+            ("from setuptools import *", "setup"),
+            ("REQS=['telnyx>=4.0']\nfrom setuptools import *", "setup"),
+        ):
+            with self.subTest(prefix=prefix):
+                self.assert_manifest({"setup.py": prefix + f'\n{callee}(install_requires=' + ("REQS" if prefix.startswith("REQS") else '["telnyx>=4.0"]') + ')\n'}, True, True)
+
+    def test_setup_import_branch_negatives_stay_unresolved(self) -> None:
+        for prefix, callee in (
+            ("if version:\n    from setuptools import setup", "setup"),
+            ("if version:\n    from setuptools import setup\nelse:\n    from other import setup", "setup"),
+            ("try:\n    from setuptools import setup\nexcept ImportError:\n    pass", "setup"),
+            ("try:\n    from setuptools import setup\nexcept ImportError as setup:\n    from distutils.core import setup", "setup"),
+            ("try:\n    from setuptools import setup\nexcept ImportError:\n    from distutils.core import setup\nfinally:\n    setup = other", "setup"),
+            ("if version:\n    from setuptools import setup\n    setup = other\nelse:\n    from setuptools import setup", "setup"),
+            ("import setuptools.command.sdist as setuptools", "setuptools.setup"),
+            ("from setuptools.command.sdist import *", "setup"),
+            ("from .setuptools import *", "setup"),
+            ("from setuptools import *\nsetup = other", "setup"),
+            ("from setuptools import *\nfrom other import *", "setup"),
+            ("import setuptools as a\nimport setuptools as b\nb.setup = other", "a.setup"),
+            ("if version:\n    import setuptools as packaging\n    packaging.setup = other\nelse:\n    import setuptools as packaging", "packaging.setup"),
+        ):
+            with self.subTest(prefix=prefix):
+                checks = self.checks({"setup.py": prefix + f'\n{callee}(install_requires=["telnyx>=4.0"])\n'})
+                self.assertNotEqual("pass", checks["telnyx_sdk_dependency"])
+                self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
+
+        for alternative in ('[]', '["telnyx>=4.0"]'):
+            with self.subTest(conditional_requirements=alternative):
+                checks = self.checks({"setup.py": 'if version:\n    from setuptools import setup\n    REQS=["telnyx>=4.0"]\nelse:\n    from distutils.core import setup\n    REQS=' + alternative + '\nsetup(install_requires=REQS)\n'})
+                self.assertNotEqual("pass", checks["telnyx_sdk_dependency"])
+                self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
+
+    def test_manifest_encodings_follow_each_format(self) -> None:
+        for name, content in (
+            ("requirements.txt", b"\xef\xbb\xbftelnyx==4.0.0\n"),
+            ("requirements.txt", b"# -*- coding: latin-1 -*-\n# caf\xe9\ntelnyx>=4.0\n"),
+            ("requirements.txt", "telnyx>=4.0\n".encode("utf-16")),
+            ("requirements.txt", "telnyx>=4.0\n".encode("utf-32")),
+            ("requirements.txt", b"# first\n# coding: latin-1\n# caf\xe9\ntelnyx>=4.0\n"),
+            ("setup.py", b'\xef\xbb\xbffrom setuptools import setup as s\ns(install_requires=["telnyx>=4.0"])\n'),
+            ("setup.py", b'# coding: latin-1\n# caf\xe9\nfrom setuptools import setup as s\ns(install_requires=["telnyx>=4.0"])\n'),
+            ("package.json", b'\xef\xbb\xbf{"dependencies":{"telnyx":"^6.0.0"}}'),
+        ):
+            with self.subTest(name=name, content=content):
+                checks = self.checks({name: content})
+                self.assertEqual("pass", checks["telnyx_sdk_dependency"])
+                self.assertEqual("pass", checks["telnyx_sdk_version_pinned"])
+
+    def test_setup_class_scope_is_not_a_method_closure(self) -> None:
+        for source, declared in (
+            ('class C:\n    from setuptools import setup as configure\n    def run(self):\n        configure(install_requires=["telnyx>=4.0"])', False),
+            ('class C:\n    import setuptools as packaging\n    def run(self):\n        packaging.setup(install_requires=["telnyx>=4.0"])', False),
+            ('class C:\n    from setuptools import setup as configure\n    class Inner:\n        configure(install_requires=["telnyx>=4.0"])', False),
+            ('class C:\n    from setuptools import setup as configure\n    values = [configure(install_requires=["telnyx>=4.0"]) for x in [1]]', False),
+            ('class C:\n    from setuptools import setup as configure\n    values = [x for x in configure(install_requires=["telnyx>=4.0"])]', True),
+            ('class C:\n    from setuptools import setup as configure\n    values = [x for configure in configure(install_requires=["telnyx>=4.0"])]', True),
+            ('from setuptools import setup as configure\nvalues = [x for configure in configure(install_requires=["telnyx>=4.0"])]', True),
+            ('class C:\n    from setuptools import setup as configure\n    configure(install_requires=["telnyx>=4.0"])', True),
+            ('from setuptools import setup as configure\nclass C:\n    configure = None\n    def run(self):\n        configure(install_requires=["telnyx>=4.0"])', True),
+            ('import setuptools as packaging\nclass C:\n    packaging.setup = other\n    def run(self):\n        packaging.setup(install_requires=["telnyx>=4.0"])', False),
+            ('from setuptools import setup as configure\nREQS=["telnyx>=4.0"]\nclass C:\n    REQS.clear()\n    def run(self):\n        configure(install_requires=REQS)', False),
+        ):
+            with self.subTest(source=source):
+                checks = self.checks({"setup.py": source})
+                self.assertEqual(declared, checks["telnyx_sdk_dependency"] == "pass")
+                self.assertEqual("pass" if declared else "warn", checks["telnyx_sdk_version_pinned"])
+
+    def test_invalid_encoding_does_not_create_dependency_evidence(self) -> None:
+        for name, content in (
+            ("requirements.txt", b"# coding: unknown-encoding\ntelnyx>=4.0\n"),
+            ("setup.py", b'\xef\xbb\xbf# coding: latin-1\nfrom setuptools import setup\nsetup(install_requires=["telnyx>=4.0"])'),
+            ("pyproject.toml", b'\xef\xbb\xbf[project]\ndependencies=["telnyx>=4.0"]'),
+            ("Pipfile", b'\xef\xbb\xbf[packages]\ntelnyx="==4.0.0"'),
+        ):
+            with self.subTest(name=name):
+                checks = self.checks({name: content})
+                self.assertNotEqual("pass", checks["telnyx_sdk_dependency"])
+                self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
+
+    def test_setup_unrelated_and_shadowed_imports_do_not_certify(self) -> None:
+        for source in (
+            'from unrelated import setup\nsetup(install_requires=["telnyx>=4.0"])',
+            'def setup(**kwargs): pass\nsetup(install_requires=["telnyx>=4.0"])',
+            'from setuptools import setup as configure\nconfigure = unrelated\nconfigure(install_requires=["telnyx>=4.0"])',
+            'from setuptools import setup as configure\ndef run(configure):\n    configure(install_requires=["telnyx>=4.0"])',
+            'from setuptools import setup as configure\ndef run():\n    configure(install_requires=["telnyx>=4.0"])\n    from unrelated import configure',
+            'from setuptools import setup as configure\ndef run():\n    configure(install_requires=["telnyx>=4.0"])\n    def configure(**kwargs): pass',
+            'import setuptools as packaging\nalias = packaging\nalias.setup = unrelated\npackaging.setup(install_requires=["telnyx>=4.0"])',
+            'def other():\n    from setuptools import setup as configure\nconfigure(install_requires=["telnyx>=4.0"])',
+            'from setuptools import setup as configure\nif enabled:\n    from unrelated import configure\nconfigure(install_requires=["telnyx>=4.0"])',
+            'from setuptools import setup as configure\nif enabled:\n    def configure(**kwargs): pass\nconfigure(install_requires=["telnyx>=4.0"])',
+            'from setuptools import setup as configure\nfrom unrelated import *\nconfigure(install_requires=["telnyx>=4.0"])',
+        ):
+            with self.subTest(source=source):
+                checks = self.checks({"setup.py": source})
+                self.assertNotEqual("pass", checks["telnyx_sdk_dependency"])
+                self.assertEqual("warn", checks["telnyx_sdk_version_pinned"])
 
     def test_setup_binding_scope_reassignment_and_mutation_are_not_stale_evidence(self) -> None:
         for source in (
@@ -11677,6 +11809,48 @@ class PhpSdkOwnershipRegression(unittest.TestCase):
 
     def products(self, source: str) -> set[str]:
         return {product for _, product in self.calls(source, ".php")}
+
+    def test_import_lists_and_namespace_aliases(self) -> None:
+        for imports, constructor in (
+            (r"use Twilio\Rest\Client, Psr\Log\LoggerInterface;", "Client"),
+            (r"use Psr\Log\LoggerInterface,Twilio\Rest\Client;", "Client"),
+            (r"use Twilio\Rest\Client as Sms,Psr\Log\LoggerInterface;", "Sms"),
+            ("use Psr\\Log\\LoggerInterface,\n Twilio\\Rest\\Client as Sms;", "Sms"),
+            (r"use Twilio\Rest as Rest, Psr\Log\LoggerInterface;", r"Rest\Client"),
+            (r"use Twilio as Sdk;", r"Sdk\Rest\Client"),
+            (r"use Twilio\Rest\{Client as Sms, function helper};", "Sms"),
+        ):
+            for receiver in ("c", "twilio"):
+                with self.subTest(imports=imports, receiver=receiver):
+                    source = f"<?php namespace App; {imports}\n${receiver} = new {constructor}();\n${receiver}->messages->create($to, []);"
+                    self.assertEqual({"messaging"}, self.products(source))
+
+    def test_import_kinds_and_scopes_are_not_interchangeable(self) -> None:
+        for imports in (
+            r"use function Other\helper, Twilio\Rest\Client;",
+            r"use const Other\VALUE, Twilio\Rest\Client;",
+            r"use Twilio\Rest\{function Client, const VALUE};",
+            r"class Holder { use Twilio\Rest\Client; }",
+            r"use Other\Client, Psr\Log\LoggerInterface;",
+        ):
+            with self.subTest(imports=imports):
+                self.assertEqual(set(), self.products("<?php " + imports + " $c = new Client(); $c->messages->create($to, []);"))
+
+    def test_factory_in_import_list_preserves_ownership(self) -> None:
+        for imports in (r"use Psr\Log\LoggerInterface, Twilio\Rest\ClientFactory as Factory;",
+                        r"use Twilio\Rest\{ClientFactory as Factory, function helper};"):
+            with self.subTest(imports=imports):
+                self.assertEqual({"messaging"}, self.products("<?php " + imports + " $factory = new Factory(); $c = $factory->create(); $c->messages->create($to, []);"))
+
+    def test_comma_imports_reach_both_public_scanners(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="php-import-list-") as directory:
+            Path(directory, "send.php").write_text(r'<?php use Twilio\Rest\Client, Psr\Log\LoggerInterface; $c = new Client($sid, $token); $c->messages->create($to, []);', encoding="utf-8")
+            for script in (SCAN_USAGE_SCRIPT, DEEP_SCAN_SCRIPT):
+                with self.subTest(script=script):
+                    command = [BASH, str(script)] if script.suffix == ".sh" else [sys.executable, str(script)]
+                    result = subprocess.run([*command, directory, *(["--json"] if script.suffix == ".sh" else [])], capture_output=True, text=True, timeout=30)
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    self.assertIn("messaging", json.loads(result.stdout)["products_used"])
 
     def test_grouped_import_alias_owns_client(self) -> None:
         source = (

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -2373,6 +2373,380 @@ class CorrectnessLinterContracts(unittest.TestCase):
             }
         )
 
+    def test_python_logical_from_imports_preserve_endpoint_provenance(self) -> None:
+        """Parentheses and continuations cannot erase imported endpoints."""
+
+        pool = "https://api.telnyx.com/v2/messages/number_pool"
+        safe = "https://api.telnyx.com/v2/messages"
+        support = {
+            "pkg/__init__.py": "",
+            "pkg/endpoints.py": (
+                f"pool_url = '{pool}'\n"
+                f"safe_url = '{safe}'\n"
+                "other = 'unused'\n"
+            ),
+        }
+        forms = {
+            "relative-parenthesized": (
+                "from .endpoints import (\n"
+                "    pool_url,\n"
+                ")\n",
+                "pool_url",
+            ),
+            "relative-parenthesized-alias": (
+                "from .endpoints import (\n"
+                "    safe_url,\n"
+                "    pool_url as endpoint,\n"
+                ")\n",
+                "endpoint",
+            ),
+            "absolute-parenthesized": (
+                "from pkg.endpoints import (\n"
+                "    pool_url,\n"
+                ")\n",
+                "pool_url",
+            ),
+            "explicit-continuation": (
+                "from pkg.endpoints import safe_url, \\\n"
+                "    pool_url as endpoint\n",
+                "endpoint",
+            ),
+            "semicolon-small-statement": (
+                "import os; from pkg.endpoints import pool_url as endpoint\n",
+                "endpoint",
+            ),
+            "trailing-semicolon-small-statement": (
+                "from pkg.endpoints import pool_url as endpoint; import os\n",
+                "endpoint",
+            ),
+        }
+        for form, (declaration, endpoint) in forms.items():
+            template = (
+                declaration
+                + "import requests\n"
+                + f"requests.post({endpoint}, json={{'to': '+1'%s}})\n"
+            )
+            with self.subTest(form=form, polarity="missing"):
+                result = self.run_required_profile_analyzer(
+                    {**support, "pkg/send.py": template % ""}
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertTrue(any("pkg/send.py" in row for row in rows[1:]))
+            with self.subTest(form=form, polarity="present"):
+                result = self.run_required_profile_analyzer(
+                    {
+                        **support,
+                        "pkg/send.py": template
+                        % ", 'messaging_profile_id': 'mp'",
+                    }
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertFalse(any(row.strip() for row in rows[1:]), result.stdout)
+
+        self.assert_required_profile_passes(
+            {
+                **support,
+                "pkg/send.py": (
+                    "from .endpoints import (safe_url,)\n"
+                    "import requests\n"
+                    "requests.post(safe_url, json={'to': '+1'})\n"
+                ),
+            }
+        )
+
+    def test_csharp_project_static_endpoint_members_resolve_by_namespace(self) -> None:
+        """Same-namespace and fully-qualified C# constants cross files."""
+
+        pool = "https://api.telnyx.com/v2/messages/number_pool"
+        safe = "https://api.telnyx.com/v2/messages"
+        forms = {
+            "file-scoped-const": (
+                "namespace Demo;\ninternal static class Endpoints { "
+                f'public const string PoolUrl = "{pool}"; }}\n',
+                "namespace Demo;\n",
+                "Endpoints.PoolUrl",
+            ),
+            "block-static-readonly": (
+                "namespace Demo { internal static class Endpoints { "
+                f'public static readonly string PoolUrl = "{pool}"; }} }}\n',
+                "namespace Demo { class Send { async Task Go() { BODY } } }\n",
+                "Endpoints.PoolUrl",
+            ),
+            "nested-type": (
+                "namespace Demo;\ninternal static class Routes { "
+                "internal static class Endpoints { "
+                f'public const string PoolUrl = "{pool}"; }} }}\n',
+                "namespace Demo;\n",
+                "Routes.Endpoints.PoolUrl",
+            ),
+            "static-readonly-uri": (
+                "namespace Demo;\ninternal static class Endpoints { "
+                "public static readonly Uri PoolUrl = new Uri("
+                f'"{pool}"); }}\n',
+                "namespace Demo;\n",
+                "Endpoints.PoolUrl",
+            ),
+            "fully-qualified-other-namespace": (
+                "namespace Other;\ninternal static class Endpoints { "
+                f'public const string PoolUrl = "{pool}"; }}\n',
+                "namespace Demo;\n",
+                "Other.Endpoints.PoolUrl",
+            ),
+            "nested-block-namespace": (
+                "namespace Outer { namespace Inner { "
+                "internal static class Endpoints { "
+                f'public const string PoolUrl = "{pool}"; }} }} }}\n',
+                "namespace Demo;\n",
+                "Outer.Inner.Endpoints.PoolUrl",
+            ),
+            "verbatim-const": (
+                "namespace Demo; internal static class Endpoints { "
+                f'public const string PoolUrl = @"{pool}"; }}\n',
+                "namespace Demo;\n",
+                "Endpoints.PoolUrl",
+            ),
+            "target-typed-uri": (
+                "namespace Demo; internal static class Endpoints { "
+                f'public static readonly Uri PoolUrl = new("{pool}"); }}\n',
+                "namespace Demo;\n",
+                "Endpoints.PoolUrl",
+            ),
+            "global-qualified": (
+                "namespace Other; internal static class Endpoints { "
+                f'public const string PoolUrl = "{pool}"; }}\n',
+                "namespace Demo;\n",
+                "global::Other.Endpoints.PoolUrl",
+            ),
+            "containing-parent-namespace": (
+                "namespace A { static class Endpoints { "
+                f'public const string PoolUrl = "{pool}"; }} }}\n',
+                "namespace A.B { class Send { async Task Go() { BODY } } }\n",
+                "Endpoints.PoolUrl",
+            ),
+        }
+        for form, (support, send_prefix, endpoint) in forms.items():
+            body = (
+                "await client.PostAsync("
+                + endpoint
+                + ", new StringContent(\"{\\\"to\\\":\\\"+1\\\"%s}\"));"
+            )
+            template = (
+                send_prefix.replace("BODY", body)
+                if "BODY" in send_prefix
+                else send_prefix + "class Send { async Task Go() { " + body + " } }\n"
+            )
+            with self.subTest(form=form, polarity="missing"):
+                result = self.run_required_profile_analyzer(
+                    {"Endpoints.cs": support, "Send.cs": template % ""}
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertTrue(any("Send.cs" in row for row in rows[1:]))
+            with self.subTest(form=form, polarity="present"):
+                result = self.run_required_profile_analyzer(
+                    {
+                        "Endpoints.cs": support,
+                        "Send.cs": template
+                        % ',\\\"messaging_profile_id\\\":\\\"mp\\\"',
+                    }
+                )
+                rows = result.stdout.splitlines()
+                self.assertEqual("1", rows[0], result.stdout)
+                self.assertFalse(any(row.strip() for row in rows[1:]), result.stdout)
+
+        self.assert_required_profile_passes(
+            {
+                "Endpoints.cs": (
+                    "namespace Demo; internal static class Endpoints { "
+                    f'public const string SafeUrl = "{safe}"; }}'
+                ),
+                "Send.cs": (
+                    "namespace Demo; await client.PostAsync(Endpoints.SafeUrl, "
+                    'new StringContent("{\\"to\\":\\"+1\\"}"));'
+                ),
+            }
+        )
+
+        # Do not cross-product members between namespaces in one source file.
+        # Both declaration orders matter because a dict overwrite once made
+        # one order false-positive and the reverse order false-negative.
+        for reverse in (False, True):
+            safe_decl = (
+                "namespace SafeNs { static class Endpoints { "
+                f'public const string Url = "{safe}"; }} }}\n'
+            )
+            pool_decl = (
+                "namespace PoolNs { static class Endpoints { "
+                f'public const string Url = "{pool}"; }} }}\n'
+            )
+            declarations = (
+                pool_decl + safe_decl if reverse else safe_decl + pool_decl
+            )
+            with self.subTest(namespace_collision_order=reverse):
+                self.assert_required_profile_passes(
+                    {
+                        "Endpoints.cs": declarations,
+                        "Send.cs": (
+                            "namespace SafeNs { class Send { async Task Go() { "
+                            "await client.PostAsync(Endpoints.Url, "
+                            'new StringContent("{\\"to\\":\\"+1\\"}")); } }}\n'
+                        ),
+                    }
+                )
+
+        # Each call site in a multi-namespace source resolves against its own
+        # lexical namespace, not a file-wide unqualified alias map.
+        multi_namespace = self.run_required_profile_analyzer(
+            {
+                "Endpoints.cs": safe_decl + pool_decl,
+                "Send.cs": (
+                    "namespace SafeNs { class SafeSend { async Task Go() { "
+                    "await client.PostAsync(Endpoints.Url, "
+                    'new StringContent("{\\"to\\":\\"+1\\"}")); } }}\n'
+                    "namespace PoolNs { class PoolSend { async Task Go() { "
+                    "await client.PostAsync(Endpoints.Url, "
+                    'new StringContent("{\\"to\\":\\"+1\\"}")); } }}\n'
+                ),
+            }
+        )
+        self.assertEqual("1", multi_namespace.stdout.splitlines()[0])
+        self.assertEqual(1, multi_namespace.stdout.count("Send.cs:"))
+
+        # A nested type shadows a same-named namespace member. Exercise both
+        # URL polarities so external lookup cannot override lexical binding.
+        for local_url, expect_missing in ((pool, True), (safe, False)):
+            outer_url = safe if expect_missing else pool
+            shadow = self.run_required_profile_analyzer(
+                {
+                    "Global.cs": (
+                        "namespace Demo; static class Endpoints { "
+                        f'public const string PoolUrl = "{outer_url}"; }}\n'
+                    ),
+                    "Send.cs": (
+                        "namespace Demo; class Send { static class Endpoints { "
+                        f'public const string PoolUrl = "{local_url}"; }} '
+                        "async Task Go() { await client.PostAsync("
+                        "Endpoints.PoolUrl, "
+                        'new StringContent("{\\"to\\":\\"+1\\"}")); }}\n'
+                    ),
+                }
+            )
+            rows = shadow.stdout.splitlines()
+            with self.subTest(nested_shadow_required=expect_missing):
+                self.assertEqual("1" if expect_missing else "0", rows[0])
+                self.assertEqual(
+                    expect_missing,
+                    any("Send.cs:" in row for row in rows[1:]),
+                    shadow.stdout,
+                )
+
+        global_only = self.run_required_profile_analyzer(
+            {
+                "Endpoints.cs": (
+                    "namespace Other { static class Endpoints { "
+                    f'public const string Url = "{pool}"; }} }}\n'
+                    "namespace Demo.Other { static class Endpoints { "
+                    f'public const string Url = "{safe}"; }} }}\n'
+                ),
+                "Send.cs": (
+                    "namespace Demo { class Send { async Task Go() { "
+                    "await client.PostAsync(global::Other.Endpoints.Url, "
+                    'new StringContent("{\\"to\\":\\"+1\\"}")); } }}\n'
+                ),
+            }
+        )
+        self.assertEqual("1", global_only.stdout.splitlines()[0])
+        self.assertIn("Send.cs:", global_only.stdout)
+
+        # Method locals shadow same-named members on a partial class.
+        for local_url, expect_missing in ((safe, False), (pool, True)):
+            field_url = pool if not expect_missing else safe
+            local_shadow = self.run_required_profile_analyzer(
+                {
+                    "Endpoints.cs": (
+                        "namespace Demo; partial class Worker { "
+                        f'public const string Url = "{field_url}"; }}\n'
+                    ),
+                    "Send.cs": (
+                        "namespace Demo; partial class Worker { async Task Go() { "
+                        f'var Url = "{local_url}"; '
+                        "await client.PostAsync(Url, "
+                        'new StringContent("{\\"to\\":\\"+1\\"}")); }}\n'
+                    ),
+                }
+            )
+            with self.subTest(local_binding_required=expect_missing):
+                rows = local_shadow.stdout.splitlines()
+                self.assertEqual("1" if expect_missing else "0", rows[0])
+                self.assertEqual(expect_missing, "Send.cs:" in local_shadow.stdout)
+
+    def test_csharp_project_static_index_is_built_once_per_cli_scan(self) -> None:
+        """Cross-file member resolution reads each C# source only linearly."""
+
+        safe = "https://api.telnyx.com/v2/messages"
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_csharp_project_index_contract",
+        )
+        with tempfile.TemporaryDirectory(prefix="telnyx-csharp-index-") as directory:
+            root = Path(directory)
+            paths = []
+            for index in range(24):
+                path = root / f"Source{index}.cs"
+                path.write_text(
+                    "namespace Demo; static class Endpoints"
+                    f'{index} {{ public const string Safe = "{safe}"; }}\n',
+                    encoding="utf-8",
+                )
+                paths.append(path)
+
+            reads = 0
+            original_read = namespace["_read_source_text"]
+
+            def tracked_read(path: Path) -> str:
+                nonlocal reads
+                reads += 1
+                return original_read(path)
+
+            namespace["_csharp_project_static_index"].__globals__[
+                "_read_source_text"
+            ] = tracked_read
+            project_values = namespace["_csharp_project_static_index"](root)
+            for path in paths:
+                namespace["analyze_file"](path, root, project_values)
+            self.assertEqual(2 * len(paths), reads)
+
+            many_calls = root / "ManyCalls.cs"
+            many_calls.write_text(
+                "namespace Demo; class Send { async Task Go() {\n"
+                + "\n".join(
+                    "await client.PostAsync(Endpoints0.Safe, "
+                    'new StringContent("{}"));'
+                    for _ in range(100)
+                )
+                + "\n} }\n",
+                encoding="utf-8",
+            )
+            globals_map = namespace["analyze_file"].__globals__
+            original_namespaces = globals_map["_csharp_namespace_spans"]
+            original_types = globals_map["_csharp_type_spans"]
+            span_calls = {"namespace": 0, "type": 0}
+
+            def tracked_namespaces(source: str):
+                span_calls["namespace"] += 1
+                return original_namespaces(source)
+
+            def tracked_types(source: str):
+                span_calls["type"] += 1
+                return original_types(source)
+
+            globals_map["_csharp_namespace_spans"] = tracked_namespaces
+            globals_map["_csharp_type_spans"] = tracked_types
+            namespace["analyze_file"](many_calls, root, project_values)
+            self.assertEqual({"namespace": 1, "type": 1}, span_calls)
+
     def test_javascript_nonrelative_import_endpoints_fail_closed(self) -> None:
         """Configured aliases and package imports retain URL provenance."""
 

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -7436,6 +7436,209 @@ class CorrectnessLinterContracts(unittest.TestCase):
             ),
         )
 
+    def test_csharp_httpclient_json_extension_contract_matrix(self) -> None:
+        """Cover the official mutating System.Net.Http.Json call surface.
+
+        Microsoft exposes Post/Put/PatchAsJsonAsync with string and Uri URLs,
+        inferred or explicit TValue, JsonSerializerOptions or JsonTypeInfo, and
+        cancellation-token overloads.  Extension methods can also be invoked
+        through an instance, the static class (including using-static/type
+        aliases), a null-safe receiver, or an expression receiver.  Every
+        supported shape is checked in missing, compliant, and non-required
+        polarities so adding a call name without selecting its value argument
+        cannot turn the fail-safe into a false block.
+        """
+
+        namespace = runpy.run_path(
+            str(MESSAGING_SOURCE_ANALYZER),
+            run_name="telnyx_csharp_json_extension_contract",
+        )
+        analyze = namespace["analyze_file"]
+        fetch_pattern = namespace["FETCH_CALL_RE"]
+        declared = (
+            namespace["CSHARP_HTTP_CONTENT_METHODS"]
+            + namespace["CSHARP_JSON_MUTATING_METHOD_NAMES"]
+        )
+        for method in declared:
+            with self.subTest(method=method, inventory="direct"):
+                self.assertIsNotNone(fetch_pattern.search(method + "(url, value)"))
+        for method in namespace["CSHARP_JSON_MUTATING_METHOD_NAMES"]:
+            with self.subTest(method=method, inventory="explicit-generic"):
+                self.assertIsNotNone(
+                    fetch_pattern.search(
+                        method + "<Dictionary<string, Payload>>(url, value)"
+                    )
+                )
+
+        def run(source: str) -> tuple[int, int]:
+            with tempfile.TemporaryDirectory(
+                prefix="telnyx-csharp-json-extension-"
+            ) as temp_dir:
+                root = Path(temp_dir)
+                fixture = root / "Send.cs"
+                fixture.write_text(source, encoding="utf-8")
+                total, missing = analyze(fixture, root)
+                return total, len(missing)
+
+        required = "https://api.telnyx.com/v2/messages/number_pool"
+        safe = "https://api.telnyx.com/v2/messages"
+        present = (
+            'new { to = "+1", messaging_profile_id = '
+            '"00000000-0000-4000-8000-000000000001" }'
+        )
+        absent = 'new { to = "+1" }'
+
+        def forms(method: str, url: str, payload: str) -> dict[str, str]:
+            return {
+                "instance-string": (
+                    f'await client.{method}("{url}", {payload});'
+                ),
+                "instance-uri-cancellation": (
+                    f'await client.{method}(new Uri("{url}"), {payload}, ct);'
+                ),
+                "instance-options": (
+                    f'await client.{method}("{url}", {payload}, options, ct);'
+                ),
+                "instance-type-info": (
+                    "JsonTypeInfo<object> typeInfo = GetTypeInfo();\n"
+                    f'await client.{method}(new Uri("{url}"), {payload}, '
+                    "typeInfo, ct);"
+                ),
+                "explicit-generic": (
+                    f'await client.{method}<object>('
+                    f'"{url}", {payload}, options, ct);'
+                ),
+                "qualified-static": (
+                    "await System.Net.Http.Json.HttpClientJsonExtensions."
+                    f'{method}(client, new Uri("{url}"), {payload}, options, ct);'
+                ),
+                "using-static": (
+                    "using static System.Net.Http.Json.HttpClientJsonExtensions;\n"
+                    f'await {method}(client, "{url}", {payload}, ct);'
+                ),
+                "aliased-static": (
+                    "using JsonHttp = System.Net.Http.Json.HttpClientJsonExtensions;\n"
+                    f'await JsonHttp.{method}(client, "{url}", {payload}, '
+                    "options, ct);"
+                ),
+                "global-aliased-static": (
+                    "global using JsonHttp = "
+                    "System.Net.Http.Json.HttpClientJsonExtensions;\n"
+                    f'await JsonHttp.{method}(client, "{url}", {payload}, '
+                    "options, ct);"
+                ),
+                "named-reordered": (
+                    f"await client.{method}(value: {payload}, "
+                    f'requestUri: new Uri("{url}"), cancellationToken: ct);'
+                ),
+                "null-safe-instance": (
+                    f'await client?.{method}("{url}", {payload});'
+                ),
+                "expression-instance": (
+                    f'await GetClient().{method}("{url}", {payload});'
+                ),
+            }
+
+        for verb in ("Post", "Put", "Patch"):
+            method = verb + "AsJsonAsync"
+            for form, source in forms(method, required, absent).items():
+                with self.subTest(verb=verb, form=form, polarity="missing"):
+                    self.assertEqual((1, 1), run(source))
+            for form, source in forms(method, required, present).items():
+                with self.subTest(verb=verb, form=form, polarity="present"):
+                    self.assertEqual((1, 0), run(source))
+            for form, source in forms(method, safe, absent).items():
+                with self.subTest(verb=verb, form=form, polarity="safe"):
+                    self.assertEqual((0, 0), run(source))
+
+            for path, expected in (
+                ("number_pool", (1, 0)),
+                ("messages", (0, 0)),
+            ):
+                source = (
+                    "client.BaseAddress = new Uri("
+                    '"https://api.telnyx.com/v2/messages/");\n'
+                    f'await client.{method}("{path}", {present});'
+                )
+                with self.subTest(verb=verb, form="base-address", path=path):
+                    self.assertEqual(expected, run(source))
+
+        # The same inventory omission also hid HttpClient's ordinary PUT/PATCH
+        # body overloads. They share the URL/body signature with PostAsync.
+        encoded_present = (
+            'new StringContent("{\\"messaging_profile_id\\":'
+            '\\"00000000-0000-4000-8000-000000000001\\",'
+            '\\"to\\":\\"+1\\"}")'
+        )
+        encoded_absent = 'new StringContent("{\\"to\\":\\"+1\\"}")'
+        for method in ("PostAsync", "PutAsync", "PatchAsync"):
+            with self.subTest(method=method, polarity="missing"):
+                self.assertEqual(
+                    (1, 1),
+                    run(f'await client.{method}("{required}", {encoded_absent});'),
+                )
+            with self.subTest(method=method, polarity="present"):
+                self.assertEqual(
+                    (1, 0),
+                    run(f'await client.{method}("{required}", {encoded_present});'),
+                )
+            with self.subTest(method=method, polarity="safe"):
+                self.assertEqual(
+                    (0, 0),
+                    run(f'await client.{method}("{safe}", {encoded_absent});'),
+                )
+
+        # The newly advertised PascalCase methods belong to .NET. An unrelated
+        # method with the same spelling in another advertised language must not
+        # become a transport call merely because it appears in the shared call
+        # inventory.
+        with tempfile.TemporaryDirectory(
+            prefix="telnyx-csharp-json-extension-language-scope-"
+        ) as temp_dir:
+            root = Path(temp_dir)
+            fixture = root / "Unrelated.java"
+            fixture.write_text(
+                f'helper.PutAsJsonAsync("{required}", payload);',
+                encoding="utf-8",
+            )
+            total, findings = analyze(fixture, root)
+            self.assertEqual(1, total)
+            self.assertEqual(1, len(findings))
+            self.assertIn("could not verify this send", findings[0])
+
+        # Pin the real public entry point from the review, not only the Python
+        # analyzer API: compliant JSON sends must unblock the migration, while
+        # the missing-profile polarity remains an actionable issue.
+        result, payload = self.run_messaging_linter(
+            {
+                "Send.cs": (
+                    f'await client.PostAsJsonAsync("{required}", {present});'
+                )
+            }
+        )
+        profile_check = next(
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        )
+        self.assertEqual(0, result.returncode)
+        self.assertEqual("pass", profile_check["status"])
+
+        result, payload = self.run_messaging_linter(
+            {
+                "Send.cs": (
+                    f'await client.PostAsJsonAsync("{required}", {absent});'
+                )
+            }
+        )
+        profile_check = next(
+            check
+            for check in payload["checks"]
+            if check["name"] == "required_messaging_profile_id"
+        )
+        self.assertEqual(1, result.returncode)
+        self.assertEqual("issue", profile_check["status"])
+
     def test_required_send_contract_matrix(self) -> None:
         """Cross-product contract matrix over the SUPPORTED SURFACE.
 

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -83,6 +83,9 @@ class CorrectnessLinterProductArgument(unittest.TestCase):
             "video",
             "iot",
             "lookup",
+            "numbers",
+            "phone-numbers",
+            "porting",
         ):
             with self.subTest(product=product):
                 result = self.run_product(product)
@@ -525,6 +528,324 @@ class CorrectnessLinterContracts(unittest.TestCase):
 
     JS_COMPONENT_FAMILY = (".astro", ".svelte", ".vue")
 
+    def test_mixed_templates_scan_only_executable_host_code(self) -> None:
+        for suffix in self.JS_COMPONENT_FAMILY:
+            with self.subTest(suffix=suffix):
+                result, payload = self.run_messaging_linter(
+                    {f"Component{suffix}": "<template><p>VoiceResponse()</p></template>\n"},
+                    product="voice",
+                )
+                self.assertEqual(0, result.returncode, payload)
+
+                result, payload = self.run_messaging_linter(
+                    {
+                        f"Component{suffix}": (
+                            '<template><Gather speechModel="phone_call"/></template>\n'
+                        )
+                    },
+                    product="voice",
+                )
+                self.assertEqual(1, result.returncode, payload)
+                self.assertTrue(
+                    any(check["status"] == "issue" for check in payload["checks"]),
+                    payload,
+                )
+
+        for suffix in (".ejs", ".jsp"):
+            with self.subTest(suffix=suffix):
+                result, payload = self.run_messaging_linter(
+                    {f"view{suffix}": '<% // <Gather speechModel="phone_call"/> %>\n'},
+                    product="voice",
+                )
+                self.assertEqual(0, result.returncode, payload)
+
+        native_comments = {
+            "view.ejs": '<%# <Gather speechModel="phone_call"/> %>\n',
+            "view.erb": '<%# <Gather speechModel="phone_call"/> %>\n',
+            "view.jsp": '<%-- <Gather speechModel="phone_call"/> --%>\n',
+            "view.hbs": '{{!-- <Gather speechModel="phone_call"/> --}}\n',
+            "view.handlebars": '{{! <Gather speechModel="phone_call"/> }}\n',
+            "view.mustache": '{{! <Gather speechModel="phone_call"/> }}\n',
+            "view.jinja": '{# <Gather speechModel="phone_call"/> #}\n',
+            "view.jinja2": '{# <Gather speechModel="phone_call"/> #}\n',
+            "view.twig": '{# <Gather speechModel="phone_call"/> #}\n',
+        }
+        for filename, contents in native_comments.items():
+            with self.subTest(native_comment=filename):
+                result, payload = self.run_messaging_linter(
+                    {filename: contents}, product="voice"
+                )
+                self.assertEqual(0, result.returncode, payload)
+
+        result, payload = self.run_messaging_linter(
+            {"View.cshtml": "<p>using Twilio is the old example</p>\n"}
+        )
+        self.assertEqual(0, result.returncode, payload)
+        result, payload = self.run_messaging_linter(
+            {
+                "View.cshtml": (
+                    "<p>preview</p>\n"
+                    "@using Twilio\n"
+                )
+            }
+        )
+        self.assertEqual(1, result.returncode, payload)
+        self.assertTrue(
+            any(
+                check["name"] == "residual_twilio_imports"
+                and check["status"] == "issue"
+                for check in payload["checks"]
+            ),
+            payload,
+        )
+
+    def test_template_literal_interpolation_remains_executable(self) -> None:
+        source = (
+            "async function send(to, text) {\n"
+            "  return `result: ${await client.messages.sendNumberPool({to, text})}`;\n"
+            "}\n"
+        )
+        _, payload = self.run_messaging_linter({"send.js": source})
+        check = next(
+            item
+            for item in payload["checks"]
+            if item["name"] == "required_messaging_profile_id"
+        )
+        self.assertEqual("issue", check["status"], json.dumps(payload["checks"]))
+
+    def test_body_field_modes_continue_after_one_unreadable_file(self) -> None:
+        with tempfile.TemporaryDirectory(
+            prefix="telnyx-body-field-fail-safe-"
+        ) as directory:
+            root = Path(directory)
+            unreadable = root / "unreadable.js"
+            unreadable.write_text("client.messages.send({body});\n", encoding="utf-8")
+            unreadable.chmod(0)
+            valid = root / "valid.js"
+            valid.write_text("client.messages.send({body});\n", encoding="utf-8")
+            try:
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(MESSAGING_SOURCE_ANALYZER),
+                        "--message-body-fields",
+                        str(root),
+                    ],
+                    cwd=ROOT,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                )
+            finally:
+                unreadable.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn("valid.js:1", result.stdout)
+        self.assertIn("unreadable.js:1", result.stdout)
+        self.assertIn("could not analyze this file", result.stdout)
+
+    def test_extensionless_rakefile_is_ruby_source(self) -> None:
+        for name in ("Rakefile", "rakefile"):
+            with self.subTest(name=name):
+                _, payload = self.run_messaging_linter(
+                    {
+                        name: (
+                            "client.send_number_pool(to: '+1', from: '+2', text: 'hi')\n"
+                        )
+                    }
+                )
+                self.assert_required_profile_detected(payload, name)
+
+    def test_project_state_is_loaded_without_repeating_the_flag(self) -> None:
+        result, payload = self.run_messaging_linter(
+            {
+                "app.py": "from twilio.rest import Client\n",
+                "migration-state.json": '{"kept_on_twilio":{"messaging":true}}\n',
+            }
+        )
+        self.assertEqual(0, result.returncode, payload)
+
+    def test_kept_conversations_calls_do_not_waive_telnyx_messaging_errors(
+        self,
+    ) -> None:
+        kept_result, kept_payload = self.run_messaging_linter(
+            {
+                "conversation.js": "\n".join(
+                    (
+                        "conversation.messages.create({body: 'kept one'});",
+                        "channel.messages.create({body: 'kept two'});",
+                        "client.conversations('CH1').messages.create({body: 'kept three'});",
+                        "client.conversations('CH2')\n  .messages.create({body: 'kept four'});",
+                    )
+                ),
+                "migration-state.json": (
+                    '{"kept_on_twilio":{"conversations":true}}\n'
+                ),
+            }
+        )
+        self.assertEqual(0, kept_result.returncode, kept_payload)
+
+        failing_result, failing_payload = self.run_messaging_linter(
+            {
+                "mixed.js": (
+                    "conversation.messages.create({body: 'kept'});\n"
+                    "client.messages.send({body: 'wrong Telnyx field'});\n"
+                ),
+                "migration-state.json": (
+                    '{"kept_on_twilio":{"conversations":true}}\n'
+                ),
+            }
+        )
+        self.assertEqual(1, failing_result.returncode, failing_payload)
+        body_check = next(
+            check
+            for check in failing_payload["checks"]
+            if check["name"] == "body_not_text"
+        )
+        self.assertEqual("issue", body_check["status"])
+        details = json.dumps(body_check["details"])
+        self.assertIn("wrong Telnyx field", details)
+        self.assertNotIn("kept", details)
+
+        messaging_result, messaging_payload = self.run_messaging_linter(
+            {
+                "twilio.js": "client.messages.create({body: 'kept messaging'});\n",
+                "migration-state.json": (
+                    '{"kept_on_twilio":{"messaging":true}}\n'
+                ),
+            }
+        )
+        self.assertEqual(0, messaging_result.returncode, messaging_payload)
+        messaging_check = next(
+            check
+            for check in messaging_payload["checks"]
+            if check["name"] == "twilio_messages_create"
+        )
+        self.assertEqual("warn", messaging_check["status"])
+
+        decoy_result, decoy_payload = self.run_messaging_linter(
+            {
+                "decoy.js": (
+                    "if (conversationEnabled) "
+                    "client.messages.send({body: 'must remain an issue'});\n"
+                ),
+                "migration-state.json": (
+                    '{"kept_on_twilio":{"conversations":true}}\n'
+                ),
+            }
+        )
+        self.assertEqual(1, decoy_result.returncode, decoy_payload)
+        self.assertIn("must remain an issue", json.dumps(decoy_payload))
+
+    def test_every_product_reports_missing_python_consistently(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="telnyx-no-python-") as directory:
+            result = subprocess.run(
+                [
+                    BASH,
+                    str(CORRECTNESS_LINTER),
+                    directory,
+                    "--product",
+                    "voice",
+                ],
+                cwd=ROOT,
+                env={"PATH": ""},
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        self.assertEqual(2, result.returncode, result.stdout + result.stderr)
+        self.assertIn("Python 3.10+ is required for correctness analysis", result.stderr)
+
+    def test_python_older_than_310_is_rejected_before_analysis(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="telnyx-old-python-") as directory:
+            tools = Path(directory) / "bin"
+            tools.mkdir()
+            fake_python = tools / "python3"
+            fake_python.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            fake_python.chmod(fake_python.stat().st_mode | stat.S_IXUSR)
+            project = Path(directory) / "project"
+            project.mkdir()
+            result = subprocess.run(
+                [BASH, str(CORRECTNESS_LINTER), str(project), "--product", "voice"],
+                cwd=ROOT,
+                env={"PATH": str(tools)},
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        self.assertEqual(2, result.returncode, result.stdout + result.stderr)
+        self.assertIn("Python 3.10+ is required", result.stderr)
+
+    def test_full_validation_invokes_the_profile_analyzer(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="telnyx-full-validation-") as directory:
+            project = Path(directory)
+            (project / "send.js").write_text(
+                "client.sendNumberPool({to: '+1', from: '+2', text: 'hi'});\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [BASH, str(MIGRATION_SCRIPTS.parent / "run-validation.sh"), directory],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+                env={**os.environ, "TELNYX_API_KEY": ""},
+            )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        self.assertIn("Correctness checks failed", result.stdout)
+        self.assertIn("Step 5.3: Smoke Test", result.stdout)
+        self.assertIn("Phase 5 Summary", result.stdout)
+
+    def test_endpoint_candidates_exclude_source_fixtures_and_assertions(self) -> None:
+        _, payload = self.run_messaging_linter(
+            {
+                "fixture.py": (
+                    "snippet = 'api.post(\"messages/number_pool\",'\n"
+                    "self.assertTrue(\n"
+                    "    required_endpoint('/v2/messages/number_pool')\n"
+                    ")\n"
+                )
+            }
+        )
+        check = next(
+            item
+            for item in payload["checks"]
+            if item["name"] == "required_messaging_profile_id"
+        )
+        self.assertEqual("pass", check["status"], json.dumps(payload["checks"]))
+
+    def test_full_validation_forwards_discovery_webhook_context(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="telnyx-scan-context-") as directory:
+            project = Path(directory)
+            (project / "handler.js").write_text(
+                "app.post('/hook', (req, res) => { const event = req.body.data.payload; res.sendStatus(200); });\n",
+                encoding="utf-8",
+            )
+            (project / "twilio-scan.json").write_text(
+                json.dumps(
+                    {
+                        "products_used": ["messaging"],
+                        "summary": {"has_webhook_validation": False},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [BASH, str(MIGRATION_SCRIPTS.parent / "run-validation.sh"), directory],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+                env={**os.environ, "TELNYX_API_KEY": ""},
+            )
+        self.assertIn("original code did not validate webhooks either", result.stdout)
+        self.assertIn("Correctness checks passed", result.stdout)
+
     def test_messaging_profile_linter_reads_every_js_module_extension(self) -> None:
         for suffix in self.JS_TS_FAMILY:
             with self.subTest(suffix=suffix):
@@ -560,6 +881,53 @@ class CorrectnessLinterContracts(unittest.TestCase):
                     and check["status"] in {"warn", "issue"}
                 ]
                 self.assertTrue(flagged, json.dumps(payload["checks"]))
+
+    def test_shell_checks_scan_executable_server_template_regions(self) -> None:
+        fixtures = {
+            "view.ejs": "<% const twilio = require('twilio'); %>\n",
+            "view.erb": "<% require 'twilio-ruby' %>\n",
+            "view.jsp": "<% import com.twilio.Twilio; %>\n",
+            "directive.jsp": '<%@ page import="com.twilio.Twilio" %>\n',
+        }
+        for name, source in fixtures.items():
+            with self.subTest(name=name):
+                _, payload = self.run_messaging_linter({name: source})
+                check = next(
+                    item
+                    for item in payload["checks"]
+                    if item["name"] == "residual_twilio_imports"
+                )
+                self.assertIn(check["status"], {"warn", "issue"})
+
+    def test_client_component_markup_is_not_a_server_webhook(self) -> None:
+        for suffix in (".vue", ".svelte", ".astro", ".ejs"):
+            with self.subTest(suffix=suffix):
+                source = (
+                    '<script>app.post("/preview", () => data.payload)</script>\n'
+                    if suffix == ".ejs"
+                    else '<button @click="postTodo">{{ data.payload }}</button>\n'
+                )
+                _, payload = self.run_messaging_linter(
+                    {f"Component{suffix}": source}
+                )
+                findings = [
+                    item
+                    for item in payload["checks"]
+                    if item["name"] == "webhook_ed25519_missing"
+                    and item["status"] in {"warn", "issue"}
+                ]
+                self.assertEqual([], findings, json.dumps(payload["checks"]))
+
+        _, payload = self.run_messaging_linter(
+            {"server.ejs": '<% app.post("/sms", () => data.payload); %>'}
+        )
+        findings = [
+            item
+            for item in payload["checks"]
+            if item["name"] == "webhook_ed25519_missing"
+            and item["status"] in {"warn", "issue"}
+        ]
+        self.assertEqual(1, len(findings), json.dumps(payload["checks"]))
 
     def test_language_aliases_are_analysed_as_their_canonical_language(self) -> None:
         # An extension is not a language. A .bash file is a shell script and a
@@ -615,6 +983,39 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 any(status in {"warn", "issue"} for status in statuses(canonical, violating)),
                 f"{canonical} did not flag a missing profile at all",
             )
+
+    def test_phtml_markup_cannot_mask_php_request(self) -> None:
+        source = (
+            "<p>Don't forget to send this message.</p>\n"
+            "<?php\n"
+            '$client->post("https://api.telnyx.com/v2/messages/number_pool", '
+            '["json" => ["to" => "+1", "text" => "hi"]]);\n'
+            "?>\n"
+        )
+        _, payload = self.run_messaging_linter({"send.phtml": source})
+        check = next(
+            item
+            for item in payload["checks"]
+            if item["name"] == "required_messaging_profile_id"
+        )
+        self.assertEqual("issue", check["status"], json.dumps(payload["checks"]))
+
+    def test_multiline_template_comments_preserve_speech_model_line(self) -> None:
+        source = (
+            "<!-- comment\n"
+            "     spanning\n"
+            "     lines -->\n"
+            '<Response><Gather speechModel="phone_call"/></Response>\n'
+        )
+        _, payload = self.run_messaging_linter(
+            {"ivr.xml": source}, product="voice"
+        )
+        check = next(
+            item
+            for item in payload["checks"]
+            if item["name"] == "gather_speech_model_attr"
+        )
+        self.assertIn("ivr.xml:4", json.dumps(check), json.dumps(payload["checks"]))
 
     # Each entry: (label, filename, violating, compliant). Violating sends to
     # /v2/messages/number_pool without messaging_profile_id and must be
@@ -712,6 +1113,139 @@ class CorrectnessLinterContracts(unittest.TestCase):
         self.assert_required_profile_passes(
             {"bin/send-pool": body % ", messaging_profile_id: 'abc'"}
         )
+
+    def test_extensionless_node_findings_are_not_duplicated(self) -> None:
+        _, payload = self.run_messaging_linter(
+            {
+                "bin/respond": (
+                    "#!/usr/bin/env node\n"
+                    "const response = new MessagingResponse();\n"
+                )
+            }
+        )
+        check = next(
+            item
+            for item in payload["checks"]
+            if item["name"] == "messaging_response_builder"
+        )
+        self.assertEqual(1, len(check["details"]["files"]))
+
+    def test_component_template_handlers_are_executable_javascript(self) -> None:
+        violating = {
+            "Send.vue": (
+                '<template><button @click="client.sendNumberPool('
+                "{to: '+1', text: 'hi'})\">Send</button></template>\n"
+            ),
+            "Submit.vue": (
+                "<template><form v-on:submit='client.sendNumberPool("
+                '{to: "+1", text: "hi"})\'></form></template>\n'
+            ),
+            "Modified.vue": (
+                '<button @click.prevent.stop="client.sendNumberPool('
+                "{to: '+1', text: 'hi'})\">Send</button>\n"
+            ),
+            "Send.svelte": (
+                '<button on:click={() => client.sendNumberPool('
+                "{to: '+1', text: 'hi'})}>Send</button>\n"
+            ),
+            "Modern.svelte": (
+                '<button onclick={() => client.sendNumberPool('
+                "{to: '+1', text: 'hi'})}>Send</button>\n"
+            ),
+            "Send.astro": (
+                '<button onclick={() => client.sendNumberPool('
+                "{to: '+1', text: 'hi'})}>Send</button>\n"
+            ),
+        }
+        for name, source in violating.items():
+            with self.subTest(name=name):
+                _, payload = self.run_messaging_linter({name: source})
+                self.assert_required_profile_detected(payload, name)
+
+        compliant = {
+            name: source.replace(
+                "text: 'hi'", "text: 'hi', messaging_profile_id: 'profile'"
+            ).replace(
+                'text: "hi"', 'text: "hi", messaging_profile_id: "profile"'
+            )
+            for name, source in violating.items()
+        }
+        self.assert_required_profile_passes(compliant)
+
+        _, payload = self.run_messaging_linter(
+            {
+                "Nested.vue": (
+                    "{{ client.sendNumberPool({to, metadata: {campaign}}) }}"
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, "Nested.vue")
+
+    def test_typescript_component_scripts_keep_typescript_resolution(self) -> None:
+        source = "\n".join(
+            (
+                '<script lang="ts">',
+                'const endpoint = "/v2/messages/number_pool" as const;',
+                'fetch(endpoint, {method: "POST", body: JSON.stringify({to: "+1"})});',
+                "</script>",
+            )
+        )
+        for suffix in (".vue", ".svelte", ".astro"):
+            with self.subTest(suffix=suffix):
+                _, payload = self.run_messaging_linter({f"Typed{suffix}": source})
+                self.assert_required_profile_detected(payload, f"Typed{suffix}")
+
+        unquoted = source.replace('lang="ts"', "lang=ts")
+        for suffix in (".vue", ".svelte"):
+            with self.subTest(unquoted_suffix=suffix):
+                _, payload = self.run_messaging_linter({f"Typed{suffix}": unquoted})
+                self.assert_required_profile_detected(payload, f"Typed{suffix}")
+
+        astro_frontmatter = "\n".join(
+            (
+                "---",
+                'const endpoint = "/v2/messages/number_pool" as const;',
+                'fetch(endpoint, {method: "POST", body: JSON.stringify({to: "+1"})});',
+                "---",
+            )
+        )
+        _, payload = self.run_messaging_linter({"Frontmatter.astro": astro_frontmatter})
+        self.assert_required_profile_detected(payload, "Frontmatter.astro")
+
+    def test_ejs_client_script_blocks_are_executable(self) -> None:
+        name = "send.ejs"
+        _, payload = self.run_messaging_linter(
+            {
+                name: (
+                    '<script>fetch("/v2/messages/number_pool", '
+                    '{method: "POST", body: JSON.stringify({to: "+1"})});</script>'
+                )
+            }
+        )
+        self.assert_required_profile_detected(payload, name)
+
+    def test_component_style_blocks_are_not_executable_requests(self) -> None:
+        for suffix in (".svelte", ".astro"):
+            with self.subTest(suffix=suffix):
+                self.assert_required_profile_passes(
+                    {
+                        f"Styled{suffix}": (
+                            '<style>.hero { background: url("/v2/messages/number_pool"); }</style>'
+                        )
+                    }
+                )
+
+    def test_commented_component_handlers_are_not_executable(self) -> None:
+        for suffix in (".vue", ".svelte", ".astro"):
+            with self.subTest(suffix=suffix):
+                self.assert_required_profile_passes(
+                    {
+                        f"Commented{suffix}": (
+                            '<!-- <button onclick={() => client.sendNumberPool('
+                            "{to: '+1', text: 'hi'})}>Send</button> -->\n"
+                        )
+                    }
+                )
 
     def test_uppercase_and_extensionless_python_sources_are_linted(self) -> None:
         # SMSBOT.PY and an extensionless #!/usr/bin/env python3 executable are
@@ -980,6 +1514,15 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 f"const api = axios.create({{baseURL:'{base}'}});\n"
                 "api.post('/number_pool', {to:'+1'%s});\n"
             ),
+            "defaults-instance.js": (
+                "const api = axios.create();\n"
+                f"api.defaults.baseURL = '{base}';\n"
+                "api.post('/number_pool', {to:'+1'%s});\n"
+            ),
+            "defaults-global.js": (
+                f"axios.defaults.baseURL = '{base}';\n"
+                "axios.post('/number_pool', {to:'+1'%s});\n"
+            ),
             "httpx.py": (
                 f"httpx.Client(base_url='{base}')"
                 ".post('/number_pool', json={'to':'+1'%s})"
@@ -1005,7 +1548,12 @@ class CorrectnessLinterContracts(unittest.TestCase):
                 "other.js": (
                     "axios.create({baseURL:'https://api.telnyx.com/v2/messages'})"
                     ".post('/', {to: '+1'});"
-                )
+                ),
+                "defaults-other.js": (
+                    "axios.defaults.baseURL = "
+                    "'https://api.telnyx.com/v2/messages';\n"
+                    "axios.post('/other', {to: '+1'});"
+                ),
             }
         )
 
@@ -4587,6 +5135,28 @@ class CorrectnessLinterContracts(unittest.TestCase):
         )
         self.assert_required_profile_detected(payload, fixture_name)
 
+    def test_recognized_call_does_not_mask_unrecognized_required_send(self) -> None:
+        fixtures = {
+            "mixed.ts": "\n".join(
+                (
+                    "client.sendNumberPool({to, messaging_profile_id: profileId});",
+                    'custom.fire("https://api.telnyx.com/v2/messages/number_pool", {to});',
+                )
+            ),
+            "multiline.ts": "\n".join(
+                (
+                    "custom.fire(",
+                    '  "https://api.telnyx.com/v2/messages/number_pool",',
+                    "  {to}",
+                    ");",
+                )
+            ),
+        }
+        result, payload = self.run_messaging_linter(fixtures)
+        self.assertEqual(1, result.returncode)
+        for fixture_name in fixtures:
+            self.assert_required_profile_detected(payload, fixture_name)
+
     def test_unrelated_requests_comments_and_strings_do_not_mask_missing_profile(
         self,
     ) -> None:
@@ -6173,6 +6743,20 @@ class CorrectnessLinterContracts(unittest.TestCase):
 
 
 class AnalyzerConsistencyContracts(unittest.TestCase):
+    def test_texml_runtime_guidance_matches_analyzer_contracts(self) -> None:
+        skill = (ROOT / "skills/telnyx-twilio-migration/SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        verbs = (
+            ROOT / "skills/telnyx-twilio-migration/references/texml-verbs.md"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn("`speechModel` does NOT exist in TeXML", skill)
+        self.assertIn("<Language speechModel", skill)
+        self.assertIn("map to the corresponding TeXML element's `model`", skill)
+        self.assertNotIn("non-Neural voices may fall back", skill)
+        self.assertNotIn("non-Neural voices may fall back", verbs)
+        self.assertIn("Preserve a supported source voice verbatim", verbs)
+
     def test_analyzer_and_shell_exclude_the_same_generated_directories(self) -> None:
         canonical = {
             ".next", ".nuxt", "coverage", ".tox", "node_modules", "dist", "build"

--- a/tests/test_twilio_migration_analyzer.py
+++ b/tests/test_twilio_migration_analyzer.py
@@ -1502,6 +1502,596 @@ class CorrectnessLinterContracts(unittest.TestCase):
             with self.subTest(shape=label, body="compliant"):
                 self.assert_required_profile_passes({name: template % profile})
 
+    def test_go_request_constructor_signatures_through_wrapper(self) -> None:
+        # net/http.NewRequestWithContext inserts ctx before method, URL, body.
+        url = '"https://api.telnyx.com/v2/messages/number_pool"'
+        for profile in (False, True):
+            files = {}
+            for constructor in ("NewRequest", "NewRequestWithContext"):
+                for alias in (False, True):
+                    context = "ctx, " if constructor.endswith("WithContext") else ""
+                    field = ', "messaging_profile_id": "mp"' if profile else ""
+                    endpoint = "endpoint" if alias else url
+                    name = f"{constructor}_{'alias' if alias else 'direct'}.go"
+                    files[name] = (
+                        "package main\nfunc send() {\n"
+                        + (f"endpoint := {url}\n" if alias else "")
+                        + 'payload := map[string]string{"to": "+1", "text": "hi"'
+                        + field + "}\nbody, _ := json.Marshal(payload)\n"
+                        + f'req, _ := http.{constructor}({context}"POST", '
+                        + f"{endpoint}, bytes.NewBuffer(body))\n"
+                        + "http.DefaultClient.Do(req)\n}\n"
+                    )
+            result, payload = self.run_messaging_linter(files)
+            with self.subTest(profile=profile):
+                self.assertEqual(0 if profile else 1, result.returncode, payload)
+            if profile:
+                self.assertEqual("pass", next(
+                    item["status"] for item in payload["checks"]
+                    if item["name"] == "required_messaging_profile_id"
+                ), payload)
+            else:
+                for name in files:
+                    with self.subTest(profile=profile, file=name):
+                        self.assert_required_profile_detected(payload, name)
+
+    def test_node_request_overloads_attach_body_to_returned_handle(self) -> None:
+        # http(s).request supports (options[, callback]) and
+        # (url[, options][, callback]); a callback is never the request body.
+        for profile in (False, True):
+            files = {}
+            for transport in ("http", "https"):
+                for url_overload in (False, True):
+                    for callback in (False, True):
+                        for body_method in ("write", "end"):
+                            name = (
+                                f"{transport}_{'url' if url_overload else 'options'}"
+                                f"_{callback}_{body_method}.js"
+                            )
+                            options = "{method:'POST'"
+                            if not url_overload:
+                                options += (
+                                    ",hostname:'api.telnyx.com',"
+                                    "path:'/v2/messages/number_pool'"
+                                )
+                            options += "}"
+                            args = options
+                            if url_overload:
+                                args = f"'{transport}://api.telnyx.com/v2/messages/number_pool', " + args
+                            if callback:
+                                args += ", response => response.resume()"
+                            field = ",messaging_profile_id:'mp'" if profile else ""
+                            files[name] = (
+                                f"const {transport} = require('{transport}');\n"
+                                f"const payload = JSON.stringify({{to:'+1',text:'hi'{field}}});\n"
+                                f"const req = {transport}.request({args});\n"
+                                f"req.{body_method}(payload);\n"
+                                + ("req.end();\n" if body_method == "write" else "")
+                            )
+            result, payload = self.run_messaging_linter(files)
+            with self.subTest(profile=profile):
+                self.assertEqual(0 if profile else 1, result.returncode, payload)
+            if profile:
+                self.assertEqual("pass", next(
+                    item["status"] for item in payload["checks"]
+                    if item["name"] == "required_messaging_profile_id"
+                ), payload)
+            else:
+                for name in files:
+                    with self.subTest(profile=profile, file=name):
+                        self.assert_required_profile_detected(payload, name)
+
+    def test_request_signature_read_only_and_unrelated_handle_controls(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        files = {}
+        for constructor in ("NewRequest", "NewRequestWithContext"):
+            context = "ctx, " if constructor.endswith("WithContext") else ""
+            for label, method in (("get", '"GET"'), ("default", '""')):
+                files[f"{constructor}_{label}.go"] = (
+                    f'endpoint := "{url}"\n'
+                    f"req, _ := http.{constructor}({context}{method}, endpoint, nil)\n"
+                    "http.DefaultClient.Do(req)\n"
+                )
+        for transport in ("http", "https"):
+            for options in ("{}", "{method:'GET'}"):
+                files[f"{transport}_{'get' if 'GET' in options else 'default'}.js"] = (
+                    f"const {transport} = require('{transport}');\n"
+                    f"const req = {transport}.request('{url}', {options}, res => res.resume());\n"
+                    "req.end();\n"
+                )
+        self.assert_required_profile_passes(files)
+
+        # A valid profile written to a different request must not satisfy req.
+        result, payload = self.run_messaging_linter({"unrelated.js": (
+            "const https = require('https');\n"
+            f"const req = https.request('{url}', {{method:'POST'}}, res => res.resume());\n"
+            "const other = https.request('https://example.com/events', {method:'POST'});\n"
+            "other.write(JSON.stringify({messaging_profile_id:'mp'}));\n"
+            "other.end();\nreq.end(JSON.stringify({to:'+1',text:'hi'}));\n"
+        )})
+        self.assertEqual(1, result.returncode, payload)
+        self.assert_required_profile_detected(payload, "unrelated.js")
+
+    def test_node_request_handle_lifetime_and_alias_matrix(self) -> None:
+        url = "https://api.telnyx.com/v2/messages/number_pool"
+        request = f"https.request('{url}', {{method:'POST'}})"
+        other = "https.request('https://example.com/events', {method:'POST'})"
+        present = "JSON.stringify({to:'+1',messaging_profile_id:'mp'})"
+        absent = "JSON.stringify({to:'+1'})"
+        prefix = "const https = require('https');\n"
+        negatives = {
+            "sibling.js": (
+                f"function first() {{ const req = {request}; req.write({absent}); }}\n"
+                f"function second() {{ const req = {other}; req.end({present}); }}\n"
+            ),
+            "shadow.js": (
+                f"const req = {request};\n"
+                f"{{ const req = {other}; req.end({present}); }}\n"
+                f"req.end({absent});\n"
+            ),
+            "reassigned.js": (
+                f"let req = {request}; req.write({absent});\n"
+                f"req = {other}; req.end({present});\n"
+            ),
+            "after_end.js": (
+                f"const req = {request}; req.end({absent});\n"
+                f"req.write({present});\n"
+            ),
+            "callback_decoy.js": (
+                f"const req = https.request('{url}', {{method:'POST'}}, res => {{\n"
+                f"  const body = {present}; console.log(body);\n"
+                "});\nreq.end();\n"
+            ),
+            "end_callback.js": (
+                f"const req = {request};\n"
+                f"req.end(() => {{ const body = {present}; console.log(body); }});\n"
+            ),
+        }
+        result, payload = self.run_messaging_linter({
+            name: prefix + source for name, source in negatives.items()
+        })
+        self.assertEqual(1, result.returncode, payload)
+        for name in negatives:
+            with self.subTest(case=name):
+                self.assert_required_profile_detected(payload, name)
+
+        positives = {}
+        for suffix in ("js", "ts"):
+            for url_overload in (False, True):
+                for body_method in ("write", "end"):
+                    options = "{method:'POST'"
+                    if not url_overload:
+                        options += ",hostname:'api.telnyx.com',path:'/v2/messages/number_pool'"
+                    options += "}"
+                    args = "endpoint, options" if url_overload else "options"
+                    name = f"aliases_{url_overload}_{body_method}.{suffix}"
+                    positives[name] = (
+                        prefix + f"const endpoint = '{url}';\nconst options = {options};\n"
+                        f"const req = https.request({args}, res => res.resume());\n"
+                        f"req.{body_method}({present});\n"
+                        + ("req.end();\n" if body_method == "write" else "")
+                    )
+        self.assert_required_profile_passes(positives)
+
+    def test_node_request_execution_paths_and_chained_bodies(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        present = "JSON.stringify({to:'+1',messaging_profile_id:'mp'})"
+        absent = "JSON.stringify({to:'+1'})"
+        request = f"https.request('{endpoint}', {{method:'POST'}})"
+        prefix = "const https = require('node:https');\n"
+        cases = {
+            "dead_write": (f"const req={request}; if(false){{req.write({present});}} req.end({absent});", False),
+            "dead_end": (f"const req={request}; if(false){{req.end();}} req.end({present});", True),
+            "optional_write": (f"const req={request}; if(flag){{req.write({present});}} req.end();", False),
+            "both_ends_present": (f"const req={request}; if(flag){{req.end({present});}}else{{req.end({present});}}", True),
+            "one_end_missing": (f"const req={request}; if(flag){{req.end({present});}}else{{req.end({absent});}}", False),
+            "both_writes_present": (f"const req={request}; if(flag){{req.write({present});}}else{{req.write({present});}} req.end();", True),
+            "uninvoked_writer": (f"const req={request}; function unused(){{req.write({present});}} req.end({absent});", False),
+            "false_and_write": (f"const req={request}; false && req.write({present}); req.end({absent});", False),
+            "true_or_write": (f"const req={request}; true || req.write({present}); req.end({absent});", False),
+            "ternary_present": (f"const req={request}; flag ? req.end({present}) : req.end({present});", True),
+            "ternary_missing": (f"const req={request}; flag ? req.end({present}) : req.end({absent});", False),
+            "handle_alias_present": (f"const req={request}; const out=req; out.end({present});", True),
+            "handle_alias_missing": (f"const req={request}; const out=req; out.end({absent});", False),
+            "dead_reassignment": (f"let req={request}; if(false){{req=other;}} req.end({present});", True),
+            "alias_before_reassignment": (f"let req={request}; const out=req; req=other; out.end({present});", True),
+            "alias_after_reassignment": (f"let req={request}; req=other; const out=req; out.end({present});", False),
+            "chained_present": (f"{request}.end({present});", True),
+            "chained_missing": (f"{request}.end({absent});", False),
+            "chained_callback_only": (f"{request}.end(()=>{{const body={present};}});", False),
+        }
+        for expected in (False, True):
+            files = {name + ".js": prefix + source for name, (source, compliant) in cases.items()
+                     if compliant == expected}
+            result, payload = self.run_messaging_linter(files)
+            self.assertEqual(0 if expected else 1, result.returncode, payload)
+            if expected:
+                self.assertEqual("pass", next(check["status"] for check in payload["checks"]
+                                             if check["name"] == "required_messaging_profile_id"), payload)
+            else:
+                for name in files:
+                    with self.subTest(file=name):
+                        self.assert_required_profile_detected(payload, name)
+
+    def test_request_member_and_execution_siblings(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        present = "JSON.stringify({to:'+1',messaging_profile_id:'mp'})"
+        absent = "JSON.stringify({to:'+1'})"
+        prefix = f"const https=require('https'); const req=https.request('{endpoint}',{{method:'POST'}});\n"
+        cases = {
+            "member_decoy": (f"const state={{req:https.request('https://example.com/events',{{method:'POST'}})}};state.req.end({present});req.end({absent});", False),
+            "member_decoy_write": (f"const state={{req:https.request('https://example.com/events',{{method:'POST'}})}};state.req.write({present});state.req.end();req.end({absent});", False),
+            "comma": (f"flag && sideEffect(), req.end({present});", True),
+            "comma_or": (f"flag || sideEffect(), req.end({present});", True),
+            "comma_missing": (f"flag && sideEffect(), req.end({absent});", False),
+            "iife_arrow": (f"(()=>req.write({present}))();req.end();", True),
+            "iife_function": (f"(function(){{req.write({present});}})();req.end();", True),
+            "unused_function": (f"const unused=()=>req.write({present});req.end({absent});", False),
+            "callback": (f"setTimeout(()=>req.write({present}),0);req.end({absent});", False),
+            "parenthesized_callback": (f"run((function(){{req.write({present});}}));req.end({absent});", False),
+            "function_callback": (f"run(function(){{req.write({present});}});req.end({absent});", False),
+            "stored_function": (f"const unused=(function(){{req.write({present});}});req.end({absent});", False),
+        }
+        for expected in (False, True):
+            files = {name+'.js':prefix+body for name,(body,good) in cases.items() if good==expected}
+            result, payload = self.run_messaging_linter(files)
+            self.assertEqual(0 if expected else 1, result.returncode, payload)
+            if not expected:
+                for name in files:
+                    self.assert_required_profile_detected(payload, name)
+        for body, expected in ((present,True),(absent,False)):
+            source = ("const https=require('https');const state={};"
+                      +f"state.req=https.request('{endpoint}',{{method:'POST'}});state.req.end({body});")
+            result,payload=self.run_messaging_linter({'member-own.js':source})
+            self.assertEqual(0 if expected else 1,result.returncode,payload)
+        source = ("const https=require('https');const left={},right={};"
+                  +f"left.req=https.request('{endpoint}',{{method:'POST'}});"
+                  +"right.req=https.request('https://example.com/events',{method:'POST'});"
+                  +f"right.req.end({present});left.req.end({absent});")
+        result,payload=self.run_messaging_linter({'member-other.js':source})
+        self.assertEqual(1,result.returncode,payload)
+        self.assert_required_profile_detected(payload,'member-other.js')
+        for mutation in ("state.req=other;", "state={};"):
+            source=("const https=require('https');let state={};"
+                    +f"state.req=https.request('{endpoint}',{{method:'POST'}});"
+                    +mutation+f"state.req.end({present});")
+            result,payload=self.run_messaging_linter({'member-reset.js':source})
+            self.assertEqual(1,result.returncode,payload)
+        source=("const https=require('https');const state={};"
+                +f"state.req=https.request('{endpoint}',{{method:'POST'}});"
+                +f"const alias=state.req;alias.end({present});")
+        self.assert_required_profile_passes({'member-alias.js':source})
+
+    def test_request_closure_defaults_and_abrupt_completion_matrix(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        present = "JSON.stringify({messaging_profile_id:'mp'})"
+        absent = "JSON.stringify({to:'+1'})"
+        prefix = f"const https=require('https');const req=https.request('{endpoint}',{{method:'POST'}});"
+        cases = {
+            "stored_arrow_default": (f"const later=(x=req.write({present}))=>{{}};req.end({absent});", False),
+            "stored_function_default": (f"const later=function(x=req.write({present})){{}};req.end({absent});", False),
+            "callback_default": (f"run((x=req.write({present}))=>{{}});req.end({absent});", False),
+            "called_arrow_default": (f"((x=req.write({present}))=>{{}})();req.end();", True),
+            "called_function_default": (f"(function(x=req.write({present})){{}})();req.end();", True),
+            "supplied_arrow_argument": (f"((x=req.write({present}))=>{{}})(1);req.end({absent});", False),
+            "supplied_function_argument": (f"(function(x=req.write({present})){{}})(1);req.end({absent});", False),
+            "undefined_default": (f"((x=req.write({present}))=>{{}})(undefined);req.end();", True),
+            "void_default": (f"((x=req.write({present}))=>{{}})(void 0);req.end();", True),
+            "null_skips_default": (f"((x=req.write({present}))=>{{}})(null);req.end({absent});", False),
+            "unreachable_arrow_write": (f"(()=>{{return;req.write({present});}})();req.end({absent});", False),
+            "unreachable_function_write": (f"(function(){{return;req.write({present});}})();req.end({absent});", False),
+            "conditional_return": (f"(()=>{{if(flag)return;req.write({present});}})();req.end({absent});", False),
+            "literal_false_return": (f"(()=>{{if(false)return;req.write({present});}})();req.end();", True),
+            "return_expression": (f"(()=>{{return req.write({present});}})();req.end();", True),
+            "write_before_return": (f"(()=>{{req.write({present});return;}})();req.end();", True),
+            "caught_throw": (f"try{{(()=>{{throw Error();req.write({present});}})();}}catch(e){{}}req.end({absent});", False),
+            "conditional_throw": (f"try{{(()=>{{if(flag)throw Error();req.write({present});}})();}}catch(e){{}}req.end({absent});", False),
+            "async_default": (f"(async(x=req.write({present}))=>{{}})();req.end({absent});", False),
+            "async_await": (f"(async()=>{{await tick();req.write({present});}})();req.end({absent});", False),
+            "generator": (f"(function*(){{req.write({present});}})();req.end({absent});", False),
+            "call_present": (f"(function(){{req.write({present});}}).call(null);req.end();", True),
+            "call_absent": (f"(function(){{req.write({absent});}}).call(null);req.end();", False),
+            "ternary_comma_present": (f"flag?side():side(),req.end({present});", True),
+            "ternary_comma_absent": (f"flag?side():side(),req.end({absent});", False),
+            "nested_comma_guard": (f"flag?(side(),req.write({present})):side();req.end({absent});", False),
+            "argument_iife": (f"((out)=>out.write({present}))(req);req.end();", True),
+            "argument_iife_missing": (f"((out)=>out.write({absent}))(req);req.end();", False),
+            "argument_iife_other": (f"((out)=>out.write({present}))(other);req.end({absent});", False),
+            "argument_iife_rebound": (f"((out)=>{{out=other;out.write({present});}})(req);req.end({absent});", False),
+            "logical_exhaustive": (f"flag&&req.end({present})||req.end({present});", True),
+            "logical_missing_first": (f"flag&&req.end({absent})||req.end({present});", False),
+            "logical_missing_last": (f"flag&&req.end({present})||req.end({absent});", False),
+            "logical_nonexhaustive": (f"flag&&req.end({present})||other&&req.end({present});", False),
+            "logical_grouped_exhaustive": (f"(flag&&req.end({present}))||req.end({present});", True),
+            "destructured_default_skipped": (f"(({{x=req.write({present})}}={{x:1}})=>{{}})();req.end({absent});", False),
+            "finally_write": (f"(()=>{{try{{return;}}finally{{req.write({present});}}}})();req.end();", True),
+            "finally_missing": (f"(()=>{{try{{return;}}finally{{req.write({absent});}}}})();req.end();", False),
+        }
+        for expected in (False, True):
+            selected = [(name + '.js', prefix + body) for name, (body, good) in cases.items() if good == expected]
+            # The public report deliberately caps issue details at 20 files.
+            for start in range(0, len(selected), 12):
+                files = dict(selected[start:start + 12])
+                result, payload = self.run_messaging_linter(files)
+                self.assertEqual(0 if expected else 1, result.returncode, payload)
+                if not expected:
+                    for name in files:
+                        with self.subTest(file=name):
+                            self.assert_required_profile_detected(payload, name)
+        source = (prefix.replace("const req=", "let req=") + "const saved=req;const other={write(){}};"
+                  + f"(()=>{{try{{return;}}finally{{req=other;}}}})();req.write({present});saved.end({absent});")
+        result, payload = self.run_messaging_linter({'finally-rebind.js': source})
+        self.assertEqual(1, result.returncode, payload)
+        self.assert_required_profile_detected(payload, 'finally-rebind.js')
+        source = (prefix.replace("const req=", "let req=") + "const saved=req;const other={write(){}};"
+                  + f"(()=>{{try{{throw Error();}}catch(e){{req=other;}}}})();req.write({present});saved.end({absent});")
+        result, payload = self.run_messaging_linter({'caught-throw-rebind.js': source})
+        self.assertEqual(1, result.returncode, payload)
+        self.assert_required_profile_detected(payload, 'caught-throw-rebind.js')
+
+    def test_request_owner_alias_lifetime_matrix(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        present = "JSON.stringify({messaging_profile_id:'mp'})"
+        absent = "JSON.stringify({to:'+1'})"
+        prefix = f"const https=require('https');let state={{}};state.req=https.request('{endpoint}',{{method:'POST'}});"
+        cases = {
+            "owner_alias": (f"const alias=state;alias.req.end({present});", True),
+            "owner_alias_missing": (f"const alias=state;alias.req.end({absent});", False),
+            "owner_rebound_alias_retained": (f"const alias=state;state={{}};alias.req.end({present});", True),
+            "owner_rebound_original_lost": (f"const alias=state;state={{}};state.req.end({present});alias.req.end({absent});", False),
+            "alias_rebound_original_retained": (f"let alias=state;alias={{}};state.req.end({present});", True),
+            "alias_rebound_lost": (f"let alias=state;alias={{}};alias.req.end({present});state.req.end({absent});", False),
+            "alias_mutates_shared_member": (f"const alias=state;alias.req=other;state.req.end({present});", False),
+            "retained_handle_after_member_mutation": (f"const alias=state;const saved=state.req;alias.req=other;saved.end({present});", True),
+            "conditional_alias": (f"let alias=other;if(flag)alias=state;alias.req.end({present});", False),
+        }
+        for expected in (False, True):
+            files = {name + '.js': prefix + body for name, (body, good) in cases.items() if good == expected}
+            result, payload = self.run_messaging_linter(files)
+            self.assertEqual(0 if expected else 1, result.returncode, payload)
+            if not expected:
+                for name in files:
+                    self.assert_required_profile_detected(payload, name)
+
+    def test_alternate_ternary_guards_do_not_certify_missing_paths(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        for operator in ("&&", "||", "??"):
+            files = {
+                "fetch.js": ("const payload={to:'+1'};flag ? payload.messaging_profile_id='mp' : other "
+                             +operator+" (payload.messaging_profile_id='other');"
+                             +f"fetch('{endpoint}',{{method:'POST',body:JSON.stringify(payload)}});"),
+                "node.js": (f"const https=require('https');const req=https.request('{endpoint}',{{method:'POST'}});"
+                            +"flag ? req.write(JSON.stringify({messaging_profile_id:'mp'})) : other "
+                            +operator+" req.write(JSON.stringify({messaging_profile_id:'mp'}));req.end();"),
+            }
+            result,payload=self.run_messaging_linter(files)
+            self.assertEqual(1,result.returncode,payload)
+            for name in files:
+                self.assert_required_profile_detected(payload,name)
+
+    def test_request_parameter_value_and_alias_boundaries(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        prefix = ("const https=require('https');let req=https.request('" + endpoint
+                  + "',{method:'POST'});const saved=req;const other={write(){}};")
+        for present in (False, True):
+            body = "JSON.stringify({messaging_profile_id:'mp'})" if present else "JSON.stringify({to:'+1'})"
+            shapes = {
+                "prior_default_alias": f"((out=req,x=out.write({body}))=>{{}})();req.end();",
+                "prior_default_alias_function": f"(function(out=req,x=out.write({body})){{}})();req.end();",
+                "prior_default_chain": f"((out=req,alias=out,x=alias.write({body}))=>{{}})();req.end();",
+                "void_call": f"function side(){{}}((x=req.write({body}))=>{{}})(void side());req.end();",
+                "void_expression": f"((x=req.write({body}))=>{{}})(void(1+2));req.end();",
+                "returned_undefined": f"((x=req.write({body}))=>{{}})((()=>{{return undefined;}})());req.end();",
+                "returned_void": f"((x=req.write({body}))=>{{}})((()=>{{return void 0;}})());req.end();",
+                "bare_return": f"((x=req.write({body}))=>{{}})((()=>{{return;}})());req.end();",
+                "call_alias": f"(function(out){{out.write({body});}}).call(null,req);req.end();",
+                "call_default_alias": f"(function(out=req){{out.write({body});}}).call(null);req.end();",
+                "call_supplied_default_alias": f"(function(out=other){{out.write({body});}}).call(null,req);req.end();",
+                "supplied_alias_next_default": f"((out,x=out.write({body}))=>{{}})(req);req.end();",
+                "captured_before_later_void": f"((out)=>out.write({body}))(req,void(req=other));saved.end();",
+                "captured_default_before_later_void": f"((out,x=out.write({body}))=>{{}})(req,void(req=other));saved.end();",
+                "default_captures_supplied_alias": f"((out,alias=out,x=alias.write({body}))=>{{}})(req);saved.end();",
+            }
+            result, payload = self.run_messaging_linter({name+'.js':prefix+source for name,source in shapes.items()})
+            self.assertEqual(0 if present else 1, result.returncode, payload)
+            if not present:
+                for name in shapes:
+                    self.assert_required_profile_detected(payload, name+'.js')
+        p = "JSON.stringify({messaging_profile_id:'mp'})"
+        absent = "saved.end(JSON.stringify({to:'+1'}));"
+        negatives = {
+            "uncalled": f"const later=(out=req,x=out.write({p}))=>{{}};"+absent,
+            "supplied_alias_other": f"((out=req,x=out.write({p}))=>{{}})(other);"+absent,
+            "call_alias_other": f"(function(out){{out.write({p});}}).call(null,other);"+absent,
+            "call_receiver_not_argument": f"(function(out=other){{out.write({p});}}).call(req);"+absent,
+            "call_alias_rebound": f"(function(out){{out=other;out.write({p});}}).call(null,req);"+absent,
+            "returned_null": f"((x=req.write({p}))=>{{}})((()=>{{return null;}})());"+absent,
+            "returned_conditional": f"((x=req.write({p}))=>{{}})((()=>{{return flag?undefined:1;}})());"+absent,
+            "shadowed_undefined": f"((undefined)=>{{((x=req.write({p}))=>{{}})((()=>{{return undefined;}})());}})(1);"+absent,
+            "unknown_result": f"((x=req.write({p}))=>{{}})(getValue());"+absent,
+            "void_reassigns_handle": f"((x=req.write({p}))=>{{}})(void(req=other));"+absent,
+            "void_comparison_defined": f"function side(){{}}((x=req.write({p}))=>{{}})(void side() === undefined);"+absent,
+            "void_logical_defined": f"function side(){{}}((x=req.write({p}))=>{{}})(void side() || 1);"+absent,
+            "void_comma_defined": f"function side(){{}}((x=req.write({p}))=>{{}})((void side(), 1));"+absent,
+            "argument_reassigns_handle": f"((out)=>out.write({p}))((req=other));"+absent,
+            "default_after_later_argument": f"((out=req,x)=>out.write({p}))(undefined,req=other);"+absent,
+            "named_void_helper_reassigns": f"function side(){{req=other;}}((x=req.write({p}))=>{{}})(void side());"+absent,
+        }
+        result,payload=self.run_messaging_linter({name+'.js':prefix+source for name,source in negatives.items()})
+        self.assertEqual(1,result.returncode,payload)
+        for name in negatives:
+            self.assert_required_profile_detected(payload,name+'.js')
+
+    def test_request_call_parameter_alias_suffix_parity(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        for present in (False, True):
+            body = "JSON.stringify({messaging_profile_id:'mp'})" if present else "JSON.stringify({to:'+1'})"
+            files = {}
+            for suffix in (".js", ".jsx", ".cjs", ".mjs", ".ts", ".tsx", ".cts", ".mts"):
+                imported = ("import * as https from 'node:https';" if suffix in {".mjs", ".mts"}
+                            else "const https=require('node:https');")
+                files['call'+suffix] = (imported+f"const req=https.request('{endpoint}',{{method:'POST'}});"
+                                       +f"(function(out){{out.write({body});}}).call(null,req);req.end();")
+            result,payload=self.run_messaging_linter(files)
+            self.assertEqual(0 if present else 1,result.returncode,payload)
+            if not present:
+                for name in files:
+                    self.assert_required_profile_detected(payload,name)
+
+    def test_request_execution_repairs_cover_js_ts_suffixes(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        write = "req.write(JSON.stringify({messaging_profile_id:'mp'}))"
+        absent = "req.end(JSON.stringify({to:'+1'}));"
+        shapes = {
+            "stored": (f"const later=(x={write})=>{{}};" + absent, False),
+            "unreachable": (f"(()=>{{return;{write};}})();" + absent, False),
+            "called": (f"((x={write})=>{{}})();req.end();", True),
+            "finally": (f"(()=>{{try{{return;}}finally{{{write};}}}})();req.end();", True),
+        }
+        for good in (False, True):
+            files = {}
+            for suffix in (".js", ".jsx", ".cjs", ".mjs", ".ts", ".tsx", ".cts", ".mts"):
+                imported = ("import * as https from 'node:https';" if suffix in {".mjs", ".mts"}
+                            else "const https=require('node:https');")
+                prefix = imported + f"const req=https.request('{endpoint}',{{method:'POST'}});"
+                for name, (body, expected) in shapes.items():
+                    if expected == good:
+                        files[name + suffix] = prefix + body
+            result, payload = self.run_messaging_linter(files)
+            self.assertEqual(0 if good else 1, result.returncode, payload)
+            if not good:
+                for name in files:
+                    self.assert_required_profile_detected(payload, name)
+
+    def test_shell_nested_substitutions_keep_their_own_quote_context(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        for present in (False, True):
+            body = '{"to":"+1"' + (',"messaging_profile_id":"mp"' if present else '') + '}'
+            curl = f"curl -X POST '{endpoint}' -d '{body}'"
+            inert = f'curl -X POST "{endpoint}" -d "{{}}"'
+            expressions = {
+                "dollar_live": (f'$(printf "%s" "$({curl})")', True),
+                "dollar_literal": (f'$(printf "%s" \'$({inert})\')', False),
+                "backtick_literal": (f'$(printf "%s" \'`{inert}`\')', False),
+                "comment_literal": (f'$(printf safe # $({inert})\n)', False),
+                "comment_open_paren": (f'$(printf safe # (\n{curl})', True),
+                "comment_close_paren": (f'$(printf safe # )\n{curl})', True),
+                "hash_in_word": (f'$(printf word#; {curl})', True),
+                "escaped_hash": (f'$(printf \\#; {curl})', True),
+                "quoted_hash": (f"$(printf '#('; {curl})", True),
+                "escaped_space_hash": (f'$(printf word\\ #; {curl})', True),
+                "backtick_live": (f'`{curl}`', True),
+                "adjacent_live": (f'$(printf "%s" \'$({inert})\')$({curl})', True),
+            }
+            for name, (expression, executes) in expressions.items():
+                with self.subTest(present=present, shape=name):
+                    source = f"cat <<DOC\n{expression}\nDOC\n"
+                    result, payload = self.run_messaging_linter({"nested.sh": source})
+                    check = next(c for c in payload["checks"] if c["name"] == "required_messaging_profile_id")
+                    self.assertEqual("issue" if executes and not present else "pass", check["status"], payload)
+                    self.assertEqual(1 if executes and not present else 0, result.returncode, payload)
+
+    def test_shell_heredoc_substitutions_obey_delimiter_quoting(self) -> None:
+        openers = (("<<DOC",True),("<< DOC",True),("<<-DOC",True),
+                   ("<<'DOC'",False),('<<"DOC"',False),("<<\\DOC",False),("<<D'OC'",False))
+        for profile in (False,True):
+            files = {}
+            required = []
+            for index,(opener,expands) in enumerate(openers):
+                body = '{"to":"+1"'+(',"messaging_profile_id":"mp"' if profile else '')+'}'
+                curl = "curl -X POST 'https://api.telnyx.com/v2/messages/number_pool' -d '"+body+"'"
+                for form,command in (("dollar",'$('+curl+')'),("backtick",'`'+curl+'`')):
+                    name=f"heredoc_{index}_{form}.sh"
+                    files[name]='cat '+opener+'\n'+command+'\nDOC\n'
+                    if expands and not profile:
+                        required.append(name)
+            files['mixed-delimiters.sh'] = 'cat <<FIRST <<\'SECOND\'\n$('+curl+')\nFIRST\n$(curl bogus)\nSECOND\n'
+            if not profile:
+                required.append('mixed-delimiters.sh')
+            files['escaped-substitution.sh'] = 'cat <<DOC\n\\$('+curl+')\nDOC\n'
+            result,payload=self.run_messaging_linter(files)
+            self.assertEqual(0 if profile else 1,result.returncode,payload)
+            check=next(c for c in payload['checks'] if c['name']=='required_messaging_profile_id')
+            for name in required:
+                self.assert_required_profile_detected(payload,name)
+            if not profile:
+                details=json.dumps(check)
+                for name in files:
+                    if name not in required:
+                        self.assertNotIn(name,details)
+
+    def test_nested_ternary_profile_writes_remain_conditional(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        for wrapper in ("%s", "(%s)", "console.log(%s)", "console.log((%s))",
+                        "flag ?? %s", "flag && %s", "flag || %s"):
+            for complete in (False, True):
+                alternate = "payload.messaging_profile_id='other'" if complete else "null"
+                source = (
+                    "const payload={to:'+1'};\n"
+                    + wrapper % ("flag ? payload.messaging_profile_id='mp' : " + alternate)
+                    + f";\nfetch('{endpoint}',{{method:'POST',body:JSON.stringify(payload)}});\n"
+                )
+                with self.subTest(wrapper=wrapper, complete=complete):
+                    result, payload = self.run_messaging_linter({"ternary.js": source})
+                    self.assertEqual(0 if complete else 1, result.returncode, payload)
+                    if not complete:
+                        self.assert_required_profile_detected(payload, "ternary.js")
+        for operator in ("&&", "||", "??", "&&=", "||=", "??="):
+            with self.subTest(outer_guard=operator):
+                source = (
+                    "const payload={to:'+1'}; let flag=getFlag();\n"
+                    f"flag {operator} (other ? payload.messaging_profile_id='mp' : payload.messaging_profile_id='other');\n"
+                    f"fetch('{endpoint}',{{method:'POST',body:JSON.stringify(payload)}});\n"
+                )
+                result, payload = self.run_messaging_linter({"outer-guard.js": source})
+                self.assertEqual(1, result.returncode, payload)
+                self.assert_required_profile_detected(payload, "outer-guard.js")
+        for operator in ("&&=", "||=", "??="):
+            with self.subTest(assignment_guard=operator):
+                source = (
+                    "const payload={to:'+1'}; let flag=getFlag();\n"
+                    f"flag {operator} other ? payload.messaging_profile_id='mp' : payload.messaging_profile_id='other';\n"
+                    f"fetch('{endpoint}',{{method:'POST',body:JSON.stringify(payload)}});\n"
+                )
+                result, payload = self.run_messaging_linter({"assignment-guard.js": source})
+                self.assertEqual(1, result.returncode, payload)
+                self.assert_required_profile_detected(payload, "assignment-guard.js")
+
+    def test_node_core_options_cannot_supply_request_body(self) -> None:
+        endpoint = "https://api.telnyx.com/v2/messages/number_pool"
+        present = "JSON.stringify({to:'+1',messaging_profile_id:'mp'})"
+        absent = "JSON.stringify({to:'+1'})"
+        imports = (
+            ("const https=require('https');", "https.request"),
+            ("const transport=require('node:https');", "transport.request"),
+            ("import transport from 'node:http';", "transport.request"),
+            ("import * as transport from 'https';", "transport.request"),
+            ("const {request}=require('node:https');", "request"),
+            ("const {request,get}=require('node:https');", "request"),
+            ("import {request,get} from 'node:https';", "request"),
+            ("import {request as request} from 'node:https';", "request"),
+        )
+        for actual_profile in (False, True):
+            files = {}
+            for index, (statement, callee) in enumerate(imports):
+                for key in ("body", "data", "json"):
+                    files[f"options_{index}_{key}.js"] = (
+                        statement + f"\nconst options={{method:'POST',{key}:{present}}};\n"
+                        f"const req={callee}('{endpoint}',options);\n"
+                        f"req.end({present if actual_profile else absent});\n"
+                    )
+            # The wrapper intentionally caps displayed findings at 20 files.
+            # Keep each batch below that cap so every negative is asserted.
+            items = list(files.items())
+            for start in range(0, len(items), 12):
+                batch = dict(items[start:start + 12])
+                result, payload = self.run_messaging_linter(batch)
+                self.assertEqual(0 if actual_profile else 1, result.returncode, payload)
+                if not actual_profile:
+                    for name in batch:
+                        with self.subTest(file=name):
+                            self.assert_required_profile_detected(payload, name)
+
     def test_extensionless_shebang_send_is_analyzed(self) -> None:
         # package.json "bin" entry points have no extension; the analyzer
         # refused to open them while the Phase-1 scanner reported them.

--- a/tests/test_twilio_migration_contracts.py
+++ b/tests/test_twilio_migration_contracts.py
@@ -3726,6 +3726,46 @@ class RunValidationContracts(unittest.TestCase):
             1, lint_failing.returncode, lint_failing.stdout + lint_failing.stderr
         )
 
+    def test_hybrid_migrated_file_scope_accepts_numeric_colons_in_root(self) -> None:
+        # Filtered findings can contain `:<digits>:` inside a legal POSIX path.
+        # Hybrid scoping must compare the known migrated path, not guess the
+        # filename boundary from the formatted finding.
+        with tempfile.TemporaryDirectory(prefix="hybrid-colon-") as directory:
+            root = Path(directory) / "root:123:part"
+            source = root / "src" / "migrated.js"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "const twilio = require('twilio');\n",
+                encoding="utf-8",
+            )
+            state = root / "migration-state.json"
+            state.write_text(
+                json.dumps(
+                    {
+                        "kept_on_twilio": {"conversations": True},
+                        "migrated_files": {"messaging": ["src/migrated.js"]},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    BASH,
+                    str(CORRECTNESS_LINTER),
+                    str(root),
+                    "--product",
+                    "all",
+                    "--state-file",
+                    str(state),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        self.assertIn("Residual Twilio imports found", result.stdout)
+
     def test_hybrid_scope_normalizes_absolute_recorded_file_paths(self) -> None:
         with tempfile.TemporaryDirectory(prefix="absolute-migrated-file-") as directory:
             root = Path(directory)


### PR DESCRIPTION
## Summary

This PR isolates the static Twilio-migration correctness analyzer split from #318. It contains analyzer implementation, source extraction, provider synchronization, and analyzer-only regression coverage without customer-facing migration guidance or operational mutation flows.

## Scope

- Required-messaging-profile call-site analysis across the advertised source languages and client shapes.
- Binding, member, container, scope, request-signature, and control-flow resolution.
- Executable-region extraction for mixed templates including Vue, Svelte, Astro, EJS, Razor, and PHTML.
- Blocking unresolved-send provenance checks and positive/negative finite-grammar matrices.
- Dedicated analyzer CI plus canonical, Claude, and Cursor provider synchronization.

## Not included

- Customer-facing guidance, public API contract, TeXML, and mutation-safety corrections retained in #318.
- Unrelated repository, WhatsApp Ruby, and WebRTC client-version changes.

## Validation

- `python3 -m unittest tests/test_twilio_migration_analyzer.py` — **141/141 passed**.
- Script end-tag sibling matrix covers Vue, Svelte, Astro, and EJS across normal, uppercase, whitespace/newline, and ignored-junk forms.
- Provider copies are byte-identical to canonical sources.
- Python compilation, shell syntax, provider drift, `git diff --check`, unit CI, analyzer-contract CI, and CodeQL passed.
- No live or billable Telnyx writes were made.

## Split

- #318: public contracts, guidance, validators, and mutation safety.
- This PR: static analyzer implementation and analyzer-only tests.
