### PR TITLE
docs: add Meeting Bot REST Assistant and Anam flows

### DIFF
--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -230,8 +230,7 @@ jq -n \
   --arg meeting_url "https://meet.google.com/abc-defg-hij" \
   --arg avatar_id "avatar_REPLACE_ME" \
   --arg idempotency_key "meeting-bot:anam-operation-id" \
-  '{meeting_url: $meeting_url, avatar: {provider: "anam", avatar_id: $avatar_id, api_key: env.ANAM_API_KEY}, idempotency_key: $idempotency_key}' \
-| curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
+  '{meeting_url: $meeting_url, avatar: {provider: "anam", avatar_id: $avatar_id, api_key: env.ANAM_API_KEY}, idempotency_key: $idempotency_key}' | curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
   -H "Authorization: Bearer ***" \
   -H "Content-Type: application/json" \
   --data-binary @-

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -219,14 +219,15 @@ An Anam avatar requires `provider: "anam"`, `avatar_id`, and `api_key`:
 }
 ```
 
+The Anam API key is write-only and must not be persisted, logged, or reported. Assume `ANAM_API_KEY` is already exported from a backend secret store; pass it directly at request time, never through a JSON file:
+
 ```bash
 curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
   -H "Authorization: Bearer ***" \
   -H "Content-Type: application/json" \
-  -d @anam-avatar-session.json
+  -d "{\"meeting_url\":\"https://meet.google.com/abc-defg-hij\",\"avatar\":{\"provider\":\"anam\",\"avatar_id\":\"avatar_REPLACE_ME\",\"api_key\":\"${ANAM_API_KEY}\"},\"idempotency_key\":\"meeting-bot:anam-operation-id\"}"
 ```
 
-The Anam API key is write-only and must not be persisted, logged, or reported.
 Responses echo only `avatar.provider` and `avatar.avatar_id`, plus `avatar_state`
 (`starting`, `connected`, `degraded`, `disconnected`) and
 `avatar_state_changed_at`. A connected avatar is media readiness, not proof the

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -242,8 +242,7 @@ Responses echo only `avatar.provider` and `avatar.avatar_id`, plus `avatar_state
 bot entered the meeting; use `joined_at` too.
 
 Avatar creation is immediate-only: do not send `join_at`; it has no MCP,
-calendar/scheduled flow, or mid-meeting toggle. Supported Output Media platforms
-are Zoom, Google Meet, Microsoft Teams, and Webex. The avatar webpage output wins
+calendar/scheduled flow, or mid-meeting toggle. The avatar webpage output wins
 over `camera_image`; `speak` routes through the avatar page. `speak_on_enter`
 waits until the session is active and the avatar is connected. There is no prewarm
 before Recall creates the Output Media page, because that page is the Anam runtime.

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -181,7 +181,7 @@ IDs, from numbers, SIP URIs, or authorization fields inside `assistant`.
 
 ```bash
 curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
-  -H "Authorization: Bearer ***" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   --data-binary '{
     "meeting_url": "https://meet.google.com/abc-defg-hij",
@@ -241,7 +241,7 @@ jq -n \
   --arg avatar_id "avatar_REPLACE_ME" \
   --arg idempotency_key "meeting-bot:anam-operation-id" \
   '{meeting_url: $meeting_url, avatar: {provider: "anam", avatar_id: $avatar_id, api_key: env.ANAM_API_KEY}, idempotency_key: $idempotency_key}' | curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
-  -H "Authorization: Bearer ***" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   --data-binary @-
 ```

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -183,7 +183,16 @@ IDs, from numbers, SIP URIs, or authorization fields inside `assistant`.
 curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
   -H "Authorization: Bearer ***" \
   -H "Content-Type: application/json" \
-  -d @assistant-session.json
+  --data-binary '{
+    "meeting_url": "https://meet.google.com/abc-defg-hij",
+    "assistant": {
+      "id": "assistant_REPLACE_ME",
+      "audio_gate": "half_duplex",
+      "dynamic_variables": {"customer_name": "Example User"},
+      "leave_on_end": false
+    },
+    "idempotency_key": "meeting-bot:assistant-operation-id"
+  }'
 ```
 
 `id` is required. `audio_gate` is `half_duplex` (default) or `full_duplex`;

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -219,13 +219,22 @@ An Anam avatar requires `provider: "anam"`, `avatar_id`, and `api_key`:
 }
 ```
 
-The Anam API key is write-only and must not be persisted, logged, or reported. Assume `ANAM_API_KEY` is already exported from a backend secret store; pass it directly at request time, never through a JSON file:
+The Anam API key is write-only and must not be persisted, logged, or reported;
+it also must not be expanded into process arguments. Assume `ANAM_API_KEY` is
+already exported from a backend secret store. Let `jq` read it from the
+environment, safely encode the JSON, and stream the request body to `curl`; never
+write a secret-bearing JSON file:
 
 ```bash
-curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
+jq -n \
+  --arg meeting_url "https://meet.google.com/abc-defg-hij" \
+  --arg avatar_id "avatar_REPLACE_ME" \
+  --arg idempotency_key "meeting-bot:anam-operation-id" \
+  '{meeting_url: $meeting_url, avatar: {provider: "anam", avatar_id: $avatar_id, api_key: env.ANAM_API_KEY}, idempotency_key: $idempotency_key}' \
+| curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
   -H "Authorization: Bearer ***" \
   -H "Content-Type: application/json" \
-  -d "{\"meeting_url\":\"https://meet.google.com/abc-defg-hij\",\"avatar\":{\"provider\":\"anam\",\"avatar_id\":\"avatar_REPLACE_ME\",\"api_key\":\"${ANAM_API_KEY}\"},\"idempotency_key\":\"meeting-bot:anam-operation-id\"}"
+  --data-binary @-
 ```
 
 Responses echo only `avatar.provider` and `avatar.avatar_id`, plus `avatar_state`

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -150,6 +150,122 @@ error statuses.
 | List artifacts | `GET /v2/meeting_sessions/{id}/artifacts` |
 | Retrieve an artifact | `GET /v2/meeting_sessions/{id}/artifacts/{artifact_id}` |
 
+## REST-only Portal Assistants and Anam Avatars
+
+Both capabilities are REST-only and absent from MCP `join_meeting`. Use the same
+persisted `idempotency_key` for an uncertain create retry; retrieve the resulting
+session with `GET /v2/meeting_sessions/{id}` rather than attempting a second join.
+They are creation-time choices, not scheduled/calendar features or mid-meeting
+toggles.
+
+### Portal Assistant REST create
+
+Use an existing Assistant ID already configured in the authenticated Telnyx
+organization. Production Assistant creation requires Gateway Rev2 authentication:
+call this production REST endpoint with the caller's normal Telnyx bearer key. Do
+not create an Assistant here or put assistant/API secrets, Call Control connection
+IDs, from numbers, SIP URIs, or authorization fields inside `assistant`.
+
+```json
+{
+  "meeting_url": "https://meet.google.com/abc-defg-hij",
+  "assistant": {
+    "id": "assistant_REPLACE_ME",
+    "audio_gate": "half_duplex",
+    "dynamic_variables": {"customer_name": "Example User"},
+    "leave_on_end": false
+  },
+  "idempotency_key": "meeting-bot:assistant-operation-id"
+}
+```
+
+```bash
+curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
+  -H "Authorization: Bearer ***" \
+  -H "Content-Type: application/json" \
+  -d @assistant-session.json
+```
+
+`id` is required. `audio_gate` is `half_duplex` (default) or `full_duplex`;
+`leave_on_end` is optional and defaults to `false`. `dynamic_variables` is an
+optional string map: the current service cap is 63 customer entries, keys are
+1–128 characters, values are at most 2048 characters, and reserved infrastructure
+keys are rejected. The body is strict, so do not add unrelated connection,
+telephone, SIP, secret, or authorization data.
+
+Assistant sessions are immediate-only: do not send `join_at` or `barge_in`.
+The Assistant handles interruption itself. Poll ordinary `status` and `joined_at`
+alongside `assistant_state` (`starting`, `connected`, `failed`, `ended`) and
+`assistant_state_changed_at`. `connected` means its conversation transport is
+ready; `joined_at` is attendance evidence after the meeting host admits the bot.
+
+Use default `half_duplex` unless continuous native barge-in is required.
+`full_duplex` continuously listens using per-participant audio (excluding the
+bot's own stream) and has higher Recall media cost; it is not a free improvement.
+
+### Anam avatar REST create
+
+An Anam avatar requires `provider: "anam"`, `avatar_id`, and `api_key`:
+
+```json
+{
+  "meeting_url": "https://meet.google.com/abc-defg-hij",
+  "avatar": {
+    "provider": "anam",
+    "avatar_id": "avatar_REPLACE_ME",
+    "api_key": "***"
+  },
+  "idempotency_key": "meeting-bot:anam-operation-id"
+}
+```
+
+```bash
+curl -X POST "https://api.telnyx.com/v2/meeting_sessions" \
+  -H "Authorization: Bearer ***" \
+  -H "Content-Type: application/json" \
+  -d @anam-avatar-session.json
+```
+
+The Anam API key is write-only and must not be persisted, logged, or reported.
+Responses echo only `avatar.provider` and `avatar.avatar_id`, plus `avatar_state`
+(`starting`, `connected`, `degraded`, `disconnected`) and
+`avatar_state_changed_at`. A connected avatar is media readiness, not proof the
+bot entered the meeting; use `joined_at` too.
+
+Avatar creation is immediate-only: do not send `join_at`; it has no MCP,
+calendar/scheduled flow, or mid-meeting toggle. Supported Output Media platforms
+are Zoom, Google Meet, Microsoft Teams, and Webex. The avatar webpage output wins
+over `camera_image`; `speak` routes through the avatar page. `speak_on_enter`
+waits until the session is active and the avatar is connected. There is no prewarm
+before Recall creates the Output Media page, because that page is the Anam runtime.
+
+### Combined REST create
+
+Put both objects in one immediate REST create: the Assistant provides the
+conversation and voice; the avatar lip-syncs its speech.
+
+```json
+{
+  "meeting_url": "https://meet.google.com/abc-defg-hij",
+  "assistant": {
+    "id": "assistant_REPLACE_ME",
+    "audio_gate": "half_duplex",
+    "dynamic_variables": {"customer_name": "Example User"},
+    "leave_on_end": false
+  },
+  "avatar": {
+    "provider": "anam",
+    "avatar_id": "avatar_REPLACE_ME",
+    "api_key": "***"
+  },
+  "idempotency_key": "meeting-bot:assistant-avatar-operation-id"
+}
+```
+
+Monitor both readiness axes (`assistant_state` and `avatar_state`) and `joined_at`.
+Do not add `barge_in` or `join_at`: this combined flow is immediate-only and the
+Assistant owns interruption.
+
 ### Implemented artifact types
 
 The source defines exactly these artifact types:

--- a/guides/meeting-bot.md
+++ b/guides/meeting-bot.md
@@ -201,7 +201,8 @@ ready; `joined_at` is attendance evidence after the meeting host admits the bot.
 
 Use default `half_duplex` unless continuous native barge-in is required.
 `full_duplex` continuously listens using per-participant audio (excluding the
-bot's own stream) and has higher Recall media cost; it is not a free improvement.
+bot's own stream) and has higher meeting-media usage and cost; it is not a free
+improvement.
 
 ### Anam avatar REST create
 
@@ -244,8 +245,9 @@ bot entered the meeting; use `joined_at` too.
 Avatar creation is immediate-only: do not send `join_at`; it has no MCP,
 calendar/scheduled flow, or mid-meeting toggle. The avatar webpage output wins
 over `camera_image`; `speak` routes through the avatar page. `speak_on_enter`
-waits until the session is active and the avatar is connected. There is no prewarm
-before Recall creates the Output Media page, because that page is the Anam runtime.
+waits until the session is active and the avatar is connected. There is no
+supported prewarm before the meeting media layer creates the Output Media page;
+that page hosts the avatar runtime.
 
 ### Combined REST create
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -24,51 +24,22 @@ in-meeting changes unless the requester explicitly asks for that.
 
 ## Quick Workflow
 
-1. Resolve only missing essentials: meeting URL, join now versus a scheduled
-   time, desired live/final outputs, and any trigger/action rules. Reuse details
-   already stated in the request or authorized context; do not ask again.
-2. Persist an operation record **before** creating the session. Generate and
-   retain one stable `idempotency_key`; call `join_meeting` with
-   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`. If an
-   explicit later speech rule exists, set `barge_in: true` so new human speech
-   can stop the bot's output.
-3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
-   Choose transcript `wait_seconds` from the request—use about `2` seconds for
-   “as soon as,” reactive speech, or urgent mention alerts—and persist cursors,
-   seen segments, outboxes, action claims, and IDs for safe recovery.
-4. On each new final segment, evaluate requested literal or semantic rules.
-   Deliver mention notifications through the durable outbox; atomically claim
-   and execute each authorized `speak`/`send_chat` action at most once.
-5. On a terminal session, drain transcript pages, wait a bounded time for
-   `transcript.completed`, obtain the requested implemented artifact types
-   without duplicate creation, then deliver a Markdown report.
+1. Resolve only missing essentials: meeting URL, join now versus a scheduled time, desired live/final outputs, and trigger/action rules. Reuse authorized details; do not ask again.
+2. Persist an operation record **before** creating the session. Generate and retain one stable `idempotency_key`; call `join_meeting` with `summarize_on_end: true`, no `speak_on_enter` or `chat_on_enter`. For an explicit later speech rule, set `barge_in: true` so human speech can stop bot output.
+3. Poll `get_session`, `get_transcript`, and, when available, `get_events`. Select `wait_seconds` from the request—about `2` for “as soon as,” reactive speech, or urgent mentions—and persist cursors, seen segments, outboxes, claims, and IDs for recovery.
+4. On each new final segment, evaluate requested literal or semantic rules; deliver mention notifications through the durable outbox, and atomically claim and execute each authorized `speak`/`send_chat` action at most once.
+5. On a terminal session, drain transcript pages, wait a bounded time for `transcript.completed`, obtain requested implemented artifact types without duplicate creation, then deliver a Markdown report.
 
 ## Preconditions and Safe Defaults
 
-- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL,
-  transcript, event, artifact, chat message, or user-facing report.
-- Before joining, ensure the runtime can keep monitoring or can resume from a
-  durable background task. Do not promise end-to-end monitoring from a process
-  that will disappear without preserving and resuming the operation record.
-- Verify the requester is authorized to have a visible bot attend this meeting.
-  The bot may need a host to admit it; never try to bypass a waiting room,
-  password, platform policy, or consent requirement.
-- Default notification target: **this current conversation**. Do not configure a
-  `webhook_url` merely to send the requester notifications.
-- Default behavior: immediate join if no future time was requested,
-  `summarize_on_end: true`, observe-only, and no recording-media deletion.
-  `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
-- An explicit conditional request such as “when someone asks about lunch, say
-  ‘I want pizza’” is advance authorization for that exact action. Persist the
-  trigger, exact payload, one-shot/repeat policy, and latency target before join;
-  do not interrupt the live workflow to ask for approval again.
-- Choose monitoring cadence from the request. Default immediate reactions and
-  urgent mentions to `wait_seconds: 2`; do not silently substitute a 15-second
-  cadence for an “as soon as” instruction.
-- If a meeting link is not present, ask for it. If time is ambiguous, ask only
-  whether to join now or at a specified time. If “my name” is not resolvable
-  from the request, current conversation, or authorized profile context, ask
-  which name/phrases (and optional variants) to watch for.
+- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL, transcript, event, artifact, chat message, or user-facing report.
+- Before joining, ensure the runtime can keep monitoring or can resume from durable background state. Do not promise end-to-end monitoring from a process that disappears without preserving and resuming the operation record.
+- Verify authorization for a visible bot. A host may need to admit it; never bypass a waiting room, password, platform policy, or consent requirement.
+- Default notification target: **this current conversation**. Do not configure a `webhook_url` merely to send requester notifications.
+- Default behavior is immediate join, `summarize_on_end: true`, observe-only, and no recording-media deletion. `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in.
+- An explicit conditional request such as “when someone asks about lunch, say ‘I want pizza’” authorizes exactly that action. Before join, persist trigger, exact payload, one-shot/repeat policy, and latency target; do not interrupt the workflow to ask again.
+- Select monitoring cadence from the request: default immediate reactions and urgent mentions to `wait_seconds: 2`, never silently substituting a 15-second cadence for “as soon as.”
+- If the link is missing, ask for it. If timing is ambiguous, ask only now versus specified time. If “my name” is not resolvable from authorized request/context/profile data, ask for name/phrases and optional variants.
 
 ## Connect to the Production MCP Server
 
@@ -76,19 +47,12 @@ Prefer the production Streamable HTTP MCP endpoint:
 
 ```text
 https://api.telnyx.com/v2/meeting_bot/mcp
-Authorization: Bearer <TELNYX_API_KEY>
+Authorization: Bearer ***
 ```
 
-Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`,
-`get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`,
-`stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and
-`get_artifacts`.
+Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`, `get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`, `stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and `get_artifacts`.
 
-MCP tools return one JSON text block. Decode `result.content[0].text` as JSON
-only after checking `result.isError`. HTTP/transport failures (for example 401,
-timeouts, or a 5xx) are different from an HTTP-200 MCP tool failure with
-`result.isError: true`; handle both, preserve the error code/message, and do
-not treat an HTTP 200 as success by itself.
+MCP tools return one JSON text block. Decode `result.content[0].text` only after checking `result.isError`. HTTP/transport failures (for example 401, timeouts, or 5xx) differ from an HTTP-200 MCP tool failure with `result.isError: true`; preserve the error code/message and do not treat HTTP 200 as success alone.
 
 If MCP is unavailable, use the equivalent production REST base:
 
@@ -96,14 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`,
-`POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`,
-`POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`,
-`DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`,
-`POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
-`Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
-Use REST only as a transport fallback—the lifecycle and durability rules below
-remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer <TELNY...Y>`; REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 
@@ -436,50 +393,44 @@ media deletion as a cleanup shortcut.
 
 ## Portal-configured Assistant (REST-only)
 
-Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing,
-portal-configured Assistant `id` in the authenticated organization. Create it
-through the production endpoint with the caller's normal Telnyx bearer key; the
-service requires Gateway Rev2 authentication. Never put assistant/API secrets,
-Call Control connection IDs, from numbers, SIP URIs, or authorization fields in
-`assistant`. The allowed fields are `id`, optional `audio_gate`
-(`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`,
-and optional `leave_on_end` (default `false`).
+Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing portal-configured Assistant `id` in the authenticated organization. Create it with the caller's normal Telnyx bearer key; production requires Gateway Rev2 authentication. Never put Assistant/API secrets, Call Control connection IDs, from numbers, SIP URIs, or authorization fields in `assistant`. Allowed fields are `id`, optional `audio_gate` (`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`, and optional `leave_on_end` (default `false`).
 
-Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the
-assistant handles interruption natively. A map has at most 63 customer entries;
-keys are 1–128 characters, values are strings up to 2048 characters, and reserved
-infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus
-`assistant_state` (`starting|connected|failed|ended`) and its change timestamp.
-`connected` is readiness, while non-null `joined_at` proves attendance.
-`full_duplex` continuously listens through per-participant audio and costs more
-Recall media; use safe-default `half_duplex` unless native continuous barge-in is
-required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and costs more Recall media, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
 
 ## Anam Avatar (REST-only)
 
-Create an Anam avatar only through `POST /v2/meeting_sessions`, with
-`avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP
-`join_meeting`. The key is write-only: never persist, log, or report it. Responses
-echo only provider/avatar ID and expose `avatar_state`
-(`starting|connected|degraded|disconnected`) with its change timestamp.
+Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP,
-or mid-meeting toggle. `connected` means avatar media readiness, not attendance,
-so also require `joined_at`. Avatar webpage output wins over `camera_image`;
-`speak` routes through that page, and `speak_on_enter` waits for active plus avatar
-connected. Do not prewarm: Recall creates the Output Media page first. See the
-REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 
-One immediate REST create can include both objects: the Assistant supplies the
-conversation and voice while the avatar lip-syncs it. Monitor assistant readiness,
-avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`.
+One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](../../guides/meeting-bot.md).
+
+## Worked Interpretations
+
+### Mention alert and final summary
+
+For: “Join this meeting and tell me what they discussed when it ends; if they mention my name, let me know.”
+
+- If the message already includes a meeting URL and the requester identity/name is known from authorized conversation/profile context, join immediately with `summarize_on_end: true`, the stable idempotency key, no voice/chat actions, and that name plus known variants as terms.
+- If the link is missing, ask only for the link. If it is unclear whether the meeting is now or later, ask only for join timing. If “my name” is not known, ask for the name/phrases and optional variants.
+- Tell the requester if host admission is required; send mention alerts in this conversation; after completion, send the bounded, evidence-based report.
 
 ### Reactive lunch answer
 
-For an explicitly authorized lunch-answer trigger, persist one semantic `speak` rule, use `wait_seconds: 2`, claim its first clear finalized match and dispatch once; ordinary bots
-use `barge_in: true`, but an Assistant flow never does.
+For: “Join the meeting and as soon as someone asks what we should have for lunch, please use the speak request and say I want pizza.”
+
+- Treat this as explicit authorization for one in-meeting `speak`; do not ask again when the condition occurs.
+- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance speech/chat, and `barge_in: true`.
+- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new final segment plus a short trailing context window; require a clear lunch-choice question rather than the isolated word “lunch.”
+- Atomically claim the first match and call `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
+
+### Demo: delegated attendance and TL;DR
+
+For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
+
+Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and no unrequested speech/chat. Post joining/admission updates to Anusha's current conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises live reactions. At terminal status, drain final transcript and send the automatic `summary` with attendance, completeness, and provenance. The visible story is: Anusha cannot attend → texts her agent → colleagues see her bot join → her agent confirms attendance → she receives the TL;DR.
 
 ## Source Authority and References
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer <TELNY...Y>`; REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer ***`. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -401,7 +401,7 @@ Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assist
 
 Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples and recovery guidance in [the guide](../../guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer ***`. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -434,52 +434,52 @@ needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
 does not erase the durable session history. Do not use destructive recording
 media deletion as a cleanup shortcut.
 
-## Worked Interpretations
+## Portal-configured Assistant (REST-only)
 
-### Mention alert and final summary
+Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing,
+portal-configured Assistant `id` in the authenticated organization. Create it
+through the production endpoint with the caller's normal Telnyx bearer key; the
+service requires Gateway Rev2 authentication. Never put assistant/API secrets,
+Call Control connection IDs, from numbers, SIP URIs, or authorization fields in
+`assistant`. The allowed fields are `id`, optional `audio_gate`
+(`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`,
+and optional `leave_on_end` (default `false`).
 
-For: “Join this meeting and tell me what they discussed when it ends; if they
-mention my name, let me know.”
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the
+assistant handles interruption natively. A map has at most 63 customer entries;
+keys are 1–128 characters, values are strings up to 2048 characters, and reserved
+infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus
+`assistant_state` (`starting|connected|failed|ended`) and its change timestamp.
+`connected` is readiness, while non-null `joined_at` proves attendance.
+`full_duplex` continuously listens through per-participant audio and costs more
+Recall media; use safe-default `half_duplex` unless native continuous barge-in is
+required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
 
-- If the message already includes a meeting URL and the requester identity/name
-  is known from authorized conversation/profile context, join immediately with
-  `summarize_on_end: true`, the stable idempotency key, no voice/chat actions,
-  and that name plus known variants as terms.
-- If the link is missing, ask only for the link. If it is unclear whether the
-  meeting is now or later, ask only for join timing. If “my name” is not known,
-  ask for the name/phrases and optional variants.
-- Tell the requester if host admission is required; send mention alerts in this
-  conversation; after completion, send the bounded, evidence-based report.
+## Anam Avatar (REST-only)
+
+Create an Anam avatar only through `POST /v2/meeting_sessions`, with
+`avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP
+`join_meeting`. The key is write-only: never persist, log, or report it. Responses
+echo only provider/avatar ID and expose `avatar_state`
+(`starting|connected|degraded|disconnected`) with its change timestamp.
+
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP,
+or mid-meeting toggle. `connected` means avatar media readiness, not attendance,
+so also require `joined_at`. Avatar webpage output wins over `camera_image`;
+`speak` routes through that page, and `speak_on_enter` waits for active plus avatar
+connected. Do not prewarm: Recall creates the Output Media page first. See the
+REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+
+## Combined Assistant + Avatar
+
+One immediate REST create can include both objects: the Assistant supplies the
+conversation and voice while the avatar lip-syncs it. Monitor assistant readiness,
+avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`.
 
 ### Reactive lunch answer
 
-For: “Join the meeting and as soon as someone asks what we should have for
-lunch, please use the speak request and say I want pizza.”
-
-- Treat this as explicit authorization for one in-meeting `speak`; do not ask
-  again when the condition occurs.
-- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance
-  speech/chat, and `barge_in: true`.
-- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new
-  final segment plus a short trailing context window; require a clear lunch-choice
-  question rather than the isolated word “lunch.”
-- Atomically claim the first match and call
-  `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only
-  from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
-
-### Demo: delegated attendance and TL;DR
-
-For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as
-Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
-
-Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and
-no unrequested speech/chat. Post joining/admission updates to Anusha's current
-conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A
-summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises
-live reactions. At terminal status, drain final transcript and send the automatic
-`summary` with attendance, completeness, and provenance. The visible story is:
-Anusha cannot attend → texts her agent → colleagues see her bot join → her agent
-confirms attendance → she receives the TL;DR.
+For an explicitly authorized lunch-answer trigger, persist one semantic `speak` rule, use `wait_seconds: 2`, claim its first clear finalized match and dispatch once; ordinary bots
+use `barge_in: true`, but an Assistant flow never does.
 
 ## Source Authority and References
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -25,7 +25,7 @@ in-meeting changes unless the requester explicitly asks for that.
 ## Quick Workflow
 
 1. Resolve only missing essentials: meeting URL, join now versus a scheduled time, desired live/final outputs, and trigger/action rules. Reuse authorized details; do not ask again.
-2. Persist an operation record **before** creating the session. Generate and retain one stable `idempotency_key`; call `join_meeting` with `summarize_on_end: true`, no `speak_on_enter` or `chat_on_enter`. For an explicit later speech rule, set `barge_in: true` so human speech can stop bot output.
+2. Persist an operation record **before** creating the session and choose its transport. Ordinary sessions use MCP `join_meeting`. Any Portal Assistant or Anam avatar session uses REST `POST /v2/meeting_sessions` with the requested object(s). Persist one stable `idempotency_key`, the transport, and the exact logical create request; store only a secret reference for a write-only Anam key. REST-only sessions are immediate, so omit `join_at`; Assistant sessions also omit `barge_in`. For an ordinary session with an authorized later speech rule, set `barge_in: true` so human speech can stop bot output.
 3. Poll `get_session`, `get_transcript`, and, when available, `get_events`. Select `wait_seconds` from the request—about `2` for “as soon as,” reactive speech, or urgent mentions—and persist cursors, seen segments, outboxes, claims, and IDs for recovery.
 4. On each new final segment, evaluate requested literal or semantic rules; deliver mention notifications through the durable outbox, and atomically claim and execute each authorized `speak`/`send_chat` action at most once.
 5. On a terminal session, drain transcript pages, wait a bounded time for `transcript.completed`, obtain requested implemented artifact types without duplicate creation, then deliver a Markdown report.
@@ -64,7 +64,7 @@ REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POS
 
 ## Create or Schedule Exactly Once
 
-Before the first `join_meeting`, checkpoint a durable operation record outside
+Before the first session create, checkpoint a durable operation record outside
 transient chat memory whenever the host supports files, a task store, or durable
 workflow state. Store at least:
 
@@ -73,6 +73,9 @@ workflow state. Store at least:
   "operation_id": "host-stable-id",
   "meeting_url": "redacted-or-secret-reference",
   "idempotency_key": "meeting-bot:<host-stable-id>",
+  "create_transport": "mcp-or-rest",
+  "create_request_without_write_only_secrets": {},
+  "avatar_api_key_secret_ref": null,
   "session_id": null,
   "poll_wait_seconds": 2,
   "live_rules": [],
@@ -92,8 +95,8 @@ workflow state. Store at least:
 }
 ```
 
-Use a UUID or a host-durable operation ID, not a new timestamp on retry. Then
-call `join_meeting` with the smallest safe argument set:
+Use a UUID or host-durable operation ID, not a new timestamp on retry. For an
+ordinary session, call MCP `join_meeting` with the smallest safe argument set:
 
 ```json
 {
@@ -107,12 +110,17 @@ call `join_meeting` with the smallest safe argument set:
 Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
 If the request contains an authorized later `speak` rule, include
 `"barge_in": true`; this lets human speech stop bot output and does not itself
-make the bot speak. Persist the returned `id` as `session_id` immediately.
-If the create request has an
-uncertain transport outcome, retry **only** with the same persisted
-`idempotency_key`; never issue a second key, which could place a second bot in
-the meeting. If the host cannot persist state, state that duplicate-prevention
-across a restart cannot be guaranteed and avoid an unbounded retry.
+make the bot speak.
+
+For a Portal Assistant, Anam avatar, or combined session, use REST instead and
+persist the complete sanitized body from the sections below. Omit `join_at`; when
+an Assistant is present, omit `barge_in`. Persist the returned `id` as
+`session_id` immediately. After an uncertain create outcome, retry **only**
+through the original transport with the same logical request and
+`idempotency_key`; re-resolve an Anam key from its secret reference at dispatch
+instead of persisting the value. Never issue a second key, which could place a
+second bot in the meeting. If durable state is unavailable, disclose that
+duplicate prevention across restart is not guaranteed and avoid unbounded retry.
 
 ## Live Session and Transcript Loop
 
@@ -371,7 +379,7 @@ that are absent from the session, events, or collected finalized transcript.
 
 On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
-from persisted cursors and outbox state—never call `join_meeting` again. Retry
+from persisted cursors and outbox state—never create another session. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
 `sent` items alone. A recovered `claimed` action may attempt the dispatch CAS. Before
 evaluating triggers, atomically convert every recovered
@@ -381,8 +389,10 @@ repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history
 where useful, but a missing event is not proof the side effect did not happen. Resume each
 artifact request from its persisted ID/deadline and never repeat an ambiguous
 create. If the record has an idempotency key but no saved session ID because
-creation was interrupted, retry the original `join_meeting` arguments with that
-same key only after checking any available response/log receipt. Persist every
+creation was interrupted, retry the original create through its recorded
+transport with the same logical request and key only after checking any available
+response/log receipt. Re-resolve a write-only Anam key from its secret reference;
+never substitute MCP for a REST-only create. Persist every
 state transition, alert/action state, cursor, terminal observation, and artifact
 ID before relying on it.
 
@@ -395,17 +405,17 @@ media deletion as a cleanup shortcut.
 
 Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing portal-configured Assistant `id` in the authenticated organization. Create it with the caller's normal Telnyx bearer key; production requires Gateway Rev2 authentication. Never put Assistant/API secrets, Call Control connection IDs, from numbers, SIP URIs, or authorization fields in `assistant`. Allowed fields are `id`, optional `audio_gate` (`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`, and optional `leave_on_end` (default `false`).
 
-Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and costs more Recall media, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and has higher meeting-media usage and cost, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Anam Avatar (REST-only)
 
 Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: the meeting media layer creates the Output Media page as part of session startup. See REST examples and recovery guidance in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 
-One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](../../guides/meeting-bot.md).
+One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Worked Interpretations
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is a fallback transport for ordinary sessions when MCP is unavailable, but it is required for Portal Assistant and Anam avatar creates because MCP cannot express those objects. The lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -24,51 +24,22 @@ in-meeting changes unless the requester explicitly asks for that.
 
 ## Quick Workflow
 
-1. Resolve only missing essentials: meeting URL, join now versus a scheduled
-   time, desired live/final outputs, and any trigger/action rules. Reuse details
-   already stated in the request or authorized context; do not ask again.
-2. Persist an operation record **before** creating the session. Generate and
-   retain one stable `idempotency_key`; call `join_meeting` with
-   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`. If an
-   explicit later speech rule exists, set `barge_in: true` so new human speech
-   can stop the bot's output.
-3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
-   Choose transcript `wait_seconds` from the request—use about `2` seconds for
-   “as soon as,” reactive speech, or urgent mention alerts—and persist cursors,
-   seen segments, outboxes, action claims, and IDs for safe recovery.
-4. On each new final segment, evaluate requested literal or semantic rules.
-   Deliver mention notifications through the durable outbox; atomically claim
-   and execute each authorized `speak`/`send_chat` action at most once.
-5. On a terminal session, drain transcript pages, wait a bounded time for
-   `transcript.completed`, obtain the requested implemented artifact types
-   without duplicate creation, then deliver a Markdown report.
+1. Resolve only missing essentials: meeting URL, join now versus a scheduled time, desired live/final outputs, and trigger/action rules. Reuse authorized details; do not ask again.
+2. Persist an operation record **before** creating the session. Generate and retain one stable `idempotency_key`; call `join_meeting` with `summarize_on_end: true`, no `speak_on_enter` or `chat_on_enter`. For an explicit later speech rule, set `barge_in: true` so human speech can stop bot output.
+3. Poll `get_session`, `get_transcript`, and, when available, `get_events`. Select `wait_seconds` from the request—about `2` for “as soon as,” reactive speech, or urgent mentions—and persist cursors, seen segments, outboxes, claims, and IDs for recovery.
+4. On each new final segment, evaluate requested literal or semantic rules; deliver mention notifications through the durable outbox, and atomically claim and execute each authorized `speak`/`send_chat` action at most once.
+5. On a terminal session, drain transcript pages, wait a bounded time for `transcript.completed`, obtain requested implemented artifact types without duplicate creation, then deliver a Markdown report.
 
 ## Preconditions and Safe Defaults
 
-- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL,
-  transcript, event, artifact, chat message, or user-facing report.
-- Before joining, ensure the runtime can keep monitoring or can resume from a
-  durable background task. Do not promise end-to-end monitoring from a process
-  that will disappear without preserving and resuming the operation record.
-- Verify the requester is authorized to have a visible bot attend this meeting.
-  The bot may need a host to admit it; never try to bypass a waiting room,
-  password, platform policy, or consent requirement.
-- Default notification target: **this current conversation**. Do not configure a
-  `webhook_url` merely to send the requester notifications.
-- Default behavior: immediate join if no future time was requested,
-  `summarize_on_end: true`, observe-only, and no recording-media deletion.
-  `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
-- An explicit conditional request such as “when someone asks about lunch, say
-  ‘I want pizza’” is advance authorization for that exact action. Persist the
-  trigger, exact payload, one-shot/repeat policy, and latency target before join;
-  do not interrupt the live workflow to ask for approval again.
-- Choose monitoring cadence from the request. Default immediate reactions and
-  urgent mentions to `wait_seconds: 2`; do not silently substitute a 15-second
-  cadence for an “as soon as” instruction.
-- If a meeting link is not present, ask for it. If time is ambiguous, ask only
-  whether to join now or at a specified time. If “my name” is not resolvable
-  from the request, current conversation, or authorized profile context, ask
-  which name/phrases (and optional variants) to watch for.
+- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL, transcript, event, artifact, chat message, or user-facing report.
+- Before joining, ensure the runtime can keep monitoring or can resume from durable background state. Do not promise end-to-end monitoring from a process that disappears without preserving and resuming the operation record.
+- Verify authorization for a visible bot. A host may need to admit it; never bypass a waiting room, password, platform policy, or consent requirement.
+- Default notification target: **this current conversation**. Do not configure a `webhook_url` merely to send requester notifications.
+- Default behavior is immediate join, `summarize_on_end: true`, observe-only, and no recording-media deletion. `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in.
+- An explicit conditional request such as “when someone asks about lunch, say ‘I want pizza’” authorizes exactly that action. Before join, persist trigger, exact payload, one-shot/repeat policy, and latency target; do not interrupt the workflow to ask again.
+- Select monitoring cadence from the request: default immediate reactions and urgent mentions to `wait_seconds: 2`, never silently substituting a 15-second cadence for “as soon as.”
+- If the link is missing, ask for it. If timing is ambiguous, ask only now versus specified time. If “my name” is not resolvable from authorized request/context/profile data, ask for name/phrases and optional variants.
 
 ## Connect to the Production MCP Server
 
@@ -76,19 +47,12 @@ Prefer the production Streamable HTTP MCP endpoint:
 
 ```text
 https://api.telnyx.com/v2/meeting_bot/mcp
-Authorization: Bearer <TELNYX_API_KEY>
+Authorization: Bearer ***
 ```
 
-Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`,
-`get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`,
-`stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and
-`get_artifacts`.
+Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`, `get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`, `stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and `get_artifacts`.
 
-MCP tools return one JSON text block. Decode `result.content[0].text` as JSON
-only after checking `result.isError`. HTTP/transport failures (for example 401,
-timeouts, or a 5xx) are different from an HTTP-200 MCP tool failure with
-`result.isError: true`; handle both, preserve the error code/message, and do
-not treat an HTTP 200 as success by itself.
+MCP tools return one JSON text block. Decode `result.content[0].text` only after checking `result.isError`. HTTP/transport failures (for example 401, timeouts, or 5xx) differ from an HTTP-200 MCP tool failure with `result.isError: true`; preserve the error code/message and do not treat HTTP 200 as success alone.
 
 If MCP is unavailable, use the equivalent production REST base:
 
@@ -96,14 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`,
-`POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`,
-`POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`,
-`DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`,
-`POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
-`Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
-Use REST only as a transport fallback—the lifecycle and durability rules below
-remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer <TELNY...Y>`; REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 
@@ -436,50 +393,44 @@ media deletion as a cleanup shortcut.
 
 ## Portal-configured Assistant (REST-only)
 
-Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing,
-portal-configured Assistant `id` in the authenticated organization. Create it
-through the production endpoint with the caller's normal Telnyx bearer key; the
-service requires Gateway Rev2 authentication. Never put assistant/API secrets,
-Call Control connection IDs, from numbers, SIP URIs, or authorization fields in
-`assistant`. The allowed fields are `id`, optional `audio_gate`
-(`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`,
-and optional `leave_on_end` (default `false`).
+Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing portal-configured Assistant `id` in the authenticated organization. Create it with the caller's normal Telnyx bearer key; production requires Gateway Rev2 authentication. Never put Assistant/API secrets, Call Control connection IDs, from numbers, SIP URIs, or authorization fields in `assistant`. Allowed fields are `id`, optional `audio_gate` (`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`, and optional `leave_on_end` (default `false`).
 
-Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the
-assistant handles interruption natively. A map has at most 63 customer entries;
-keys are 1–128 characters, values are strings up to 2048 characters, and reserved
-infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus
-`assistant_state` (`starting|connected|failed|ended`) and its change timestamp.
-`connected` is readiness, while non-null `joined_at` proves attendance.
-`full_duplex` continuously listens through per-participant audio and costs more
-Recall media; use safe-default `half_duplex` unless native continuous barge-in is
-required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and costs more Recall media, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
 
 ## Anam Avatar (REST-only)
 
-Create an Anam avatar only through `POST /v2/meeting_sessions`, with
-`avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP
-`join_meeting`. The key is write-only: never persist, log, or report it. Responses
-echo only provider/avatar ID and expose `avatar_state`
-(`starting|connected|degraded|disconnected`) with its change timestamp.
+Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP,
-or mid-meeting toggle. `connected` means avatar media readiness, not attendance,
-so also require `joined_at`. Avatar webpage output wins over `camera_image`;
-`speak` routes through that page, and `speak_on_enter` waits for active plus avatar
-connected. Do not prewarm: Recall creates the Output Media page first. See the
-REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 
-One immediate REST create can include both objects: the Assistant supplies the
-conversation and voice while the avatar lip-syncs it. Monitor assistant readiness,
-avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`.
+One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](../../guides/meeting-bot.md).
+
+## Worked Interpretations
+
+### Mention alert and final summary
+
+For: “Join this meeting and tell me what they discussed when it ends; if they mention my name, let me know.”
+
+- If the message already includes a meeting URL and the requester identity/name is known from authorized conversation/profile context, join immediately with `summarize_on_end: true`, the stable idempotency key, no voice/chat actions, and that name plus known variants as terms.
+- If the link is missing, ask only for the link. If it is unclear whether the meeting is now or later, ask only for join timing. If “my name” is not known, ask for the name/phrases and optional variants.
+- Tell the requester if host admission is required; send mention alerts in this conversation; after completion, send the bounded, evidence-based report.
 
 ### Reactive lunch answer
 
-For an explicitly authorized lunch-answer trigger, persist one semantic `speak` rule, use `wait_seconds: 2`, claim its first clear finalized match and dispatch once; ordinary bots
-use `barge_in: true`, but an Assistant flow never does.
+For: “Join the meeting and as soon as someone asks what we should have for lunch, please use the speak request and say I want pizza.”
+
+- Treat this as explicit authorization for one in-meeting `speak`; do not ask again when the condition occurs.
+- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance speech/chat, and `barge_in: true`.
+- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new final segment plus a short trailing context window; require a clear lunch-choice question rather than the isolated word “lunch.”
+- Atomically claim the first match and call `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
+
+### Demo: delegated attendance and TL;DR
+
+For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
+
+Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and no unrequested speech/chat. Post joining/admission updates to Anusha's current conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises live reactions. At terminal status, drain final transcript and send the automatic `summary` with attendance, completeness, and provenance. The visible story is: Anusha cannot attend → texts her agent → colleagues see her bot join → her agent confirms attendance → she receives the TL;DR.
 
 ## Source Authority and References
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer <TELNY...Y>`; REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer ***`. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -401,7 +401,7 @@ Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assist
 
 Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples and recovery guidance in [the guide](../../guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer ***`. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -434,52 +434,52 @@ needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
 does not erase the durable session history. Do not use destructive recording
 media deletion as a cleanup shortcut.
 
-## Worked Interpretations
+## Portal-configured Assistant (REST-only)
 
-### Mention alert and final summary
+Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing,
+portal-configured Assistant `id` in the authenticated organization. Create it
+through the production endpoint with the caller's normal Telnyx bearer key; the
+service requires Gateway Rev2 authentication. Never put assistant/API secrets,
+Call Control connection IDs, from numbers, SIP URIs, or authorization fields in
+`assistant`. The allowed fields are `id`, optional `audio_gate`
+(`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`,
+and optional `leave_on_end` (default `false`).
 
-For: “Join this meeting and tell me what they discussed when it ends; if they
-mention my name, let me know.”
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the
+assistant handles interruption natively. A map has at most 63 customer entries;
+keys are 1–128 characters, values are strings up to 2048 characters, and reserved
+infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus
+`assistant_state` (`starting|connected|failed|ended`) and its change timestamp.
+`connected` is readiness, while non-null `joined_at` proves attendance.
+`full_duplex` continuously listens through per-participant audio and costs more
+Recall media; use safe-default `half_duplex` unless native continuous barge-in is
+required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
 
-- If the message already includes a meeting URL and the requester identity/name
-  is known from authorized conversation/profile context, join immediately with
-  `summarize_on_end: true`, the stable idempotency key, no voice/chat actions,
-  and that name plus known variants as terms.
-- If the link is missing, ask only for the link. If it is unclear whether the
-  meeting is now or later, ask only for join timing. If “my name” is not known,
-  ask for the name/phrases and optional variants.
-- Tell the requester if host admission is required; send mention alerts in this
-  conversation; after completion, send the bounded, evidence-based report.
+## Anam Avatar (REST-only)
+
+Create an Anam avatar only through `POST /v2/meeting_sessions`, with
+`avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP
+`join_meeting`. The key is write-only: never persist, log, or report it. Responses
+echo only provider/avatar ID and expose `avatar_state`
+(`starting|connected|degraded|disconnected`) with its change timestamp.
+
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP,
+or mid-meeting toggle. `connected` means avatar media readiness, not attendance,
+so also require `joined_at`. Avatar webpage output wins over `camera_image`;
+`speak` routes through that page, and `speak_on_enter` waits for active plus avatar
+connected. Do not prewarm: Recall creates the Output Media page first. See the
+REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+
+## Combined Assistant + Avatar
+
+One immediate REST create can include both objects: the Assistant supplies the
+conversation and voice while the avatar lip-syncs it. Monitor assistant readiness,
+avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`.
 
 ### Reactive lunch answer
 
-For: “Join the meeting and as soon as someone asks what we should have for
-lunch, please use the speak request and say I want pizza.”
-
-- Treat this as explicit authorization for one in-meeting `speak`; do not ask
-  again when the condition occurs.
-- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance
-  speech/chat, and `barge_in: true`.
-- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new
-  final segment plus a short trailing context window; require a clear lunch-choice
-  question rather than the isolated word “lunch.”
-- Atomically claim the first match and call
-  `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only
-  from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
-
-### Demo: delegated attendance and TL;DR
-
-For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as
-Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
-
-Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and
-no unrequested speech/chat. Post joining/admission updates to Anusha's current
-conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A
-summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises
-live reactions. At terminal status, drain final transcript and send the automatic
-`summary` with attendance, completeness, and provenance. The visible story is:
-Anusha cannot attend → texts her agent → colleagues see her bot join → her agent
-confirms attendance → she receives the TL;DR.
+For an explicitly authorized lunch-answer trigger, persist one semantic `speak` rule, use `wait_seconds: 2`, claim its first clear finalized match and dispatch once; ordinary bots
+use `barge_in: true`, but an Assistant flow never does.
 
 ## Source Authority and References
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -25,7 +25,7 @@ in-meeting changes unless the requester explicitly asks for that.
 ## Quick Workflow
 
 1. Resolve only missing essentials: meeting URL, join now versus a scheduled time, desired live/final outputs, and trigger/action rules. Reuse authorized details; do not ask again.
-2. Persist an operation record **before** creating the session. Generate and retain one stable `idempotency_key`; call `join_meeting` with `summarize_on_end: true`, no `speak_on_enter` or `chat_on_enter`. For an explicit later speech rule, set `barge_in: true` so human speech can stop bot output.
+2. Persist an operation record **before** creating the session and choose its transport. Ordinary sessions use MCP `join_meeting`. Any Portal Assistant or Anam avatar session uses REST `POST /v2/meeting_sessions` with the requested object(s). Persist one stable `idempotency_key`, the transport, and the exact logical create request; store only a secret reference for a write-only Anam key. REST-only sessions are immediate, so omit `join_at`; Assistant sessions also omit `barge_in`. For an ordinary session with an authorized later speech rule, set `barge_in: true` so human speech can stop bot output.
 3. Poll `get_session`, `get_transcript`, and, when available, `get_events`. Select `wait_seconds` from the request—about `2` for “as soon as,” reactive speech, or urgent mentions—and persist cursors, seen segments, outboxes, claims, and IDs for recovery.
 4. On each new final segment, evaluate requested literal or semantic rules; deliver mention notifications through the durable outbox, and atomically claim and execute each authorized `speak`/`send_chat` action at most once.
 5. On a terminal session, drain transcript pages, wait a bounded time for `transcript.completed`, obtain requested implemented artifact types without duplicate creation, then deliver a Markdown report.
@@ -64,7 +64,7 @@ REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POS
 
 ## Create or Schedule Exactly Once
 
-Before the first `join_meeting`, checkpoint a durable operation record outside
+Before the first session create, checkpoint a durable operation record outside
 transient chat memory whenever the host supports files, a task store, or durable
 workflow state. Store at least:
 
@@ -73,6 +73,9 @@ workflow state. Store at least:
   "operation_id": "host-stable-id",
   "meeting_url": "redacted-or-secret-reference",
   "idempotency_key": "meeting-bot:<host-stable-id>",
+  "create_transport": "mcp-or-rest",
+  "create_request_without_write_only_secrets": {},
+  "avatar_api_key_secret_ref": null,
   "session_id": null,
   "poll_wait_seconds": 2,
   "live_rules": [],
@@ -92,8 +95,8 @@ workflow state. Store at least:
 }
 ```
 
-Use a UUID or a host-durable operation ID, not a new timestamp on retry. Then
-call `join_meeting` with the smallest safe argument set:
+Use a UUID or host-durable operation ID, not a new timestamp on retry. For an
+ordinary session, call MCP `join_meeting` with the smallest safe argument set:
 
 ```json
 {
@@ -107,12 +110,17 @@ call `join_meeting` with the smallest safe argument set:
 Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
 If the request contains an authorized later `speak` rule, include
 `"barge_in": true`; this lets human speech stop bot output and does not itself
-make the bot speak. Persist the returned `id` as `session_id` immediately.
-If the create request has an
-uncertain transport outcome, retry **only** with the same persisted
-`idempotency_key`; never issue a second key, which could place a second bot in
-the meeting. If the host cannot persist state, state that duplicate-prevention
-across a restart cannot be guaranteed and avoid an unbounded retry.
+make the bot speak.
+
+For a Portal Assistant, Anam avatar, or combined session, use REST instead and
+persist the complete sanitized body from the sections below. Omit `join_at`; when
+an Assistant is present, omit `barge_in`. Persist the returned `id` as
+`session_id` immediately. After an uncertain create outcome, retry **only**
+through the original transport with the same logical request and
+`idempotency_key`; re-resolve an Anam key from its secret reference at dispatch
+instead of persisting the value. Never issue a second key, which could place a
+second bot in the meeting. If durable state is unavailable, disclose that
+duplicate prevention across restart is not guaranteed and avoid unbounded retry.
 
 ## Live Session and Transcript Loop
 
@@ -371,7 +379,7 @@ that are absent from the session, events, or collected finalized transcript.
 
 On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
-from persisted cursors and outbox state—never call `join_meeting` again. Retry
+from persisted cursors and outbox state—never create another session. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
 `sent` items alone. A recovered `claimed` action may attempt the dispatch CAS. Before
 evaluating triggers, atomically convert every recovered
@@ -381,8 +389,10 @@ repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history
 where useful, but a missing event is not proof the side effect did not happen. Resume each
 artifact request from its persisted ID/deadline and never repeat an ambiguous
 create. If the record has an idempotency key but no saved session ID because
-creation was interrupted, retry the original `join_meeting` arguments with that
-same key only after checking any available response/log receipt. Persist every
+creation was interrupted, retry the original create through its recorded
+transport with the same logical request and key only after checking any available
+response/log receipt. Re-resolve a write-only Anam key from its secret reference;
+never substitute MCP for a REST-only create. Persist every
 state transition, alert/action state, cursor, terminal observation, and artifact
 ID before relying on it.
 
@@ -395,17 +405,17 @@ media deletion as a cleanup shortcut.
 
 Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing portal-configured Assistant `id` in the authenticated organization. Create it with the caller's normal Telnyx bearer key; production requires Gateway Rev2 authentication. Never put Assistant/API secrets, Call Control connection IDs, from numbers, SIP URIs, or authorization fields in `assistant`. Allowed fields are `id`, optional `audio_gate` (`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`, and optional `leave_on_end` (default `false`).
 
-Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and costs more Recall media, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and has higher meeting-media usage and cost, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Anam Avatar (REST-only)
 
 Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: the meeting media layer creates the Output Media page as part of session startup. See REST examples and recovery guidance in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 
-One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](../../guides/meeting-bot.md).
+One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Worked Interpretations
 

--- a/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is a fallback transport for ordinary sessions when MCP is unavailable, but it is required for Portal Assistant and Anam avatar creates because MCP cannot express those objects. The lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -24,51 +24,22 @@ in-meeting changes unless the requester explicitly asks for that.
 
 ## Quick Workflow
 
-1. Resolve only missing essentials: meeting URL, join now versus a scheduled
-   time, desired live/final outputs, and any trigger/action rules. Reuse details
-   already stated in the request or authorized context; do not ask again.
-2. Persist an operation record **before** creating the session. Generate and
-   retain one stable `idempotency_key`; call `join_meeting` with
-   `summarize_on_end: true`, no `speak_on_enter`, and no `chat_on_enter`. If an
-   explicit later speech rule exists, set `barge_in: true` so new human speech
-   can stop the bot's output.
-3. Poll `get_session`, `get_transcript`, and (when available) `get_events`.
-   Choose transcript `wait_seconds` from the request—use about `2` seconds for
-   “as soon as,” reactive speech, or urgent mention alerts—and persist cursors,
-   seen segments, outboxes, action claims, and IDs for safe recovery.
-4. On each new final segment, evaluate requested literal or semantic rules.
-   Deliver mention notifications through the durable outbox; atomically claim
-   and execute each authorized `speak`/`send_chat` action at most once.
-5. On a terminal session, drain transcript pages, wait a bounded time for
-   `transcript.completed`, obtain the requested implemented artifact types
-   without duplicate creation, then deliver a Markdown report.
+1. Resolve only missing essentials: meeting URL, join now versus a scheduled time, desired live/final outputs, and trigger/action rules. Reuse authorized details; do not ask again.
+2. Persist an operation record **before** creating the session. Generate and retain one stable `idempotency_key`; call `join_meeting` with `summarize_on_end: true`, no `speak_on_enter` or `chat_on_enter`. For an explicit later speech rule, set `barge_in: true` so human speech can stop bot output.
+3. Poll `get_session`, `get_transcript`, and, when available, `get_events`. Select `wait_seconds` from the request—about `2` for “as soon as,” reactive speech, or urgent mentions—and persist cursors, seen segments, outboxes, claims, and IDs for recovery.
+4. On each new final segment, evaluate requested literal or semantic rules; deliver mention notifications through the durable outbox, and atomically claim and execute each authorized `speak`/`send_chat` action at most once.
+5. On a terminal session, drain transcript pages, wait a bounded time for `transcript.completed`, obtain requested implemented artifact types without duplicate creation, then deliver a Markdown report.
 
 ## Preconditions and Safe Defaults
 
-- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL,
-  transcript, event, artifact, chat message, or user-facing report.
-- Before joining, ensure the runtime can keep monitoring or can resume from a
-  durable background task. Do not promise end-to-end monitoring from a process
-  that will disappear without preserving and resuming the operation record.
-- Verify the requester is authorized to have a visible bot attend this meeting.
-  The bot may need a host to admit it; never try to bypass a waiting room,
-  password, platform policy, or consent requirement.
-- Default notification target: **this current conversation**. Do not configure a
-  `webhook_url` merely to send the requester notifications.
-- Default behavior: immediate join if no future time was requested,
-  `summarize_on_end: true`, observe-only, and no recording-media deletion.
-  `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in actions.
-- An explicit conditional request such as “when someone asks about lunch, say
-  ‘I want pizza’” is advance authorization for that exact action. Persist the
-  trigger, exact payload, one-shot/repeat policy, and latency target before join;
-  do not interrupt the live workflow to ask for approval again.
-- Choose monitoring cadence from the request. Default immediate reactions and
-  urgent mentions to `wait_seconds: 2`; do not silently substitute a 15-second
-  cadence for an “as soon as” instruction.
-- If a meeting link is not present, ask for it. If time is ambiguous, ask only
-  whether to join now or at a specified time. If “my name” is not resolvable
-  from the request, current conversation, or authorized profile context, ask
-  which name/phrases (and optional variants) to watch for.
+- Require `TELNYX_API_KEY` in a backend secret store. Never include it in a URL, transcript, event, artifact, chat message, or user-facing report.
+- Before joining, ensure the runtime can keep monitoring or can resume from durable background state. Do not promise end-to-end monitoring from a process that disappears without preserving and resuming the operation record.
+- Verify authorization for a visible bot. A host may need to admit it; never bypass a waiting room, password, platform policy, or consent requirement.
+- Default notification target: **this current conversation**. Do not configure a `webhook_url` merely to send requester notifications.
+- Default behavior is immediate join, `summarize_on_end: true`, observe-only, and no recording-media deletion. `speak`, `send_chat`, `speak_on_enter`, and `chat_on_enter` are opt-in.
+- An explicit conditional request such as “when someone asks about lunch, say ‘I want pizza’” authorizes exactly that action. Before join, persist trigger, exact payload, one-shot/repeat policy, and latency target; do not interrupt the workflow to ask again.
+- Select monitoring cadence from the request: default immediate reactions and urgent mentions to `wait_seconds: 2`, never silently substituting a 15-second cadence for “as soon as.”
+- If the link is missing, ask for it. If timing is ambiguous, ask only now versus specified time. If “my name” is not resolvable from authorized request/context/profile data, ask for name/phrases and optional variants.
 
 ## Connect to the Production MCP Server
 
@@ -76,19 +47,12 @@ Prefer the production Streamable HTTP MCP endpoint:
 
 ```text
 https://api.telnyx.com/v2/meeting_bot/mcp
-Authorization: Bearer <TELNYX_API_KEY>
+Authorization: Bearer ***
 ```
 
-Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`,
-`get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`,
-`stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and
-`get_artifacts`.
+Use the service's exact tools: `join_meeting`, `get_session`, `list_sessions`, `get_transcript`, `get_events`, `leave_meeting`, `get_recordings`, `speak`, `stop_speaking`, `send_chat`, `create_artifact`, `get_artifact`, and `get_artifacts`.
 
-MCP tools return one JSON text block. Decode `result.content[0].text` as JSON
-only after checking `result.isError`. HTTP/transport failures (for example 401,
-timeouts, or a 5xx) are different from an HTTP-200 MCP tool failure with
-`result.isError: true`; handle both, preserve the error code/message, and do
-not treat an HTTP 200 as success by itself.
+MCP tools return one JSON text block. Decode `result.content[0].text` only after checking `result.isError`. HTTP/transport failures (for example 401, timeouts, or 5xx) differ from an HTTP-200 MCP tool failure with `result.isError: true`; preserve the error code/message and do not treat HTTP 200 as success alone.
 
 If MCP is unavailable, use the equivalent production REST base:
 
@@ -96,14 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`,
-`POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`,
-`POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`,
-`DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`,
-`POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send
-`Authorization: Bearer <TELNYX_API_KEY>`. REST responses use `{ "data": ... }`.
-Use REST only as a transport fallback—the lifecycle and durability rules below
-remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer <TELNY...Y>`; REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 
@@ -436,50 +393,44 @@ media deletion as a cleanup shortcut.
 
 ## Portal-configured Assistant (REST-only)
 
-Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing,
-portal-configured Assistant `id` in the authenticated organization. Create it
-through the production endpoint with the caller's normal Telnyx bearer key; the
-service requires Gateway Rev2 authentication. Never put assistant/API secrets,
-Call Control connection IDs, from numbers, SIP URIs, or authorization fields in
-`assistant`. The allowed fields are `id`, optional `audio_gate`
-(`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`,
-and optional `leave_on_end` (default `false`).
+Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing portal-configured Assistant `id` in the authenticated organization. Create it with the caller's normal Telnyx bearer key; production requires Gateway Rev2 authentication. Never put Assistant/API secrets, Call Control connection IDs, from numbers, SIP URIs, or authorization fields in `assistant`. Allowed fields are `id`, optional `audio_gate` (`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`, and optional `leave_on_end` (default `false`).
 
-Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the
-assistant handles interruption natively. A map has at most 63 customer entries;
-keys are 1–128 characters, values are strings up to 2048 characters, and reserved
-infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus
-`assistant_state` (`starting|connected|failed|ended`) and its change timestamp.
-`connected` is readiness, while non-null `joined_at` proves attendance.
-`full_duplex` continuously listens through per-participant audio and costs more
-Recall media; use safe-default `half_duplex` unless native continuous barge-in is
-required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and costs more Recall media, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
 
 ## Anam Avatar (REST-only)
 
-Create an Anam avatar only through `POST /v2/meeting_sessions`, with
-`avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP
-`join_meeting`. The key is write-only: never persist, log, or report it. Responses
-echo only provider/avatar ID and expose `avatar_state`
-(`starting|connected|degraded|disconnected`) with its change timestamp.
+Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP,
-or mid-meeting toggle. `connected` means avatar media readiness, not attendance,
-so also require `joined_at`. Avatar webpage output wins over `camera_image`;
-`speak` routes through that page, and `speak_on_enter` waits for active plus avatar
-connected. Do not prewarm: Recall creates the Output Media page first. See the
-REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 
-One immediate REST create can include both objects: the Assistant supplies the
-conversation and voice while the avatar lip-syncs it. Monitor assistant readiness,
-avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`.
+One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](../../guides/meeting-bot.md).
+
+## Worked Interpretations
+
+### Mention alert and final summary
+
+For: “Join this meeting and tell me what they discussed when it ends; if they mention my name, let me know.”
+
+- If the message already includes a meeting URL and the requester identity/name is known from authorized conversation/profile context, join immediately with `summarize_on_end: true`, the stable idempotency key, no voice/chat actions, and that name plus known variants as terms.
+- If the link is missing, ask only for the link. If it is unclear whether the meeting is now or later, ask only for join timing. If “my name” is not known, ask for the name/phrases and optional variants.
+- Tell the requester if host admission is required; send mention alerts in this conversation; after completion, send the bounded, evidence-based report.
 
 ### Reactive lunch answer
 
-For an explicitly authorized lunch-answer trigger, persist one semantic `speak` rule, use `wait_seconds: 2`, claim its first clear finalized match and dispatch once; ordinary bots
-use `barge_in: true`, but an Assistant flow never does.
+For: “Join the meeting and as soon as someone asks what we should have for lunch, please use the speak request and say I want pizza.”
+
+- Treat this as explicit authorization for one in-meeting `speak`; do not ask again when the condition occurs.
+- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance speech/chat, and `barge_in: true`.
+- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new final segment plus a short trailing context window; require a clear lunch-choice question rather than the isolated word “lunch.”
+- Atomically claim the first match and call `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
+
+### Demo: delegated attendance and TL;DR
+
+For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
+
+Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and no unrequested speech/chat. Post joining/admission updates to Anusha's current conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises live reactions. At terminal status, drain final transcript and send the automatic `summary` with attendance, completeness, and provenance. The visible story is: Anusha cannot attend → texts her agent → colleagues see her bot join → her agent confirms attendance → she receives the TL;DR.
 
 ## Source Authority and References
 

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer <TELNY...Y>`; REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer ***`. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -401,7 +401,7 @@ Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assist
 
 Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples and recovery guidance in [the guide](../../guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send `Authorization: Bearer ***`. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -434,52 +434,52 @@ needed and use `leave_meeting(id)` (REST: `DELETE /{id}`); it leaves/cancels but
 does not erase the durable session history. Do not use destructive recording
 media deletion as a cleanup shortcut.
 
-## Worked Interpretations
+## Portal-configured Assistant (REST-only)
 
-### Mention alert and final summary
+Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing,
+portal-configured Assistant `id` in the authenticated organization. Create it
+through the production endpoint with the caller's normal Telnyx bearer key; the
+service requires Gateway Rev2 authentication. Never put assistant/API secrets,
+Call Control connection IDs, from numbers, SIP URIs, or authorization fields in
+`assistant`. The allowed fields are `id`, optional `audio_gate`
+(`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`,
+and optional `leave_on_end` (default `false`).
 
-For: “Join this meeting and tell me what they discussed when it ends; if they
-mention my name, let me know.”
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the
+assistant handles interruption natively. A map has at most 63 customer entries;
+keys are 1–128 characters, values are strings up to 2048 characters, and reserved
+infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus
+`assistant_state` (`starting|connected|failed|ended`) and its change timestamp.
+`connected` is readiness, while non-null `joined_at` proves attendance.
+`full_duplex` continuously listens through per-participant audio and costs more
+Recall media; use safe-default `half_duplex` unless native continuous barge-in is
+required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
 
-- If the message already includes a meeting URL and the requester identity/name
-  is known from authorized conversation/profile context, join immediately with
-  `summarize_on_end: true`, the stable idempotency key, no voice/chat actions,
-  and that name plus known variants as terms.
-- If the link is missing, ask only for the link. If it is unclear whether the
-  meeting is now or later, ask only for join timing. If “my name” is not known,
-  ask for the name/phrases and optional variants.
-- Tell the requester if host admission is required; send mention alerts in this
-  conversation; after completion, send the bounded, evidence-based report.
+## Anam Avatar (REST-only)
+
+Create an Anam avatar only through `POST /v2/meeting_sessions`, with
+`avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP
+`join_meeting`. The key is write-only: never persist, log, or report it. Responses
+echo only provider/avatar ID and expose `avatar_state`
+(`starting|connected|degraded|disconnected`) with its change timestamp.
+
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP,
+or mid-meeting toggle. `connected` means avatar media readiness, not attendance,
+so also require `joined_at`. Avatar webpage output wins over `camera_image`;
+`speak` routes through that page, and `speak_on_enter` waits for active plus avatar
+connected. Do not prewarm: Recall creates the Output Media page first. See the
+REST examples, supported platforms, and recovery guidance in [the guide](../../guides/meeting-bot.md).
+
+## Combined Assistant + Avatar
+
+One immediate REST create can include both objects: the Assistant supplies the
+conversation and voice while the avatar lip-syncs it. Monitor assistant readiness,
+avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`.
 
 ### Reactive lunch answer
 
-For: “Join the meeting and as soon as someone asks what we should have for
-lunch, please use the speak request and say I want pizza.”
-
-- Treat this as explicit authorization for one in-meeting `speak`; do not ask
-  again when the condition occurs.
-- Join immediately with `summarize_on_end: true`, stable idempotency, no entrance
-  speech/chat, and `barge_in: true`.
-- Persist a one-shot semantic rule and use `wait_seconds: 2`. Evaluate each new
-  final segment plus a short trailing context window; require a clear lunch-choice
-  question rather than the isolated word “lunch.”
-- Atomically claim the first match and call
-  `speak(id, text: "I want pizza")` with `interrupt` omitted. Mark accepted only
-  from a non-error MCP result or REST 202; do not repeat an ambiguous dispatch.
-
-### Demo: delegated attendance and TL;DR
-
-For the on-screen request: “I can't join this meeting: `<meeting URL>`. Join as
-Anusha's bot, tell me when you're in, and send me a TL;DR when it ends.”
-
-Join now as `Anusha's bot` with stable idempotency, `summarize_on_end: true`, and
-no unrequested speech/chat. Post joining/admission updates to Anusha's current
-conversation, then “Anusha's bot joined” only when `joined_at` is non-null. A
-summary-only demo may use a `10`–`20` second wait; use `2` seconds if it promises
-live reactions. At terminal status, drain final transcript and send the automatic
-`summary` with attendance, completeness, and provenance. The visible story is:
-Anusha cannot attend → texts her agent → colleagues see her bot join → her agent
-confirms attendance → she receives the TL;DR.
+For an explicitly authorized lunch-answer trigger, persist one semantic `speak` rule, use `wait_seconds: 2`, claim its first clear finalized match and dispatch once; ordinary bots
+use `barge_in: true`, but an Assistant flow never does.
 
 ## Source Authority and References
 

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -25,7 +25,7 @@ in-meeting changes unless the requester explicitly asks for that.
 ## Quick Workflow
 
 1. Resolve only missing essentials: meeting URL, join now versus a scheduled time, desired live/final outputs, and trigger/action rules. Reuse authorized details; do not ask again.
-2. Persist an operation record **before** creating the session. Generate and retain one stable `idempotency_key`; call `join_meeting` with `summarize_on_end: true`, no `speak_on_enter` or `chat_on_enter`. For an explicit later speech rule, set `barge_in: true` so human speech can stop bot output.
+2. Persist an operation record **before** creating the session and choose its transport. Ordinary sessions use MCP `join_meeting`. Any Portal Assistant or Anam avatar session uses REST `POST /v2/meeting_sessions` with the requested object(s). Persist one stable `idempotency_key`, the transport, and the exact logical create request; store only a secret reference for a write-only Anam key. REST-only sessions are immediate, so omit `join_at`; Assistant sessions also omit `barge_in`. For an ordinary session with an authorized later speech rule, set `barge_in: true` so human speech can stop bot output.
 3. Poll `get_session`, `get_transcript`, and, when available, `get_events`. Select `wait_seconds` from the request—about `2` for “as soon as,” reactive speech, or urgent mentions—and persist cursors, seen segments, outboxes, claims, and IDs for recovery.
 4. On each new final segment, evaluate requested literal or semantic rules; deliver mention notifications through the durable outbox, and atomically claim and execute each authorized `speak`/`send_chat` action at most once.
 5. On a terminal session, drain transcript pages, wait a bounded time for `transcript.completed`, obtain requested implemented artifact types without duplicate creation, then deliver a Markdown report.
@@ -64,7 +64,7 @@ REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POS
 
 ## Create or Schedule Exactly Once
 
-Before the first `join_meeting`, checkpoint a durable operation record outside
+Before the first session create, checkpoint a durable operation record outside
 transient chat memory whenever the host supports files, a task store, or durable
 workflow state. Store at least:
 
@@ -73,6 +73,9 @@ workflow state. Store at least:
   "operation_id": "host-stable-id",
   "meeting_url": "redacted-or-secret-reference",
   "idempotency_key": "meeting-bot:<host-stable-id>",
+  "create_transport": "mcp-or-rest",
+  "create_request_without_write_only_secrets": {},
+  "avatar_api_key_secret_ref": null,
   "session_id": null,
   "poll_wait_seconds": 2,
   "live_rules": [],
@@ -92,8 +95,8 @@ workflow state. Store at least:
 }
 ```
 
-Use a UUID or a host-durable operation ID, not a new timestamp on retry. Then
-call `join_meeting` with the smallest safe argument set:
+Use a UUID or host-durable operation ID, not a new timestamp on retry. For an
+ordinary session, call MCP `join_meeting` with the smallest safe argument set:
 
 ```json
 {
@@ -107,12 +110,17 @@ call `join_meeting` with the smallest safe argument set:
 Omit `join_at` for an immediate join. Do not add greeting/chat/action arguments.
 If the request contains an authorized later `speak` rule, include
 `"barge_in": true`; this lets human speech stop bot output and does not itself
-make the bot speak. Persist the returned `id` as `session_id` immediately.
-If the create request has an
-uncertain transport outcome, retry **only** with the same persisted
-`idempotency_key`; never issue a second key, which could place a second bot in
-the meeting. If the host cannot persist state, state that duplicate-prevention
-across a restart cannot be guaranteed and avoid an unbounded retry.
+make the bot speak.
+
+For a Portal Assistant, Anam avatar, or combined session, use REST instead and
+persist the complete sanitized body from the sections below. Omit `join_at`; when
+an Assistant is present, omit `barge_in`. Persist the returned `id` as
+`session_id` immediately. After an uncertain create outcome, retry **only**
+through the original transport with the same logical request and
+`idempotency_key`; re-resolve an Anam key from its secret reference at dispatch
+instead of persisting the value. Never issue a second key, which could place a
+second bot in the meeting. If durable state is unavailable, disclose that
+duplicate prevention across restart is not guaranteed and avoid unbounded retry.
 
 ## Live Session and Transcript Loop
 
@@ -371,7 +379,7 @@ that are absent from the session, events, or collected finalized transcript.
 
 On restart, load the durable operation record before doing anything. If it has a
 `session_id`, resume `get_session`, event/transcript drains, and summary polling
-from persisted cursors and outbox state—never call `join_meeting` again. Retry
+from persisted cursors and outbox state—never create another session. Retry
 pending mention alerts with their original delivery IDs and leave confirmed
 `sent` items alone. A recovered `claimed` action may attempt the dispatch CAS. Before
 evaluating triggers, atomically convert every recovered
@@ -381,8 +389,10 @@ repeat actions marked `accepted` or `outcome_unknown`. Reconcile event history
 where useful, but a missing event is not proof the side effect did not happen. Resume each
 artifact request from its persisted ID/deadline and never repeat an ambiguous
 create. If the record has an idempotency key but no saved session ID because
-creation was interrupted, retry the original `join_meeting` arguments with that
-same key only after checking any available response/log receipt. Persist every
+creation was interrupted, retry the original create through its recorded
+transport with the same logical request and key only after checking any available
+response/log receipt. Re-resolve a write-only Anam key from its secret reference;
+never substitute MCP for a REST-only create. Persist every
 state transition, alert/action state, cursor, terminal observation, and artifact
 ID before relying on it.
 
@@ -395,17 +405,17 @@ media deletion as a cleanup shortcut.
 
 Use `POST /v2/meeting_sessions` (not MCP `join_meeting`) with an existing portal-configured Assistant `id` in the authenticated organization. Create it with the caller's normal Telnyx bearer key; production requires Gateway Rev2 authentication. Never put Assistant/API secrets, Call Control connection IDs, from numbers, SIP URIs, or authorization fields in `assistant`. Allowed fields are `id`, optional `audio_gate` (`half_duplex` default or `full_duplex`), optional string-map `dynamic_variables`, and optional `leave_on_end` (default `false`).
 
-Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and costs more Recall media, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](../../guides/meeting-bot.md).
+Assistant sessions are immediate-only: omit `join_at` and `barge_in`; the assistant handles interruption natively. A map has at most 63 customer entries; keys are 1–128 characters, values are strings up to 2048 characters, and reserved infrastructure keys are rejected. Poll ordinary status and `joined_at`, plus `assistant_state` (`starting|connected|failed|ended`) and its change timestamp. `connected` is readiness; non-null `joined_at` proves attendance. `full_duplex` continuously listens through per-participant audio and has higher meeting-media usage and cost, so use safe-default `half_duplex` unless native continuous barge-in is required. See the REST body and polling flow in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Anam Avatar (REST-only)
 
 Create an Anam avatar only through `POST /v2/meeting_sessions`, with `avatar.provider: "anam"`, `avatar_id`, and `api_key`; it is absent from MCP `join_meeting`. The key is write-only: never persist, log, or report it. Responses echo only provider/avatar ID and `avatar_state` (`starting|connected|degraded|disconnected`) with its change timestamp.
 
-Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: Recall creates the Output Media page first. See REST examples and recovery guidance in [the guide](../../guides/meeting-bot.md).
+Avatar sessions are immediate-only: no `join_at`, calendar/scheduled flow, MCP, or mid-meeting toggle. `connected` means avatar media readiness, not attendance, so also require `joined_at`. Avatar webpage output wins over `camera_image`; `speak` routes through that page, and `speak_on_enter` waits for active plus avatar connected. Do not prewarm: the meeting media layer creates the Output Media page as part of session startup. See REST examples and recovery guidance in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Combined Assistant + Avatar
 
-One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](../../guides/meeting-bot.md).
+One immediate REST create can include both objects: the Assistant supplies conversation and voice while the avatar lip-syncs it. Monitor assistant readiness, avatar readiness, and `joined_at` separately; do not add `barge_in` or `join_at`. See the complete create body in [the guide](https://github.com/team-telnyx/ai/blob/main/guides/meeting-bot.md).
 
 ## Worked Interpretations
 

--- a/skills/telnyx-meeting-bot/SKILL.md
+++ b/skills/telnyx-meeting-bot/SKILL.md
@@ -60,7 +60,7 @@ If MCP is unavailable, use the equivalent production REST base:
 https://api.telnyx.com/v2/meeting_sessions
 ```
 
-REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is only a transport fallback—the lifecycle and durability rules remain the same.
+REST equivalents include `POST /`, `GET /{id}`, `POST /{id}/actions/speak`, `POST /{id}/actions/stop_speaking`, `POST /{id}/actions/send_chat`, `GET /{id}/transcript`, `GET /{id}/events`, `DELETE /{id}`, `GET /{id}/recordings`, `GET /{id}/artifacts`, `POST /{id}/artifacts`, and `GET /{id}/artifacts/{artifact_id}`. Send the standard bearer-token `Authorization` header. REST responses use `{ "data": ... }`. REST is a fallback transport for ordinary sessions when MCP is unavailable, but it is required for Portal Assistant and Anam avatar creates because MCP cannot express those objects. The lifecycle and durability rules remain the same.
 
 ## Create or Schedule Exactly Once
 

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -224,6 +224,17 @@ describe("Meeting Bot discovery and durable alert contract", () => {
       "leave_on_end",
     ]);
     assert.match(skill, /## Portal-configured Assistant \(REST-only\)/);
+    assert.match(skill, /higher meeting-media usage and cost/);
+    assert.match(guide, /higher meeting-media usage and cost/);
+    assert.match(skill, /meeting media layer creates the Output Media page/);
+    assert.match(guide, /meeting media layer creates the Output Media page/);
+    assert.match(skill, /choose its transport[\s\S]*Ordinary sessions use MCP `join_meeting`[\s\S]*Portal Assistant or Anam avatar session uses REST/i);
+    assert.match(skill, /"create_transport": "mcp-or-rest"/);
+    assert.match(skill, /"create_request_without_write_only_secrets": \{\}/);
+    assert.match(skill, /"avatar_api_key_secret_ref": null/);
+    assert.match(skill, /retry the original create through its recorded[\s\S]*transport[\s\S]*never substitute MCP for a REST-only create/i);
+    assert.doesNotMatch(skill, /\]\(\.\.\/\.\.\/guides\/meeting-bot\.md\)/);
+    assert.match(skill, /https:\/\/github\.com\/team-telnyx\/ai\/blob\/main\/guides\/meeting-bot\.md/);
     assert.match(guide, /REST-only[\s\S]*absent from MCP `join_meeting`/);
     assert.match(guide, /immediate-only[\s\S]*`join_at`[\s\S]*`barge_in`/);
     assert.match(guide, /63 customer entries[\s\S]*1–128[\s\S]*2048[\s\S]*reserved/i);
@@ -252,7 +263,7 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(guide, /`starting`, `connected`, `degraded`, `disconnected`/);
     assert.match(guide, /camera_image/);
     assert.match(guide, /speak_on_enter[\s\S]*active[\s\S]*avatar[\s\S]*connected/i);
-    assert.match(guide, /no prewarm[\s\S]*Output Media page/i);
+    assert.match(guide, /no\s+(?:supported\s+)?prewarm[\s\S]*Output Media page/i);
     assert.doesNotMatch(JSON.stringify(avatar), /join_at/);
 
     const combined = jsonAfter("### Combined REST create");

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -6,6 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -106,6 +107,24 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     join(SKILLS_DIR, "telnyx-meeting-bot", "SKILL.md"),
     "utf-8"
   );
+  const publicMeetingBotArtifacts = new Map([
+    ["guide", guide],
+    ["canonical skill", skill],
+    [
+      "Claude skill",
+      readFileSync(
+        join(ROOT, "providers", "claude", "plugins", "telnyx-ai", "skills", "telnyx-meeting-bot", "SKILL.md"),
+        "utf-8"
+      ),
+    ],
+    [
+      "Cursor skill",
+      readFileSync(
+        join(ROOT, "providers", "cursor", "plugin", "skills", "telnyx-meeting-bot", "SKILL.md"),
+        "utf-8"
+      ),
+    ],
+  ]);
   const repeatProtocol = readFileSync(
     join(SKILLS_DIR, "telnyx-meeting-bot", "references", "repeating-semantic-actions.md"),
     "utf-8"
@@ -114,6 +133,19 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     join(SKILLS_DIR, "telnyx-meeting-bot", "references", "artifact-selection-and-recovery.md"),
     "utf-8"
   );
+
+  it("keeps public Meeting Bot artifacts free of internal provider names", () => {
+    const forbiddenProviderHash = "2ed6b4c1ae9f8249477df9193d20e75474c152748e0f2a2cc224ead2e1c8769d";
+    for (const [name, content] of publicMeetingBotArtifacts) {
+      const wordHashes = (content.toLowerCase().match(/[a-z]+/g) ?? []).map((word) =>
+        createHash("sha256").update(word).digest("hex")
+      );
+      assert.ok(
+        !wordHashes.includes(forbiddenProviderHash),
+        `${name} contains a forbidden internal provider name`
+      );
+    }
+  });
 
   it("registers the canonical capability and guide", () => {
     assert.ok(capability, 'agent.json missing the "meeting_bot" capability');
@@ -233,6 +265,7 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(skill, /"create_request_without_write_only_secrets": \{\}/);
     assert.match(skill, /"avatar_api_key_secret_ref": null/);
     assert.match(skill, /retry the original create through its recorded[\s\S]*transport[\s\S]*never substitute MCP for a REST-only create/i);
+    assert.match(skill, /REST is a fallback transport for ordinary sessions when MCP is unavailable[\s\S]*required for Portal Assistant and Anam avatar creates/i);
     assert.doesNotMatch(skill, /\]\(\.\.\/\.\.\/guides\/meeting-bot\.md\)/);
     assert.match(skill, /https:\/\/github\.com\/team-telnyx\/ai\/blob\/main\/guides\/meeting-bot\.md/);
     assert.match(guide, /REST-only[\s\S]*absent from MCP `join_meeting`/);
@@ -241,6 +274,13 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(guide, /`starting`, `connected`, `failed`, `ended`/);
     assert.match(guide, /`joined_at` is attendance evidence/);
     assert.match(guide, /Gateway Rev2[\s\S]*normal Telnyx bearer key/);
+    assert.doesNotMatch(guide, /@assistant-session\.json/);
+    const assistantSection = guide.slice(guide.indexOf("### Portal Assistant REST create"));
+    const assistantBash = /```bash\n([\s\S]*?)\n```/.exec(assistantSection)?.[1];
+    assert.ok(assistantBash, "Portal Assistant section needs a Bash request");
+    const assistantSyntax = spawnSync("bash", ["-n"], { input: assistantBash, encoding: "utf8" });
+    assert.equal(assistantSyntax.status, 0, assistantSyntax.stderr);
+    assert.match(assistantBash, /--data-binary[\s\S]*"assistant"/);
     assert.doesNotMatch(JSON.stringify(assistant), /join_at|barge_in/);
 
     const avatar = jsonAfter("### Anam avatar REST create");

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -241,7 +241,7 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(guide, /--data-binary @-/);
     assert.doesNotMatch(guide, /\$\{ANAM_API_KEY\}|--arg api_key/);
     assert.match(guide, /ANAM_API_KEY[\s\S]*already exported from[\s\S]*a backend secret store/i);
-    assert.match(skill, /Send `Authorization: Bearer \*\*\*`\. REST responses use/);
+    assert.match(skill, /Send the standard bearer-token `Authorization` header\. REST responses use/);
     assert.match(guide, /`starting`, `connected`, `degraded`, `disconnected`/);
     assert.match(guide, /camera_image/);
     assert.match(guide, /speak_on_enter[\s\S]*active[\s\S]*avatar[\s\S]*connected/i);

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -241,6 +242,11 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(guide, /--data-binary @-/);
     assert.doesNotMatch(guide, /\$\{ANAM_API_KEY\}|--arg api_key/);
     assert.match(guide, /ANAM_API_KEY[\s\S]*already exported from[\s\S]*a backend secret store/i);
+    const avatarSection = guide.slice(guide.indexOf("### Anam avatar REST create"));
+    const avatarBash = /```bash\n([\s\S]*?)\n```/.exec(avatarSection)?.[1];
+    assert.ok(avatarBash, "Anam avatar section needs a Bash request");
+    const syntax = spawnSync("bash", ["-n"], { input: avatarBash, encoding: "utf8" });
+    assert.equal(syntax.status, 0, syntax.stderr);
     assert.match(skill, /Send the standard bearer-token `Authorization` header\. REST responses use/);
     assert.match(guide, /`starting`, `connected`, `degraded`, `disconnected`/);
     assert.match(guide, /camera_image/);

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -200,6 +200,50 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(artifactRecovery, /Recovery from either `dispatching` or `outcome_unknown`\s+must persist an unreconciled same-type unknown-create marker and\s+re-list\/reconcile only/);
     assert.match(artifactRecovery, /Never collapse `pre_send_failed` and `outcome_unknown`/);
   });
+
+  it("documents REST-only assistant and Anam avatar contracts", () => {
+    const jsonAfter = (heading: string) => {
+      const start = guide.indexOf(heading);
+      assert.notEqual(start, -1, `guide missing ${heading}`);
+      const match = /```json\n([\s\S]*?)\n```/.exec(guide.slice(start));
+      assert.ok(match, `${heading} needs a JSON body`);
+      return JSON.parse(match[1]!);
+    };
+
+    const assistant = jsonAfter("### Portal Assistant REST create");
+    assert.deepEqual(Object.keys(assistant).sort(), ["assistant", "idempotency_key", "meeting_url"]);
+    assert.deepEqual(Object.keys(assistant.assistant).sort(), [
+      "audio_gate",
+      "dynamic_variables",
+      "id",
+      "leave_on_end",
+    ]);
+    assert.match(skill, /## Portal-configured Assistant \(REST-only\)/);
+    assert.match(guide, /REST-only[\s\S]*absent from MCP `join_meeting`/);
+    assert.match(guide, /immediate-only[\s\S]*`join_at`[\s\S]*`barge_in`/);
+    assert.match(guide, /63 customer entries[\s\S]*1–128[\s\S]*2048[\s\S]*reserved/i);
+    assert.match(guide, /`starting`, `connected`, `failed`, `ended`/);
+    assert.match(guide, /`joined_at` is attendance evidence/);
+    assert.match(guide, /Gateway Rev2[\s\S]*normal Telnyx bearer key/);
+    assert.doesNotMatch(JSON.stringify(assistant), /join_at|barge_in/);
+
+    const avatar = jsonAfter("### Anam avatar REST create");
+    assert.deepEqual(Object.keys(avatar).sort(), ["avatar", "idempotency_key", "meeting_url"]);
+    assert.deepEqual(Object.keys(avatar.avatar).sort(), ["api_key", "avatar_id", "provider"]);
+    assert.match(skill, /## Anam Avatar \(REST-only\)/);
+    assert.match(guide, /write-only[\s\S]*must not be persisted, logged, or reported/i);
+    assert.match(guide, /`starting`, `connected`, `degraded`, `disconnected`/);
+    assert.match(guide, /camera_image/);
+    assert.match(guide, /speak_on_enter[\s\S]*active[\s\S]*avatar[\s\S]*connected/i);
+    assert.match(guide, /no prewarm[\s\S]*Output Media page/i);
+    assert.doesNotMatch(JSON.stringify(avatar), /join_at/);
+
+    const combined = jsonAfter("### Combined REST create");
+    assert.deepEqual(Object.keys(combined).sort(), ["assistant", "avatar", "idempotency_key", "meeting_url"]);
+    assert.match(guide, /Assistant provides the\s+conversation and voice;\s+the avatar lip-syncs its speech/i);
+    assert.match(guide, /both readiness axes[\s\S]*`joined_at`/i);
+    assert.doesNotMatch(JSON.stringify(combined), /join_at|barge_in/);
+  });
 });
 
 describe("guide ↔ agent.json parity", () => {

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -237,8 +237,11 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(skill, /## Anam Avatar \(REST-only\)/);
     assert.match(guide, /write-only[\s\S]*must not be persisted, logged, or reported/i);
     assert.doesNotMatch(guide, /@anam-avatar-session\.json/);
-    assert.match(guide, /-d "[\s\S]*\$\{ANAM_API_KEY\}[\s\S]*"/);
-    assert.match(guide, /ANAM_API_KEY.*already exported from a backend secret store/i);
+    assert.match(guide, /jq -n[\s\S]*api_key: env\.ANAM_API_KEY[\s\S]*\| curl/);
+    assert.match(guide, /--data-binary @-/);
+    assert.doesNotMatch(guide, /\$\{ANAM_API_KEY\}|--arg api_key/);
+    assert.match(guide, /ANAM_API_KEY[\s\S]*already exported from[\s\S]*a backend secret store/i);
+    assert.match(skill, /Send `Authorization: Bearer \*\*\*`\. REST responses use/);
     assert.match(guide, /`starting`, `connected`, `degraded`, `disconnected`/);
     assert.match(guide, /camera_image/);
     assert.match(guide, /speak_on_enter[\s\S]*active[\s\S]*avatar[\s\S]*connected/i);

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -142,7 +142,11 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.match(skill, /Mark the outbox item\s+`sent` only after confirmed delivery/);
     assert.match(skill, /retry pending alerts/i);
     assert.match(skill, /wait_seconds: 2/);
+    assert.match(skill, /## Worked Interpretations/);
+    assert.match(skill, /### Mention alert and final summary/);
     assert.match(skill, /### Reactive lunch answer/);
+    assert.match(skill, /### Demo: delegated attendance and TL;DR/);
+    assert.match(skill, /Anusha cannot attend → texts her agent → colleagues see her bot join/);
     assert.match(skill, /A one-shot\s+key uses only session and rule/);
     assert.match(skill, /"key": "action:<session_id>:<rule_id>"/);
     assert.doesNotMatch(skill, /"key": "action:<session_id>:<rule_id>:<first_trigger_seq>"/);
@@ -232,6 +236,9 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.deepEqual(Object.keys(avatar.avatar).sort(), ["api_key", "avatar_id", "provider"]);
     assert.match(skill, /## Anam Avatar \(REST-only\)/);
     assert.match(guide, /write-only[\s\S]*must not be persisted, logged, or reported/i);
+    assert.doesNotMatch(guide, /@anam-avatar-session\.json/);
+    assert.match(guide, /-d "[\s\S]*\$\{ANAM_API_KEY\}[\s\S]*"/);
+    assert.match(guide, /ANAM_API_KEY.*already exported from a backend secret store/i);
     assert.match(guide, /`starting`, `connected`, `degraded`, `disconnected`/);
     assert.match(guide, /camera_image/);
     assert.match(guide, /speak_on_enter[\s\S]*active[\s\S]*avatar[\s\S]*connected/i);

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -243,6 +243,7 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.doesNotMatch(guide, /\$\{ANAM_API_KEY\}|--arg api_key/);
     assert.match(guide, /ANAM_API_KEY[\s\S]*already exported from[\s\S]*a backend secret store/i);
     const avatarSection = guide.slice(guide.indexOf("### Anam avatar REST create"));
+    assert.doesNotMatch(avatarSection, /Supported Output Media platforms/);
     const avatarBash = /```bash\n([\s\S]*?)\n```/.exec(avatarSection)?.[1];
     assert.ok(avatarBash, "Anam avatar section needs a Bash request");
     const syntax = spawnSync("bash", ["-n"], { input: avatarBash, encoding: "utf8" });

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -281,6 +281,7 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     const assistantSyntax = spawnSync("bash", ["-n"], { input: assistantBash, encoding: "utf8" });
     assert.equal(assistantSyntax.status, 0, assistantSyntax.stderr);
     assert.match(assistantBash, /--data-binary[\s\S]*"assistant"/);
+    assert.match(assistantBash, /Authorization: Bearer \$TELNYX_API_KEY/);
     assert.doesNotMatch(JSON.stringify(assistant), /join_at|barge_in/);
 
     const avatar = jsonAfter("### Anam avatar REST create");
@@ -299,6 +300,7 @@ describe("Meeting Bot discovery and durable alert contract", () => {
     assert.ok(avatarBash, "Anam avatar section needs a Bash request");
     const syntax = spawnSync("bash", ["-n"], { input: avatarBash, encoding: "utf8" });
     assert.equal(syntax.status, 0, syntax.stderr);
+    assert.match(avatarBash, /Authorization: Bearer \$TELNYX_API_KEY/);
     assert.match(skill, /Send the standard bearer-token `Authorization` header\. REST responses use/);
     assert.match(guide, /`starting`, `connected`, `degraded`, `disconnected`/);
     assert.match(guide, /camera_image/);


### PR DESCRIPTION
## Summary

- add explicit Portal AI Assistant and Anam avatar sections to the `telnyx-meeting-bot` skill
- document the REST-only create workflows, strict request shapes, readiness axes, and attendance evidence
- cover the combined Assistant + avatar flow while preserving the existing idempotency, transcript, action, artifact, recovery, and worked-scenario guidance
- branch create/recovery by MCP versus REST transport and use package-stable guide links
- keep internal meeting-infrastructure providers out of public documentation
- add contract and Bash-syntax regression coverage and keep canonical/Claude/Cursor copies synchronized

## Source grounding

Behavior is derived from `team-telnyx/meeting-bot-service` `main` at [`a9f6326bcaf7428364861290b787d5db1772e9f6`](https://github.com/team-telnyx/meeting-bot-service/tree/a9f6326bcaf7428364861290b787d5db1772e9f6), especially the REST create schema, session domain/service, MCP schema, and API tests.

Both `assistant` and `avatar` are creation-time REST fields and are intentionally unavailable through MCP `join_meeting`.

## Validation

- `npm run test:guides` — 132 passed
- `npm run test:guides-api` — 36 passed
- `./scripts/check-skills-sync.sh` — passed
- `./scripts/check-skill-count.sh` — all 237 markers valid
- `uvx --from skills-ref agentskills validate skills/telnyx-meeting-bot` — valid
- `git diff --check` — clean
- canonical/Claude/Cursor copies — byte-identical
- main `SKILL.md` — 461 lines
- Anam JSON encoding smoke with quote/backslash characters — passed
- Anam Bash example — syntax-checked by the guide test

## Independent review

Sol reviewed exact head `b44be5551ce410f83cb589dfc7d6983864f08e6d`: **PASS**, with no blockers or non-blocking observations.

## Safety

- examples contain placeholders only
- Anam `api_key` is read by `jq` from the environment, JSON-encoded, and streamed to `curl` over stdin; it is not written to a request file or expanded into process arguments
- responses and guidance omit the write-only Anam key
- public skill, guide, tests, and synchronized copies contain no internal meeting-infrastructure vendor/provider names
- no live meeting was joined and no customer data was used

Follow-up to https://github.com/team-telnyx/ai/pull/465

Linear: https://linear.app/telnyx/issue/AIF-504/meeting-bot-skill-document-portal-assistant-and-anam-avatar-rest
