### PR TITLE
Update auto-generated Telnyx skills

### DIFF
--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-10dlc-java/SKILL.md
+++ b/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-messaging-java/SKILL.md
+++ b/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-numbers-java/SKILL.md
+++ b/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-java/SKILL.md
+++ b/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.89.0</version>
+    <version>6.91.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.89.0")
+implementation("com.telnyx.sdk:telnyx:6.91.0")
 ```
 
 ## Setup


### PR DESCRIPTION
## Auto-generated Telnyx skills update

Updates canonical `skills/` in `team-telnyx/ai` from the OpenAPI skill-generation pipeline and runs `./scripts/sync-skills.sh` to refresh Claude/Cursor provider copies.

- Generated canonical skills copied: 30
- Manual/non-target skills preserved: 206
- Canonical skills total: 236
