### PR TITLE
feat: add meeting bot agent skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "telnyx-ai",
       "source": "./providers/claude/plugins/telnyx-ai",
-      "description": "Telnyx AI — LLM inference, chat completions, embeddings, AI assistants, conversation insights",
+      "description": "Telnyx AI — LLM inference, chat completions, embeddings, AI assistants, Meeting Bot, conversation insights",
       "version": "0.4.0"
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file is a complement to `README.md` (human-facing) and `.github/CONTRIBUTIN
 
 ## What this repo is
 
-The one-stop shop for AI agents and AI-first developers building with Telnyx. It contains agent toolkits (Python/TypeScript), an agent CLI, per-product plugins for Claude Code / Cursor / Gemini CLI / OpenCode, an MCP proxy, <!-- SKILL_COUNT -->236<!-- /SKILL_COUNT --> Agent Skills, and operational guides.
+The one-stop shop for AI agents and AI-first developers building with Telnyx. It contains agent toolkits (Python/TypeScript), an agent CLI, per-product plugins for Claude Code / Cursor / Gemini CLI / OpenCode, an MCP proxy, <!-- SKILL_COUNT -->237<!-- /SKILL_COUNT --> Agent Skills, and operational guides.
 
 ---
 
@@ -48,7 +48,7 @@ Run the relevant package's test suite before declaring a task done. Don't run al
 
 | Path                    | What it contains                                                          |
 | ----------------------- | ------------------------------------------------------------------------- |
-| `skills/`               | Canonical agent skills (SKILL.md files). <!-- SKILL_COUNT -->236<!-- /SKILL_COUNT --> skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration. |
+| `skills/`               | Canonical agent skills (SKILL.md files). <!-- SKILL_COUNT -->237<!-- /SKILL_COUNT --> skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration. |
 | `providers/claude/`     | Claude Code plugin packaging — synced from `skills/` via `scripts/sync-skills.sh`. Don't edit by hand. |
 | `providers/cursor/`     | Cursor plugin packaging — synced from `skills/` via `scripts/sync-skills.sh`. Don't edit by hand. |
 | `plugins/opencode/`     | OpenCode plugin (auth + TUI for Telnyx-hosted models).                    |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Empowers agents to generate correct, production-ready code — and to manage the
 /plugin install telnyx-verify@telnyx     # Phone verification / 2FA
 /plugin install telnyx-numbers@telnyx    # Number management, 10DLC, porting
 /plugin install telnyx-webrtc@telnyx     # WebRTC and client SDKs
-/plugin install telnyx-ai@telnyx         # AI inference and assistants
+/plugin install telnyx-ai@telnyx         # AI inference, assistants, and Meeting Bot
 /plugin install telnyx-platform@telnyx   # Account, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration
 ```
 

--- a/agent.json
+++ b/agent.json
@@ -3,7 +3,7 @@
   "name": "Telnyx",
   "description": "Programmable telecom platform — voice, messaging, email, IoT, AI, networking, storage.",
   "version": "1.0.0",
-  "updated": "2026-07-29T00:00:00Z",
+  "updated": "2026-09-03T00:00:00Z",
 
   "auth": {
     "type": "api_key",
@@ -62,6 +62,15 @@
       "cli": "telnyx ai chat 'Hello'",
       "api": "POST /v2/ai/chat/completions",
       "docs": "https://developers.telnyx.com/docs/ai/inference",
+      "requires": []
+    },
+    {
+      "id": "meeting_bot",
+      "name": "Meeting Bot",
+      "description": "Send a visible bot to Zoom, Google Meet, Microsoft Teams, or Webex to follow finalized transcripts, perform explicitly authorized live actions, and create transcript artifacts.",
+      "guide": "/guides/meeting-bot.md",
+      "api": "POST /v2/meeting_sessions",
+      "docs": "https://developers.telnyx.com/docs/meeting",
       "requires": []
     },
     {

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -108,9 +108,10 @@ the replacement; it does not mean “interrupt a human.” The session must be
 The service synthesizes and hands off audio before returning `{ "accepted": true
 }` and appending `bot.speak_requested`. That is accepted handoff, not proof that
 every participant audibly heard the whole utterance. Because `speak` has no
-caller-supplied idempotency key, persist and atomically claim each reactive rule
-before dispatch. After an ambiguous transport timeout, mark the action outcome
-unknown and do not automatically speak again. On restart, convert any recovered
+caller-supplied idempotency key, first persist a `claimed` rule, then require a
+successful `claimed` → `dispatching` CAS immediately before transport. After an
+ambiguous transport timeout, mark the action outcome unknown and do not
+automatically speak again. On restart, convert any recovered
 `dispatching` speech/chat claim to `outcome_unknown` before evaluating triggers
 unless durable transport evidence proves that no request bytes were sent.
 
@@ -170,8 +171,9 @@ responses also expose `model_provenance` and a failure reason when applicable.
 `summarize_on_end: true` attempts only a `summary`. The public artifact shape has
 no automatic-origin marker: persist `transcript.completed.occurred_at`, exclude
 known manual IDs, re-list all post-completion summary candidates, and prefer the
-unique completed candidate created closest after that event only when it does not
-coexist with an unreconciled outcome-unknown manual summary create. Equal-time
+unique closest candidate across all statuses. Select it only when completed and
+no outcome-unknown manual summary create remains unreconciled; wait if it is
+pending and fall back if it fails rather than choosing a later artifact. Equal-time
 candidates and all unrecognized candidates during same-type uncertainty are
 ambiguous; never use artifact ID, list order, completion order, or client-clock
 windows to break an origin tie. Re-list and poll every candidate before fallback

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -110,7 +110,9 @@ The service synthesizes and hands off audio before returning `{ "accepted": true
 every participant audibly heard the whole utterance. Because `speak` has no
 caller-supplied idempotency key, persist and atomically claim each reactive rule
 before dispatch. After an ambiguous transport timeout, mark the action outcome
-unknown and do not automatically speak again.
+unknown and do not automatically speak again. On restart, convert any recovered
+`dispatching` speech/chat claim to `outcome_unknown` before evaluating triggers
+unless durable transport evidence proves that no request bytes were sent.
 
 ## API Reference
 

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -1,0 +1,256 @@
+# Meeting Bot
+
+> Join Zoom, Google Meet, Microsoft Teams, or Webex with a visible bot; react to finalized speech; and collect transcript-derived results.
+
+This guide is grounded in the current
+[`meeting-bot-service` implementation at `a9f6326`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326bcaf7428364861290b787d5db1772e9f6).
+Treat its routes, MCP schemas, domain types, services, and tests as the behavioral
+authority. Public documentation is linked for navigation, but may lag the
+implementation. MCP agents should call `tools/list` against the deployed server
+before relying on a cached schema.
+
+## Prerequisites
+
+- A Telnyx API key ([get one](https://telnyx.com/agent-signup.md))
+- A supported meeting URL that the requester is authorized to have a bot attend
+- Host admission when the meeting uses a waiting room
+- A durable worker or scheduler for long-running monitoring
+
+For intent parsing, crash recovery, reactive actions, and final delivery, use the
+canonical [`telnyx-meeting-bot` skill](../skills/telnyx-meeting-bot/SKILL.md).
+
+## Quick Start
+
+Create the session with one persisted idempotency key. Reuse that exact key after
+an uncertain create outcome so a retry cannot place a second bot in the meeting.
+
+```bash
+curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "meeting_url": "https://meet.google.com/abc-defg-hij",
+    "bot_name": "Project Notetaker",
+    "summarize_on_end": true,
+    "idempotency_key": "meeting-bot:stable-operation-id"
+  }'
+```
+
+Save `data.id` immediately. A future RFC 3339 `join_at` schedules the join.
+When a request includes a future speaking rule, set `barge_in: true` at creation
+so new human speech can stop the bot's output.
+
+Poll status until the session is active or terminal:
+
+```bash
+curl "https://api.telnyx.com/v2/meeting_sessions/mtgsess_REPLACE_ME" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+`waiting_for_admission` means a host must admit the visible bot. A non-null
+`joined_at` is positive attendance evidence.
+
+For immediate mention or action requests, long-poll finalized transcript with a
+2-second wait:
+
+```bash
+curl "https://api.telnyx.com/v2/meeting_sessions/mtgsess_REPLACE_ME/transcript?after=0&limit=1000&wait_seconds=2" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+The request returns as soon as new finalized speech is available; two seconds is
+the maximum held-request wait, not an added delay after speech arrives. Advance
+`after` to the maximum processed `seq`. Use `wait_seconds: 0` only to drain an
+already-full page immediately.
+
+## Choose Polling Cadence From the Request
+
+| Request intent | Starting `wait_seconds` |
+|---|---:|
+| “As soon as…”, reactive `speak`, or urgent mention alert | `2` |
+| Ordinary live updates | `2`–`5` |
+| Attend silently and summarize only after the meeting | `10`–`20`, or webhook-driven |
+
+The implementation accepts integer values from `0` through `25`. Preserve the
+requester's latency expectation in durable state. Back off transient failures,
+but return to the selected cadence after recovery. Finalized transcript and TTS
+introduce their own latency, so “as soon as” means as soon as the agent observes
+a matching **final** segment—not raw-audio instantaneous reaction.
+
+## React Once With Speech
+
+The implemented MCP tool is:
+
+```json
+{
+  "name": "speak",
+  "arguments": {
+    "id": "mtgsess_REPLACE_ME",
+    "text": "I want pizza"
+  }
+}
+```
+
+REST equivalent:
+
+```bash
+curl -X POST "https://api.telnyx.com/v2/meeting_sessions/mtgsess_REPLACE_ME/actions/speak" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"I want pizza"}'
+```
+
+`speak` accepts `text` (1–4000 characters), optional `voice`, and optional
+`interrupt`. `interrupt: true` stops the **bot's current audio** before playing
+the replacement; it does not mean “interrupt a human.” The session must be
+`active`, support audio output, and have TTS configured.
+
+The service synthesizes and hands off audio before returning `{ "accepted": true
+}` and appending `bot.speak_requested`. That is accepted handoff, not proof that
+every participant audibly heard the whole utterance. Because `speak` has no
+caller-supplied idempotency key, persist and atomically claim each reactive rule
+before dispatch. After an ambiguous transport timeout, mark the action outcome
+unknown and do not automatically speak again.
+
+## API Reference
+
+### Production MCP endpoint
+
+```text
+https://api.telnyx.com/v2/meeting_bot/mcp
+```
+
+Use the standard bearer-token `Authorization` header and
+`Accept: application/json, text/event-stream`. Implemented session tools include
+`join_meeting`, `get_session`, `list_sessions`, `get_transcript`, `get_events`,
+`speak`, `stop_speaking`, `send_chat`, `leave_meeting`, `get_recordings`,
+`create_artifact`, `get_artifact`, and `get_artifacts`.
+
+MCP tool failures can use HTTP 200 with `result.isError: true`; check that before
+parsing `result.content[0].text`. Transport and authentication failures use HTTP
+error statuses.
+
+### REST operations
+
+| Operation | Endpoint |
+|---|---|
+| Create or schedule | `POST /v2/meeting_sessions` |
+| Retrieve status | `GET /v2/meeting_sessions/{id}` |
+| Speak | `POST /v2/meeting_sessions/{id}/actions/speak` |
+| Stop bot speech | `POST /v2/meeting_sessions/{id}/actions/stop_speaking` |
+| Send meeting chat | `POST /v2/meeting_sessions/{id}/actions/send_chat` |
+| Follow transcript | `GET /v2/meeting_sessions/{id}/transcript` |
+| Read events | `GET /v2/meeting_sessions/{id}/events` |
+| Leave or cancel | `DELETE /v2/meeting_sessions/{id}` |
+| List recordings | `GET /v2/meeting_sessions/{id}/recordings` |
+| Create an artifact | `POST /v2/meeting_sessions/{id}/artifacts` |
+| List artifacts | `GET /v2/meeting_sessions/{id}/artifacts` |
+| Retrieve an artifact | `GET /v2/meeting_sessions/{id}/artifacts/{artifact_id}` |
+
+### Implemented artifact types
+
+The source defines exactly these artifact types:
+
+| Type | Result |
+|---|---|
+| `summary` | Concise factual meeting summary |
+| `action_items` | Clear actionable items, or an explicit statement that none were found |
+| `decisions` | Decisions and named owners when supported by transcript |
+| `topics` | Discussed themes with short notes |
+| `open_questions` | Unanswered questions and unresolved items |
+| `custom` | Answer to a caller-supplied transcript-grounded prompt |
+
+Only `custom` accepts `prompt` (1–4000 trimmed characters); it requires one. The
+named types reject `prompt`. Creation returns an asynchronous artifact with
+`pending`, `completed`, or `failed` status. On completion, read `content.text`;
+responses also expose `model_provenance` and a failure reason when applicable.
+
+`summarize_on_end: true` attempts only a `summary`. List artifacts before any
+manual create because creation is non-idempotent. At this source revision,
+artifact generation reads at most the first 10,000 transcript segments and does
+not expose a truncation warning; caveat exceptionally long meetings or build the
+final report from the agent's fully collected transcript.
+
+### Python
+
+```python
+import os
+import requests
+
+base = "https://api.telnyx.com/v2/meeting_sessions"
+headers = {"Authorization": f"Bearer {os.environ['TELNYX_API_KEY']}"}
+session_id = "mtgsess_REPLACE_ME"
+after = 0
+
+response = requests.get(
+    f"{base}/{session_id}/transcript",
+    headers=headers,
+    params={"after": after, "limit": 1000, "wait_seconds": 2},
+    timeout=10,
+)
+response.raise_for_status()
+segments = response.json()["data"]
+if segments:
+    after = max(segment["seq"] for segment in segments)
+```
+
+### TypeScript
+
+```typescript
+const sessionId = "mtgsess_REPLACE_ME";
+let after = 0;
+const url = new URL(
+  `https://api.telnyx.com/v2/meeting_sessions/${sessionId}/transcript`,
+);
+url.searchParams.set("after", String(after));
+url.searchParams.set("limit", "1000");
+url.searchParams.set("wait_seconds", "2");
+
+const apiKey = process.env.TELNYX_API_KEY;
+if (!apiKey) throw new Error("TELNYX_API_KEY is required");
+const headers = new Headers();
+headers.set("Authorization", ["Bearer", apiKey].join(" "));
+const response = await fetch(url, { headers });
+if (!response.ok) throw new Error(`Transcript request failed: ${response.status}`);
+const { data: segments } = await response.json();
+if (segments.length) after = Math.max(...segments.map((segment: any) => segment.seq));
+```
+
+## Demo: Delegated Attendance and TL;DR
+
+Example message shown on screen:
+
+> I can't join this meeting: `<meeting URL>`. Join as Anusha's bot, let me know
+> when you're in, and send me a TL;DR when it ends.
+
+Expected visible sequence:
+
+1. The agent persists the operation and joins immediately as `Anusha's bot` with
+   `summarize_on_end: true` and no unrequested speech or chat.
+2. If status is `waiting_for_admission`, the agent tells Anusha that a host must
+   admit the bot.
+3. When `joined_at` becomes non-null, the agent posts “Anusha's bot joined the
+   meeting” in Anusha's conversation. That chat update is not spoken in-meeting.
+4. The agent follows the transcript in the background and checkpoints its cursor.
+5. At terminal status, it drains final segments, obtains the `summary` artifact,
+   and sends the TL;DR with attendance, completeness, and provenance.
+
+## Example: Reactive Lunch Answer
+
+> Join the meeting and, as soon as someone asks what we should have for lunch,
+> use the speak request and say “I want pizza.”
+
+Interpret this as an immediate join plus a one-shot semantic trigger. Use
+`wait_seconds: 2`; evaluate each new final segment and a short trailing context
+window; atomically claim the first clear match; then call `speak` once with exact
+text `I want pizza`. Do not wait for another approval—the original request is the
+authorization. Do not repeat after an accepted or outcome-unknown dispatch.
+
+## Source References
+
+- [Artifact domain types](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/domain/artifact.ts)
+- [Artifact generation behavior](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/services/artifactService.ts)
+- [Meeting-session REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/routes/meetingSessions.ts)
+- [MCP tool definitions](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/mcp/server.ts)
+- [Speech implementation](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/services/sessionService.ts#L1021-L1142)
+- [Meeting overview](https://developers.telnyx.com/docs/meeting) (secondary)

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -165,11 +165,23 @@ named types reject `prompt`. Creation returns an asynchronous artifact with
 `pending`, `completed`, or `failed` status. On completion, read `content.text`;
 responses also expose `model_provenance` and a failure reason when applicable.
 
-`summarize_on_end: true` attempts only a `summary`. List artifacts before any
-manual create because creation is non-idempotent. At this source revision,
-artifact generation reads at most the first 10,000 transcript segments and does
-not expose a truncation warning; caveat exceptionally long meetings or build the
-final report from the agent's fully collected transcript.
+`summarize_on_end: true` attempts only a `summary`. The public artifact shape has
+no automatic-origin marker: persist `transcript.completed.occurred_at`, exclude
+known manual IDs, re-list all post-completion summary candidates, and prefer the
+unique completed candidate created closest after that event only when it does not
+coexist with an unreconciled outcome-unknown manual summary create. Equal-time
+candidates and all unrecognized candidates during same-type uncertainty are
+ambiguous; never use artifact ID, list order, completion order, or client-clock
+windows to break an origin tie. Re-list and poll every candidate before fallback
+rather than locking onto the first pending summary.
+
+Manual creation is non-idempotent. Persist a create state that distinguishes
+`pre_send_failed` (the client proved no request bytes were sent, so a bounded
+retry is safe) from `outcome_unknown` (bytes may have been sent, so recovery may
+only re-list). At this source revision, artifact generation reads at most the
+first 10,000 transcript segments and does not expose a truncation warning; caveat
+exceptionally long meetings or build the final report from the agent's fully
+collected transcript.
 
 ### Python
 

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "telnyx",
   "version": "0.4.0",
-  "description": "Telnyx Agent Plugin — Agent Skills for voice, messaging, email, numbers, verify, TTS/STT, AI inference and platform services, plus the hosted Telnyx MCP server.",
+  "description": "Telnyx Agent Plugin — Agent Skills for voice, messaging, email, numbers, verify, TTS/STT, AI inference, Meeting Bot, and platform services, plus the hosted Telnyx MCP server.",
   "author": {
     "name": "Telnyx",
     "url": "https://telnyx.com"

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -17,7 +17,7 @@ Telnyx ships one Claude Code plugin per product area. Install only what your pro
 | `telnyx-verify` | Phone verification via SMS, call, or flash call (2FA OTP) | 6 |
 | `telnyx-numbers` | Phone numbers — search, buy, manage, 10DLC compliance, porting | 42 |
 | `telnyx-webrtc` | WebRTC — video rooms and browser/mobile client SDKs | 17 |
-| `telnyx-ai` | AI — LLM inference, chat completions, embeddings, AI assistants, conversation insights | 12 |
+| `telnyx-ai` | AI — LLM inference, chat completions, embeddings, AI assistants, Meeting Bot, conversation insights | 13 |
 | `telnyx-platform` | Everything account-level and cross-product — account management, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration | 98 |
 
 Install with:

--- a/providers/claude/plugins/telnyx-ai/.claude-plugin/plugin.json
+++ b/providers/claude/plugins/telnyx-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "telnyx-ai",
-  "description": "Telnyx AI \u2014 LLM inference, chat completions, embeddings, AI assistants, conversation insights",
+  "description": "Telnyx AI \u2014 LLM inference, chat completions, embeddings, AI assistants, Meeting Bot, conversation insights",
   "version": "0.4.0",
   "author": {
     "name": "Telnyx",
@@ -10,6 +10,7 @@
   "repository": "https://github.com/team-telnyx/ai",
   "license": "MIT",
   "keywords": [
-    "ai"
+    "ai",
+    "meeting-bot"
   ]
 }

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -126,8 +126,12 @@ workflow state. Store at least:
   "mentions": [],
   "action_claims": [],
   "artifact_requests": {},
+  "known_manual_artifact_ids": [],
+  "unreconciled_unknown_manual_creates": [],
+  "transcript_completed_at": null,
+  "summary_candidate_ids": [],
   "summary_artifact_id": null,
-  "summary_creation_attempted": false,
+  "summary_creation": {"state": "not_started", "attempt_count": 0, "max_pre_send_retries": 2, "artifact_id": null},
   "summary_poll_deadline_at": null,
   "terminal_observed_at": null,
   "transcript_completed": false
@@ -337,11 +341,11 @@ reject `prompt`. Each create is asynchronous with `pending`, `completed`, or
 `model_provenance`/failure information. `summarize_on_end: true` attempts only a
 `summary`; create other requested types separately.
 
-For every manual artifact, keep one durable record keyed by type plus a stable
-hash of the custom prompt. Persist `creation_attempted`, the fixed poll deadline,
-and then the returned artifact ID. Since creation is non-idempotent, never repeat
-an ambiguous create. Apply the detailed summary discipline below to every
-manually requested artifact.
+For every manual artifact, follow the [artifact selection and creation recovery
+protocol](references/artifact-selection-and-recovery.md). Keep its durable state
+machine, fixed deadline, manual artifact IDs, and returned ID. Retry only a
+proven `pre_send_failed` or confirmed pre-creation rejection; an ambiguous create
+is `outcome_unknown` and may only be reconciled by listing.
 
 At implementation commit `a9f6326`, generation reads at most the first 10,000
 finalized transcript segments without exposing a truncation warning. For an
@@ -350,31 +354,22 @@ result from the full transcript the agent actually collected.
 
 ### Summary flow
 
-First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
-especially the one expected from `summarize_on_end: true`. Poll the selected
-artifact via `get_artifact(id, artifact_id)` until `status` is `completed` or
-`failed` or a persisted deadline expires; use `content.text` only when
-completed. When selecting any pending summary, persist its ID and one fixed
-`summary_poll_deadline_at` (for example five minutes from the first selection).
-Recovery must reuse, never extend, that deadline. During the normal automatic
-summary delay, poll the list on a bounded cadence (for example 2, 5, then 10
-seconds, for up to two minutes after transcript completion/settle).
+Follow the linked recovery protocol. Persist `transcript.completed.occurred_at`,
+exclude `known_manual_artifact_ids`, and repeatedly re-list all post-completion
+summary candidates. The API has no automatic-origin marker, so select only a
+unique completed candidate whose `created_at` is closest after the completion
+event, but only when no same-type manual create has an unreconciled unknown
+outcome. Equal-time candidates are also ambiguous. Because no ID was returned
+and clocks may differ, never use artifact ID, list order, completion order, or
+client-clock windows as an origin tie-breaker. Do not lock onto the first pending
+artifact or silently use a pre-completion partial summary. Immediately before
+fallback, re-list and poll every current candidate within the fixed deadline.
 
-If no summary exists after that bounded wait:
-
-1. Check the durable record. If `summary_artifact_id` exists, poll it using the
-   original persisted deadline. If `summary_creation_attempted` is true but no
-   ID was returned, do **not** create another artifact—re-list only until that
-   same deadline, then report the ambiguous outcome and use the fallback.
-2. Otherwise persist `summary_creation_attempted: true`, call
-   `create_artifact(id, type: "summary")` **exactly once**, and immediately
-   persist the returned artifact ID. Set the fixed summary-poll deadline before
-   the call so an interrupted or ambiguous create cannot restart the clock.
-3. Poll that ID with `get_artifact` using bounded backoff until `completed`,
-   `failed`, or the persisted deadline expires. Artifact creation is
-   non-idempotent, so never retry an uncertain create call by creating another
-   summary. If the deadline expires while the artifact is still pending, keep
-   its ID/status for provenance and move to the transcript-grounded fallback.
+If no trustworthy automatic candidate appears, use the protocol's manual-create
+state machine. A proven pre-send failure may retry within the original bound;
+`dispatching` after a crash or any possibly sent/ambiguous call becomes
+`outcome_unknown` and must never create again. Poll accepted IDs to terminal state
+and retain pending/failed provenance before using the transcript fallback.
 
 If service inference is unavailable, fails, or times out, still deliver an
 **Agent-generated summary (service summary unavailable)** based solely on the

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -126,13 +126,10 @@ workflow state. Store at least:
   "mentions": [],
   "action_claims": [],
   "artifact_requests": {},
-  "known_manual_artifact_ids": [],
-  "unreconciled_unknown_manual_creates": [],
-  "transcript_completed_at": null,
-  "summary_candidate_ids": [],
-  "summary_artifact_id": null,
+  "known_manual_artifact_ids": [], "unreconciled_unknown_manual_creates": [],
+  "transcript_completed_at": null, "summary_candidate_ids": [],
+  "summary_artifact_id": null, "summary_poll_deadline_at": null,
   "summary_creation": {"state": "not_started", "attempt_count": 0, "max_pre_send_retries": 2, "artifact_id": null},
-  "summary_poll_deadline_at": null,
   "terminal_observed_at": null,
   "transcript_completed": false
 }
@@ -280,13 +277,14 @@ Permit a new repeat key only after its stale-safe ordered clear commits; never k
   "rule_id": "lunch-question",
   "type": "speak",
   "text": "I want pizza",
-  "status": "dispatching",
+  "status": "claimed",
   "trigger_seqs": [42]
 }
 ```
 
-Only the process that wins that claim may dispatch. Atomically set `dispatching`
-immediately before invoking the transport. For MCP, call
+Creating the claim only reserves its key. Dispatch only if a CAS changes `claimed`
+(or proven `pre_send_failed`) to `dispatching` immediately before the transport
+call; a CAS loser skips. For MCP, call
 `speak(id, text, voice?, interrupt?)`; for REST, call
 `POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
 unless replacing the bot's own current audio—it does not mean “interrupt the
@@ -359,10 +357,11 @@ result from the full transcript the agent actually collected.
 
 Follow the linked recovery protocol. Persist `transcript.completed.occurred_at`,
 exclude `known_manual_artifact_ids`, and repeatedly re-list all post-completion
-summary candidates. The API has no automatic-origin marker, so select only a
-unique completed candidate whose `created_at` is closest after the completion
-event, but only when no same-type manual create has an unreconciled unknown
-outcome. Equal-time candidates are also ambiguous. Because no ID was returned
+summary candidates. The API has no automatic-origin marker, so first identify the
+unique closest candidate across **all statuses**. Use it only if completed and no
+same-type manual create has an unreconciled unknown outcome; if pending, wait, and
+if failed, fall back rather than choosing a later artifact. Equal-time candidates
+are ambiguous. Because no ID was returned
 and clocks may differ, never use artifact ID, list order, completion order, or
 client-clock windows as an origin tie-breaker. Do not lock onto the first pending
 artifact or silently use a pre-completion partial summary. Immediately before
@@ -417,7 +416,8 @@ On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
 from persisted cursors and outbox state—never call `join_meeting` again. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
-`sent` items alone. Before evaluating triggers, atomically convert every recovered
+`sent` items alone. A recovered `claimed` action may attempt the dispatch CAS. Before
+evaluating triggers, atomically convert every recovered
 live-action claim still marked `dispatching` to `outcome_unknown` unless durable
 transport evidence proves no request bytes were sent; never redispatch it. Never
 repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: telnyx-meeting-bot
 description: >-
-  Use when an agent must safely join, observe, monitor, transcribe, summarize,
-  or follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
-  Telnyx Meeting Bot. Handles vague requests, scheduled joins, admission,
-  durable transcript polling, name/phrase alerts, recovery, and final meeting
-  artifacts without speaking or sending chat by default.
+  Use when an agent must join, observe, react in, transcribe, summarize, or
+  follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
+  Telnyx Meeting Bot. Handles vague requests, request-specific live polling,
+  name/phrase and semantic triggers, explicitly authorized speak/chat actions,
+  recovery, and all implemented transcript artifact types.
 metadata:
   author: telnyx
   product: meeting-bot
@@ -16,28 +16,32 @@ metadata:
 
 # Telnyx Meeting Bot
 
-Use this skill to attend a meeting visibly as an **observe-only** bot, monitor
-its finalized transcript, alert the requester about selected mentions, and
-produce an evidence-based meeting report. The bot must not speak, send chat, or
-make other in-meeting changes unless the requester explicitly asks for that.
+Use this skill to attend a meeting visibly, monitor its finalized transcript,
+alert the requester, execute explicitly authorized live rules such as speaking
+one response, and produce evidence-based meeting results. The bot is
+**observe-only by default**: it must not speak, send chat, or make other
+in-meeting changes unless the requester explicitly asks for that.
 
 ## Quick Workflow
 
 1. Resolve only missing essentials: meeting URL, join now versus a scheduled
-   time, and mention terms. Reuse terms already stated in the request or known
-   from the current conversation/profile; do not ask again or guess a person's
-   name.
+   time, desired live/final outputs, and any trigger/action rules. Reuse details
+   already stated in the request or authorized context; do not ask again.
 2. Persist an operation record **before** creating the session. Generate and
    retain one stable `idempotency_key`; call `join_meeting` with
-   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`.
+   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`. If an
+   explicit later speech rule exists, set `barge_in: true` so new human speech
+   can stop the bot's output.
 3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
-   Persist cursors, seen segment sequences, sent mention-alert keys, and IDs so
-   a restart resumes safely.
-4. On each new final transcript segment, detect whole-name/phrase mentions and
-   alert the requester in the current conversation once per segment/match.
+   Choose transcript `wait_seconds` from the request—use about `2` seconds for
+   “as soon as,” reactive speech, or urgent mention alerts—and persist cursors,
+   seen segments, outboxes, action claims, and IDs for safe recovery.
+4. On each new final segment, evaluate requested literal or semantic rules.
+   Deliver mention notifications through the durable outbox; atomically claim
+   and execute each authorized `speak`/`send_chat` action at most once.
 5. On a terminal session, drain transcript pages, wait a bounded time for
-   `transcript.completed`, obtain an existing summary artifact or create only
-   one fallback summary artifact, then deliver a Markdown report.
+   `transcript.completed`, obtain the requested implemented artifact types
+   without duplicate creation, then deliver a Markdown report.
 
 ## Preconditions and Safe Defaults
 
@@ -54,6 +58,13 @@ make other in-meeting changes unless the requester explicitly asks for that.
 - Default behavior: immediate join if no future time was requested,
   `summarize_on_end: true`, observe-only, and no recording-media deletion.
   `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
+- An explicit conditional request such as “when someone asks about lunch, say
+  ‘I want pizza’” is advance authorization for that exact action. Persist the
+  trigger, exact payload, one-shot/repeat policy, and latency target before join;
+  do not interrupt the live workflow to ask for approval again.
+- Choose monitoring cadence from the request. Default immediate reactions and
+  urgent mentions to `wait_seconds: 2`; do not silently substitute a 15-second
+  cadence for an “as soon as” instruction.
 - If a meeting link is not present, ask for it. If time is ambiguous, ask only
   whether to join now or at a specified time. If “my name” is not resolvable
   from the request, current conversation, or authorized profile context, ask
@@ -85,8 +96,10 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents are `POST /`, `GET /{id}`, `GET /{id}/transcript`,
-`GET /{id}/events`, `DELETE /{id}`, `GET /{id}/artifacts`,
+REST equivalents include `POST /`, `GET /{id}`,
+`POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`,
+`POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`,
+`DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`,
 `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
 `Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
 Use REST only as a transport fallback—the lifecycle and durability rules below
@@ -104,11 +117,15 @@ workflow state. Store at least:
   "meeting_url": "redacted-or-secret-reference",
   "idempotency_key": "meeting-bot:<host-stable-id>",
   "session_id": null,
+  "poll_wait_seconds": 2,
+  "live_rules": [],
   "transcript_after_seq": 0,
   "event_after_seq": 0,
   "seen_transcript_seqs": [],
-  "mention_alert_keys": [],
+  "mention_alerts": [],
   "mentions": [],
+  "action_claims": [],
+  "artifact_requests": {},
   "summary_artifact_id": null,
   "summary_creation_attempted": false,
   "summary_poll_deadline_at": null,
@@ -130,7 +147,10 @@ call `join_meeting` with the smallest safe argument set:
 ```
 
 Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
-Persist the returned `id` as `session_id` immediately. If the create request has an
+If the request contains an authorized later `speak` rule, include
+`"barge_in": true`; this lets human speech stop bot output and does not itself
+make the bot speak. Persist the returned `id` as `session_id` immediately.
+If the create request has an
 uncertain transport outcome, retry **only** with the same persisted
 `idempotency_key`; never issue a second key, which could place a second bot in
 the meeting. If the host cannot persist state, state that duplicate-prevention
@@ -141,18 +161,22 @@ across a restart cannot be guaranteed and avoid an unbounded retry.
 Interleave session checks with transcript reads; a successful transcript read
 alone is not proof the bot attended.
 
-1. Call `get_session(id)` at startup, after errors, and on a bounded cadence
-   (for example every 15–30 seconds while joining/active, with backoff after
-   transient failures).
+1. Call `get_session(id)` at startup, after errors, and on a bounded cadence.
+   Use roughly every 5–10 seconds for a reactive workflow and 15–30 seconds for
+   passive monitoring, with backoff after transient failures.
 2. Treat `waiting_for_admission` as a request for a meeting host to admit the
    visible bot. Tell the requester promptly; keep monitoring rather than
    claiming attendance. A non-null `joined_at` is the positive evidence that
    the bot actually attended.
 3. Treat `ended`, `failed`, and `admission_denied` as terminal. Record status,
-   `failure_reason`/status detail when present, and `joined_at`.
+   `status_detail` when present, and `joined_at`.
 4. Long-poll finalized segments with
    `get_transcript(id, after_seq, limit, wait_seconds)`. Use `limit: 1000` and
-   `wait_seconds: 15` to `20` (never above the service maximum of 25 seconds).
+   select/persist the wait from the request: `2` seconds for “as soon as,”
+   reactive `speak`, or urgent mentions; `2`–`5` for ordinary live updates;
+   `10`–`20` for summary-only passive attendance. The implemented integer range
+   is `0`–`25`. The call returns as soon as new finalized speech exists, so the
+   wait is a maximum held-request duration, not an added post-transcript delay.
 5. Deduplicate by durable `seq`. For each new segment, persist it or its needed
    fields, process mentions, set `after_seq` to the **maximum processed seq**,
    and checkpoint before the next call.
@@ -160,7 +184,8 @@ alone is not proof the bot attended.
    updated cursor and `wait_seconds: 0` until the page is short. Then resume
    the short long-poll. Do not rely on a server `next_after` value in place of
    the maximum sequence you successfully processed, and never reset the cursor
-   when a poll returns an empty page or a null continuation value.
+   when a poll returns an empty page or a null continuation value. Return to the
+   selected request cadence after the immediate drain.
 7. Use `get_events(id, after_seq, limit)` on a bounded cadence as well; advance
    and persist its independent event cursor only after deduping event sequences.
    It is useful for lifecycle and `transcript.completed` evidence, but is not a
@@ -172,7 +197,9 @@ cursors. For authentication errors, malformed requests, `not_found`, or an MCP
 `result.isError` that is not plausibly transient, stop automatic retries and
 surface the actionable error without exposing credentials or meeting secrets.
 
-## Mention Detection and Prompt Alerts
+## Live Trigger Detection, Alerts, and Actions
+
+### Name/phrase alerts
 
 Match **only finalized transcript segments** returned by `get_transcript`.
 Normalize with Unicode case-folding and whitespace normalization. For each known
@@ -182,9 +209,25 @@ match “ann lee,” but not “ann leeds,” and avoids false positives such as
 inside `annual`. Keep variants only when known from the requester or authorized
 profile/context; do not invent aliases.
 
-For every new `(session_id, segment.seq, normalized_variant)` match, persist an
-alert key before/with delivery and send one prompt notice to the current
-conversation:
+For every new `(session_id, segment.seq, normalized_variant)` match, derive one
+stable alert key and delivery ID such as
+`mention:<session_id>:<segment.seq>:<normalized_variant>`. Persist the mention
+and an outbox item **before** delivery:
+
+```json
+{
+  "key": "mention:<session_id>:<seq>:<normalized_variant>",
+  "delivery_id": "same-stable-value",
+  "status": "pending",
+  "attempts": 0,
+  "last_error": null,
+  "sent_at": null
+}
+```
+
+If that key already has `status: "sent"`, skip it. If it is `pending`, reuse the
+same outbox item rather than creating a second one. Send the notice to the
+current conversation:
 
 ```text
 Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
@@ -192,10 +235,65 @@ Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
 ```
 
 Use the segment's `relative_ts` (format it as a relative timestamp if available)
-and retain the exact quote without paraphrasing. A segment can produce alerts
-for distinct requested terms, but never repeat the same segment/term after a
-retry or resume. Append every alert record (term/variant, speaker, timestamp,
-seq, exact quote) to the durable mention log for the final report.
+and retain the exact quote without paraphrasing. Pass the stable `delivery_id`
+to the host notification API when it supports idempotency. Mark the outbox item
+`sent` only after confirmed delivery; otherwise leave it `pending`, increment
+its attempt metadata, and retry it with bounded backoff without blocking later
+transcript collection. On recovery, retry pending alerts before/alongside new
+segments. If the host cannot deduplicate an ambiguous send, prefer at-least-once
+delivery and note that a retry may duplicate the alert—never convert an unknown
+outcome into `sent` and silently lose the requested notification.
+
+A segment can produce alerts for distinct requested terms. Append every match
+(term/variant, speaker, timestamp, seq, exact quote) to the durable mention log
+for the final report, independent of its alert-delivery status.
+
+### Explicit reactive `speak` or `send_chat`
+
+Translate each authorized live rule into durable fields before joining:
+
+- a stable `rule_id`;
+- literal terms or a precise semantic condition;
+- action type and exact text;
+- one-shot versus explicitly requested repeat behavior;
+- selected `poll_wait_seconds` (default `2` for immediate reactions).
+
+For a literal rule, use the same boundary-safe matching as mention detection.
+For a semantic condition such as “someone asks what we should have for lunch,”
+evaluate each newest final segment with only a short trailing context window.
+Require clear transcript evidence; do not trigger from an unrelated occurrence
+of one keyword. Persist the evidence seq(s) and exact quote.
+
+Before executing the first match, atomically create an action claim such as:
+
+```json
+{
+  "key": "action:<session_id>:<rule_id>:<first_trigger_seq>",
+  "rule_id": "lunch-question",
+  "type": "speak",
+  "text": "I want pizza",
+  "status": "dispatching",
+  "attempts": 1,
+  "trigger_seqs": [42]
+}
+```
+
+Only the process that wins that claim may dispatch. For MCP, call
+`speak(id, text, voice?, interrupt?)`; for REST, call
+`POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
+unless replacing the bot's own current audio—it does not mean “interrupt the
+human speaker.” The session must be `active`, support audio output, and have TTS
+configured. `send_chat` is similarly opt-in and may be unsupported by the
+meeting platform.
+
+After MCP returns non-error `{ "accepted": true }` or REST returns 202, mark the
+claim `accepted`; `bot.speak_requested` in `get_events` is additional durable
+evidence. Accepted means TTS and the provider/page handoff succeeded, not proof
+that every attendee heard the complete utterance. Because `speak` and
+`send_chat` expose no caller idempotency key, do **not** automatically repeat an
+accepted action or one whose transport outcome became ambiguous after dispatch.
+Mark the latter `outcome_unknown`, tell the requester, and keep monitoring.
+Retry only a failure proved to occur before the action request was sent.
 
 ## Terminal Drain and Completeness
 
@@ -217,7 +315,37 @@ transcript is complete.
 A failed or denied session with `joined_at: null` means no verified attendance;
 report that honestly and do not invent a discussion summary.
 
-## Obtain a Summary Without Duplicating Work
+## Choose and Obtain Artifacts Without Duplicating Work
+
+The implementation defines exactly six artifact types:
+
+| Type | Use for |
+|---|---|
+| `summary` | Concise factual TL;DR |
+| `action_items` | Explicit tasks, or a statement that none were found |
+| `decisions` | Decisions and named owners when present |
+| `topics` | Discussed themes with short notes |
+| `open_questions` | Unanswered questions and unresolved items |
+| `custom` | A caller-supplied question answered only from transcript |
+
+Only `custom` accepts `prompt` (required, 1–4000 trimmed characters); named types
+reject `prompt`. Each create is asynchronous with `pending`, `completed`, or
+`failed` status. Read `content.text` only after completion and retain
+`model_provenance`/failure information. `summarize_on_end: true` attempts only a
+`summary`; create other requested types separately.
+
+For every manual artifact, keep one durable record keyed by type plus a stable
+hash of the custom prompt. Persist `creation_attempted`, the fixed poll deadline,
+and then the returned artifact ID. Since creation is non-idempotent, never repeat
+an ambiguous create. Apply the detailed summary discipline below to every
+manually requested artifact.
+
+At implementation commit `a9f6326`, generation reads at most the first 10,000
+finalized transcript segments without exposing a truncation warning. For an
+exceptionally long meeting, disclose that limit and prefer an agent-generated
+result from the full transcript the agent actually collected.
+
+### Summary flow
 
 First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
 especially the one expected from `summarize_on_end: true`. Poll the selected
@@ -258,24 +386,23 @@ in durable host storage when supported. Include:
 
 ```markdown
 # Meeting report
-
 ## Executive summary
 - <service `content.text`, or an explicitly labeled transcript-grounded fallback>
-
 ## Topics, decisions, and action items
-- Include only items supported by the transcript; otherwise say “None identified in the collected transcript.”
-
+- Use requested service artifacts when completed; include only items supported by the transcript.
+- Otherwise say “None identified in the collected transcript.”
 ## Mention log
-- +00:00 — Speaker — matched term: “exact transcript quote”
-
+- +00:00 — Speaker — matched term — alert sent|pending: “exact transcript quote”
+## Live actions
+- +00:00 — Rule — `speak|send_chat` — accepted|failed|outcome unknown — trigger quote
 ## Attendance and completeness
 - Session: `mtgsess_...`
 - Status: `ended|failed|admission_denied`
 - Joined evidence: `joined_at` value, or “not verified”
 - Transcript: confirmed by `transcript.completed` | not confirmed (reason)
-
 ## Provenance
 - Transcript segment sequence range/count and collection caveats
+- Service artifacts: `<type>: <id>, status, model_provenance>`
 - Summary: service artifact `<id>` (`content.text`) | agent-generated fallback (reason)
 ```
 
@@ -287,18 +414,26 @@ that are absent from the session, events, or collected finalized transcript.
 
 On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
-from persisted cursors and dedupe keys—never call `join_meeting` again. If it has
-an idempotency key but no saved session ID because creation was interrupted,
-retry the original `join_meeting` arguments with that same key only after
-checking any available response/log receipt. Persist every state transition,
-alert key, cursor, terminal observation, and artifact ID before relying on it.
+from persisted cursors and outbox state—never call `join_meeting` again. Retry
+pending mention alerts with their original delivery IDs and leave confirmed
+`sent` items alone. Never repeat live actions marked `accepted` or
+`outcome_unknown`; reconcile event history where useful, but do not treat a
+missing event as proof that an audible side effect did not happen. Resume each
+artifact request from its persisted ID/deadline and never repeat an ambiguous
+create. If the record has an idempotency key but no saved session ID because
+creation was interrupted, retry the original `join_meeting` arguments with that
+same key only after checking any available response/log receipt. Persist every
+state transition, alert/action state, cursor, terminal observation, and artifact
+ID before relying on it.
 
 If the requester asks to stop a non-terminal session, confirm the scope when
 needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
 does not erase the durable session history. Do not use destructive recording
 media deletion as a cleanup shortcut.
 
-## Worked Interpretation of a Vague Request
+## Worked Interpretations
+
+### Mention alert and final summary
 
 For: “Join this meeting and tell me what they discussed when it ends; if they
 mention my name, let me know.”
@@ -313,22 +448,49 @@ mention my name, let me know.”
 - Tell the requester if host admission is required; send mention alerts in this
   conversation; after completion, send the bounded, evidence-based report.
 
-## References
+### Reactive lunch answer
 
-Use the public Meeting Bot documentation as the consumer-facing contract:
+For: “Join the meeting and as soon as someone asks what we should have for
+lunch, please use the speak request and say I want pizza.”
 
-- [Meeting Bot overview](https://developers.telnyx.com/docs/meeting)
-- [Meeting Bot quick start](https://developers.telnyx.com/docs/meeting/quick-start)
-- [Meeting Bot MCP reference](https://developers.telnyx.com/docs/meeting/mcp)
-- [Collect results](https://developers.telnyx.com/docs/meeting/collect-results)
+- Treat this as explicit authorization for one in-meeting `speak`; do not ask
+  again when the condition occurs.
+- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance
+  speech/chat, and `barge_in: true`.
+- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new
+  final segment plus a short trailing context window; require a clear lunch-choice
+  question rather than the isolated word “lunch.”
+- Atomically claim the first match and call
+  `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only
+  from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
 
-This workflow was also checked against the service implementation at commit
-[`a9f6326`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326):
+### Demo: delegated attendance and TL;DR
 
-- [Service README](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/README.md)
-- [Production REST demo](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/docs/basic-rest-demo.md)
-- [Meeting-session REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/routes/meetingSessions.ts)
-- [MCP tool definitions](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/mcp/server.ts)
+For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as
+Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
+
+Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and
+no unrequested speech/chat. Post joining/admission updates to Anusha's current
+conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A
+summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises
+live reactions. At terminal status, drain final transcript and send the automatic
+`summary` with attendance, completeness, and provenance. The visible story is:
+Anusha cannot attend → texts her agent → colleagues see her bot join → her agent
+confirms attendance → she receives the TL;DR.
+
+## Source Authority and References
+
+Behavior in this skill is grounded in the current `meeting-bot-service`
+`origin/main`, verified at commit
+[`a9f6326bcaf7428364861290b787d5db1772e9f6`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326bcaf7428364861290b787d5db1772e9f6).
+Treat implementation and tests as authoritative when public documentation lags:
+
+- [Artifact types](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/domain/artifact.ts) and [generation](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/services/artifactService.ts)
+- [REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/routes/meetingSessions.ts), [MCP tools](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/mcp/server.ts), and [speech](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/services/sessionService.ts#L1021-L1142)
+- [Session action tests](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/tests/sessionService.test.ts#L642-L708) and [artifact tests](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/tests/artifactService.test.ts)
+
+Public [Meeting Bot documentation](https://developers.telnyx.com/docs/meeting) is a
+secondary navigation surface, not the source used to derive this workflow.
 
 Recheck tool schemas with MCP `tools/list` when a deployed service changes, and
 never copy credentials, private meeting URLs, webhook secrets, or transient

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -285,7 +285,8 @@ Permit a new repeat key only after its stale-safe ordered clear commits; never k
 }
 ```
 
-Only the process that wins that claim may dispatch. For MCP, call
+Only the process that wins that claim may dispatch. Atomically set `dispatching`
+immediately before invoking the transport. For MCP, call
 `speak(id, text, voice?, interrupt?)`; for REST, call
 `POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
 unless replacing the bot's own current audio—it does not mean “interrupt the
@@ -300,7 +301,9 @@ that every attendee heard the complete utterance. Because `speak` and
 `send_chat` expose no caller idempotency key, do **not** automatically repeat an
 accepted action or one whose transport outcome became ambiguous after dispatch.
 Mark the latter `outcome_unknown`, tell the requester, and keep monitoring.
-Retry only a failure proved to occur before the action request was sent.
+Within the same live attempt, only durable transport evidence that no request
+bytes were sent may mark `pre_send_failed` and allow a bounded transition of that
+same claim back to `dispatching`.
 
 ## Terminal Drain and Completeness
 
@@ -414,9 +417,11 @@ On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
 from persisted cursors and outbox state—never call `join_meeting` again. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
-`sent` items alone. Never repeat live actions marked `accepted` or
-`outcome_unknown`; reconcile event history where useful, but do not treat a
-missing event as proof that an audible side effect did not happen. Resume each
+`sent` items alone. Before evaluating triggers, atomically convert every recovered
+live-action claim still marked `dispatching` to `outcome_unknown` unless durable
+transport evidence proves no request bytes were sent; never redispatch it. Never
+repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history
+where useful, but a missing event is not proof the side effect did not happen. Resume each
 artifact request from its persisted ID/deadline and never repeat an ambiguous
 create. If the record has an idempotency key but no saved session ID because
 creation was interrupted, retry the original `join_meeting` arguments with that

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -264,9 +264,11 @@ evaluate each newest final segment with only a short trailing context window.
 Require clear transcript evidence; do not trigger from an unrelated occurrence
 of one keyword. Persist the evidence seq(s) and exact quote.
 
-Before executing the first match, atomically create an action claim. For a
-one-shot rule, key it only by session and rule; retain trigger seq(s) as evidence.
-Only an explicitly repeating rule may add the trigger seq to its claim key:
+Before executing the first match, atomically create an action claim. A one-shot key uses only session and rule; trigger seq(s) are evidence.
+For an explicitly repeating literal rule, atomically claim `action:<session_id>:<rule_id>:repeat:<segment.seq>` once per matching finalized segment.
+For an explicitly repeating semantic rule, follow the [repeating-action protocol](references/repeating-semantic-actions.md); persist `occurrence_first_seq` and `evidence_seqs`.
+Under its ordered lease/CAS, all workers use `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>` and reuse the active occurrence across windows.
+Permit a new repeat key only after its stale-safe ordered clear commits; never key from the newest evaluation segment.
 
 ```json
 {
@@ -275,7 +277,6 @@ Only an explicitly repeating rule may add the trigger seq to its claim key:
   "type": "speak",
   "text": "I want pizza",
   "status": "dispatching",
-  "attempts": 1,
   "trigger_seqs": [42]
 }
 ```

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -264,11 +264,13 @@ evaluate each newest final segment with only a short trailing context window.
 Require clear transcript evidence; do not trigger from an unrelated occurrence
 of one keyword. Persist the evidence seq(s) and exact quote.
 
-Before executing the first match, atomically create an action claim such as:
+Before executing the first match, atomically create an action claim. For a
+one-shot rule, key it only by session and rule; retain trigger seq(s) as evidence.
+Only an explicitly repeating rule may add the trigger seq to its claim key:
 
 ```json
 {
-  "key": "action:<session_id>:<rule_id>:<first_trigger_seq>",
+  "key": "action:<session_id>:<rule_id>",
   "rule_id": "lunch-question",
   "type": "speak",
   "text": "I want pizza",

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: telnyx-meeting-bot
+description: >-
+  Use when an agent must safely join, observe, monitor, transcribe, summarize,
+  or follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
+  Telnyx Meeting Bot. Handles vague requests, scheduled joins, admission,
+  durable transcript polling, name/phrase alerts, recovery, and final meeting
+  artifacts without speaking or sending chat by default.
+metadata:
+  author: telnyx
+  product: meeting-bot
+  requires:
+    env:
+      - TELNYX_API_KEY
+---
+
+# Telnyx Meeting Bot
+
+Use this skill to attend a meeting visibly as an **observe-only** bot, monitor
+its finalized transcript, alert the requester about selected mentions, and
+produce an evidence-based meeting report. The bot must not speak, send chat, or
+make other in-meeting changes unless the requester explicitly asks for that.
+
+## Quick Workflow
+
+1. Resolve only missing essentials: meeting URL, join now versus a scheduled
+   time, and mention terms. Reuse terms already stated in the request or known
+   from the current conversation/profile; do not ask again or guess a person's
+   name.
+2. Persist an operation record **before** creating the session. Generate and
+   retain one stable `idempotency_key`; call `join_meeting` with
+   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`.
+3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
+   Persist cursors, seen segment sequences, sent mention-alert keys, and IDs so
+   a restart resumes safely.
+4. On each new final transcript segment, detect whole-name/phrase mentions and
+   alert the requester in the current conversation once per segment/match.
+5. On a terminal session, drain transcript pages, wait a bounded time for
+   `transcript.completed`, obtain an existing summary artifact or create only
+   one fallback summary artifact, then deliver a Markdown report.
+
+## Preconditions and Safe Defaults
+
+- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL,
+  transcript, event, artifact, chat message, or user-facing report.
+- Before joining, ensure the runtime can keep monitoring or can resume from a
+  durable background task. Do not promise end-to-end monitoring from a process
+  that will disappear without preserving and resuming the operation record.
+- Verify the requester is authorized to have a visible bot attend this meeting.
+  The bot may need a host to admit it; never try to bypass a waiting room,
+  password, platform policy, or consent requirement.
+- Default notification target: **this current conversation**. Do not configure a
+  `webhook_url` merely to send the requester notifications.
+- Default behavior: immediate join if no future time was requested,
+  `summarize_on_end: true`, observe-only, and no recording-media deletion.
+  `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
+- If a meeting link is not present, ask for it. If time is ambiguous, ask only
+  whether to join now or at a specified time. If “my name” is not resolvable
+  from the request, current conversation, or authorized profile context, ask
+  which name/phrases (and optional variants) to watch for.
+
+## Connect to the Production MCP Server
+
+Prefer the production Streamable HTTP MCP endpoint:
+
+```text
+https://api.telnyx.com/v2/meeting_bot/mcp
+Authorization: Bearer <TELNYX_API_KEY>
+```
+
+Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`,
+`get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`,
+`stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and
+`get_artifacts`.
+
+MCP tools return one JSON text block. Decode `result.content[0].text` as JSON
+only after checking `result.isError`. HTTP/transport failures (for example 401,
+timeouts, or a 5xx) are different from an HTTP-200 MCP tool failure with
+`result.isError: true`; handle both, preserve the error code/message, and do
+not treat an HTTP 200 as success by itself.
+
+If MCP is unavailable, use the equivalent production REST base:
+
+```text
+https://api.telnyx.com/v2/meeting_sessions
+```
+
+REST equivalents are `POST /`, `GET /{id}`, `GET /{id}/transcript`,
+`GET /{id}/events`, `DELETE /{id}`, `GET /{id}/artifacts`,
+`POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
+`Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
+Use REST only as a transport fallback—the lifecycle and durability rules below
+remain the same.
+
+## Create or Schedule Exactly Once
+
+Before the first `join_meeting`, checkpoint a durable operation record outside
+transient chat memory whenever the host supports files, a task store, or durable
+workflow state. Store at least:
+
+```json
+{
+  "operation_id": "host-stable-id",
+  "meeting_url": "redacted-or-secret-reference",
+  "idempotency_key": "meeting-bot:<host-stable-id>",
+  "session_id": null,
+  "transcript_after_seq": 0,
+  "event_after_seq": 0,
+  "seen_transcript_seqs": [],
+  "mention_alert_keys": [],
+  "mentions": [],
+  "summary_artifact_id": null,
+  "summary_creation_attempted": false,
+  "summary_poll_deadline_at": null,
+  "terminal_observed_at": null,
+  "transcript_completed": false
+}
+```
+
+Use a UUID or a host-durable operation ID, not a new timestamp on retry. Then
+call `join_meeting` with the smallest safe argument set:
+
+```json
+{
+  "meeting_url": "<resolved meeting URL>",
+  "join_at": "<future RFC 3339 time only when scheduled>",
+  "summarize_on_end": true,
+  "idempotency_key": "meeting-bot:<host-stable-id>"
+}
+```
+
+Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
+Persist the returned `id` as `session_id` immediately. If the create request has an
+uncertain transport outcome, retry **only** with the same persisted
+`idempotency_key`; never issue a second key, which could place a second bot in
+the meeting. If the host cannot persist state, state that duplicate-prevention
+across a restart cannot be guaranteed and avoid an unbounded retry.
+
+## Live Session and Transcript Loop
+
+Interleave session checks with transcript reads; a successful transcript read
+alone is not proof the bot attended.
+
+1. Call `get_session(id)` at startup, after errors, and on a bounded cadence
+   (for example every 15–30 seconds while joining/active, with backoff after
+   transient failures).
+2. Treat `waiting_for_admission` as a request for a meeting host to admit the
+   visible bot. Tell the requester promptly; keep monitoring rather than
+   claiming attendance. A non-null `joined_at` is the positive evidence that
+   the bot actually attended.
+3. Treat `ended`, `failed`, and `admission_denied` as terminal. Record status,
+   `failure_reason`/status detail when present, and `joined_at`.
+4. Long-poll finalized segments with
+   `get_transcript(id, after_seq, limit, wait_seconds)`. Use `limit: 1000` and
+   `wait_seconds: 15` to `20` (never above the service maximum of 25 seconds).
+5. Deduplicate by durable `seq`. For each new segment, persist it or its needed
+   fields, process mentions, set `after_seq` to the **maximum processed seq**,
+   and checkpoint before the next call.
+6. If a response fills the page (`1000` rows), drain immediately with the
+   updated cursor and `wait_seconds: 0` until the page is short. Then resume
+   the short long-poll. Do not rely on a server `next_after` value in place of
+   the maximum sequence you successfully processed, and never reset the cursor
+   when a poll returns an empty page or a null continuation value.
+7. Use `get_events(id, after_seq, limit)` on a bounded cadence as well; advance
+   and persist its independent event cursor only after deduping event sequences.
+   It is useful for lifecycle and `transcript.completed` evidence, but is not a
+   replacement for transcript reads.
+
+Use bounded retries for transient network/5xx/429 errors, for example delays of
+1, 2, 4, 8, then at most 15 seconds with jitter. Keep the same session and
+cursors. For authentication errors, malformed requests, `not_found`, or an MCP
+`result.isError` that is not plausibly transient, stop automatic retries and
+surface the actionable error without exposing credentials or meeting secrets.
+
+## Mention Detection and Prompt Alerts
+
+Match **only finalized transcript segments** returned by `get_transcript`.
+Normalize with Unicode case-folding and whitespace normalization. For each known
+name or phrase variant, use escaped whole-phrase boundaries: it must not have a
+letter or number immediately before or after the phrase. This lets “Ann Lee”
+match “ann lee,” but not “ann leeds,” and avoids false positives such as `Ann`
+inside `annual`. Keep variants only when known from the requester or authorized
+profile/context; do not invent aliases.
+
+For every new `(session_id, segment.seq, normalized_variant)` match, persist an
+alert key before/with delivery and send one prompt notice to the current
+conversation:
+
+```text
+Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
+“<exact segment text>”
+```
+
+Use the segment's `relative_ts` (format it as a relative timestamp if available)
+and retain the exact quote without paraphrasing. A segment can produce alerts
+for distinct requested terms, but never repeat the same segment/term after a
+retry or resume. Append every alert record (term/variant, speaker, timestamp,
+seq, exact quote) to the durable mention log for the final report.
+
+## Terminal Drain and Completeness
+
+After a terminal status, do not conclude that an empty transcript poll means the
+transcript is complete.
+
+1. Record the first terminal observation time and repeatedly drain all available
+   transcript pages as above.
+2. Continue checking `get_events` for `transcript.completed` for a bounded
+   settle window (for example up to 90 seconds, with 2–10 second backoff) while
+   continuing short transcript drains.
+3. If the completion event arrives, make one final full drain and mark transcript
+   completeness as `confirmed by transcript.completed`.
+4. If the bound expires without that event, make at least two empty-drain checks
+   separated by a delay, then mark the report `not confirmed; bounded settle
+   window expired`. Include the terminal status and never describe the summary
+   as a complete account of the meeting in this case.
+
+A failed or denied session with `joined_at: null` means no verified attendance;
+report that honestly and do not invent a discussion summary.
+
+## Obtain a Summary Without Duplicating Work
+
+First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
+especially the one expected from `summarize_on_end: true`. Poll the selected
+artifact via `get_artifact(id, artifact_id)` until `status` is `completed` or
+`failed` or a persisted deadline expires; use `content.text` only when
+completed. When selecting any pending summary, persist its ID and one fixed
+`summary_poll_deadline_at` (for example five minutes from the first selection).
+Recovery must reuse, never extend, that deadline. During the normal automatic
+summary delay, poll the list on a bounded cadence (for example 2, 5, then 10
+seconds, for up to two minutes after transcript completion/settle).
+
+If no summary exists after that bounded wait:
+
+1. Check the durable record. If `summary_artifact_id` exists, poll it using the
+   original persisted deadline. If `summary_creation_attempted` is true but no
+   ID was returned, do **not** create another artifact—re-list only until that
+   same deadline, then report the ambiguous outcome and use the fallback.
+2. Otherwise persist `summary_creation_attempted: true`, call
+   `create_artifact(id, type: "summary")` **exactly once**, and immediately
+   persist the returned artifact ID. Set the fixed summary-poll deadline before
+   the call so an interrupted or ambiguous create cannot restart the clock.
+3. Poll that ID with `get_artifact` using bounded backoff until `completed`,
+   `failed`, or the persisted deadline expires. Artifact creation is
+   non-idempotent, so never retry an uncertain create call by creating another
+   summary. If the deadline expires while the artifact is still pending, keep
+   its ID/status for provenance and move to the transcript-grounded fallback.
+
+If service inference is unavailable, fails, or times out, still deliver an
+**Agent-generated summary (service summary unavailable)** based solely on the
+collected final transcript. Label transcript completeness and the inference
+failure/caveat. Do not fill in decisions, owners, actions, or discussion that
+the transcript does not support.
+
+## Deliver the Final Markdown Artifact
+
+Create a user-facing Markdown attachment or host-native artifact, retaining it
+in durable host storage when supported. Include:
+
+```markdown
+# Meeting report
+
+## Executive summary
+- <service `content.text`, or an explicitly labeled transcript-grounded fallback>
+
+## Topics, decisions, and action items
+- Include only items supported by the transcript; otherwise say “None identified in the collected transcript.”
+
+## Mention log
+- +00:00 — Speaker — matched term: “exact transcript quote”
+
+## Attendance and completeness
+- Session: `mtgsess_...`
+- Status: `ended|failed|admission_denied`
+- Joined evidence: `joined_at` value, or “not verified”
+- Transcript: confirmed by `transcript.completed` | not confirmed (reason)
+
+## Provenance
+- Transcript segment sequence range/count and collection caveats
+- Summary: service artifact `<id>` (`content.text`) | agent-generated fallback (reason)
+```
+
+Quote or link the meeting URL only where the recipient is already authorized;
+otherwise redact it. Never claim attendees, decisions, outcomes, or completeness
+that are absent from the session, events, or collected finalized transcript.
+
+## Recovery Rules
+
+On restart, load the durable operation record before doing anything. If it has a
+`session_id`, resume `get_session`, event/transcript drains, and summary polling
+from persisted cursors and dedupe keys—never call `join_meeting` again. If it has
+an idempotency key but no saved session ID because creation was interrupted,
+retry the original `join_meeting` arguments with that same key only after
+checking any available response/log receipt. Persist every state transition,
+alert key, cursor, terminal observation, and artifact ID before relying on it.
+
+If the requester asks to stop a non-terminal session, confirm the scope when
+needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
+does not erase the durable session history. Do not use destructive recording
+media deletion as a cleanup shortcut.
+
+## Worked Interpretation of a Vague Request
+
+For: “Join this meeting and tell me what they discussed when it ends; if they
+mention my name, let me know.”
+
+- If the message already includes a meeting URL and the requester identity/name
+  is known from authorized conversation/profile context, join immediately with
+  `summarize_on_end: true`, the stable idempotency key, no voice/chat actions,
+  and that name plus known variants as terms.
+- If the link is missing, ask only for the link. If it is unclear whether the
+  meeting is now or later, ask only for join timing. If “my name” is not known,
+  ask for the name/phrases and optional variants.
+- Tell the requester if host admission is required; send mention alerts in this
+  conversation; after completion, send the bounded, evidence-based report.
+
+## References
+
+Use the public Meeting Bot documentation as the consumer-facing contract:
+
+- [Meeting Bot overview](https://developers.telnyx.com/docs/meeting)
+- [Meeting Bot quick start](https://developers.telnyx.com/docs/meeting/quick-start)
+- [Meeting Bot MCP reference](https://developers.telnyx.com/docs/meeting/mcp)
+- [Collect results](https://developers.telnyx.com/docs/meeting/collect-results)
+
+This workflow was also checked against the service implementation at commit
+[`a9f6326`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326):
+
+- [Service README](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/README.md)
+- [Production REST demo](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/docs/basic-rest-demo.md)
+- [Meeting-session REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/routes/meetingSessions.ts)
+- [MCP tool definitions](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/mcp/server.ts)
+
+Recheck tool schemas with MCP `tools/list` when a deployed service changes, and
+never copy credentials, private meeting URLs, webhook secrets, or transient
+deployment details into this skill.

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
@@ -63,17 +63,19 @@ service clocks need not be comparable, and the unknown create returned no ID.
    `known_manual_artifact_ids`, and `created_at >= transcript_completed_at`.
 3. Persist every candidate ID. Poll all current candidates; do not lock onto the
    first pending artifact and ignore summaries that appear or complete later.
-4. A selectable likely-automatic result must be the **unique** completed
-   candidate with the smallest non-negative
+4. First identify the candidate with the smallest non-negative
    `created_at - transcript_completed_at` delta because the implementation calls
-   automatic creation immediately after appending `transcript.completed`. It
-   is eligible only when there is no unreconciled outcome-unknown manual
-   `summary` create. If two candidates share the minimum timestamp, or any
-   same-type unknown create remains unreconciled, origin is ambiguous. Never use
+   automatic creation immediately after appending `transcript.completed`. Rank
+   **all statuses** before filtering by status. It must be the unique minimum and
+   is eligible only when no same-type unknown create remains unreconciled. If two
+   candidates share the minimum timestamp, origin is ambiguous. Never use
    artifact ID, list order, completion order, or client-clock windows as an
    origin tie-breaker; use the labeled transcript-grounded fallback instead.
-5. A pending or failed early candidate does not end the search. Continue
-   re-listing and polling all post-completion candidates until the fixed deadline.
+5. Select that unique closest candidate only if it is `completed`. If it is
+   `pending`, keep re-listing and polling it and every candidate through the fixed
+   deadline; never skip to a later completed candidate. If the unique closest is
+   `failed` at the final reconciliation, use the fallback rather than a later
+   artifact.
 6. Immediately before fallback, re-list once more and poll every current
    candidate to terminal status within the remaining deadline.
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
@@ -1,0 +1,131 @@
+# Artifact Selection and Creation Recovery
+
+Use this protocol for final summaries and every manually requested transcript
+artifact.
+
+## Observable Implementation Contract
+
+- When `summarize_on_end` is enabled, the finalizer appends
+  `transcript.completed` and then calls the normal asynchronous
+  `create_artifact(..., "summary")` path.
+- `get_events` exposes each event's `occurred_at` timestamp.
+- Artifact responses expose `id`, `type`, `status`, `content`, `prompt`,
+  `model_provenance`, `failure_reason`, `created_at`, and `updated_at`.
+- The public artifact shape has no `automatic`, `origin`, or final-summary marker.
+- Artifact lists are newest-first by `created_at`; do not treat list position as
+  proof of automatic origin.
+- Creation is non-idempotent and returns a durable `pending` row before generation
+  completes.
+
+Do not invent an automatic-artifact marker that the implementation does not
+provide.
+
+## Durable State
+
+Persist per session:
+
+```json
+{
+  "transcript_completed_at": null,
+  "known_manual_artifact_ids": [],
+  "unreconciled_unknown_manual_creates": [],
+  "summary_candidate_ids": [],
+  "selected_summary_artifact_id": null,
+  "summary_poll_deadline_at": null,
+  "summary_creation": {
+    "state": "not_started",
+    "attempt_count": 0,
+    "max_pre_send_retries": 2,
+    "artifact_id": null,
+    "last_error": null
+  }
+}
+```
+
+Creation states are `not_started`, `dispatching`, `accepted`,
+`pre_send_failed`, `rejected`, and `outcome_unknown`. Set one fixed deadline
+before the first attempt; recovery never extends it.
+
+Every successful manual creation must add the returned ID to
+`known_manual_artifact_ids` immediately. Keep the type, stable custom-prompt
+hash, and dispatch start time in the corresponding manual request record. If a
+manual create becomes `outcome_unknown`, add that request and artifact type to
+`unreconciled_unknown_manual_creates`. Do not infer that any unrecognized
+same-type artifact is automatic while that uncertainty remains: client and
+service clocks need not be comparable, and the unknown create returned no ID.
+
+## Select the End-of-Meeting Summary
+
+1. Drain the final transcript and page `get_events` until `transcript.completed`
+   appears. Persist its `occurred_at` as `transcript_completed_at`.
+2. During the bounded automatic-summary window, repeatedly re-list artifacts.
+   A likely automatic candidate has `type: "summary"`, an ID absent from
+   `known_manual_artifact_ids`, and `created_at >= transcript_completed_at`.
+3. Persist every candidate ID. Poll all current candidates; do not lock onto the
+   first pending artifact and ignore summaries that appear or complete later.
+4. A selectable likely-automatic result must be the **unique** completed
+   candidate with the smallest non-negative
+   `created_at - transcript_completed_at` delta because the implementation calls
+   automatic creation immediately after appending `transcript.completed`. It
+   is eligible only when there is no unreconciled outcome-unknown manual
+   `summary` create. If two candidates share the minimum timestamp, or any
+   same-type unknown create remains unreconciled, origin is ambiguous. Never use
+   artifact ID, list order, completion order, or client-clock windows as an
+   origin tie-breaker; use the labeled transcript-grounded fallback instead.
+5. A pending or failed early candidate does not end the search. Continue
+   re-listing and polling all post-completion candidates until the fixed deadline.
+6. Immediately before fallback, re-list once more and poll every current
+   candidate to terminal status within the remaining deadline.
+
+If `transcript.completed` was not observed, `ended_at` is only a weaker lower
+bound. Label selection as unconfirmed and never present a summary created before
+that bound as the final meeting summary.
+
+Because the public API has no origin marker, an unknown external caller can create
+a manual summary after `transcript.completed` that is indistinguishable from the
+automatic one. An outcome-unknown create can likewise leave its ID absent from
+`known_manual_artifact_ids`; conservatively quarantine automatic-origin
+selection for that artifact type until the unknown request is reconciled to an
+ID by stronger host evidence. If timing and known IDs do not identify one unique
+candidate, say so and prefer the transcript-grounded fallback over claiming an
+artifact is the automatic end-of-meeting summary.
+
+## Manual Create State Machine
+
+1. Persist the fixed poll deadline and bounded `max_pre_send_retries` before the
+   first call.
+2. Immediately before invoking REST or MCP, atomically move the request to
+   `dispatching` and increment `attempt_count`.
+3. If the client proves that no request bytes were sent—for example, local
+   serialization/validation failure, client-queue rejection, or connection/TLS
+   failure before request transmission—record `pre_send_failed`. The same durable
+   request may return to `dispatching` and retry within its original deadline and
+   retry budget because no artifact could have been created.
+4. A complete implementation response with `invalid_request`, `invalid_state`,
+   `not_configured`, or `not_found` is `rejected`; these checks occur before the
+   artifact row is created. Correct the cause before any bounded retry.
+5. Once any request bytes may have been sent, a timeout, disconnect, process
+   interruption, malformed response, or unknown server error is
+   `outcome_unknown`. Recovery from either `dispatching` or `outcome_unknown`
+   must persist an unreconciled same-type unknown-create marker and
+   re-list/reconcile only; it must not issue another create. Until stronger host
+   evidence maps that request to a returned ID, every otherwise-unrecognized
+   same-type artifact is possible manual output, not evidence of automatic
+   origin.
+6. When the response returns an artifact ID, atomically record `accepted`, the
+   ID, and the manual ID set before polling it.
+
+Never collapse `pre_send_failed` and `outcome_unknown` into one
+`creation_attempted` boolean. Only a proven pre-send failure or a confirmed
+pre-creation rejection may retry; ambiguous create outcomes never do.
+
+## Polling and Fallback
+
+Poll every accepted/candidate ID until `completed`, `failed`, or the original
+fixed deadline. Read `content.text` only from `completed`. Preserve IDs, status,
+provenance, and failure reason. Before falling back, perform the final list/poll
+reconciliation above.
+
+If no trustworthy completed service artifact is available, deliver the parent
+skill's explicitly labeled transcript-grounded fallback and state whether final
+transcript completeness was confirmed.

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
@@ -55,10 +55,11 @@ active.
    `last_evaluated_seq`. That same transaction must advance `last_evaluated_seq`,
    persist the evaluation result and canonical `evidence_seqs`, and perform the
    applicable occurrence transition: create `active_occurrence` plus the durable
-   action claim `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
+   `claimed` action `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
    retain the active occurrence, atomically clear it, or retain no occurrence.
-5. Dispatch only after that combined transaction commits and only when it returns
-   a newly created claim. A CAS loser reloads state without dispatching.
+5. After that transaction commits, dispatch only if a second CAS changes that
+   claim from `claimed` to `dispatching` immediately before transport invocation.
+   A CAS loser reloads state without dispatching.
 6. While an occurrence is active, every positive overlapping window reuses its
    persisted claim key. It cannot create another claim, even if the newest
    evaluation sequence differs or a shorter evidence suffix later appears.
@@ -83,6 +84,9 @@ still-later ordered evaluation produces a new false-to-true transition.
   transition committed in the same transaction, so never reclassify it.
 - If the lease expired, acquire a newer generation before evaluating.
 - If `active_occurrence` exists, reuse its claim key and action state.
+- A recovered `claimed` action may compete once for the `claimed` → `dispatching`
+  CAS. A recovered `dispatching` action becomes `outcome_unknown` before any
+  trigger evaluation unless durable transport evidence proves no bytes were sent.
 - Preserve the parent skill's side-effect rule: never automatically repeat an
   accepted or outcome-unknown `speak`/`send_chat` dispatch.
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
@@ -1,0 +1,90 @@
+# Repeating Semantic Action Protocol
+
+Use this protocol only when the requester explicitly asks a semantic `speak` or
+`send_chat` rule to repeat. One-shot rules use the simpler session-and-rule claim
+key in the parent skill.
+
+## Persisted Rule State
+
+Persist one record scoped by `(session_id, rule_id)`:
+
+```json
+{
+  "lease_owner": null,
+  "lease_expires_at": null,
+  "generation": 0,
+  "last_evaluated_seq": 0,
+  "context_segments": 3,
+  "active_occurrence": null
+}
+```
+
+When active, `active_occurrence` is:
+
+```json
+{
+  "occurrence_first_seq": 41,
+  "evidence_seqs": [41, 42],
+  "claim_key": "action:<session_id>:<rule_id>:repeat:41",
+  "status": "active"
+}
+```
+
+Persist the semantic condition, action payload, classifier/configuration, and
+fixed `context_segments` with the rule. Do not change them while the rule is
+active.
+
+## Ordered Evaluation and Canonical Evidence
+
+1. Acquire a durable exclusive lease for `(session_id, rule_id)` with an atomic
+   compare-and-swap (CAS). Only the current lease owner may classify transcript
+   windows or update this rule state. A replacement worker must wait for lease
+   expiry and then acquire a newer `generation`.
+2. Consume finalized transcript segments in strictly increasing `seq` order.
+   Evaluate each sequence once using the fixed trailing window ending at that
+   sequence, but do not advance the durable cursor in a separate write.
+3. When no occurrence is active and the condition becomes true, choose the
+   **shortest contiguous suffix ending at the current sequence** that still
+   satisfies the persisted semantic condition. This structurally determines one
+   evidence list; its first element is `occurrence_first_seq`. If semantic
+   classification is stochastic, only the lease owner runs it and persists the
+   selected evidence through the transaction below—other workers never
+   independently classify a committed sequence.
+4. For every evaluated sequence, execute one per-sequence CAS transaction that
+   compares the prior `generation`, lease owner/validity, and prior
+   `last_evaluated_seq`. That same transaction must advance `last_evaluated_seq`,
+   persist the evaluation result and canonical `evidence_seqs`, and perform the
+   applicable occurrence transition: create `active_occurrence` plus the durable
+   action claim `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
+   retain the active occurrence, atomically clear it, or retain no occurrence.
+5. Dispatch only after that combined transaction commits and only when it returns
+   a newly created claim. A CAS loser reloads state without dispatching.
+6. While an occurrence is active, every positive overlapping window reuses its
+   persisted claim key. It cannot create another claim, even if the newest
+   evaluation sequence differs or a shorter evidence suffix later appears.
+
+## Clearing and Re-arming
+
+Clear `active_occurrence` only when a later ordered evaluation satisfies both:
+
+- its fixed context window contains none of the persisted `evidence_seqs`; and
+- the persisted semantic condition evaluates false.
+
+The clear is the occurrence transition inside the same per-sequence transaction
+that advances `last_evaluated_seq`; never advance the cursor and clear in separate
+writes. Compare the current `generation`, lease owner/validity, active claim key,
+and prior cursor. An older/stale worker must fail that CAS and reload without
+clearing. A new repeat claim is permitted only after the clear commits and a
+still-later ordered evaluation produces a new false-to-true transition.
+
+## Crash Recovery
+
+- Resume from the persisted `last_evaluated_seq`; its evaluation and occurrence
+  transition committed in the same transaction, so never reclassify it.
+- If the lease expired, acquire a newer generation before evaluating.
+- If `active_occurrence` exists, reuse its claim key and action state.
+- Preserve the parent skill's side-effect rule: never automatically repeat an
+  accepted or outcome-unknown `speak`/`send_chat` dispatch.
+
+This protocol intentionally favors at-most-once action delivery over reacting to
+ambiguous consecutive utterances that never produce a clear transition.

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -126,8 +126,12 @@ workflow state. Store at least:
   "mentions": [],
   "action_claims": [],
   "artifact_requests": {},
+  "known_manual_artifact_ids": [],
+  "unreconciled_unknown_manual_creates": [],
+  "transcript_completed_at": null,
+  "summary_candidate_ids": [],
   "summary_artifact_id": null,
-  "summary_creation_attempted": false,
+  "summary_creation": {"state": "not_started", "attempt_count": 0, "max_pre_send_retries": 2, "artifact_id": null},
   "summary_poll_deadline_at": null,
   "terminal_observed_at": null,
   "transcript_completed": false
@@ -337,11 +341,11 @@ reject `prompt`. Each create is asynchronous with `pending`, `completed`, or
 `model_provenance`/failure information. `summarize_on_end: true` attempts only a
 `summary`; create other requested types separately.
 
-For every manual artifact, keep one durable record keyed by type plus a stable
-hash of the custom prompt. Persist `creation_attempted`, the fixed poll deadline,
-and then the returned artifact ID. Since creation is non-idempotent, never repeat
-an ambiguous create. Apply the detailed summary discipline below to every
-manually requested artifact.
+For every manual artifact, follow the [artifact selection and creation recovery
+protocol](references/artifact-selection-and-recovery.md). Keep its durable state
+machine, fixed deadline, manual artifact IDs, and returned ID. Retry only a
+proven `pre_send_failed` or confirmed pre-creation rejection; an ambiguous create
+is `outcome_unknown` and may only be reconciled by listing.
 
 At implementation commit `a9f6326`, generation reads at most the first 10,000
 finalized transcript segments without exposing a truncation warning. For an
@@ -350,31 +354,22 @@ result from the full transcript the agent actually collected.
 
 ### Summary flow
 
-First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
-especially the one expected from `summarize_on_end: true`. Poll the selected
-artifact via `get_artifact(id, artifact_id)` until `status` is `completed` or
-`failed` or a persisted deadline expires; use `content.text` only when
-completed. When selecting any pending summary, persist its ID and one fixed
-`summary_poll_deadline_at` (for example five minutes from the first selection).
-Recovery must reuse, never extend, that deadline. During the normal automatic
-summary delay, poll the list on a bounded cadence (for example 2, 5, then 10
-seconds, for up to two minutes after transcript completion/settle).
+Follow the linked recovery protocol. Persist `transcript.completed.occurred_at`,
+exclude `known_manual_artifact_ids`, and repeatedly re-list all post-completion
+summary candidates. The API has no automatic-origin marker, so select only a
+unique completed candidate whose `created_at` is closest after the completion
+event, but only when no same-type manual create has an unreconciled unknown
+outcome. Equal-time candidates are also ambiguous. Because no ID was returned
+and clocks may differ, never use artifact ID, list order, completion order, or
+client-clock windows as an origin tie-breaker. Do not lock onto the first pending
+artifact or silently use a pre-completion partial summary. Immediately before
+fallback, re-list and poll every current candidate within the fixed deadline.
 
-If no summary exists after that bounded wait:
-
-1. Check the durable record. If `summary_artifact_id` exists, poll it using the
-   original persisted deadline. If `summary_creation_attempted` is true but no
-   ID was returned, do **not** create another artifact—re-list only until that
-   same deadline, then report the ambiguous outcome and use the fallback.
-2. Otherwise persist `summary_creation_attempted: true`, call
-   `create_artifact(id, type: "summary")` **exactly once**, and immediately
-   persist the returned artifact ID. Set the fixed summary-poll deadline before
-   the call so an interrupted or ambiguous create cannot restart the clock.
-3. Poll that ID with `get_artifact` using bounded backoff until `completed`,
-   `failed`, or the persisted deadline expires. Artifact creation is
-   non-idempotent, so never retry an uncertain create call by creating another
-   summary. If the deadline expires while the artifact is still pending, keep
-   its ID/status for provenance and move to the transcript-grounded fallback.
+If no trustworthy automatic candidate appears, use the protocol's manual-create
+state machine. A proven pre-send failure may retry within the original bound;
+`dispatching` after a crash or any possibly sent/ambiguous call becomes
+`outcome_unknown` and must never create again. Poll accepted IDs to terminal state
+and retain pending/failed provenance before using the transcript fallback.
 
 If service inference is unavailable, fails, or times out, still deliver an
 **Agent-generated summary (service summary unavailable)** based solely on the

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -126,13 +126,10 @@ workflow state. Store at least:
   "mentions": [],
   "action_claims": [],
   "artifact_requests": {},
-  "known_manual_artifact_ids": [],
-  "unreconciled_unknown_manual_creates": [],
-  "transcript_completed_at": null,
-  "summary_candidate_ids": [],
-  "summary_artifact_id": null,
+  "known_manual_artifact_ids": [], "unreconciled_unknown_manual_creates": [],
+  "transcript_completed_at": null, "summary_candidate_ids": [],
+  "summary_artifact_id": null, "summary_poll_deadline_at": null,
   "summary_creation": {"state": "not_started", "attempt_count": 0, "max_pre_send_retries": 2, "artifact_id": null},
-  "summary_poll_deadline_at": null,
   "terminal_observed_at": null,
   "transcript_completed": false
 }
@@ -280,13 +277,14 @@ Permit a new repeat key only after its stale-safe ordered clear commits; never k
   "rule_id": "lunch-question",
   "type": "speak",
   "text": "I want pizza",
-  "status": "dispatching",
+  "status": "claimed",
   "trigger_seqs": [42]
 }
 ```
 
-Only the process that wins that claim may dispatch. Atomically set `dispatching`
-immediately before invoking the transport. For MCP, call
+Creating the claim only reserves its key. Dispatch only if a CAS changes `claimed`
+(or proven `pre_send_failed`) to `dispatching` immediately before the transport
+call; a CAS loser skips. For MCP, call
 `speak(id, text, voice?, interrupt?)`; for REST, call
 `POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
 unless replacing the bot's own current audio—it does not mean “interrupt the
@@ -359,10 +357,11 @@ result from the full transcript the agent actually collected.
 
 Follow the linked recovery protocol. Persist `transcript.completed.occurred_at`,
 exclude `known_manual_artifact_ids`, and repeatedly re-list all post-completion
-summary candidates. The API has no automatic-origin marker, so select only a
-unique completed candidate whose `created_at` is closest after the completion
-event, but only when no same-type manual create has an unreconciled unknown
-outcome. Equal-time candidates are also ambiguous. Because no ID was returned
+summary candidates. The API has no automatic-origin marker, so first identify the
+unique closest candidate across **all statuses**. Use it only if completed and no
+same-type manual create has an unreconciled unknown outcome; if pending, wait, and
+if failed, fall back rather than choosing a later artifact. Equal-time candidates
+are ambiguous. Because no ID was returned
 and clocks may differ, never use artifact ID, list order, completion order, or
 client-clock windows as an origin tie-breaker. Do not lock onto the first pending
 artifact or silently use a pre-completion partial summary. Immediately before
@@ -417,7 +416,8 @@ On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
 from persisted cursors and outbox state—never call `join_meeting` again. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
-`sent` items alone. Before evaluating triggers, atomically convert every recovered
+`sent` items alone. A recovered `claimed` action may attempt the dispatch CAS. Before
+evaluating triggers, atomically convert every recovered
 live-action claim still marked `dispatching` to `outcome_unknown` unless durable
 transport evidence proves no request bytes were sent; never redispatch it. Never
 repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: telnyx-meeting-bot
 description: >-
-  Use when an agent must safely join, observe, monitor, transcribe, summarize,
-  or follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
-  Telnyx Meeting Bot. Handles vague requests, scheduled joins, admission,
-  durable transcript polling, name/phrase alerts, recovery, and final meeting
-  artifacts without speaking or sending chat by default.
+  Use when an agent must join, observe, react in, transcribe, summarize, or
+  follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
+  Telnyx Meeting Bot. Handles vague requests, request-specific live polling,
+  name/phrase and semantic triggers, explicitly authorized speak/chat actions,
+  recovery, and all implemented transcript artifact types.
 metadata:
   author: telnyx
   product: meeting-bot
@@ -16,28 +16,32 @@ metadata:
 
 # Telnyx Meeting Bot
 
-Use this skill to attend a meeting visibly as an **observe-only** bot, monitor
-its finalized transcript, alert the requester about selected mentions, and
-produce an evidence-based meeting report. The bot must not speak, send chat, or
-make other in-meeting changes unless the requester explicitly asks for that.
+Use this skill to attend a meeting visibly, monitor its finalized transcript,
+alert the requester, execute explicitly authorized live rules such as speaking
+one response, and produce evidence-based meeting results. The bot is
+**observe-only by default**: it must not speak, send chat, or make other
+in-meeting changes unless the requester explicitly asks for that.
 
 ## Quick Workflow
 
 1. Resolve only missing essentials: meeting URL, join now versus a scheduled
-   time, and mention terms. Reuse terms already stated in the request or known
-   from the current conversation/profile; do not ask again or guess a person's
-   name.
+   time, desired live/final outputs, and any trigger/action rules. Reuse details
+   already stated in the request or authorized context; do not ask again.
 2. Persist an operation record **before** creating the session. Generate and
    retain one stable `idempotency_key`; call `join_meeting` with
-   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`.
+   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`. If an
+   explicit later speech rule exists, set `barge_in: true` so new human speech
+   can stop the bot's output.
 3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
-   Persist cursors, seen segment sequences, sent mention-alert keys, and IDs so
-   a restart resumes safely.
-4. On each new final transcript segment, detect whole-name/phrase mentions and
-   alert the requester in the current conversation once per segment/match.
+   Choose transcript `wait_seconds` from the request—use about `2` seconds for
+   “as soon as,” reactive speech, or urgent mention alerts—and persist cursors,
+   seen segments, outboxes, action claims, and IDs for safe recovery.
+4. On each new final segment, evaluate requested literal or semantic rules.
+   Deliver mention notifications through the durable outbox; atomically claim
+   and execute each authorized `speak`/`send_chat` action at most once.
 5. On a terminal session, drain transcript pages, wait a bounded time for
-   `transcript.completed`, obtain an existing summary artifact or create only
-   one fallback summary artifact, then deliver a Markdown report.
+   `transcript.completed`, obtain the requested implemented artifact types
+   without duplicate creation, then deliver a Markdown report.
 
 ## Preconditions and Safe Defaults
 
@@ -54,6 +58,13 @@ make other in-meeting changes unless the requester explicitly asks for that.
 - Default behavior: immediate join if no future time was requested,
   `summarize_on_end: true`, observe-only, and no recording-media deletion.
   `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
+- An explicit conditional request such as “when someone asks about lunch, say
+  ‘I want pizza’” is advance authorization for that exact action. Persist the
+  trigger, exact payload, one-shot/repeat policy, and latency target before join;
+  do not interrupt the live workflow to ask for approval again.
+- Choose monitoring cadence from the request. Default immediate reactions and
+  urgent mentions to `wait_seconds: 2`; do not silently substitute a 15-second
+  cadence for an “as soon as” instruction.
 - If a meeting link is not present, ask for it. If time is ambiguous, ask only
   whether to join now or at a specified time. If “my name” is not resolvable
   from the request, current conversation, or authorized profile context, ask
@@ -85,8 +96,10 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents are `POST /`, `GET /{id}`, `GET /{id}/transcript`,
-`GET /{id}/events`, `DELETE /{id}`, `GET /{id}/artifacts`,
+REST equivalents include `POST /`, `GET /{id}`,
+`POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`,
+`POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`,
+`DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`,
 `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
 `Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
 Use REST only as a transport fallback—the lifecycle and durability rules below
@@ -104,11 +117,15 @@ workflow state. Store at least:
   "meeting_url": "redacted-or-secret-reference",
   "idempotency_key": "meeting-bot:<host-stable-id>",
   "session_id": null,
+  "poll_wait_seconds": 2,
+  "live_rules": [],
   "transcript_after_seq": 0,
   "event_after_seq": 0,
   "seen_transcript_seqs": [],
-  "mention_alert_keys": [],
+  "mention_alerts": [],
   "mentions": [],
+  "action_claims": [],
+  "artifact_requests": {},
   "summary_artifact_id": null,
   "summary_creation_attempted": false,
   "summary_poll_deadline_at": null,
@@ -130,7 +147,10 @@ call `join_meeting` with the smallest safe argument set:
 ```
 
 Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
-Persist the returned `id` as `session_id` immediately. If the create request has an
+If the request contains an authorized later `speak` rule, include
+`"barge_in": true`; this lets human speech stop bot output and does not itself
+make the bot speak. Persist the returned `id` as `session_id` immediately.
+If the create request has an
 uncertain transport outcome, retry **only** with the same persisted
 `idempotency_key`; never issue a second key, which could place a second bot in
 the meeting. If the host cannot persist state, state that duplicate-prevention
@@ -141,18 +161,22 @@ across a restart cannot be guaranteed and avoid an unbounded retry.
 Interleave session checks with transcript reads; a successful transcript read
 alone is not proof the bot attended.
 
-1. Call `get_session(id)` at startup, after errors, and on a bounded cadence
-   (for example every 15–30 seconds while joining/active, with backoff after
-   transient failures).
+1. Call `get_session(id)` at startup, after errors, and on a bounded cadence.
+   Use roughly every 5–10 seconds for a reactive workflow and 15–30 seconds for
+   passive monitoring, with backoff after transient failures.
 2. Treat `waiting_for_admission` as a request for a meeting host to admit the
    visible bot. Tell the requester promptly; keep monitoring rather than
    claiming attendance. A non-null `joined_at` is the positive evidence that
    the bot actually attended.
 3. Treat `ended`, `failed`, and `admission_denied` as terminal. Record status,
-   `failure_reason`/status detail when present, and `joined_at`.
+   `status_detail` when present, and `joined_at`.
 4. Long-poll finalized segments with
    `get_transcript(id, after_seq, limit, wait_seconds)`. Use `limit: 1000` and
-   `wait_seconds: 15` to `20` (never above the service maximum of 25 seconds).
+   select/persist the wait from the request: `2` seconds for “as soon as,”
+   reactive `speak`, or urgent mentions; `2`–`5` for ordinary live updates;
+   `10`–`20` for summary-only passive attendance. The implemented integer range
+   is `0`–`25`. The call returns as soon as new finalized speech exists, so the
+   wait is a maximum held-request duration, not an added post-transcript delay.
 5. Deduplicate by durable `seq`. For each new segment, persist it or its needed
    fields, process mentions, set `after_seq` to the **maximum processed seq**,
    and checkpoint before the next call.
@@ -160,7 +184,8 @@ alone is not proof the bot attended.
    updated cursor and `wait_seconds: 0` until the page is short. Then resume
    the short long-poll. Do not rely on a server `next_after` value in place of
    the maximum sequence you successfully processed, and never reset the cursor
-   when a poll returns an empty page or a null continuation value.
+   when a poll returns an empty page or a null continuation value. Return to the
+   selected request cadence after the immediate drain.
 7. Use `get_events(id, after_seq, limit)` on a bounded cadence as well; advance
    and persist its independent event cursor only after deduping event sequences.
    It is useful for lifecycle and `transcript.completed` evidence, but is not a
@@ -172,7 +197,9 @@ cursors. For authentication errors, malformed requests, `not_found`, or an MCP
 `result.isError` that is not plausibly transient, stop automatic retries and
 surface the actionable error without exposing credentials or meeting secrets.
 
-## Mention Detection and Prompt Alerts
+## Live Trigger Detection, Alerts, and Actions
+
+### Name/phrase alerts
 
 Match **only finalized transcript segments** returned by `get_transcript`.
 Normalize with Unicode case-folding and whitespace normalization. For each known
@@ -182,9 +209,25 @@ match “ann lee,” but not “ann leeds,” and avoids false positives such as
 inside `annual`. Keep variants only when known from the requester or authorized
 profile/context; do not invent aliases.
 
-For every new `(session_id, segment.seq, normalized_variant)` match, persist an
-alert key before/with delivery and send one prompt notice to the current
-conversation:
+For every new `(session_id, segment.seq, normalized_variant)` match, derive one
+stable alert key and delivery ID such as
+`mention:<session_id>:<segment.seq>:<normalized_variant>`. Persist the mention
+and an outbox item **before** delivery:
+
+```json
+{
+  "key": "mention:<session_id>:<seq>:<normalized_variant>",
+  "delivery_id": "same-stable-value",
+  "status": "pending",
+  "attempts": 0,
+  "last_error": null,
+  "sent_at": null
+}
+```
+
+If that key already has `status: "sent"`, skip it. If it is `pending`, reuse the
+same outbox item rather than creating a second one. Send the notice to the
+current conversation:
 
 ```text
 Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
@@ -192,10 +235,65 @@ Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
 ```
 
 Use the segment's `relative_ts` (format it as a relative timestamp if available)
-and retain the exact quote without paraphrasing. A segment can produce alerts
-for distinct requested terms, but never repeat the same segment/term after a
-retry or resume. Append every alert record (term/variant, speaker, timestamp,
-seq, exact quote) to the durable mention log for the final report.
+and retain the exact quote without paraphrasing. Pass the stable `delivery_id`
+to the host notification API when it supports idempotency. Mark the outbox item
+`sent` only after confirmed delivery; otherwise leave it `pending`, increment
+its attempt metadata, and retry it with bounded backoff without blocking later
+transcript collection. On recovery, retry pending alerts before/alongside new
+segments. If the host cannot deduplicate an ambiguous send, prefer at-least-once
+delivery and note that a retry may duplicate the alert—never convert an unknown
+outcome into `sent` and silently lose the requested notification.
+
+A segment can produce alerts for distinct requested terms. Append every match
+(term/variant, speaker, timestamp, seq, exact quote) to the durable mention log
+for the final report, independent of its alert-delivery status.
+
+### Explicit reactive `speak` or `send_chat`
+
+Translate each authorized live rule into durable fields before joining:
+
+- a stable `rule_id`;
+- literal terms or a precise semantic condition;
+- action type and exact text;
+- one-shot versus explicitly requested repeat behavior;
+- selected `poll_wait_seconds` (default `2` for immediate reactions).
+
+For a literal rule, use the same boundary-safe matching as mention detection.
+For a semantic condition such as “someone asks what we should have for lunch,”
+evaluate each newest final segment with only a short trailing context window.
+Require clear transcript evidence; do not trigger from an unrelated occurrence
+of one keyword. Persist the evidence seq(s) and exact quote.
+
+Before executing the first match, atomically create an action claim such as:
+
+```json
+{
+  "key": "action:<session_id>:<rule_id>:<first_trigger_seq>",
+  "rule_id": "lunch-question",
+  "type": "speak",
+  "text": "I want pizza",
+  "status": "dispatching",
+  "attempts": 1,
+  "trigger_seqs": [42]
+}
+```
+
+Only the process that wins that claim may dispatch. For MCP, call
+`speak(id, text, voice?, interrupt?)`; for REST, call
+`POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
+unless replacing the bot's own current audio—it does not mean “interrupt the
+human speaker.” The session must be `active`, support audio output, and have TTS
+configured. `send_chat` is similarly opt-in and may be unsupported by the
+meeting platform.
+
+After MCP returns non-error `{ "accepted": true }` or REST returns 202, mark the
+claim `accepted`; `bot.speak_requested` in `get_events` is additional durable
+evidence. Accepted means TTS and the provider/page handoff succeeded, not proof
+that every attendee heard the complete utterance. Because `speak` and
+`send_chat` expose no caller idempotency key, do **not** automatically repeat an
+accepted action or one whose transport outcome became ambiguous after dispatch.
+Mark the latter `outcome_unknown`, tell the requester, and keep monitoring.
+Retry only a failure proved to occur before the action request was sent.
 
 ## Terminal Drain and Completeness
 
@@ -217,7 +315,37 @@ transcript is complete.
 A failed or denied session with `joined_at: null` means no verified attendance;
 report that honestly and do not invent a discussion summary.
 
-## Obtain a Summary Without Duplicating Work
+## Choose and Obtain Artifacts Without Duplicating Work
+
+The implementation defines exactly six artifact types:
+
+| Type | Use for |
+|---|---|
+| `summary` | Concise factual TL;DR |
+| `action_items` | Explicit tasks, or a statement that none were found |
+| `decisions` | Decisions and named owners when present |
+| `topics` | Discussed themes with short notes |
+| `open_questions` | Unanswered questions and unresolved items |
+| `custom` | A caller-supplied question answered only from transcript |
+
+Only `custom` accepts `prompt` (required, 1–4000 trimmed characters); named types
+reject `prompt`. Each create is asynchronous with `pending`, `completed`, or
+`failed` status. Read `content.text` only after completion and retain
+`model_provenance`/failure information. `summarize_on_end: true` attempts only a
+`summary`; create other requested types separately.
+
+For every manual artifact, keep one durable record keyed by type plus a stable
+hash of the custom prompt. Persist `creation_attempted`, the fixed poll deadline,
+and then the returned artifact ID. Since creation is non-idempotent, never repeat
+an ambiguous create. Apply the detailed summary discipline below to every
+manually requested artifact.
+
+At implementation commit `a9f6326`, generation reads at most the first 10,000
+finalized transcript segments without exposing a truncation warning. For an
+exceptionally long meeting, disclose that limit and prefer an agent-generated
+result from the full transcript the agent actually collected.
+
+### Summary flow
 
 First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
 especially the one expected from `summarize_on_end: true`. Poll the selected
@@ -258,24 +386,23 @@ in durable host storage when supported. Include:
 
 ```markdown
 # Meeting report
-
 ## Executive summary
 - <service `content.text`, or an explicitly labeled transcript-grounded fallback>
-
 ## Topics, decisions, and action items
-- Include only items supported by the transcript; otherwise say “None identified in the collected transcript.”
-
+- Use requested service artifacts when completed; include only items supported by the transcript.
+- Otherwise say “None identified in the collected transcript.”
 ## Mention log
-- +00:00 — Speaker — matched term: “exact transcript quote”
-
+- +00:00 — Speaker — matched term — alert sent|pending: “exact transcript quote”
+## Live actions
+- +00:00 — Rule — `speak|send_chat` — accepted|failed|outcome unknown — trigger quote
 ## Attendance and completeness
 - Session: `mtgsess_...`
 - Status: `ended|failed|admission_denied`
 - Joined evidence: `joined_at` value, or “not verified”
 - Transcript: confirmed by `transcript.completed` | not confirmed (reason)
-
 ## Provenance
 - Transcript segment sequence range/count and collection caveats
+- Service artifacts: `<type>: <id>, status, model_provenance>`
 - Summary: service artifact `<id>` (`content.text`) | agent-generated fallback (reason)
 ```
 
@@ -287,18 +414,26 @@ that are absent from the session, events, or collected finalized transcript.
 
 On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
-from persisted cursors and dedupe keys—never call `join_meeting` again. If it has
-an idempotency key but no saved session ID because creation was interrupted,
-retry the original `join_meeting` arguments with that same key only after
-checking any available response/log receipt. Persist every state transition,
-alert key, cursor, terminal observation, and artifact ID before relying on it.
+from persisted cursors and outbox state—never call `join_meeting` again. Retry
+pending mention alerts with their original delivery IDs and leave confirmed
+`sent` items alone. Never repeat live actions marked `accepted` or
+`outcome_unknown`; reconcile event history where useful, but do not treat a
+missing event as proof that an audible side effect did not happen. Resume each
+artifact request from its persisted ID/deadline and never repeat an ambiguous
+create. If the record has an idempotency key but no saved session ID because
+creation was interrupted, retry the original `join_meeting` arguments with that
+same key only after checking any available response/log receipt. Persist every
+state transition, alert/action state, cursor, terminal observation, and artifact
+ID before relying on it.
 
 If the requester asks to stop a non-terminal session, confirm the scope when
 needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
 does not erase the durable session history. Do not use destructive recording
 media deletion as a cleanup shortcut.
 
-## Worked Interpretation of a Vague Request
+## Worked Interpretations
+
+### Mention alert and final summary
 
 For: “Join this meeting and tell me what they discussed when it ends; if they
 mention my name, let me know.”
@@ -313,22 +448,49 @@ mention my name, let me know.”
 - Tell the requester if host admission is required; send mention alerts in this
   conversation; after completion, send the bounded, evidence-based report.
 
-## References
+### Reactive lunch answer
 
-Use the public Meeting Bot documentation as the consumer-facing contract:
+For: “Join the meeting and as soon as someone asks what we should have for
+lunch, please use the speak request and say I want pizza.”
 
-- [Meeting Bot overview](https://developers.telnyx.com/docs/meeting)
-- [Meeting Bot quick start](https://developers.telnyx.com/docs/meeting/quick-start)
-- [Meeting Bot MCP reference](https://developers.telnyx.com/docs/meeting/mcp)
-- [Collect results](https://developers.telnyx.com/docs/meeting/collect-results)
+- Treat this as explicit authorization for one in-meeting `speak`; do not ask
+  again when the condition occurs.
+- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance
+  speech/chat, and `barge_in: true`.
+- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new
+  final segment plus a short trailing context window; require a clear lunch-choice
+  question rather than the isolated word “lunch.”
+- Atomically claim the first match and call
+  `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only
+  from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
 
-This workflow was also checked against the service implementation at commit
-[`a9f6326`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326):
+### Demo: delegated attendance and TL;DR
 
-- [Service README](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/README.md)
-- [Production REST demo](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/docs/basic-rest-demo.md)
-- [Meeting-session REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/routes/meetingSessions.ts)
-- [MCP tool definitions](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/mcp/server.ts)
+For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as
+Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
+
+Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and
+no unrequested speech/chat. Post joining/admission updates to Anusha's current
+conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A
+summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises
+live reactions. At terminal status, drain final transcript and send the automatic
+`summary` with attendance, completeness, and provenance. The visible story is:
+Anusha cannot attend → texts her agent → colleagues see her bot join → her agent
+confirms attendance → she receives the TL;DR.
+
+## Source Authority and References
+
+Behavior in this skill is grounded in the current `meeting-bot-service`
+`origin/main`, verified at commit
+[`a9f6326bcaf7428364861290b787d5db1772e9f6`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326bcaf7428364861290b787d5db1772e9f6).
+Treat implementation and tests as authoritative when public documentation lags:
+
+- [Artifact types](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/domain/artifact.ts) and [generation](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/services/artifactService.ts)
+- [REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/routes/meetingSessions.ts), [MCP tools](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/mcp/server.ts), and [speech](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/services/sessionService.ts#L1021-L1142)
+- [Session action tests](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/tests/sessionService.test.ts#L642-L708) and [artifact tests](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/tests/artifactService.test.ts)
+
+Public [Meeting Bot documentation](https://developers.telnyx.com/docs/meeting) is a
+secondary navigation surface, not the source used to derive this workflow.
 
 Recheck tool schemas with MCP `tools/list` when a deployed service changes, and
 never copy credentials, private meeting URLs, webhook secrets, or transient

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -285,7 +285,8 @@ Permit a new repeat key only after its stale-safe ordered clear commits; never k
 }
 ```
 
-Only the process that wins that claim may dispatch. For MCP, call
+Only the process that wins that claim may dispatch. Atomically set `dispatching`
+immediately before invoking the transport. For MCP, call
 `speak(id, text, voice?, interrupt?)`; for REST, call
 `POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
 unless replacing the bot's own current audio—it does not mean “interrupt the
@@ -300,7 +301,9 @@ that every attendee heard the complete utterance. Because `speak` and
 `send_chat` expose no caller idempotency key, do **not** automatically repeat an
 accepted action or one whose transport outcome became ambiguous after dispatch.
 Mark the latter `outcome_unknown`, tell the requester, and keep monitoring.
-Retry only a failure proved to occur before the action request was sent.
+Within the same live attempt, only durable transport evidence that no request
+bytes were sent may mark `pre_send_failed` and allow a bounded transition of that
+same claim back to `dispatching`.
 
 ## Terminal Drain and Completeness
 
@@ -414,9 +417,11 @@ On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
 from persisted cursors and outbox state—never call `join_meeting` again. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
-`sent` items alone. Never repeat live actions marked `accepted` or
-`outcome_unknown`; reconcile event history where useful, but do not treat a
-missing event as proof that an audible side effect did not happen. Resume each
+`sent` items alone. Before evaluating triggers, atomically convert every recovered
+live-action claim still marked `dispatching` to `outcome_unknown` unless durable
+transport evidence proves no request bytes were sent; never redispatch it. Never
+repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history
+where useful, but a missing event is not proof the side effect did not happen. Resume each
 artifact request from its persisted ID/deadline and never repeat an ambiguous
 create. If the record has an idempotency key but no saved session ID because
 creation was interrupted, retry the original `join_meeting` arguments with that

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -264,9 +264,11 @@ evaluate each newest final segment with only a short trailing context window.
 Require clear transcript evidence; do not trigger from an unrelated occurrence
 of one keyword. Persist the evidence seq(s) and exact quote.
 
-Before executing the first match, atomically create an action claim. For a
-one-shot rule, key it only by session and rule; retain trigger seq(s) as evidence.
-Only an explicitly repeating rule may add the trigger seq to its claim key:
+Before executing the first match, atomically create an action claim. A one-shot key uses only session and rule; trigger seq(s) are evidence.
+For an explicitly repeating literal rule, atomically claim `action:<session_id>:<rule_id>:repeat:<segment.seq>` once per matching finalized segment.
+For an explicitly repeating semantic rule, follow the [repeating-action protocol](references/repeating-semantic-actions.md); persist `occurrence_first_seq` and `evidence_seqs`.
+Under its ordered lease/CAS, all workers use `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>` and reuse the active occurrence across windows.
+Permit a new repeat key only after its stale-safe ordered clear commits; never key from the newest evaluation segment.
 
 ```json
 {
@@ -275,7 +277,6 @@ Only an explicitly repeating rule may add the trigger seq to its claim key:
   "type": "speak",
   "text": "I want pizza",
   "status": "dispatching",
-  "attempts": 1,
   "trigger_seqs": [42]
 }
 ```

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -264,11 +264,13 @@ evaluate each newest final segment with only a short trailing context window.
 Require clear transcript evidence; do not trigger from an unrelated occurrence
 of one keyword. Persist the evidence seq(s) and exact quote.
 
-Before executing the first match, atomically create an action claim such as:
+Before executing the first match, atomically create an action claim. For a
+one-shot rule, key it only by session and rule; retain trigger seq(s) as evidence.
+Only an explicitly repeating rule may add the trigger seq to its claim key:
 
 ```json
 {
-  "key": "action:<session_id>:<rule_id>:<first_trigger_seq>",
+  "key": "action:<session_id>:<rule_id>",
   "rule_id": "lunch-question",
   "type": "speak",
   "text": "I want pizza",

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: telnyx-meeting-bot
+description: >-
+  Use when an agent must safely join, observe, monitor, transcribe, summarize,
+  or follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
+  Telnyx Meeting Bot. Handles vague requests, scheduled joins, admission,
+  durable transcript polling, name/phrase alerts, recovery, and final meeting
+  artifacts without speaking or sending chat by default.
+metadata:
+  author: telnyx
+  product: meeting-bot
+  requires:
+    env:
+      - TELNYX_API_KEY
+---
+
+# Telnyx Meeting Bot
+
+Use this skill to attend a meeting visibly as an **observe-only** bot, monitor
+its finalized transcript, alert the requester about selected mentions, and
+produce an evidence-based meeting report. The bot must not speak, send chat, or
+make other in-meeting changes unless the requester explicitly asks for that.
+
+## Quick Workflow
+
+1. Resolve only missing essentials: meeting URL, join now versus a scheduled
+   time, and mention terms. Reuse terms already stated in the request or known
+   from the current conversation/profile; do not ask again or guess a person's
+   name.
+2. Persist an operation record **before** creating the session. Generate and
+   retain one stable `idempotency_key`; call `join_meeting` with
+   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`.
+3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
+   Persist cursors, seen segment sequences, sent mention-alert keys, and IDs so
+   a restart resumes safely.
+4. On each new final transcript segment, detect whole-name/phrase mentions and
+   alert the requester in the current conversation once per segment/match.
+5. On a terminal session, drain transcript pages, wait a bounded time for
+   `transcript.completed`, obtain an existing summary artifact or create only
+   one fallback summary artifact, then deliver a Markdown report.
+
+## Preconditions and Safe Defaults
+
+- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL,
+  transcript, event, artifact, chat message, or user-facing report.
+- Before joining, ensure the runtime can keep monitoring or can resume from a
+  durable background task. Do not promise end-to-end monitoring from a process
+  that will disappear without preserving and resuming the operation record.
+- Verify the requester is authorized to have a visible bot attend this meeting.
+  The bot may need a host to admit it; never try to bypass a waiting room,
+  password, platform policy, or consent requirement.
+- Default notification target: **this current conversation**. Do not configure a
+  `webhook_url` merely to send the requester notifications.
+- Default behavior: immediate join if no future time was requested,
+  `summarize_on_end: true`, observe-only, and no recording-media deletion.
+  `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
+- If a meeting link is not present, ask for it. If time is ambiguous, ask only
+  whether to join now or at a specified time. If “my name” is not resolvable
+  from the request, current conversation, or authorized profile context, ask
+  which name/phrases (and optional variants) to watch for.
+
+## Connect to the Production MCP Server
+
+Prefer the production Streamable HTTP MCP endpoint:
+
+```text
+https://api.telnyx.com/v2/meeting_bot/mcp
+Authorization: Bearer <TELNYX_API_KEY>
+```
+
+Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`,
+`get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`,
+`stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and
+`get_artifacts`.
+
+MCP tools return one JSON text block. Decode `result.content[0].text` as JSON
+only after checking `result.isError`. HTTP/transport failures (for example 401,
+timeouts, or a 5xx) are different from an HTTP-200 MCP tool failure with
+`result.isError: true`; handle both, preserve the error code/message, and do
+not treat an HTTP 200 as success by itself.
+
+If MCP is unavailable, use the equivalent production REST base:
+
+```text
+https://api.telnyx.com/v2/meeting_sessions
+```
+
+REST equivalents are `POST /`, `GET /{id}`, `GET /{id}/transcript`,
+`GET /{id}/events`, `DELETE /{id}`, `GET /{id}/artifacts`,
+`POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
+`Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
+Use REST only as a transport fallback—the lifecycle and durability rules below
+remain the same.
+
+## Create or Schedule Exactly Once
+
+Before the first `join_meeting`, checkpoint a durable operation record outside
+transient chat memory whenever the host supports files, a task store, or durable
+workflow state. Store at least:
+
+```json
+{
+  "operation_id": "host-stable-id",
+  "meeting_url": "redacted-or-secret-reference",
+  "idempotency_key": "meeting-bot:<host-stable-id>",
+  "session_id": null,
+  "transcript_after_seq": 0,
+  "event_after_seq": 0,
+  "seen_transcript_seqs": [],
+  "mention_alert_keys": [],
+  "mentions": [],
+  "summary_artifact_id": null,
+  "summary_creation_attempted": false,
+  "summary_poll_deadline_at": null,
+  "terminal_observed_at": null,
+  "transcript_completed": false
+}
+```
+
+Use a UUID or a host-durable operation ID, not a new timestamp on retry. Then
+call `join_meeting` with the smallest safe argument set:
+
+```json
+{
+  "meeting_url": "<resolved meeting URL>",
+  "join_at": "<future RFC 3339 time only when scheduled>",
+  "summarize_on_end": true,
+  "idempotency_key": "meeting-bot:<host-stable-id>"
+}
+```
+
+Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
+Persist the returned `id` as `session_id` immediately. If the create request has an
+uncertain transport outcome, retry **only** with the same persisted
+`idempotency_key`; never issue a second key, which could place a second bot in
+the meeting. If the host cannot persist state, state that duplicate-prevention
+across a restart cannot be guaranteed and avoid an unbounded retry.
+
+## Live Session and Transcript Loop
+
+Interleave session checks with transcript reads; a successful transcript read
+alone is not proof the bot attended.
+
+1. Call `get_session(id)` at startup, after errors, and on a bounded cadence
+   (for example every 15–30 seconds while joining/active, with backoff after
+   transient failures).
+2. Treat `waiting_for_admission` as a request for a meeting host to admit the
+   visible bot. Tell the requester promptly; keep monitoring rather than
+   claiming attendance. A non-null `joined_at` is the positive evidence that
+   the bot actually attended.
+3. Treat `ended`, `failed`, and `admission_denied` as terminal. Record status,
+   `failure_reason`/status detail when present, and `joined_at`.
+4. Long-poll finalized segments with
+   `get_transcript(id, after_seq, limit, wait_seconds)`. Use `limit: 1000` and
+   `wait_seconds: 15` to `20` (never above the service maximum of 25 seconds).
+5. Deduplicate by durable `seq`. For each new segment, persist it or its needed
+   fields, process mentions, set `after_seq` to the **maximum processed seq**,
+   and checkpoint before the next call.
+6. If a response fills the page (`1000` rows), drain immediately with the
+   updated cursor and `wait_seconds: 0` until the page is short. Then resume
+   the short long-poll. Do not rely on a server `next_after` value in place of
+   the maximum sequence you successfully processed, and never reset the cursor
+   when a poll returns an empty page or a null continuation value.
+7. Use `get_events(id, after_seq, limit)` on a bounded cadence as well; advance
+   and persist its independent event cursor only after deduping event sequences.
+   It is useful for lifecycle and `transcript.completed` evidence, but is not a
+   replacement for transcript reads.
+
+Use bounded retries for transient network/5xx/429 errors, for example delays of
+1, 2, 4, 8, then at most 15 seconds with jitter. Keep the same session and
+cursors. For authentication errors, malformed requests, `not_found`, or an MCP
+`result.isError` that is not plausibly transient, stop automatic retries and
+surface the actionable error without exposing credentials or meeting secrets.
+
+## Mention Detection and Prompt Alerts
+
+Match **only finalized transcript segments** returned by `get_transcript`.
+Normalize with Unicode case-folding and whitespace normalization. For each known
+name or phrase variant, use escaped whole-phrase boundaries: it must not have a
+letter or number immediately before or after the phrase. This lets “Ann Lee”
+match “ann lee,” but not “ann leeds,” and avoids false positives such as `Ann`
+inside `annual`. Keep variants only when known from the requester or authorized
+profile/context; do not invent aliases.
+
+For every new `(session_id, segment.seq, normalized_variant)` match, persist an
+alert key before/with delivery and send one prompt notice to the current
+conversation:
+
+```text
+Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
+“<exact segment text>”
+```
+
+Use the segment's `relative_ts` (format it as a relative timestamp if available)
+and retain the exact quote without paraphrasing. A segment can produce alerts
+for distinct requested terms, but never repeat the same segment/term after a
+retry or resume. Append every alert record (term/variant, speaker, timestamp,
+seq, exact quote) to the durable mention log for the final report.
+
+## Terminal Drain and Completeness
+
+After a terminal status, do not conclude that an empty transcript poll means the
+transcript is complete.
+
+1. Record the first terminal observation time and repeatedly drain all available
+   transcript pages as above.
+2. Continue checking `get_events` for `transcript.completed` for a bounded
+   settle window (for example up to 90 seconds, with 2–10 second backoff) while
+   continuing short transcript drains.
+3. If the completion event arrives, make one final full drain and mark transcript
+   completeness as `confirmed by transcript.completed`.
+4. If the bound expires without that event, make at least two empty-drain checks
+   separated by a delay, then mark the report `not confirmed; bounded settle
+   window expired`. Include the terminal status and never describe the summary
+   as a complete account of the meeting in this case.
+
+A failed or denied session with `joined_at: null` means no verified attendance;
+report that honestly and do not invent a discussion summary.
+
+## Obtain a Summary Without Duplicating Work
+
+First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
+especially the one expected from `summarize_on_end: true`. Poll the selected
+artifact via `get_artifact(id, artifact_id)` until `status` is `completed` or
+`failed` or a persisted deadline expires; use `content.text` only when
+completed. When selecting any pending summary, persist its ID and one fixed
+`summary_poll_deadline_at` (for example five minutes from the first selection).
+Recovery must reuse, never extend, that deadline. During the normal automatic
+summary delay, poll the list on a bounded cadence (for example 2, 5, then 10
+seconds, for up to two minutes after transcript completion/settle).
+
+If no summary exists after that bounded wait:
+
+1. Check the durable record. If `summary_artifact_id` exists, poll it using the
+   original persisted deadline. If `summary_creation_attempted` is true but no
+   ID was returned, do **not** create another artifact—re-list only until that
+   same deadline, then report the ambiguous outcome and use the fallback.
+2. Otherwise persist `summary_creation_attempted: true`, call
+   `create_artifact(id, type: "summary")` **exactly once**, and immediately
+   persist the returned artifact ID. Set the fixed summary-poll deadline before
+   the call so an interrupted or ambiguous create cannot restart the clock.
+3. Poll that ID with `get_artifact` using bounded backoff until `completed`,
+   `failed`, or the persisted deadline expires. Artifact creation is
+   non-idempotent, so never retry an uncertain create call by creating another
+   summary. If the deadline expires while the artifact is still pending, keep
+   its ID/status for provenance and move to the transcript-grounded fallback.
+
+If service inference is unavailable, fails, or times out, still deliver an
+**Agent-generated summary (service summary unavailable)** based solely on the
+collected final transcript. Label transcript completeness and the inference
+failure/caveat. Do not fill in decisions, owners, actions, or discussion that
+the transcript does not support.
+
+## Deliver the Final Markdown Artifact
+
+Create a user-facing Markdown attachment or host-native artifact, retaining it
+in durable host storage when supported. Include:
+
+```markdown
+# Meeting report
+
+## Executive summary
+- <service `content.text`, or an explicitly labeled transcript-grounded fallback>
+
+## Topics, decisions, and action items
+- Include only items supported by the transcript; otherwise say “None identified in the collected transcript.”
+
+## Mention log
+- +00:00 — Speaker — matched term: “exact transcript quote”
+
+## Attendance and completeness
+- Session: `mtgsess_...`
+- Status: `ended|failed|admission_denied`
+- Joined evidence: `joined_at` value, or “not verified”
+- Transcript: confirmed by `transcript.completed` | not confirmed (reason)
+
+## Provenance
+- Transcript segment sequence range/count and collection caveats
+- Summary: service artifact `<id>` (`content.text`) | agent-generated fallback (reason)
+```
+
+Quote or link the meeting URL only where the recipient is already authorized;
+otherwise redact it. Never claim attendees, decisions, outcomes, or completeness
+that are absent from the session, events, or collected finalized transcript.
+
+## Recovery Rules
+
+On restart, load the durable operation record before doing anything. If it has a
+`session_id`, resume `get_session`, event/transcript drains, and summary polling
+from persisted cursors and dedupe keys—never call `join_meeting` again. If it has
+an idempotency key but no saved session ID because creation was interrupted,
+retry the original `join_meeting` arguments with that same key only after
+checking any available response/log receipt. Persist every state transition,
+alert key, cursor, terminal observation, and artifact ID before relying on it.
+
+If the requester asks to stop a non-terminal session, confirm the scope when
+needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
+does not erase the durable session history. Do not use destructive recording
+media deletion as a cleanup shortcut.
+
+## Worked Interpretation of a Vague Request
+
+For: “Join this meeting and tell me what they discussed when it ends; if they
+mention my name, let me know.”
+
+- If the message already includes a meeting URL and the requester identity/name
+  is known from authorized conversation/profile context, join immediately with
+  `summarize_on_end: true`, the stable idempotency key, no voice/chat actions,
+  and that name plus known variants as terms.
+- If the link is missing, ask only for the link. If it is unclear whether the
+  meeting is now or later, ask only for join timing. If “my name” is not known,
+  ask for the name/phrases and optional variants.
+- Tell the requester if host admission is required; send mention alerts in this
+  conversation; after completion, send the bounded, evidence-based report.
+
+## References
+
+Use the public Meeting Bot documentation as the consumer-facing contract:
+
+- [Meeting Bot overview](https://developers.telnyx.com/docs/meeting)
+- [Meeting Bot quick start](https://developers.telnyx.com/docs/meeting/quick-start)
+- [Meeting Bot MCP reference](https://developers.telnyx.com/docs/meeting/mcp)
+- [Collect results](https://developers.telnyx.com/docs/meeting/collect-results)
+
+This workflow was also checked against the service implementation at commit
+[`a9f6326`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326):
+
+- [Service README](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/README.md)
+- [Production REST demo](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/docs/basic-rest-demo.md)
+- [Meeting-session REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/routes/meetingSessions.ts)
+- [MCP tool definitions](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/mcp/server.ts)
+
+Recheck tool schemas with MCP `tools/list` when a deployed service changes, and
+never copy credentials, private meeting URLs, webhook secrets, or transient
+deployment details into this skill.

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
@@ -63,17 +63,19 @@ service clocks need not be comparable, and the unknown create returned no ID.
    `known_manual_artifact_ids`, and `created_at >= transcript_completed_at`.
 3. Persist every candidate ID. Poll all current candidates; do not lock onto the
    first pending artifact and ignore summaries that appear or complete later.
-4. A selectable likely-automatic result must be the **unique** completed
-   candidate with the smallest non-negative
+4. First identify the candidate with the smallest non-negative
    `created_at - transcript_completed_at` delta because the implementation calls
-   automatic creation immediately after appending `transcript.completed`. It
-   is eligible only when there is no unreconciled outcome-unknown manual
-   `summary` create. If two candidates share the minimum timestamp, or any
-   same-type unknown create remains unreconciled, origin is ambiguous. Never use
+   automatic creation immediately after appending `transcript.completed`. Rank
+   **all statuses** before filtering by status. It must be the unique minimum and
+   is eligible only when no same-type unknown create remains unreconciled. If two
+   candidates share the minimum timestamp, origin is ambiguous. Never use
    artifact ID, list order, completion order, or client-clock windows as an
    origin tie-breaker; use the labeled transcript-grounded fallback instead.
-5. A pending or failed early candidate does not end the search. Continue
-   re-listing and polling all post-completion candidates until the fixed deadline.
+5. Select that unique closest candidate only if it is `completed`. If it is
+   `pending`, keep re-listing and polling it and every candidate through the fixed
+   deadline; never skip to a later completed candidate. If the unique closest is
+   `failed` at the final reconciliation, use the fallback rather than a later
+   artifact.
 6. Immediately before fallback, re-list once more and poll every current
    candidate to terminal status within the remaining deadline.
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
@@ -1,0 +1,131 @@
+# Artifact Selection and Creation Recovery
+
+Use this protocol for final summaries and every manually requested transcript
+artifact.
+
+## Observable Implementation Contract
+
+- When `summarize_on_end` is enabled, the finalizer appends
+  `transcript.completed` and then calls the normal asynchronous
+  `create_artifact(..., "summary")` path.
+- `get_events` exposes each event's `occurred_at` timestamp.
+- Artifact responses expose `id`, `type`, `status`, `content`, `prompt`,
+  `model_provenance`, `failure_reason`, `created_at`, and `updated_at`.
+- The public artifact shape has no `automatic`, `origin`, or final-summary marker.
+- Artifact lists are newest-first by `created_at`; do not treat list position as
+  proof of automatic origin.
+- Creation is non-idempotent and returns a durable `pending` row before generation
+  completes.
+
+Do not invent an automatic-artifact marker that the implementation does not
+provide.
+
+## Durable State
+
+Persist per session:
+
+```json
+{
+  "transcript_completed_at": null,
+  "known_manual_artifact_ids": [],
+  "unreconciled_unknown_manual_creates": [],
+  "summary_candidate_ids": [],
+  "selected_summary_artifact_id": null,
+  "summary_poll_deadline_at": null,
+  "summary_creation": {
+    "state": "not_started",
+    "attempt_count": 0,
+    "max_pre_send_retries": 2,
+    "artifact_id": null,
+    "last_error": null
+  }
+}
+```
+
+Creation states are `not_started`, `dispatching`, `accepted`,
+`pre_send_failed`, `rejected`, and `outcome_unknown`. Set one fixed deadline
+before the first attempt; recovery never extends it.
+
+Every successful manual creation must add the returned ID to
+`known_manual_artifact_ids` immediately. Keep the type, stable custom-prompt
+hash, and dispatch start time in the corresponding manual request record. If a
+manual create becomes `outcome_unknown`, add that request and artifact type to
+`unreconciled_unknown_manual_creates`. Do not infer that any unrecognized
+same-type artifact is automatic while that uncertainty remains: client and
+service clocks need not be comparable, and the unknown create returned no ID.
+
+## Select the End-of-Meeting Summary
+
+1. Drain the final transcript and page `get_events` until `transcript.completed`
+   appears. Persist its `occurred_at` as `transcript_completed_at`.
+2. During the bounded automatic-summary window, repeatedly re-list artifacts.
+   A likely automatic candidate has `type: "summary"`, an ID absent from
+   `known_manual_artifact_ids`, and `created_at >= transcript_completed_at`.
+3. Persist every candidate ID. Poll all current candidates; do not lock onto the
+   first pending artifact and ignore summaries that appear or complete later.
+4. A selectable likely-automatic result must be the **unique** completed
+   candidate with the smallest non-negative
+   `created_at - transcript_completed_at` delta because the implementation calls
+   automatic creation immediately after appending `transcript.completed`. It
+   is eligible only when there is no unreconciled outcome-unknown manual
+   `summary` create. If two candidates share the minimum timestamp, or any
+   same-type unknown create remains unreconciled, origin is ambiguous. Never use
+   artifact ID, list order, completion order, or client-clock windows as an
+   origin tie-breaker; use the labeled transcript-grounded fallback instead.
+5. A pending or failed early candidate does not end the search. Continue
+   re-listing and polling all post-completion candidates until the fixed deadline.
+6. Immediately before fallback, re-list once more and poll every current
+   candidate to terminal status within the remaining deadline.
+
+If `transcript.completed` was not observed, `ended_at` is only a weaker lower
+bound. Label selection as unconfirmed and never present a summary created before
+that bound as the final meeting summary.
+
+Because the public API has no origin marker, an unknown external caller can create
+a manual summary after `transcript.completed` that is indistinguishable from the
+automatic one. An outcome-unknown create can likewise leave its ID absent from
+`known_manual_artifact_ids`; conservatively quarantine automatic-origin
+selection for that artifact type until the unknown request is reconciled to an
+ID by stronger host evidence. If timing and known IDs do not identify one unique
+candidate, say so and prefer the transcript-grounded fallback over claiming an
+artifact is the automatic end-of-meeting summary.
+
+## Manual Create State Machine
+
+1. Persist the fixed poll deadline and bounded `max_pre_send_retries` before the
+   first call.
+2. Immediately before invoking REST or MCP, atomically move the request to
+   `dispatching` and increment `attempt_count`.
+3. If the client proves that no request bytes were sent—for example, local
+   serialization/validation failure, client-queue rejection, or connection/TLS
+   failure before request transmission—record `pre_send_failed`. The same durable
+   request may return to `dispatching` and retry within its original deadline and
+   retry budget because no artifact could have been created.
+4. A complete implementation response with `invalid_request`, `invalid_state`,
+   `not_configured`, or `not_found` is `rejected`; these checks occur before the
+   artifact row is created. Correct the cause before any bounded retry.
+5. Once any request bytes may have been sent, a timeout, disconnect, process
+   interruption, malformed response, or unknown server error is
+   `outcome_unknown`. Recovery from either `dispatching` or `outcome_unknown`
+   must persist an unreconciled same-type unknown-create marker and
+   re-list/reconcile only; it must not issue another create. Until stronger host
+   evidence maps that request to a returned ID, every otherwise-unrecognized
+   same-type artifact is possible manual output, not evidence of automatic
+   origin.
+6. When the response returns an artifact ID, atomically record `accepted`, the
+   ID, and the manual ID set before polling it.
+
+Never collapse `pre_send_failed` and `outcome_unknown` into one
+`creation_attempted` boolean. Only a proven pre-send failure or a confirmed
+pre-creation rejection may retry; ambiguous create outcomes never do.
+
+## Polling and Fallback
+
+Poll every accepted/candidate ID until `completed`, `failed`, or the original
+fixed deadline. Read `content.text` only from `completed`. Preserve IDs, status,
+provenance, and failure reason. Before falling back, perform the final list/poll
+reconciliation above.
+
+If no trustworthy completed service artifact is available, deliver the parent
+skill's explicitly labeled transcript-grounded fallback and state whether final
+transcript completeness was confirmed.

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
@@ -55,10 +55,11 @@ active.
    `last_evaluated_seq`. That same transaction must advance `last_evaluated_seq`,
    persist the evaluation result and canonical `evidence_seqs`, and perform the
    applicable occurrence transition: create `active_occurrence` plus the durable
-   action claim `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
+   `claimed` action `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
    retain the active occurrence, atomically clear it, or retain no occurrence.
-5. Dispatch only after that combined transaction commits and only when it returns
-   a newly created claim. A CAS loser reloads state without dispatching.
+5. After that transaction commits, dispatch only if a second CAS changes that
+   claim from `claimed` to `dispatching` immediately before transport invocation.
+   A CAS loser reloads state without dispatching.
 6. While an occurrence is active, every positive overlapping window reuses its
    persisted claim key. It cannot create another claim, even if the newest
    evaluation sequence differs or a shorter evidence suffix later appears.
@@ -83,6 +84,9 @@ still-later ordered evaluation produces a new false-to-true transition.
   transition committed in the same transaction, so never reclassify it.
 - If the lease expired, acquire a newer generation before evaluating.
 - If `active_occurrence` exists, reuse its claim key and action state.
+- A recovered `claimed` action may compete once for the `claimed` → `dispatching`
+  CAS. A recovered `dispatching` action becomes `outcome_unknown` before any
+  trigger evaluation unless durable transport evidence proves no bytes were sent.
 - Preserve the parent skill's side-effect rule: never automatically repeat an
   accepted or outcome-unknown `speak`/`send_chat` dispatch.
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
@@ -1,0 +1,90 @@
+# Repeating Semantic Action Protocol
+
+Use this protocol only when the requester explicitly asks a semantic `speak` or
+`send_chat` rule to repeat. One-shot rules use the simpler session-and-rule claim
+key in the parent skill.
+
+## Persisted Rule State
+
+Persist one record scoped by `(session_id, rule_id)`:
+
+```json
+{
+  "lease_owner": null,
+  "lease_expires_at": null,
+  "generation": 0,
+  "last_evaluated_seq": 0,
+  "context_segments": 3,
+  "active_occurrence": null
+}
+```
+
+When active, `active_occurrence` is:
+
+```json
+{
+  "occurrence_first_seq": 41,
+  "evidence_seqs": [41, 42],
+  "claim_key": "action:<session_id>:<rule_id>:repeat:41",
+  "status": "active"
+}
+```
+
+Persist the semantic condition, action payload, classifier/configuration, and
+fixed `context_segments` with the rule. Do not change them while the rule is
+active.
+
+## Ordered Evaluation and Canonical Evidence
+
+1. Acquire a durable exclusive lease for `(session_id, rule_id)` with an atomic
+   compare-and-swap (CAS). Only the current lease owner may classify transcript
+   windows or update this rule state. A replacement worker must wait for lease
+   expiry and then acquire a newer `generation`.
+2. Consume finalized transcript segments in strictly increasing `seq` order.
+   Evaluate each sequence once using the fixed trailing window ending at that
+   sequence, but do not advance the durable cursor in a separate write.
+3. When no occurrence is active and the condition becomes true, choose the
+   **shortest contiguous suffix ending at the current sequence** that still
+   satisfies the persisted semantic condition. This structurally determines one
+   evidence list; its first element is `occurrence_first_seq`. If semantic
+   classification is stochastic, only the lease owner runs it and persists the
+   selected evidence through the transaction below—other workers never
+   independently classify a committed sequence.
+4. For every evaluated sequence, execute one per-sequence CAS transaction that
+   compares the prior `generation`, lease owner/validity, and prior
+   `last_evaluated_seq`. That same transaction must advance `last_evaluated_seq`,
+   persist the evaluation result and canonical `evidence_seqs`, and perform the
+   applicable occurrence transition: create `active_occurrence` plus the durable
+   action claim `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
+   retain the active occurrence, atomically clear it, or retain no occurrence.
+5. Dispatch only after that combined transaction commits and only when it returns
+   a newly created claim. A CAS loser reloads state without dispatching.
+6. While an occurrence is active, every positive overlapping window reuses its
+   persisted claim key. It cannot create another claim, even if the newest
+   evaluation sequence differs or a shorter evidence suffix later appears.
+
+## Clearing and Re-arming
+
+Clear `active_occurrence` only when a later ordered evaluation satisfies both:
+
+- its fixed context window contains none of the persisted `evidence_seqs`; and
+- the persisted semantic condition evaluates false.
+
+The clear is the occurrence transition inside the same per-sequence transaction
+that advances `last_evaluated_seq`; never advance the cursor and clear in separate
+writes. Compare the current `generation`, lease owner/validity, active claim key,
+and prior cursor. An older/stale worker must fail that CAS and reload without
+clearing. A new repeat claim is permitted only after the clear commits and a
+still-later ordered evaluation produces a new false-to-true transition.
+
+## Crash Recovery
+
+- Resume from the persisted `last_evaluated_seq`; its evaluation and occurrence
+  transition committed in the same transaction, so never reclassify it.
+- If the lease expired, acquire a newer generation before evaluating.
+- If `active_occurrence` exists, reuse its claim key and action state.
+- Preserve the parent skill's side-effect rule: never automatically repeat an
+  accepted or outcome-unknown `speak`/`send_chat` dispatch.
+
+This protocol intentionally favors at-most-once action delivery over reacting to
+ambiguous consecutive utterances that never produce a clear transition.

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -22,7 +22,7 @@ PLUGIN_PATTERNS=(
   "telnyx-tts|telnyx-tts-|0"
   "telnyx-stt|telnyx-stt-|0"
   "telnyx-verify|telnyx-verify-|0"
-  "telnyx-ai|telnyx-ai-assistants-,telnyx-ai-inference-|0"
+  "telnyx-ai|telnyx-ai-assistants-,telnyx-ai-inference-,telnyx-meeting-bot|0"
   "telnyx-numbers|telnyx-numbers-,telnyx-10dlc-,telnyx-porting-|0"
   "telnyx-webrtc|telnyx-webrtc-,telnyx-video-|0"
   "telnyx-email|telnyx-email-|0"

--- a/skills/README.md
+++ b/skills/README.md
@@ -149,6 +149,7 @@ npx skills add team-telnyx/ai --skill telnyx-messaging-python --agent cursor
 |-------|-------------|
 | `telnyx-ai-assistants-*` | AI voice assistants with knowledge bases |
 | `telnyx-ai-inference-*` | LLM inference, embeddings, AI analytics |
+| `telnyx-meeting-bot` | Join, observe, react in, transcribe, and summarize Zoom, Google Meet, Microsoft Teams, and Webex meetings |
 | `telnyx-missions-*` | Automated AI-driven workflows and tasks |
 
 #### IoT & Networking
@@ -273,7 +274,7 @@ Telnyx ships one plugin per product area, so you install only the skills your pr
 /plugin install telnyx-verify@telnyx     # Phone verification / 2FA
 /plugin install telnyx-numbers@telnyx    # Number management, 10DLC, porting
 /plugin install telnyx-webrtc@telnyx     # WebRTC and client SDKs
-/plugin install telnyx-ai@telnyx         # AI inference and assistants
+/plugin install telnyx-ai@telnyx         # AI inference, assistants, and Meeting Bot
 /plugin install telnyx-platform@telnyx   # Account, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration
 ```
 

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -126,8 +126,12 @@ workflow state. Store at least:
   "mentions": [],
   "action_claims": [],
   "artifact_requests": {},
+  "known_manual_artifact_ids": [],
+  "unreconciled_unknown_manual_creates": [],
+  "transcript_completed_at": null,
+  "summary_candidate_ids": [],
   "summary_artifact_id": null,
-  "summary_creation_attempted": false,
+  "summary_creation": {"state": "not_started", "attempt_count": 0, "max_pre_send_retries": 2, "artifact_id": null},
   "summary_poll_deadline_at": null,
   "terminal_observed_at": null,
   "transcript_completed": false
@@ -337,11 +341,11 @@ reject `prompt`. Each create is asynchronous with `pending`, `completed`, or
 `model_provenance`/failure information. `summarize_on_end: true` attempts only a
 `summary`; create other requested types separately.
 
-For every manual artifact, keep one durable record keyed by type plus a stable
-hash of the custom prompt. Persist `creation_attempted`, the fixed poll deadline,
-and then the returned artifact ID. Since creation is non-idempotent, never repeat
-an ambiguous create. Apply the detailed summary discipline below to every
-manually requested artifact.
+For every manual artifact, follow the [artifact selection and creation recovery
+protocol](references/artifact-selection-and-recovery.md). Keep its durable state
+machine, fixed deadline, manual artifact IDs, and returned ID. Retry only a
+proven `pre_send_failed` or confirmed pre-creation rejection; an ambiguous create
+is `outcome_unknown` and may only be reconciled by listing.
 
 At implementation commit `a9f6326`, generation reads at most the first 10,000
 finalized transcript segments without exposing a truncation warning. For an
@@ -350,31 +354,22 @@ result from the full transcript the agent actually collected.
 
 ### Summary flow
 
-First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
-especially the one expected from `summarize_on_end: true`. Poll the selected
-artifact via `get_artifact(id, artifact_id)` until `status` is `completed` or
-`failed` or a persisted deadline expires; use `content.text` only when
-completed. When selecting any pending summary, persist its ID and one fixed
-`summary_poll_deadline_at` (for example five minutes from the first selection).
-Recovery must reuse, never extend, that deadline. During the normal automatic
-summary delay, poll the list on a bounded cadence (for example 2, 5, then 10
-seconds, for up to two minutes after transcript completion/settle).
+Follow the linked recovery protocol. Persist `transcript.completed.occurred_at`,
+exclude `known_manual_artifact_ids`, and repeatedly re-list all post-completion
+summary candidates. The API has no automatic-origin marker, so select only a
+unique completed candidate whose `created_at` is closest after the completion
+event, but only when no same-type manual create has an unreconciled unknown
+outcome. Equal-time candidates are also ambiguous. Because no ID was returned
+and clocks may differ, never use artifact ID, list order, completion order, or
+client-clock windows as an origin tie-breaker. Do not lock onto the first pending
+artifact or silently use a pre-completion partial summary. Immediately before
+fallback, re-list and poll every current candidate within the fixed deadline.
 
-If no summary exists after that bounded wait:
-
-1. Check the durable record. If `summary_artifact_id` exists, poll it using the
-   original persisted deadline. If `summary_creation_attempted` is true but no
-   ID was returned, do **not** create another artifact—re-list only until that
-   same deadline, then report the ambiguous outcome and use the fallback.
-2. Otherwise persist `summary_creation_attempted: true`, call
-   `create_artifact(id, type: "summary")` **exactly once**, and immediately
-   persist the returned artifact ID. Set the fixed summary-poll deadline before
-   the call so an interrupted or ambiguous create cannot restart the clock.
-3. Poll that ID with `get_artifact` using bounded backoff until `completed`,
-   `failed`, or the persisted deadline expires. Artifact creation is
-   non-idempotent, so never retry an uncertain create call by creating another
-   summary. If the deadline expires while the artifact is still pending, keep
-   its ID/status for provenance and move to the transcript-grounded fallback.
+If no trustworthy automatic candidate appears, use the protocol's manual-create
+state machine. A proven pre-send failure may retry within the original bound;
+`dispatching` after a crash or any possibly sent/ambiguous call becomes
+`outcome_unknown` and must never create again. Poll accepted IDs to terminal state
+and retain pending/failed provenance before using the transcript fallback.
 
 If service inference is unavailable, fails, or times out, still deliver an
 **Agent-generated summary (service summary unavailable)** based solely on the

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -126,13 +126,10 @@ workflow state. Store at least:
   "mentions": [],
   "action_claims": [],
   "artifact_requests": {},
-  "known_manual_artifact_ids": [],
-  "unreconciled_unknown_manual_creates": [],
-  "transcript_completed_at": null,
-  "summary_candidate_ids": [],
-  "summary_artifact_id": null,
+  "known_manual_artifact_ids": [], "unreconciled_unknown_manual_creates": [],
+  "transcript_completed_at": null, "summary_candidate_ids": [],
+  "summary_artifact_id": null, "summary_poll_deadline_at": null,
   "summary_creation": {"state": "not_started", "attempt_count": 0, "max_pre_send_retries": 2, "artifact_id": null},
-  "summary_poll_deadline_at": null,
   "terminal_observed_at": null,
   "transcript_completed": false
 }
@@ -280,13 +277,14 @@ Permit a new repeat key only after its stale-safe ordered clear commits; never k
   "rule_id": "lunch-question",
   "type": "speak",
   "text": "I want pizza",
-  "status": "dispatching",
+  "status": "claimed",
   "trigger_seqs": [42]
 }
 ```
 
-Only the process that wins that claim may dispatch. Atomically set `dispatching`
-immediately before invoking the transport. For MCP, call
+Creating the claim only reserves its key. Dispatch only if a CAS changes `claimed`
+(or proven `pre_send_failed`) to `dispatching` immediately before the transport
+call; a CAS loser skips. For MCP, call
 `speak(id, text, voice?, interrupt?)`; for REST, call
 `POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
 unless replacing the bot's own current audio—it does not mean “interrupt the
@@ -359,10 +357,11 @@ result from the full transcript the agent actually collected.
 
 Follow the linked recovery protocol. Persist `transcript.completed.occurred_at`,
 exclude `known_manual_artifact_ids`, and repeatedly re-list all post-completion
-summary candidates. The API has no automatic-origin marker, so select only a
-unique completed candidate whose `created_at` is closest after the completion
-event, but only when no same-type manual create has an unreconciled unknown
-outcome. Equal-time candidates are also ambiguous. Because no ID was returned
+summary candidates. The API has no automatic-origin marker, so first identify the
+unique closest candidate across **all statuses**. Use it only if completed and no
+same-type manual create has an unreconciled unknown outcome; if pending, wait, and
+if failed, fall back rather than choosing a later artifact. Equal-time candidates
+are ambiguous. Because no ID was returned
 and clocks may differ, never use artifact ID, list order, completion order, or
 client-clock windows as an origin tie-breaker. Do not lock onto the first pending
 artifact or silently use a pre-completion partial summary. Immediately before
@@ -417,7 +416,8 @@ On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
 from persisted cursors and outbox state—never call `join_meeting` again. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
-`sent` items alone. Before evaluating triggers, atomically convert every recovered
+`sent` items alone. A recovered `claimed` action may attempt the dispatch CAS. Before
+evaluating triggers, atomically convert every recovered
 live-action claim still marked `dispatching` to `outcome_unknown` unless durable
 transport evidence proves no request bytes were sent; never redispatch it. Never
 repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: telnyx-meeting-bot
 description: >-
-  Use when an agent must safely join, observe, monitor, transcribe, summarize,
-  or follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
-  Telnyx Meeting Bot. Handles vague requests, scheduled joins, admission,
-  durable transcript polling, name/phrase alerts, recovery, and final meeting
-  artifacts without speaking or sending chat by default.
+  Use when an agent must join, observe, react in, transcribe, summarize, or
+  follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
+  Telnyx Meeting Bot. Handles vague requests, request-specific live polling,
+  name/phrase and semantic triggers, explicitly authorized speak/chat actions,
+  recovery, and all implemented transcript artifact types.
 metadata:
   author: telnyx
   product: meeting-bot
@@ -16,28 +16,32 @@ metadata:
 
 # Telnyx Meeting Bot
 
-Use this skill to attend a meeting visibly as an **observe-only** bot, monitor
-its finalized transcript, alert the requester about selected mentions, and
-produce an evidence-based meeting report. The bot must not speak, send chat, or
-make other in-meeting changes unless the requester explicitly asks for that.
+Use this skill to attend a meeting visibly, monitor its finalized transcript,
+alert the requester, execute explicitly authorized live rules such as speaking
+one response, and produce evidence-based meeting results. The bot is
+**observe-only by default**: it must not speak, send chat, or make other
+in-meeting changes unless the requester explicitly asks for that.
 
 ## Quick Workflow
 
 1. Resolve only missing essentials: meeting URL, join now versus a scheduled
-   time, and mention terms. Reuse terms already stated in the request or known
-   from the current conversation/profile; do not ask again or guess a person's
-   name.
+   time, desired live/final outputs, and any trigger/action rules. Reuse details
+   already stated in the request or authorized context; do not ask again.
 2. Persist an operation record **before** creating the session. Generate and
    retain one stable `idempotency_key`; call `join_meeting` with
-   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`.
+   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`. If an
+   explicit later speech rule exists, set `barge_in: true` so new human speech
+   can stop the bot's output.
 3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
-   Persist cursors, seen segment sequences, sent mention-alert keys, and IDs so
-   a restart resumes safely.
-4. On each new final transcript segment, detect whole-name/phrase mentions and
-   alert the requester in the current conversation once per segment/match.
+   Choose transcript `wait_seconds` from the request—use about `2` seconds for
+   “as soon as,” reactive speech, or urgent mention alerts—and persist cursors,
+   seen segments, outboxes, action claims, and IDs for safe recovery.
+4. On each new final segment, evaluate requested literal or semantic rules.
+   Deliver mention notifications through the durable outbox; atomically claim
+   and execute each authorized `speak`/`send_chat` action at most once.
 5. On a terminal session, drain transcript pages, wait a bounded time for
-   `transcript.completed`, obtain an existing summary artifact or create only
-   one fallback summary artifact, then deliver a Markdown report.
+   `transcript.completed`, obtain the requested implemented artifact types
+   without duplicate creation, then deliver a Markdown report.
 
 ## Preconditions and Safe Defaults
 
@@ -54,6 +58,13 @@ make other in-meeting changes unless the requester explicitly asks for that.
 - Default behavior: immediate join if no future time was requested,
   `summarize_on_end: true`, observe-only, and no recording-media deletion.
   `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
+- An explicit conditional request such as “when someone asks about lunch, say
+  ‘I want pizza’” is advance authorization for that exact action. Persist the
+  trigger, exact payload, one-shot/repeat policy, and latency target before join;
+  do not interrupt the live workflow to ask for approval again.
+- Choose monitoring cadence from the request. Default immediate reactions and
+  urgent mentions to `wait_seconds: 2`; do not silently substitute a 15-second
+  cadence for an “as soon as” instruction.
 - If a meeting link is not present, ask for it. If time is ambiguous, ask only
   whether to join now or at a specified time. If “my name” is not resolvable
   from the request, current conversation, or authorized profile context, ask
@@ -85,8 +96,10 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents are `POST /`, `GET /{id}`, `GET /{id}/transcript`,
-`GET /{id}/events`, `DELETE /{id}`, `GET /{id}/artifacts`,
+REST equivalents include `POST /`, `GET /{id}`,
+`POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`,
+`POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`,
+`DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`,
 `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
 `Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
 Use REST only as a transport fallback—the lifecycle and durability rules below
@@ -104,11 +117,15 @@ workflow state. Store at least:
   "meeting_url": "redacted-or-secret-reference",
   "idempotency_key": "meeting-bot:<host-stable-id>",
   "session_id": null,
+  "poll_wait_seconds": 2,
+  "live_rules": [],
   "transcript_after_seq": 0,
   "event_after_seq": 0,
   "seen_transcript_seqs": [],
-  "mention_alert_keys": [],
+  "mention_alerts": [],
   "mentions": [],
+  "action_claims": [],
+  "artifact_requests": {},
   "summary_artifact_id": null,
   "summary_creation_attempted": false,
   "summary_poll_deadline_at": null,
@@ -130,7 +147,10 @@ call `join_meeting` with the smallest safe argument set:
 ```
 
 Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
-Persist the returned `id` as `session_id` immediately. If the create request has an
+If the request contains an authorized later `speak` rule, include
+`"barge_in": true`; this lets human speech stop bot output and does not itself
+make the bot speak. Persist the returned `id` as `session_id` immediately.
+If the create request has an
 uncertain transport outcome, retry **only** with the same persisted
 `idempotency_key`; never issue a second key, which could place a second bot in
 the meeting. If the host cannot persist state, state that duplicate-prevention
@@ -141,18 +161,22 @@ across a restart cannot be guaranteed and avoid an unbounded retry.
 Interleave session checks with transcript reads; a successful transcript read
 alone is not proof the bot attended.
 
-1. Call `get_session(id)` at startup, after errors, and on a bounded cadence
-   (for example every 15–30 seconds while joining/active, with backoff after
-   transient failures).
+1. Call `get_session(id)` at startup, after errors, and on a bounded cadence.
+   Use roughly every 5–10 seconds for a reactive workflow and 15–30 seconds for
+   passive monitoring, with backoff after transient failures.
 2. Treat `waiting_for_admission` as a request for a meeting host to admit the
    visible bot. Tell the requester promptly; keep monitoring rather than
    claiming attendance. A non-null `joined_at` is the positive evidence that
    the bot actually attended.
 3. Treat `ended`, `failed`, and `admission_denied` as terminal. Record status,
-   `failure_reason`/status detail when present, and `joined_at`.
+   `status_detail` when present, and `joined_at`.
 4. Long-poll finalized segments with
    `get_transcript(id, after_seq, limit, wait_seconds)`. Use `limit: 1000` and
-   `wait_seconds: 15` to `20` (never above the service maximum of 25 seconds).
+   select/persist the wait from the request: `2` seconds for “as soon as,”
+   reactive `speak`, or urgent mentions; `2`–`5` for ordinary live updates;
+   `10`–`20` for summary-only passive attendance. The implemented integer range
+   is `0`–`25`. The call returns as soon as new finalized speech exists, so the
+   wait is a maximum held-request duration, not an added post-transcript delay.
 5. Deduplicate by durable `seq`. For each new segment, persist it or its needed
    fields, process mentions, set `after_seq` to the **maximum processed seq**,
    and checkpoint before the next call.
@@ -160,7 +184,8 @@ alone is not proof the bot attended.
    updated cursor and `wait_seconds: 0` until the page is short. Then resume
    the short long-poll. Do not rely on a server `next_after` value in place of
    the maximum sequence you successfully processed, and never reset the cursor
-   when a poll returns an empty page or a null continuation value.
+   when a poll returns an empty page or a null continuation value. Return to the
+   selected request cadence after the immediate drain.
 7. Use `get_events(id, after_seq, limit)` on a bounded cadence as well; advance
    and persist its independent event cursor only after deduping event sequences.
    It is useful for lifecycle and `transcript.completed` evidence, but is not a
@@ -172,7 +197,9 @@ cursors. For authentication errors, malformed requests, `not_found`, or an MCP
 `result.isError` that is not plausibly transient, stop automatic retries and
 surface the actionable error without exposing credentials or meeting secrets.
 
-## Mention Detection and Prompt Alerts
+## Live Trigger Detection, Alerts, and Actions
+
+### Name/phrase alerts
 
 Match **only finalized transcript segments** returned by `get_transcript`.
 Normalize with Unicode case-folding and whitespace normalization. For each known
@@ -182,9 +209,25 @@ match “ann lee,” but not “ann leeds,” and avoids false positives such as
 inside `annual`. Keep variants only when known from the requester or authorized
 profile/context; do not invent aliases.
 
-For every new `(session_id, segment.seq, normalized_variant)` match, persist an
-alert key before/with delivery and send one prompt notice to the current
-conversation:
+For every new `(session_id, segment.seq, normalized_variant)` match, derive one
+stable alert key and delivery ID such as
+`mention:<session_id>:<segment.seq>:<normalized_variant>`. Persist the mention
+and an outbox item **before** delivery:
+
+```json
+{
+  "key": "mention:<session_id>:<seq>:<normalized_variant>",
+  "delivery_id": "same-stable-value",
+  "status": "pending",
+  "attempts": 0,
+  "last_error": null,
+  "sent_at": null
+}
+```
+
+If that key already has `status: "sent"`, skip it. If it is `pending`, reuse the
+same outbox item rather than creating a second one. Send the notice to the
+current conversation:
 
 ```text
 Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
@@ -192,10 +235,65 @@ Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
 ```
 
 Use the segment's `relative_ts` (format it as a relative timestamp if available)
-and retain the exact quote without paraphrasing. A segment can produce alerts
-for distinct requested terms, but never repeat the same segment/term after a
-retry or resume. Append every alert record (term/variant, speaker, timestamp,
-seq, exact quote) to the durable mention log for the final report.
+and retain the exact quote without paraphrasing. Pass the stable `delivery_id`
+to the host notification API when it supports idempotency. Mark the outbox item
+`sent` only after confirmed delivery; otherwise leave it `pending`, increment
+its attempt metadata, and retry it with bounded backoff without blocking later
+transcript collection. On recovery, retry pending alerts before/alongside new
+segments. If the host cannot deduplicate an ambiguous send, prefer at-least-once
+delivery and note that a retry may duplicate the alert—never convert an unknown
+outcome into `sent` and silently lose the requested notification.
+
+A segment can produce alerts for distinct requested terms. Append every match
+(term/variant, speaker, timestamp, seq, exact quote) to the durable mention log
+for the final report, independent of its alert-delivery status.
+
+### Explicit reactive `speak` or `send_chat`
+
+Translate each authorized live rule into durable fields before joining:
+
+- a stable `rule_id`;
+- literal terms or a precise semantic condition;
+- action type and exact text;
+- one-shot versus explicitly requested repeat behavior;
+- selected `poll_wait_seconds` (default `2` for immediate reactions).
+
+For a literal rule, use the same boundary-safe matching as mention detection.
+For a semantic condition such as “someone asks what we should have for lunch,”
+evaluate each newest final segment with only a short trailing context window.
+Require clear transcript evidence; do not trigger from an unrelated occurrence
+of one keyword. Persist the evidence seq(s) and exact quote.
+
+Before executing the first match, atomically create an action claim such as:
+
+```json
+{
+  "key": "action:<session_id>:<rule_id>:<first_trigger_seq>",
+  "rule_id": "lunch-question",
+  "type": "speak",
+  "text": "I want pizza",
+  "status": "dispatching",
+  "attempts": 1,
+  "trigger_seqs": [42]
+}
+```
+
+Only the process that wins that claim may dispatch. For MCP, call
+`speak(id, text, voice?, interrupt?)`; for REST, call
+`POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
+unless replacing the bot's own current audio—it does not mean “interrupt the
+human speaker.” The session must be `active`, support audio output, and have TTS
+configured. `send_chat` is similarly opt-in and may be unsupported by the
+meeting platform.
+
+After MCP returns non-error `{ "accepted": true }` or REST returns 202, mark the
+claim `accepted`; `bot.speak_requested` in `get_events` is additional durable
+evidence. Accepted means TTS and the provider/page handoff succeeded, not proof
+that every attendee heard the complete utterance. Because `speak` and
+`send_chat` expose no caller idempotency key, do **not** automatically repeat an
+accepted action or one whose transport outcome became ambiguous after dispatch.
+Mark the latter `outcome_unknown`, tell the requester, and keep monitoring.
+Retry only a failure proved to occur before the action request was sent.
 
 ## Terminal Drain and Completeness
 
@@ -217,7 +315,37 @@ transcript is complete.
 A failed or denied session with `joined_at: null` means no verified attendance;
 report that honestly and do not invent a discussion summary.
 
-## Obtain a Summary Without Duplicating Work
+## Choose and Obtain Artifacts Without Duplicating Work
+
+The implementation defines exactly six artifact types:
+
+| Type | Use for |
+|---|---|
+| `summary` | Concise factual TL;DR |
+| `action_items` | Explicit tasks, or a statement that none were found |
+| `decisions` | Decisions and named owners when present |
+| `topics` | Discussed themes with short notes |
+| `open_questions` | Unanswered questions and unresolved items |
+| `custom` | A caller-supplied question answered only from transcript |
+
+Only `custom` accepts `prompt` (required, 1–4000 trimmed characters); named types
+reject `prompt`. Each create is asynchronous with `pending`, `completed`, or
+`failed` status. Read `content.text` only after completion and retain
+`model_provenance`/failure information. `summarize_on_end: true` attempts only a
+`summary`; create other requested types separately.
+
+For every manual artifact, keep one durable record keyed by type plus a stable
+hash of the custom prompt. Persist `creation_attempted`, the fixed poll deadline,
+and then the returned artifact ID. Since creation is non-idempotent, never repeat
+an ambiguous create. Apply the detailed summary discipline below to every
+manually requested artifact.
+
+At implementation commit `a9f6326`, generation reads at most the first 10,000
+finalized transcript segments without exposing a truncation warning. For an
+exceptionally long meeting, disclose that limit and prefer an agent-generated
+result from the full transcript the agent actually collected.
+
+### Summary flow
 
 First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
 especially the one expected from `summarize_on_end: true`. Poll the selected
@@ -258,24 +386,23 @@ in durable host storage when supported. Include:
 
 ```markdown
 # Meeting report
-
 ## Executive summary
 - <service `content.text`, or an explicitly labeled transcript-grounded fallback>
-
 ## Topics, decisions, and action items
-- Include only items supported by the transcript; otherwise say “None identified in the collected transcript.”
-
+- Use requested service artifacts when completed; include only items supported by the transcript.
+- Otherwise say “None identified in the collected transcript.”
 ## Mention log
-- +00:00 — Speaker — matched term: “exact transcript quote”
-
+- +00:00 — Speaker — matched term — alert sent|pending: “exact transcript quote”
+## Live actions
+- +00:00 — Rule — `speak|send_chat` — accepted|failed|outcome unknown — trigger quote
 ## Attendance and completeness
 - Session: `mtgsess_...`
 - Status: `ended|failed|admission_denied`
 - Joined evidence: `joined_at` value, or “not verified”
 - Transcript: confirmed by `transcript.completed` | not confirmed (reason)
-
 ## Provenance
 - Transcript segment sequence range/count and collection caveats
+- Service artifacts: `<type>: <id>, status, model_provenance>`
 - Summary: service artifact `<id>` (`content.text`) | agent-generated fallback (reason)
 ```
 
@@ -287,18 +414,26 @@ that are absent from the session, events, or collected finalized transcript.
 
 On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
-from persisted cursors and dedupe keys—never call `join_meeting` again. If it has
-an idempotency key but no saved session ID because creation was interrupted,
-retry the original `join_meeting` arguments with that same key only after
-checking any available response/log receipt. Persist every state transition,
-alert key, cursor, terminal observation, and artifact ID before relying on it.
+from persisted cursors and outbox state—never call `join_meeting` again. Retry
+pending mention alerts with their original delivery IDs and leave confirmed
+`sent` items alone. Never repeat live actions marked `accepted` or
+`outcome_unknown`; reconcile event history where useful, but do not treat a
+missing event as proof that an audible side effect did not happen. Resume each
+artifact request from its persisted ID/deadline and never repeat an ambiguous
+create. If the record has an idempotency key but no saved session ID because
+creation was interrupted, retry the original `join_meeting` arguments with that
+same key only after checking any available response/log receipt. Persist every
+state transition, alert/action state, cursor, terminal observation, and artifact
+ID before relying on it.
 
 If the requester asks to stop a non-terminal session, confirm the scope when
 needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
 does not erase the durable session history. Do not use destructive recording
 media deletion as a cleanup shortcut.
 
-## Worked Interpretation of a Vague Request
+## Worked Interpretations
+
+### Mention alert and final summary
 
 For: “Join this meeting and tell me what they discussed when it ends; if they
 mention my name, let me know.”
@@ -313,22 +448,49 @@ mention my name, let me know.”
 - Tell the requester if host admission is required; send mention alerts in this
   conversation; after completion, send the bounded, evidence-based report.
 
-## References
+### Reactive lunch answer
 
-Use the public Meeting Bot documentation as the consumer-facing contract:
+For: “Join the meeting and as soon as someone asks what we should have for
+lunch, please use the speak request and say I want pizza.”
 
-- [Meeting Bot overview](https://developers.telnyx.com/docs/meeting)
-- [Meeting Bot quick start](https://developers.telnyx.com/docs/meeting/quick-start)
-- [Meeting Bot MCP reference](https://developers.telnyx.com/docs/meeting/mcp)
-- [Collect results](https://developers.telnyx.com/docs/meeting/collect-results)
+- Treat this as explicit authorization for one in-meeting `speak`; do not ask
+  again when the condition occurs.
+- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance
+  speech/chat, and `barge_in: true`.
+- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new
+  final segment plus a short trailing context window; require a clear lunch-choice
+  question rather than the isolated word “lunch.”
+- Atomically claim the first match and call
+  `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only
+  from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
 
-This workflow was also checked against the service implementation at commit
-[`a9f6326`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326):
+### Demo: delegated attendance and TL;DR
 
-- [Service README](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/README.md)
-- [Production REST demo](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/docs/basic-rest-demo.md)
-- [Meeting-session REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/routes/meetingSessions.ts)
-- [MCP tool definitions](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/mcp/server.ts)
+For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as
+Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
+
+Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and
+no unrequested speech/chat. Post joining/admission updates to Anusha's current
+conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A
+summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises
+live reactions. At terminal status, drain final transcript and send the automatic
+`summary` with attendance, completeness, and provenance. The visible story is:
+Anusha cannot attend → texts her agent → colleagues see her bot join → her agent
+confirms attendance → she receives the TL;DR.
+
+## Source Authority and References
+
+Behavior in this skill is grounded in the current `meeting-bot-service`
+`origin/main`, verified at commit
+[`a9f6326bcaf7428364861290b787d5db1772e9f6`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326bcaf7428364861290b787d5db1772e9f6).
+Treat implementation and tests as authoritative when public documentation lags:
+
+- [Artifact types](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/domain/artifact.ts) and [generation](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/services/artifactService.ts)
+- [REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/routes/meetingSessions.ts), [MCP tools](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/mcp/server.ts), and [speech](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/src/services/sessionService.ts#L1021-L1142)
+- [Session action tests](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/tests/sessionService.test.ts#L642-L708) and [artifact tests](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326bcaf7428364861290b787d5db1772e9f6/tests/artifactService.test.ts)
+
+Public [Meeting Bot documentation](https://developers.telnyx.com/docs/meeting) is a
+secondary navigation surface, not the source used to derive this workflow.
 
 Recheck tool schemas with MCP `tools/list` when a deployed service changes, and
 never copy credentials, private meeting URLs, webhook secrets, or transient

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -285,7 +285,8 @@ Permit a new repeat key only after its stale-safe ordered clear commits; never k
 }
 ```
 
-Only the process that wins that claim may dispatch. For MCP, call
+Only the process that wins that claim may dispatch. Atomically set `dispatching`
+immediately before invoking the transport. For MCP, call
 `speak(id, text, voice?, interrupt?)`; for REST, call
 `POST /{id}/actions/speak`. `text` is 1–4000 characters. Omit `interrupt`
 unless replacing the bot's own current audio—it does not mean “interrupt the
@@ -300,7 +301,9 @@ that every attendee heard the complete utterance. Because `speak` and
 `send_chat` expose no caller idempotency key, do **not** automatically repeat an
 accepted action or one whose transport outcome became ambiguous after dispatch.
 Mark the latter `outcome_unknown`, tell the requester, and keep monitoring.
-Retry only a failure proved to occur before the action request was sent.
+Within the same live attempt, only durable transport evidence that no request
+bytes were sent may mark `pre_send_failed` and allow a bounded transition of that
+same claim back to `dispatching`.
 
 ## Terminal Drain and Completeness
 
@@ -414,9 +417,11 @@ On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
 from persisted cursors and outbox state—never call `join_meeting` again. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
-`sent` items alone. Never repeat live actions marked `accepted` or
-`outcome_unknown`; reconcile event history where useful, but do not treat a
-missing event as proof that an audible side effect did not happen. Resume each
+`sent` items alone. Before evaluating triggers, atomically convert every recovered
+live-action claim still marked `dispatching` to `outcome_unknown` unless durable
+transport evidence proves no request bytes were sent; never redispatch it. Never
+repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history
+where useful, but a missing event is not proof the side effect did not happen. Resume each
 artifact request from its persisted ID/deadline and never repeat an ambiguous
 create. If the record has an idempotency key but no saved session ID because
 creation was interrupted, retry the original `join_meeting` arguments with that

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -264,9 +264,11 @@ evaluate each newest final segment with only a short trailing context window.
 Require clear transcript evidence; do not trigger from an unrelated occurrence
 of one keyword. Persist the evidence seq(s) and exact quote.
 
-Before executing the first match, atomically create an action claim. For a
-one-shot rule, key it only by session and rule; retain trigger seq(s) as evidence.
-Only an explicitly repeating rule may add the trigger seq to its claim key:
+Before executing the first match, atomically create an action claim. A one-shot key uses only session and rule; trigger seq(s) are evidence.
+For an explicitly repeating literal rule, atomically claim `action:<session_id>:<rule_id>:repeat:<segment.seq>` once per matching finalized segment.
+For an explicitly repeating semantic rule, follow the [repeating-action protocol](references/repeating-semantic-actions.md); persist `occurrence_first_seq` and `evidence_seqs`.
+Under its ordered lease/CAS, all workers use `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>` and reuse the active occurrence across windows.
+Permit a new repeat key only after its stale-safe ordered clear commits; never key from the newest evaluation segment.
 
 ```json
 {
@@ -275,7 +277,6 @@ Only an explicitly repeating rule may add the trigger seq to its claim key:
   "type": "speak",
   "text": "I want pizza",
   "status": "dispatching",
-  "attempts": 1,
   "trigger_seqs": [42]
 }
 ```

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -264,11 +264,13 @@ evaluate each newest final segment with only a short trailing context window.
 Require clear transcript evidence; do not trigger from an unrelated occurrence
 of one keyword. Persist the evidence seq(s) and exact quote.
 
-Before executing the first match, atomically create an action claim such as:
+Before executing the first match, atomically create an action claim. For a
+one-shot rule, key it only by session and rule; retain trigger seq(s) as evidence.
+Only an explicitly repeating rule may add the trigger seq to its claim key:
 
 ```json
 {
-  "key": "action:<session_id>:<rule_id>:<first_trigger_seq>",
+  "key": "action:<session_id>:<rule_id>",
   "rule_id": "lunch-question",
   "type": "speak",
   "text": "I want pizza",

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: telnyx-meeting-bot
+description: >-
+  Use when an agent must safely join, observe, monitor, transcribe, summarize,
+  or follow up on a Zoom, Google Meet, Microsoft Teams, or Webex meeting with
+  Telnyx Meeting Bot. Handles vague requests, scheduled joins, admission,
+  durable transcript polling, name/phrase alerts, recovery, and final meeting
+  artifacts without speaking or sending chat by default.
+metadata:
+  author: telnyx
+  product: meeting-bot
+  requires:
+    env:
+      - TELNYX_API_KEY
+---
+
+# Telnyx Meeting Bot
+
+Use this skill to attend a meeting visibly as an **observe-only** bot, monitor
+its finalized transcript, alert the requester about selected mentions, and
+produce an evidence-based meeting report. The bot must not speak, send chat, or
+make other in-meeting changes unless the requester explicitly asks for that.
+
+## Quick Workflow
+
+1. Resolve only missing essentials: meeting URL, join now versus a scheduled
+   time, and mention terms. Reuse terms already stated in the request or known
+   from the current conversation/profile; do not ask again or guess a person's
+   name.
+2. Persist an operation record **before** creating the session. Generate and
+   retain one stable `idempotency_key`; call `join_meeting` with
+   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`.
+3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
+   Persist cursors, seen segment sequences, sent mention-alert keys, and IDs so
+   a restart resumes safely.
+4. On each new final transcript segment, detect whole-name/phrase mentions and
+   alert the requester in the current conversation once per segment/match.
+5. On a terminal session, drain transcript pages, wait a bounded time for
+   `transcript.completed`, obtain an existing summary artifact or create only
+   one fallback summary artifact, then deliver a Markdown report.
+
+## Preconditions and Safe Defaults
+
+- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL,
+  transcript, event, artifact, chat message, or user-facing report.
+- Before joining, ensure the runtime can keep monitoring or can resume from a
+  durable background task. Do not promise end-to-end monitoring from a process
+  that will disappear without preserving and resuming the operation record.
+- Verify the requester is authorized to have a visible bot attend this meeting.
+  The bot may need a host to admit it; never try to bypass a waiting room,
+  password, platform policy, or consent requirement.
+- Default notification target: **this current conversation**. Do not configure a
+  `webhook_url` merely to send the requester notifications.
+- Default behavior: immediate join if no future time was requested,
+  `summarize_on_end: true`, observe-only, and no recording-media deletion.
+  `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
+- If a meeting link is not present, ask for it. If time is ambiguous, ask only
+  whether to join now or at a specified time. If “my name” is not resolvable
+  from the request, current conversation, or authorized profile context, ask
+  which name/phrases (and optional variants) to watch for.
+
+## Connect to the Production MCP Server
+
+Prefer the production Streamable HTTP MCP endpoint:
+
+```text
+https://api.telnyx.com/v2/meeting_bot/mcp
+Authorization: Bearer <TELNYX_API_KEY>
+```
+
+Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`,
+`get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`,
+`stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and
+`get_artifacts`.
+
+MCP tools return one JSON text block. Decode `result.content[0].text` as JSON
+only after checking `result.isError`. HTTP/transport failures (for example 401,
+timeouts, or a 5xx) are different from an HTTP-200 MCP tool failure with
+`result.isError: true`; handle both, preserve the error code/message, and do
+not treat an HTTP 200 as success by itself.
+
+If MCP is unavailable, use the equivalent production REST base:
+
+```text
+https://api.telnyx.com/v2/meeting_sessions
+```
+
+REST equivalents are `POST /`, `GET /{id}`, `GET /{id}/transcript`,
+`GET /{id}/events`, `DELETE /{id}`, `GET /{id}/artifacts`,
+`POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
+`Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
+Use REST only as a transport fallback—the lifecycle and durability rules below
+remain the same.
+
+## Create or Schedule Exactly Once
+
+Before the first `join_meeting`, checkpoint a durable operation record outside
+transient chat memory whenever the host supports files, a task store, or durable
+workflow state. Store at least:
+
+```json
+{
+  "operation_id": "host-stable-id",
+  "meeting_url": "redacted-or-secret-reference",
+  "idempotency_key": "meeting-bot:<host-stable-id>",
+  "session_id": null,
+  "transcript_after_seq": 0,
+  "event_after_seq": 0,
+  "seen_transcript_seqs": [],
+  "mention_alert_keys": [],
+  "mentions": [],
+  "summary_artifact_id": null,
+  "summary_creation_attempted": false,
+  "summary_poll_deadline_at": null,
+  "terminal_observed_at": null,
+  "transcript_completed": false
+}
+```
+
+Use a UUID or a host-durable operation ID, not a new timestamp on retry. Then
+call `join_meeting` with the smallest safe argument set:
+
+```json
+{
+  "meeting_url": "<resolved meeting URL>",
+  "join_at": "<future RFC 3339 time only when scheduled>",
+  "summarize_on_end": true,
+  "idempotency_key": "meeting-bot:<host-stable-id>"
+}
+```
+
+Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
+Persist the returned `id` as `session_id` immediately. If the create request has an
+uncertain transport outcome, retry **only** with the same persisted
+`idempotency_key`; never issue a second key, which could place a second bot in
+the meeting. If the host cannot persist state, state that duplicate-prevention
+across a restart cannot be guaranteed and avoid an unbounded retry.
+
+## Live Session and Transcript Loop
+
+Interleave session checks with transcript reads; a successful transcript read
+alone is not proof the bot attended.
+
+1. Call `get_session(id)` at startup, after errors, and on a bounded cadence
+   (for example every 15–30 seconds while joining/active, with backoff after
+   transient failures).
+2. Treat `waiting_for_admission` as a request for a meeting host to admit the
+   visible bot. Tell the requester promptly; keep monitoring rather than
+   claiming attendance. A non-null `joined_at` is the positive evidence that
+   the bot actually attended.
+3. Treat `ended`, `failed`, and `admission_denied` as terminal. Record status,
+   `failure_reason`/status detail when present, and `joined_at`.
+4. Long-poll finalized segments with
+   `get_transcript(id, after_seq, limit, wait_seconds)`. Use `limit: 1000` and
+   `wait_seconds: 15` to `20` (never above the service maximum of 25 seconds).
+5. Deduplicate by durable `seq`. For each new segment, persist it or its needed
+   fields, process mentions, set `after_seq` to the **maximum processed seq**,
+   and checkpoint before the next call.
+6. If a response fills the page (`1000` rows), drain immediately with the
+   updated cursor and `wait_seconds: 0` until the page is short. Then resume
+   the short long-poll. Do not rely on a server `next_after` value in place of
+   the maximum sequence you successfully processed, and never reset the cursor
+   when a poll returns an empty page or a null continuation value.
+7. Use `get_events(id, after_seq, limit)` on a bounded cadence as well; advance
+   and persist its independent event cursor only after deduping event sequences.
+   It is useful for lifecycle and `transcript.completed` evidence, but is not a
+   replacement for transcript reads.
+
+Use bounded retries for transient network/5xx/429 errors, for example delays of
+1, 2, 4, 8, then at most 15 seconds with jitter. Keep the same session and
+cursors. For authentication errors, malformed requests, `not_found`, or an MCP
+`result.isError` that is not plausibly transient, stop automatic retries and
+surface the actionable error without exposing credentials or meeting secrets.
+
+## Mention Detection and Prompt Alerts
+
+Match **only finalized transcript segments** returned by `get_transcript`.
+Normalize with Unicode case-folding and whitespace normalization. For each known
+name or phrase variant, use escaped whole-phrase boundaries: it must not have a
+letter or number immediately before or after the phrase. This lets “Ann Lee”
+match “ann lee,” but not “ann leeds,” and avoids false positives such as `Ann`
+inside `annual`. Keep variants only when known from the requester or authorized
+profile/context; do not invent aliases.
+
+For every new `(session_id, segment.seq, normalized_variant)` match, persist an
+alert key before/with delivery and send one prompt notice to the current
+conversation:
+
+```text
+Mention detected — <speaker_label or "Unknown speaker"> at +<relative_ts>:
+“<exact segment text>”
+```
+
+Use the segment's `relative_ts` (format it as a relative timestamp if available)
+and retain the exact quote without paraphrasing. A segment can produce alerts
+for distinct requested terms, but never repeat the same segment/term after a
+retry or resume. Append every alert record (term/variant, speaker, timestamp,
+seq, exact quote) to the durable mention log for the final report.
+
+## Terminal Drain and Completeness
+
+After a terminal status, do not conclude that an empty transcript poll means the
+transcript is complete.
+
+1. Record the first terminal observation time and repeatedly drain all available
+   transcript pages as above.
+2. Continue checking `get_events` for `transcript.completed` for a bounded
+   settle window (for example up to 90 seconds, with 2–10 second backoff) while
+   continuing short transcript drains.
+3. If the completion event arrives, make one final full drain and mark transcript
+   completeness as `confirmed by transcript.completed`.
+4. If the bound expires without that event, make at least two empty-drain checks
+   separated by a delay, then mark the report `not confirmed; bounded settle
+   window expired`. Include the terminal status and never describe the summary
+   as a complete account of the meeting in this case.
+
+A failed or denied session with `joined_at: null` means no verified attendance;
+report that honestly and do not invent a discussion summary.
+
+## Obtain a Summary Without Duplicating Work
+
+First use `get_artifacts(id)` to find existing `type: "summary"` artifacts,
+especially the one expected from `summarize_on_end: true`. Poll the selected
+artifact via `get_artifact(id, artifact_id)` until `status` is `completed` or
+`failed` or a persisted deadline expires; use `content.text` only when
+completed. When selecting any pending summary, persist its ID and one fixed
+`summary_poll_deadline_at` (for example five minutes from the first selection).
+Recovery must reuse, never extend, that deadline. During the normal automatic
+summary delay, poll the list on a bounded cadence (for example 2, 5, then 10
+seconds, for up to two minutes after transcript completion/settle).
+
+If no summary exists after that bounded wait:
+
+1. Check the durable record. If `summary_artifact_id` exists, poll it using the
+   original persisted deadline. If `summary_creation_attempted` is true but no
+   ID was returned, do **not** create another artifact—re-list only until that
+   same deadline, then report the ambiguous outcome and use the fallback.
+2. Otherwise persist `summary_creation_attempted: true`, call
+   `create_artifact(id, type: "summary")` **exactly once**, and immediately
+   persist the returned artifact ID. Set the fixed summary-poll deadline before
+   the call so an interrupted or ambiguous create cannot restart the clock.
+3. Poll that ID with `get_artifact` using bounded backoff until `completed`,
+   `failed`, or the persisted deadline expires. Artifact creation is
+   non-idempotent, so never retry an uncertain create call by creating another
+   summary. If the deadline expires while the artifact is still pending, keep
+   its ID/status for provenance and move to the transcript-grounded fallback.
+
+If service inference is unavailable, fails, or times out, still deliver an
+**Agent-generated summary (service summary unavailable)** based solely on the
+collected final transcript. Label transcript completeness and the inference
+failure/caveat. Do not fill in decisions, owners, actions, or discussion that
+the transcript does not support.
+
+## Deliver the Final Markdown Artifact
+
+Create a user-facing Markdown attachment or host-native artifact, retaining it
+in durable host storage when supported. Include:
+
+```markdown
+# Meeting report
+
+## Executive summary
+- <service `content.text`, or an explicitly labeled transcript-grounded fallback>
+
+## Topics, decisions, and action items
+- Include only items supported by the transcript; otherwise say “None identified in the collected transcript.”
+
+## Mention log
+- +00:00 — Speaker — matched term: “exact transcript quote”
+
+## Attendance and completeness
+- Session: `mtgsess_...`
+- Status: `ended|failed|admission_denied`
+- Joined evidence: `joined_at` value, or “not verified”
+- Transcript: confirmed by `transcript.completed` | not confirmed (reason)
+
+## Provenance
+- Transcript segment sequence range/count and collection caveats
+- Summary: service artifact `<id>` (`content.text`) | agent-generated fallback (reason)
+```
+
+Quote or link the meeting URL only where the recipient is already authorized;
+otherwise redact it. Never claim attendees, decisions, outcomes, or completeness
+that are absent from the session, events, or collected finalized transcript.
+
+## Recovery Rules
+
+On restart, load the durable operation record before doing anything. If it has a
+`session_id`, resume `get_session`, event/transcript drains, and summary polling
+from persisted cursors and dedupe keys—never call `join_meeting` again. If it has
+an idempotency key but no saved session ID because creation was interrupted,
+retry the original `join_meeting` arguments with that same key only after
+checking any available response/log receipt. Persist every state transition,
+alert key, cursor, terminal observation, and artifact ID before relying on it.
+
+If the requester asks to stop a non-terminal session, confirm the scope when
+needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
+does not erase the durable session history. Do not use destructive recording
+media deletion as a cleanup shortcut.
+
+## Worked Interpretation of a Vague Request
+
+For: “Join this meeting and tell me what they discussed when it ends; if they
+mention my name, let me know.”
+
+- If the message already includes a meeting URL and the requester identity/name
+  is known from authorized conversation/profile context, join immediately with
+  `summarize_on_end: true`, the stable idempotency key, no voice/chat actions,
+  and that name plus known variants as terms.
+- If the link is missing, ask only for the link. If it is unclear whether the
+  meeting is now or later, ask only for join timing. If “my name” is not known,
+  ask for the name/phrases and optional variants.
+- Tell the requester if host admission is required; send mention alerts in this
+  conversation; after completion, send the bounded, evidence-based report.
+
+## References
+
+Use the public Meeting Bot documentation as the consumer-facing contract:
+
+- [Meeting Bot overview](https://developers.telnyx.com/docs/meeting)
+- [Meeting Bot quick start](https://developers.telnyx.com/docs/meeting/quick-start)
+- [Meeting Bot MCP reference](https://developers.telnyx.com/docs/meeting/mcp)
+- [Collect results](https://developers.telnyx.com/docs/meeting/collect-results)
+
+This workflow was also checked against the service implementation at commit
+[`a9f6326`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326):
+
+- [Service README](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/README.md)
+- [Production REST demo](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/docs/basic-rest-demo.md)
+- [Meeting-session REST routes](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/routes/meetingSessions.ts)
+- [MCP tool definitions](https://github.com/team-telnyx/meeting-bot-service/blob/a9f6326/src/mcp/server.ts)
+
+Recheck tool schemas with MCP `tools/list` when a deployed service changes, and
+never copy credentials, private meeting URLs, webhook secrets, or transient
+deployment details into this skill.

--- a/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
+++ b/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
@@ -63,17 +63,19 @@ service clocks need not be comparable, and the unknown create returned no ID.
    `known_manual_artifact_ids`, and `created_at >= transcript_completed_at`.
 3. Persist every candidate ID. Poll all current candidates; do not lock onto the
    first pending artifact and ignore summaries that appear or complete later.
-4. A selectable likely-automatic result must be the **unique** completed
-   candidate with the smallest non-negative
+4. First identify the candidate with the smallest non-negative
    `created_at - transcript_completed_at` delta because the implementation calls
-   automatic creation immediately after appending `transcript.completed`. It
-   is eligible only when there is no unreconciled outcome-unknown manual
-   `summary` create. If two candidates share the minimum timestamp, or any
-   same-type unknown create remains unreconciled, origin is ambiguous. Never use
+   automatic creation immediately after appending `transcript.completed`. Rank
+   **all statuses** before filtering by status. It must be the unique minimum and
+   is eligible only when no same-type unknown create remains unreconciled. If two
+   candidates share the minimum timestamp, origin is ambiguous. Never use
    artifact ID, list order, completion order, or client-clock windows as an
    origin tie-breaker; use the labeled transcript-grounded fallback instead.
-5. A pending or failed early candidate does not end the search. Continue
-   re-listing and polling all post-completion candidates until the fixed deadline.
+5. Select that unique closest candidate only if it is `completed`. If it is
+   `pending`, keep re-listing and polling it and every candidate through the fixed
+   deadline; never skip to a later completed candidate. If the unique closest is
+   `failed` at the final reconciliation, use the fallback rather than a later
+   artifact.
 6. Immediately before fallback, re-list once more and poll every current
    candidate to terminal status within the remaining deadline.
 

--- a/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
+++ b/skills/telnyx-meeting-bot/references/artifact-selection-and-recovery.md
@@ -1,0 +1,131 @@
+# Artifact Selection and Creation Recovery
+
+Use this protocol for final summaries and every manually requested transcript
+artifact.
+
+## Observable Implementation Contract
+
+- When `summarize_on_end` is enabled, the finalizer appends
+  `transcript.completed` and then calls the normal asynchronous
+  `create_artifact(..., "summary")` path.
+- `get_events` exposes each event's `occurred_at` timestamp.
+- Artifact responses expose `id`, `type`, `status`, `content`, `prompt`,
+  `model_provenance`, `failure_reason`, `created_at`, and `updated_at`.
+- The public artifact shape has no `automatic`, `origin`, or final-summary marker.
+- Artifact lists are newest-first by `created_at`; do not treat list position as
+  proof of automatic origin.
+- Creation is non-idempotent and returns a durable `pending` row before generation
+  completes.
+
+Do not invent an automatic-artifact marker that the implementation does not
+provide.
+
+## Durable State
+
+Persist per session:
+
+```json
+{
+  "transcript_completed_at": null,
+  "known_manual_artifact_ids": [],
+  "unreconciled_unknown_manual_creates": [],
+  "summary_candidate_ids": [],
+  "selected_summary_artifact_id": null,
+  "summary_poll_deadline_at": null,
+  "summary_creation": {
+    "state": "not_started",
+    "attempt_count": 0,
+    "max_pre_send_retries": 2,
+    "artifact_id": null,
+    "last_error": null
+  }
+}
+```
+
+Creation states are `not_started`, `dispatching`, `accepted`,
+`pre_send_failed`, `rejected`, and `outcome_unknown`. Set one fixed deadline
+before the first attempt; recovery never extends it.
+
+Every successful manual creation must add the returned ID to
+`known_manual_artifact_ids` immediately. Keep the type, stable custom-prompt
+hash, and dispatch start time in the corresponding manual request record. If a
+manual create becomes `outcome_unknown`, add that request and artifact type to
+`unreconciled_unknown_manual_creates`. Do not infer that any unrecognized
+same-type artifact is automatic while that uncertainty remains: client and
+service clocks need not be comparable, and the unknown create returned no ID.
+
+## Select the End-of-Meeting Summary
+
+1. Drain the final transcript and page `get_events` until `transcript.completed`
+   appears. Persist its `occurred_at` as `transcript_completed_at`.
+2. During the bounded automatic-summary window, repeatedly re-list artifacts.
+   A likely automatic candidate has `type: "summary"`, an ID absent from
+   `known_manual_artifact_ids`, and `created_at >= transcript_completed_at`.
+3. Persist every candidate ID. Poll all current candidates; do not lock onto the
+   first pending artifact and ignore summaries that appear or complete later.
+4. A selectable likely-automatic result must be the **unique** completed
+   candidate with the smallest non-negative
+   `created_at - transcript_completed_at` delta because the implementation calls
+   automatic creation immediately after appending `transcript.completed`. It
+   is eligible only when there is no unreconciled outcome-unknown manual
+   `summary` create. If two candidates share the minimum timestamp, or any
+   same-type unknown create remains unreconciled, origin is ambiguous. Never use
+   artifact ID, list order, completion order, or client-clock windows as an
+   origin tie-breaker; use the labeled transcript-grounded fallback instead.
+5. A pending or failed early candidate does not end the search. Continue
+   re-listing and polling all post-completion candidates until the fixed deadline.
+6. Immediately before fallback, re-list once more and poll every current
+   candidate to terminal status within the remaining deadline.
+
+If `transcript.completed` was not observed, `ended_at` is only a weaker lower
+bound. Label selection as unconfirmed and never present a summary created before
+that bound as the final meeting summary.
+
+Because the public API has no origin marker, an unknown external caller can create
+a manual summary after `transcript.completed` that is indistinguishable from the
+automatic one. An outcome-unknown create can likewise leave its ID absent from
+`known_manual_artifact_ids`; conservatively quarantine automatic-origin
+selection for that artifact type until the unknown request is reconciled to an
+ID by stronger host evidence. If timing and known IDs do not identify one unique
+candidate, say so and prefer the transcript-grounded fallback over claiming an
+artifact is the automatic end-of-meeting summary.
+
+## Manual Create State Machine
+
+1. Persist the fixed poll deadline and bounded `max_pre_send_retries` before the
+   first call.
+2. Immediately before invoking REST or MCP, atomically move the request to
+   `dispatching` and increment `attempt_count`.
+3. If the client proves that no request bytes were sent—for example, local
+   serialization/validation failure, client-queue rejection, or connection/TLS
+   failure before request transmission—record `pre_send_failed`. The same durable
+   request may return to `dispatching` and retry within its original deadline and
+   retry budget because no artifact could have been created.
+4. A complete implementation response with `invalid_request`, `invalid_state`,
+   `not_configured`, or `not_found` is `rejected`; these checks occur before the
+   artifact row is created. Correct the cause before any bounded retry.
+5. Once any request bytes may have been sent, a timeout, disconnect, process
+   interruption, malformed response, or unknown server error is
+   `outcome_unknown`. Recovery from either `dispatching` or `outcome_unknown`
+   must persist an unreconciled same-type unknown-create marker and
+   re-list/reconcile only; it must not issue another create. Until stronger host
+   evidence maps that request to a returned ID, every otherwise-unrecognized
+   same-type artifact is possible manual output, not evidence of automatic
+   origin.
+6. When the response returns an artifact ID, atomically record `accepted`, the
+   ID, and the manual ID set before polling it.
+
+Never collapse `pre_send_failed` and `outcome_unknown` into one
+`creation_attempted` boolean. Only a proven pre-send failure or a confirmed
+pre-creation rejection may retry; ambiguous create outcomes never do.
+
+## Polling and Fallback
+
+Poll every accepted/candidate ID until `completed`, `failed`, or the original
+fixed deadline. Read `content.text` only from `completed`. Preserve IDs, status,
+provenance, and failure reason. Before falling back, perform the final list/poll
+reconciliation above.
+
+If no trustworthy completed service artifact is available, deliver the parent
+skill's explicitly labeled transcript-grounded fallback and state whether final
+transcript completeness was confirmed.

--- a/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
+++ b/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
@@ -55,10 +55,11 @@ active.
    `last_evaluated_seq`. That same transaction must advance `last_evaluated_seq`,
    persist the evaluation result and canonical `evidence_seqs`, and perform the
    applicable occurrence transition: create `active_occurrence` plus the durable
-   action claim `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
+   `claimed` action `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
    retain the active occurrence, atomically clear it, or retain no occurrence.
-5. Dispatch only after that combined transaction commits and only when it returns
-   a newly created claim. A CAS loser reloads state without dispatching.
+5. After that transaction commits, dispatch only if a second CAS changes that
+   claim from `claimed` to `dispatching` immediately before transport invocation.
+   A CAS loser reloads state without dispatching.
 6. While an occurrence is active, every positive overlapping window reuses its
    persisted claim key. It cannot create another claim, even if the newest
    evaluation sequence differs or a shorter evidence suffix later appears.
@@ -83,6 +84,9 @@ still-later ordered evaluation produces a new false-to-true transition.
   transition committed in the same transaction, so never reclassify it.
 - If the lease expired, acquire a newer generation before evaluating.
 - If `active_occurrence` exists, reuse its claim key and action state.
+- A recovered `claimed` action may compete once for the `claimed` → `dispatching`
+  CAS. A recovered `dispatching` action becomes `outcome_unknown` before any
+  trigger evaluation unless durable transport evidence proves no bytes were sent.
 - Preserve the parent skill's side-effect rule: never automatically repeat an
   accepted or outcome-unknown `speak`/`send_chat` dispatch.
 

--- a/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
+++ b/skills/telnyx-meeting-bot/references/repeating-semantic-actions.md
@@ -1,0 +1,90 @@
+# Repeating Semantic Action Protocol
+
+Use this protocol only when the requester explicitly asks a semantic `speak` or
+`send_chat` rule to repeat. One-shot rules use the simpler session-and-rule claim
+key in the parent skill.
+
+## Persisted Rule State
+
+Persist one record scoped by `(session_id, rule_id)`:
+
+```json
+{
+  "lease_owner": null,
+  "lease_expires_at": null,
+  "generation": 0,
+  "last_evaluated_seq": 0,
+  "context_segments": 3,
+  "active_occurrence": null
+}
+```
+
+When active, `active_occurrence` is:
+
+```json
+{
+  "occurrence_first_seq": 41,
+  "evidence_seqs": [41, 42],
+  "claim_key": "action:<session_id>:<rule_id>:repeat:41",
+  "status": "active"
+}
+```
+
+Persist the semantic condition, action payload, classifier/configuration, and
+fixed `context_segments` with the rule. Do not change them while the rule is
+active.
+
+## Ordered Evaluation and Canonical Evidence
+
+1. Acquire a durable exclusive lease for `(session_id, rule_id)` with an atomic
+   compare-and-swap (CAS). Only the current lease owner may classify transcript
+   windows or update this rule state. A replacement worker must wait for lease
+   expiry and then acquire a newer `generation`.
+2. Consume finalized transcript segments in strictly increasing `seq` order.
+   Evaluate each sequence once using the fixed trailing window ending at that
+   sequence, but do not advance the durable cursor in a separate write.
+3. When no occurrence is active and the condition becomes true, choose the
+   **shortest contiguous suffix ending at the current sequence** that still
+   satisfies the persisted semantic condition. This structurally determines one
+   evidence list; its first element is `occurrence_first_seq`. If semantic
+   classification is stochastic, only the lease owner runs it and persists the
+   selected evidence through the transaction below—other workers never
+   independently classify a committed sequence.
+4. For every evaluated sequence, execute one per-sequence CAS transaction that
+   compares the prior `generation`, lease owner/validity, and prior
+   `last_evaluated_seq`. That same transaction must advance `last_evaluated_seq`,
+   persist the evaluation result and canonical `evidence_seqs`, and perform the
+   applicable occurrence transition: create `active_occurrence` plus the durable
+   action claim `action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>`,
+   retain the active occurrence, atomically clear it, or retain no occurrence.
+5. Dispatch only after that combined transaction commits and only when it returns
+   a newly created claim. A CAS loser reloads state without dispatching.
+6. While an occurrence is active, every positive overlapping window reuses its
+   persisted claim key. It cannot create another claim, even if the newest
+   evaluation sequence differs or a shorter evidence suffix later appears.
+
+## Clearing and Re-arming
+
+Clear `active_occurrence` only when a later ordered evaluation satisfies both:
+
+- its fixed context window contains none of the persisted `evidence_seqs`; and
+- the persisted semantic condition evaluates false.
+
+The clear is the occurrence transition inside the same per-sequence transaction
+that advances `last_evaluated_seq`; never advance the cursor and clear in separate
+writes. Compare the current `generation`, lease owner/validity, active claim key,
+and prior cursor. An older/stale worker must fail that CAS and reload without
+clearing. A new repeat claim is permitted only after the clear commits and a
+still-later ordered evaluation produces a new false-to-true transition.
+
+## Crash Recovery
+
+- Resume from the persisted `last_evaluated_seq`; its evaluation and occurrence
+  transition committed in the same transaction, so never reclassify it.
+- If the lease expired, acquire a newer generation before evaluating.
+- If `active_occurrence` exists, reuse its claim key and action state.
+- Preserve the parent skill's side-effect rule: never automatically repeat an
+  accepted or outcome-unknown `speak`/`send_chat` dispatch.
+
+This protocol intentionally favors at-most-once action delivery over reacting to
+ambiguous consecutive utterances that never produce a clear transition.

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -97,6 +97,9 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(skill, /retry pending alerts/i);
     assert.match(skill, /wait_seconds: 2/);
     assert.match(skill, /### Reactive lunch answer/);
+    assert.match(skill, /For a\s+one-shot rule, key it only by session and rule/);
+    assert.match(skill, /"key": "action:<session_id>:<rule_id>"/);
+    assert.doesNotMatch(skill, /"key": "action:<session_id>:<rule_id>:<first_trigger_seq>"/);
     assert.match(skill, /do \*\*not\*\* automatically repeat an\s+accepted action/);
   });
 });

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -58,6 +58,44 @@ describe("agent.json validity", () => {
   });
 });
 
+describe("Meeting Bot plugin catalogs", () => {
+  const rootReadme = readFileSync(join(ROOT, "README.md"), "utf-8");
+  const pluginsReadme = readFileSync(join(ROOT, "plugins", "README.md"), "utf-8");
+  const skillsReadme = readFileSync(join(SKILLS_DIR, "README.md"), "utf-8");
+  const rootPlugin = JSON.parse(readFileSync(join(ROOT, "plugin.json"), "utf-8"));
+  const marketplace = JSON.parse(
+    readFileSync(join(ROOT, ".claude-plugin", "marketplace.json"), "utf-8")
+  );
+  const aiPluginDir = join(ROOT, "providers", "claude", "plugins", "telnyx-ai");
+  const aiManifest = JSON.parse(
+    readFileSync(join(aiPluginDir, ".claude-plugin", "plugin.json"), "utf-8")
+  );
+  const aiSkillCount = readdirSync(join(aiPluginDir, "skills"), {
+    withFileTypes: true,
+  }).filter((entry: { isDirectory(): boolean }) => entry.isDirectory()).length;
+  const catalogRow = pluginsReadme
+    .split("\n")
+    .find((line: string) => line.startsWith("| `telnyx-ai` |"));
+  const aiMarketplace = marketplace.plugins.find(
+    (plugin: any) => plugin.name === "telnyx-ai"
+  );
+
+  it("advertises Meeting Bot with the actual telnyx-ai skill count", () => {
+    assert.equal(aiSkillCount, 13);
+    assert.ok(catalogRow, "plugins/README.md missing telnyx-ai row");
+    assert.match(catalogRow, /Meeting Bot/);
+    assert.ok(catalogRow.endsWith(`| ${aiSkillCount} |`));
+    assert.match(rootReadme, /telnyx-ai@telnyx[^\n]*Meeting Bot/);
+    assert.match(rootPlugin.description, /Meeting Bot/);
+    assert.match(skillsReadme, /`telnyx-meeting-bot`[^\n]*Zoom[^\n]*Webex/);
+    assert.match(skillsReadme, /telnyx-ai@telnyx[^\n]*Meeting Bot/);
+    assert.ok(aiMarketplace, "marketplace missing telnyx-ai plugin");
+    assert.match(aiMarketplace.description, /Meeting Bot/);
+    assert.equal(aiManifest.description, aiMarketplace.description);
+    assert.ok(aiManifest.keywords.includes("meeting-bot"));
+  });
+});
+
 describe("Meeting Bot discovery and durable alert contract", () => {
   const capability = agentJson.capabilities.find(
     (candidate: any) => candidate.id === "meeting_bot"

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -120,8 +120,8 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(repeatProtocol, /must fail that CAS/);
     assert.match(repeatProtocol, /one per-sequence CAS transaction/);
     assert.match(repeatProtocol, /That same transaction must advance `last_evaluated_seq`/);
-    assert.match(repeatProtocol, /create `active_occurrence` plus the durable\s+action claim/);
-    assert.match(repeatProtocol, /Dispatch only after that combined transaction commits/);
+    assert.match(repeatProtocol, /create `active_occurrence` plus the durable\s+`claimed` action/);
+    assert.match(repeatProtocol, /second CAS changes that\s+claim from `claimed` to `dispatching`/);
     assert.match(repeatProtocol, /CAS loser reloads state without dispatching/);
     assert.match(repeatProtocol, /never advance the cursor and clear in separate\s+writes/);
     assert.match(repeatProtocol, /every positive overlapping window reuses its\s+persisted claim key/);
@@ -129,10 +129,12 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(repeatProtocol, /persisted semantic condition evaluates false/);
     assert.match(repeatProtocol, /clear commits and a\s+still-later ordered evaluation produces a new false-to-true transition/);
     assert.match(skill, /do \*\*not\*\* automatically repeat an\s+accepted action/);
-    assert.match(skill, /Atomically set `dispatching`\s+immediately before invoking the transport/);
+    assert.match(skill, /Creating the claim only reserves its key/);
+    assert.match(skill, /a CAS changes `claimed`\s+\(or proven `pre_send_failed`\) to `dispatching` immediately before the transport\s+call/);
     assert.match(skill, /no request\s+bytes were sent may mark `pre_send_failed`/);
-    assert.match(skill, /Before evaluating triggers, atomically convert every recovered\s+live-action claim still marked `dispatching` to `outcome_unknown`/);
+    assert.match(skill, /Before\s+evaluating triggers, atomically convert every recovered\s+live-action claim still marked `dispatching` to `outcome_unknown`/);
     assert.match(skill, /never redispatch it/);
+    assert.match(guide, /successful `claimed` → `dispatching` CAS immediately before transport/);
     assert.match(guide, /convert any recovered\s+`dispatching` speech\/chat claim to `outcome_unknown` before evaluating triggers/);
   });
 
@@ -149,7 +151,10 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(artifactRecovery, /`created_at >= transcript_completed_at`/);
     assert.match(artifactRecovery, /Poll all current candidates/);
     assert.match(artifactRecovery, /Never use\s+artifact ID, list order, completion order, or client-clock windows as an\s+origin tie-breaker/);
-    assert.match(artifactRecovery, /two candidates share\s+the minimum timestamp/);
+    assert.match(artifactRecovery, /two\s+candidates share the minimum timestamp/);
+    assert.match(artifactRecovery, /Rank\s+\*\*all statuses\*\* before filtering by status/);
+    assert.match(artifactRecovery, /never skip to a later completed candidate/);
+    assert.match(artifactRecovery, /unique closest is\s+`failed`.*use the fallback rather than a later\s+artifact/s);
     assert.match(artifactRecovery, /same-type unknown create remains unreconciled/);
     assert.match(artifactRecovery, /every otherwise-unrecognized\s+same-type artifact is possible manual output/);
     assert.match(artifactRecovery, /Immediately before fallback, re-list once more/);

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -67,6 +67,10 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     join(SKILLS_DIR, "telnyx-meeting-bot", "SKILL.md"),
     "utf-8"
   );
+  const repeatProtocol = readFileSync(
+    join(SKILLS_DIR, "telnyx-meeting-bot", "references", "repeating-semantic-actions.md"),
+    "utf-8"
+  );
 
   it("registers the canonical capability and guide", () => {
     assert.ok(capability, 'agent.json missing the "meeting_bot" capability');
@@ -97,9 +101,29 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(skill, /retry pending alerts/i);
     assert.match(skill, /wait_seconds: 2/);
     assert.match(skill, /### Reactive lunch answer/);
-    assert.match(skill, /For a\s+one-shot rule, key it only by session and rule/);
+    assert.match(skill, /A one-shot\s+key uses only session and rule/);
     assert.match(skill, /"key": "action:<session_id>:<rule_id>"/);
     assert.doesNotMatch(skill, /"key": "action:<session_id>:<rule_id>:<first_trigger_seq>"/);
+    assert.match(skill, /repeating-semantic-actions\.md/);
+    assert.match(skill, /persist `occurrence_first_seq` and `evidence_seqs`/);
+    assert.match(skill, /action:<session_id>:<rule_id>:repeat:<occurrence_first_seq>/);
+    assert.match(skill, /repeating literal rule, atomically claim `action:<session_id>:<rule_id>:repeat:<segment\.seq>`/);
+    assert.match(skill, /never key from the newest evaluation segment/);
+    assert.match(repeatProtocol, /shortest contiguous suffix ending at the current sequence/);
+    assert.match(repeatProtocol, /durable exclusive lease/);
+    assert.match(repeatProtocol, /active_occurrence/);
+    assert.match(repeatProtocol, /compares the prior `generation`, lease owner\/validity, and prior\s+`last_evaluated_seq`/);
+    assert.match(repeatProtocol, /must fail that CAS/);
+    assert.match(repeatProtocol, /one per-sequence CAS transaction/);
+    assert.match(repeatProtocol, /That same transaction must advance `last_evaluated_seq`/);
+    assert.match(repeatProtocol, /create `active_occurrence` plus the durable\s+action claim/);
+    assert.match(repeatProtocol, /Dispatch only after that combined transaction commits/);
+    assert.match(repeatProtocol, /CAS loser reloads state without dispatching/);
+    assert.match(repeatProtocol, /never advance the cursor and clear in separate\s+writes/);
+    assert.match(repeatProtocol, /every positive overlapping window reuses its\s+persisted claim key/);
+    assert.match(repeatProtocol, /context window contains none of the persisted `evidence_seqs`/);
+    assert.match(repeatProtocol, /persisted semantic condition evaluates false/);
+    assert.match(repeatProtocol, /clear commits and a\s+still-later ordered evaluation produces a new false-to-true transition/);
     assert.match(skill, /do \*\*not\*\* automatically repeat an\s+accepted action/);
   });
 });

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -71,6 +71,10 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     join(SKILLS_DIR, "telnyx-meeting-bot", "references", "repeating-semantic-actions.md"),
     "utf-8"
   );
+  const artifactRecovery = readFileSync(
+    join(SKILLS_DIR, "telnyx-meeting-bot", "references", "artifact-selection-and-recovery.md"),
+    "utf-8"
+  );
 
   it("registers the canonical capability and guide", () => {
     assert.ok(capability, 'agent.json missing the "meeting_bot" capability');
@@ -125,6 +129,28 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(repeatProtocol, /persisted semantic condition evaluates false/);
     assert.match(repeatProtocol, /clear commits and a\s+still-later ordered evaluation produces a new false-to-true transition/);
     assert.match(skill, /do \*\*not\*\* automatically repeat an\s+accepted action/);
+  });
+
+  it("selects the final summary and retries only proven non-dispatches", () => {
+    assert.match(skill, /artifact-selection-and-recovery\.md/);
+    assert.match(skill, /`transcript\.completed\.occurred_at`/);
+    assert.doesNotMatch(skill, /summary_creation_attempted/);
+    assert.match(guide, /no automatic-origin marker/);
+    assert.match(guide, /`pre_send_failed`/);
+    assert.match(guide, /`outcome_unknown`/);
+    assert.match(artifactRecovery, /no `automatic`, `origin`, or final-summary marker/);
+    assert.match(artifactRecovery, /known_manual_artifact_ids/);
+    assert.match(artifactRecovery, /unreconciled_unknown_manual_creates/);
+    assert.match(artifactRecovery, /`created_at >= transcript_completed_at`/);
+    assert.match(artifactRecovery, /Poll all current candidates/);
+    assert.match(artifactRecovery, /Never use\s+artifact ID, list order, completion order, or client-clock windows as an\s+origin tie-breaker/);
+    assert.match(artifactRecovery, /two candidates share\s+the minimum timestamp/);
+    assert.match(artifactRecovery, /same-type unknown create remains unreconciled/);
+    assert.match(artifactRecovery, /every otherwise-unrecognized\s+same-type artifact is possible manual output/);
+    assert.match(artifactRecovery, /Immediately before fallback, re-list once more/);
+    assert.match(artifactRecovery, /proves that no request bytes were sent/);
+    assert.match(artifactRecovery, /Recovery from either `dispatching` or `outcome_unknown`\s+must persist an unreconciled same-type unknown-create marker and\s+re-list\/reconcile only/);
+    assert.match(artifactRecovery, /Never collapse `pre_send_failed` and `outcome_unknown`/);
   });
 });
 

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -129,6 +129,11 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(repeatProtocol, /persisted semantic condition evaluates false/);
     assert.match(repeatProtocol, /clear commits and a\s+still-later ordered evaluation produces a new false-to-true transition/);
     assert.match(skill, /do \*\*not\*\* automatically repeat an\s+accepted action/);
+    assert.match(skill, /Atomically set `dispatching`\s+immediately before invoking the transport/);
+    assert.match(skill, /no request\s+bytes were sent may mark `pre_send_failed`/);
+    assert.match(skill, /Before evaluating triggers, atomically convert every recovered\s+live-action claim still marked `dispatching` to `outcome_unknown`/);
+    assert.match(skill, /never redispatch it/);
+    assert.match(guide, /convert any recovered\s+`dispatching` speech\/chat claim to `outcome_unknown` before evaluating triggers/);
   });
 
   it("selects the final summary and retries only proven non-dispatches", () => {

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -14,6 +14,7 @@ const __dirname = typeof import.meta.dirname === "string"
   : dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..");
 const GUIDES_DIR = join(ROOT, "guides");
+const SKILLS_DIR = join(ROOT, "skills");
 // agent.json lives alongside guides in the repo root (site is a separate repo)
 const AGENT_JSON_PATH = join(ROOT, "agent.json");
 
@@ -54,6 +55,49 @@ describe("agent.json validity", () => {
     assert.match(guide, /telnyx-agent rcs-send/);
     assert.match(guide, /telnyx-agent rcs-capabilities/);
     assert.match(guide, /skills\/telnyx-messaging-hosted-curl\/SKILL\.md/);
+  });
+});
+
+describe("Meeting Bot discovery and durable alert contract", () => {
+  const capability = agentJson.capabilities.find(
+    (candidate: any) => candidate.id === "meeting_bot"
+  );
+  const guide = readFileSync(join(GUIDES_DIR, "meeting-bot.md"), "utf-8");
+  const skill = readFileSync(
+    join(SKILLS_DIR, "telnyx-meeting-bot", "SKILL.md"),
+    "utf-8"
+  );
+
+  it("registers the canonical capability and guide", () => {
+    assert.ok(capability, 'agent.json missing the "meeting_bot" capability');
+    assert.equal(capability.guide, "/guides/meeting-bot.md");
+    assert.equal(capability.api, "POST /v2/meeting_sessions");
+    assert.equal(capability.docs, "https://developers.telnyx.com/docs/meeting");
+    assert.match(guide, /https:\/\/api\.telnyx\.com\/v2\/meeting_bot\/mcp/);
+    assert.match(guide, /skills\/telnyx-meeting-bot\/SKILL\.md/);
+    assert.match(guide, /meeting-bot-service\/tree\/a9f6326bcaf7428364861290b787d5db1772e9f6/);
+    assert.match(guide, /wait_seconds=2/);
+    assert.match(guide, /actions\/speak/);
+    assert.match(
+      guide,
+      /headers\.set\("Authorization", \["Bearer", apiKey\]\.join\(" "\)\);/
+    );
+    for (const type of ["summary", "action_items", "decisions", "topics", "open_questions", "custom"]) {
+      assert.ok(
+        guide.includes("| `" + type + "` |"),
+        `meeting-bot guide missing artifact type: ${type}`
+      );
+    }
+  });
+
+  it("keeps mention delivery crash-safe", () => {
+    assert.match(skill, /"status": "pending"/);
+    assert.match(skill, /stable `delivery_id`/);
+    assert.match(skill, /Mark the outbox item\s+`sent` only after confirmed delivery/);
+    assert.match(skill, /retry pending alerts/i);
+    assert.match(skill, /wait_seconds: 2/);
+    assert.match(skill, /### Reactive lunch answer/);
+    assert.match(skill, /do \*\*not\*\* automatically repeat an\s+accepted action/);
   });
 });
 


### PR DESCRIPTION
## Summary

- add a hand-authored `telnyx-meeting-bot` Agent Skill and register it as the canonical `meeting_bot` capability in `agent.json`
- add a source-grounded consumer guide at `guides/meeting-bot.md`
- turn vague requests into durable idempotent joins, request-sensitive transcript polling, crash-safe name/phrase alerts, explicitly authorized live `speak`/chat actions, terminal transcript draining, and final artifact delivery
- document all implemented artifact types: `summary`, `action_items`, `decisions`, `topics`, `open_questions`, and `custom`
- route the skill into the Claude `telnyx-ai` plugin and keep Claude/Cursor copies byte-identical
- keep both canonical skill-count markers at 237

## Implementation grounding

Behavior is derived from the current `team-telnyx/meeting-bot-service` `origin/main` implementation and tests at [`a9f6326bcaf7428364861290b787d5db1772e9f6`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326bcaf7428364861290b787d5db1772e9f6), especially its REST routes, MCP schemas, session service, artifact domain/service, finalizer, and tests. Public Meeting Bot docs are explicitly secondary because they can lag the implementation.

Key source-grounded details include:

- transcript `wait_seconds` is an integer from 0–25 and long-poll returns when finalized speech is available
- immediate reactions and urgent mentions use about 2 seconds by default; lower-churn summary-only monitoring can use a longer request-selected wait
- `speak` is an explicitly authorized, non-idempotent side effect with durable one-shot claim/outcome handling
- `summarize_on_end` creates only `summary`; other artifact types are created separately
- current artifact generation reads up to 10,000 transcript segments, which is disclosed

## Worked workflows

- **Reactive speech:** when someone clearly asks what the group should have for lunch, atomically claim the first finalized-transcript match and say exactly “I want pizza” once using `speak`
- **Demo:** Anusha texts her agent that she cannot attend; the agent immediately joins as `Anusha's bot`, reports admission/join status to her conversation, monitors durably, and sends a transcript-grounded TL;DR at the end

## Review feedback resolved

- register Meeting Bot in `agent.json` and add its referenced guide
- replace pre-send mention deduplication with a durable `pending|sent` outbox, stable delivery ID, confirmed-send transition, and restart recovery
- key one-shot live-action claims by session and rule so multiple matching transcript segments cannot dispatch duplicate speech/chat; retain sequence numbers only as evidence
- define `segment.seq`-scoped claims for explicitly repeating literal rules so each matching finalized segment can dispatch once
- add a linked deterministic protocol for explicitly repeating semantic rules: exclusive rule lease, ordered finalized-segment evaluation, canonical minimal evidence, one per-sequence CAS for cursor/occurrence/claim transitions, overlap reuse, stale-worker rejection, and false-to-true re-arming
- add a source-grounded artifact selection/recovery protocol that identifies the unique closest post-completion candidate across all statuses before status filtering, waits rather than skipping a pending nearest candidate, and falls back on a failed, tied, or origin-ambiguous nearest candidate
- distinguish proven `pre_send_failed` artifact creation from `outcome_unknown`, allowing bounded retry only when no request bytes could have been sent and never retrying an ambiguous non-idempotent create
- create `speak`/`send_chat` claims as durable `claimed` records and authorize transport only through an atomic `claimed|pre_send_failed` → `dispatching` CAS; recovered `claimed` work can compete safely, while recovered `dispatching` becomes `outcome_unknown` unless durable transport evidence proves no request bytes were sent
- expose Meeting Bot in every `telnyx-ai` install/catalog surface, update the derived plugin count to 13, and enforce manifest/description/listing parity with a disk-derived regression test

## Validation

- `npm run test:guides` — **130 passed**
- `npm run test:guides-api` — **36 passed**
- `./scripts/check-skills-sync.sh` — passed
- `./scripts/check-skill-count.sh` — passed (237)
- `uvx --from skills-ref agentskills validate skills/telnyx-meeting-bot` — valid
- canonical/Claude/Cursor skill copies — byte-identical
- implementation-to-prose parity assertions — passed against `a9f6326bcaf7428364861290b787d5db1772e9f6`
- staged added-line secret scan and `git diff --check` — passed
- independent exact-head Sol review — **PASS** on `62525322bc0012652227858858cdd5750ca727b7` with no P0/P1/P2 findings

## Notes

No live meeting was joined and no customer data was used while validating this documentation/skill change.
