### PR TITLE
feat: Add Edge v0.5.1 capability detection to agent CLI

### DIFF
--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -377,7 +377,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       nextSteps.push("Export a remote SQL database with: telnyx-edge storage sqldb export <database> --remote --output ./database.sql");
     }
     if (sqlDatabaseExportSupported && sqlStdinImportSupported) {
-      nextSteps.push("Copy SQL data cautiously with: telnyx-edge storage sqldb export <source-database> --remote --output - | telnyx-edge storage sqldb execute <destination-database> --remote --file -");
+      nextSteps.push("Copy SQL data only to an empty/disposable destination (imports can partially modify it on failure): telnyx-edge storage sqldb export <source-database> --remote --output - | telnyx-edge storage sqldb execute <destination-database> --remote --file -");
     }
     if (customDomainsSupported) {
       nextSteps.push("Route a hostname with: telnyx-edge domains add <hostname> <function-id>, then follow the DNS verification and TLS certificate workflow.");

--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -20,11 +20,14 @@ import {
   supportsNonInteractiveConfirmation,
   supportsResetFunc,
   supportsResetFuncNonInteractiveConfirmation,
+  supportsRuntimeLogs,
   supportsSecretsAdd,
   supportsShip,
   supportsShipStatus,
   supportsSqlBoundParameters,
+  supportsSqlDatabaseExport,
   supportsSqlDatabases,
+  supportsSqlStdinImport,
   supportsStatefulActors,
   supportsTypes,
 } from "../edge-cli.ts";
@@ -41,6 +44,7 @@ interface EdgeDoctorResult {
   secrets_add_supported: boolean;
   ship_supported: boolean;
   ship_status_supported: boolean;
+  runtime_logs_supported: boolean;
   stateful_actors_supported: boolean;
   inspect_supported: boolean;
   actor_instances_supported: boolean;
@@ -52,6 +56,8 @@ interface EdgeDoctorResult {
   kv_key_management_supported: boolean;
   sql_databases_supported: boolean;
   sql_bound_parameters_supported: boolean;
+  sql_database_export_supported: boolean;
+  sql_stdin_import_supported: boolean;
   custom_domains_supported: boolean;
   checks: Array<{ name: string; ok: boolean; detail: string }>;
   next_steps: string[];
@@ -70,6 +76,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let secretsAddSupported = false;
   let shipSupported = false;
   let shipStatusSupported = false;
+  let runtimeLogsSupported = false;
   let statefulActorsSupported = false;
   let inspectSupported = false;
   let actorInstancesSupported = false;
@@ -81,6 +88,8 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let kvKeyManagementSupported = false;
   let sqlDatabasesSupported = false;
   let sqlBoundParametersSupported = false;
+  let sqlDatabaseExportSupported = false;
+  let sqlStdinImportSupported = false;
   let customDomainsSupported = false;
 
   try {
@@ -105,6 +114,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     secretsAddSupported = supportsSecretsAdd();
     shipSupported = supportsShip();
     shipStatusSupported = supportsShipStatus();
+    runtimeLogsSupported = supportsRuntimeLogs();
     statefulActorsSupported = supportsStatefulActors();
     inspectSupported = supportsInspect();
     actorInstancesSupported = supportsActorInstances();
@@ -116,6 +126,8 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     kvKeyManagementSupported = supportsKvKeyManagement();
     sqlDatabasesSupported = supportsSqlDatabases();
     sqlBoundParametersSupported = supportsSqlBoundParameters();
+    sqlDatabaseExportSupported = supportsSqlDatabaseExport();
+    sqlStdinImportSupported = supportsSqlStdinImport();
     customDomainsSupported = supportsCustomDomains();
 
     checks.push({
@@ -148,6 +160,13 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       detail: shipStatusSupported
         ? "ship status <function> --logs is available"
         : "ship status --help did not advertise both <function> usage and --logs",
+    });
+    checks.push({
+      name: "Function runtime logs",
+      ok: runtimeLogsSupported,
+      detail: runtimeLogsSupported
+        ? "logs <function> supports --since, --last, and --json"
+        : "logs --help did not advertise <function> usage with --since, --last, and --json",
     });
     checks.push({
       name: "Stateful actors supported",
@@ -219,6 +238,20 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       detail: sqlBoundParametersSupported
         ? "storage sqldb execute supports --param and --param-json"
         : "storage sqldb execute --help did not advertise both --param and --param-json",
+    });
+    checks.push({
+      name: "SQL database export",
+      ok: sqlDatabaseExportSupported,
+      detail: sqlDatabaseExportSupported
+        ? "storage sqldb export supports --remote, --output, --table, --no-data, and --no-schema"
+        : "storage sqldb export --help did not advertise the complete export surface",
+    });
+    checks.push({
+      name: "SQL standard-input import",
+      ok: sqlStdinImportSupported,
+      detail: sqlStdinImportSupported
+        ? "storage sqldb execute accepts --file - from standard input"
+        : "storage sqldb execute --help did not advertise --file - standard-input input",
     });
     checks.push({
       name: "Custom domains",
@@ -322,6 +355,9 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     if (shipStatusSupported) {
       nextSteps.push("Diagnose the latest ship before resetting it: telnyx-edge ship status <function-name> --logs");
     }
+    if (runtimeLogsSupported) {
+      nextSteps.push("Read deployed-function runtime logs with: telnyx-edge logs <function-name> --since 10m --last 200");
+    }
     if (resetFuncSupported) {
       nextSteps.push(`Recover a failed deployment with: telnyx-edge reset-func <function-name>${resetFuncNoninteractiveConfirmationSupported ? " --yes" : ""}`);
     }
@@ -337,11 +373,18 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     if (sqlBoundParametersSupported) {
       nextSteps.push("Bind SQL inputs safely with repeatable --param (strings) and --param-json (numbers, booleans, or null).");
     }
+    if (sqlDatabaseExportSupported) {
+      nextSteps.push("Export a remote SQL database with: telnyx-edge storage sqldb export <database> --remote --output ./database.sql");
+    }
+    if (sqlDatabaseExportSupported && sqlStdinImportSupported) {
+      nextSteps.push("Copy SQL data cautiously with: telnyx-edge storage sqldb export <source-database> --remote --output - | telnyx-edge storage sqldb execute <destination-database> --remote --file -");
+    }
     if (customDomainsSupported) {
       nextSteps.push("Route a hostname with: telnyx-edge domains add <hostname> <function-id>, then follow the DNS verification and TLS certificate workflow.");
     }
     const missingOptional = [
       !shipStatusSupported && "ship status <function> --logs diagnostics",
+      !runtimeLogsSupported && "runtime logs",
       !resetFuncSupported && "reset-func",
       resetFuncSupported && !resetFuncNoninteractiveConfirmationSupported && "reset-func --yes",
       !noninteractiveConfirmationSupported && "destructive-command --yes",
@@ -350,6 +393,8 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       !kvKeyManagementSupported && "KV keys",
       !sqlDatabasesSupported && "remote SQL execution",
       !sqlBoundParametersSupported && "SQL --param/--param-json bindings",
+      !sqlDatabaseExportSupported && "SQL database export",
+      !sqlStdinImportSupported && "SQL standard-input import",
       !customDomainsSupported && "custom domains",
     ].filter((value): value is string => Boolean(value));
     if (missingOptional.length > 0) {
@@ -369,6 +414,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     secrets_add_supported: secretsAddSupported,
     ship_supported: shipSupported,
     ship_status_supported: shipStatusSupported,
+    runtime_logs_supported: runtimeLogsSupported,
     stateful_actors_supported: statefulActorsSupported,
     inspect_supported: inspectSupported,
     actor_instances_supported: actorInstancesSupported,
@@ -380,6 +426,8 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     kv_key_management_supported: kvKeyManagementSupported,
     sql_databases_supported: sqlDatabasesSupported,
     sql_bound_parameters_supported: sqlBoundParametersSupported,
+    sql_database_export_supported: sqlDatabaseExportSupported,
+    sql_stdin_import_supported: sqlStdinImportSupported,
     custom_domains_supported: customDomainsSupported,
     checks,
     next_steps: nextSteps,

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -86,6 +86,17 @@ export function supportsShipStatus(): boolean {
   }
 }
 
+/** Detect deployed-function runtime logs from the released v0.5.1 help surface. */
+export function supportsRuntimeLogs(): boolean {
+  try {
+    const out = runEdge(["logs", "--help"]);
+    return /\blogs\s+<function>(?:\s|\[|$)/i.test(out) &&
+      ["since", "last", "json"].every((flag) => new RegExp(`--${flag}\\b`, "i").test(out));
+  } catch {
+    return false;
+  }
+}
+
 /** Detect non-interactive confirmation from a destructive command's own help. */
 export function supportsNonInteractiveConfirmation(): boolean {
   try {
@@ -180,6 +191,30 @@ export function supportsSqlBoundParameters(): boolean {
   try {
     const out = runEdge(["storage", "sqldb", "execute", "--help"]);
     return /--param(?:[\s=,]|$)/i.test(out) && /--param-json\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/** Detect the released SQL export surface without inferring it from SQL execute. */
+export function supportsSqlDatabaseExport(): boolean {
+  try {
+    const out = runEdge(["storage", "sqldb", "export", "--help"]);
+    return /\bstorage\s+sqldb\s+export\s+<[^>]+>/i.test(out) &&
+      ["remote", "output", "table", "no-data", "no-schema"]
+        .every((flag) => new RegExp(`--${flag}\\b`, "i").test(out));
+  } catch {
+    return false;
+  }
+}
+
+/** Detect the released `execute --file -` standard-input import form. */
+export function supportsSqlStdinImport(): boolean {
+  try {
+    const out = runEdge(["storage", "sqldb", "execute", "--help"]);
+    return /\bstorage\s+sqldb\s+execute\s+<[^>]+>/i.test(out) &&
+      /--remote\b/i.test(out) &&
+      /--file[^\r\n]*-\s*(?:means|for|reads?\s+from)?\s*(?:standard input|stdin)\b/i.test(out);
   } catch {
     return false;
   }

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -202,7 +202,8 @@ export function supportsSqlDatabaseExport(): boolean {
     const out = runEdge(["storage", "sqldb", "export", "--help"]);
     return /\bstorage\s+sqldb\s+export\s+<[^>]+>/i.test(out) &&
       ["remote", "output", "table", "no-data", "no-schema"]
-        .every((flag) => new RegExp(`--${flag}\\b`, "i").test(out));
+        .every((flag) => new RegExp(`--${flag}\\b`, "i").test(out)) &&
+      /--output\b[^\r\n]*-\s+writes?\s+to\s+stdout\b/i.test(out);
   } catch {
     return false;
   }

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -20,6 +20,10 @@ type FakeEdgeOptions = {
   ship?: boolean;
   shipStatusFunctionUsage?: boolean;
   shipStatusLogs?: boolean;
+  runtimeLogsFunctionUsage?: boolean;
+  runtimeLogsSince?: boolean;
+  runtimeLogsLast?: boolean;
+  runtimeLogsJson?: boolean;
   resetFunc?: boolean;
   resetNoninteractiveConfirmation?: boolean;
   noninteractiveConfirmation?: boolean;
@@ -30,6 +34,9 @@ type FakeEdgeOptions = {
   sqlDatabases?: boolean;
   sqlParam?: boolean;
   sqlParamJson?: boolean;
+  sqlDatabaseExport?: boolean;
+  sqlDatabaseExportNoSchema?: boolean;
+  sqlStdinImport?: boolean;
   customDomainCommands?: Array<"add" | "verify" | "list" | "delete" | "cert">;
   customDomainCertUpload?: boolean;
   customDomainCertFlag?: boolean;
@@ -49,6 +56,10 @@ function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
   const ship = config.ship ?? true;
   const shipStatusFunctionUsage = config.shipStatusFunctionUsage ?? true;
   const shipStatusLogs = config.shipStatusLogs ?? true;
+  const runtimeLogsFunctionUsage = config.runtimeLogsFunctionUsage ?? true;
+  const runtimeLogsSince = config.runtimeLogsSince ?? true;
+  const runtimeLogsLast = config.runtimeLogsLast ?? true;
+  const runtimeLogsJson = config.runtimeLogsJson ?? true;
   const resetFunc = config.resetFunc ?? true;
   const resetNoninteractiveConfirmation = config.resetNoninteractiveConfirmation ?? false;
   const noninteractiveConfirmation = config.noninteractiveConfirmation ?? true;
@@ -59,6 +70,9 @@ function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
   const sqlDatabases = config.sqlDatabases ?? true;
   const sqlParam = config.sqlParam ?? true;
   const sqlParamJson = config.sqlParamJson ?? true;
+  const sqlDatabaseExport = config.sqlDatabaseExport ?? true;
+  const sqlDatabaseExportNoSchema = config.sqlDatabaseExportNoSchema ?? true;
+  const sqlStdinImport = config.sqlStdinImport ?? true;
   const customDomainCommands = config.customDomainCommands ?? ["add", "verify", "list", "delete", "cert"];
   const customDomainCertUpload = config.customDomainCertUpload ?? true;
   const customDomainCertFlag = config.customDomainCertFlag ?? true;
@@ -98,6 +112,10 @@ if (args[0] === 'secrets' && args[1] === 'add' && args.includes('--help')) {
 }
 if (args[0] === 'ship' && args[1] === 'status' && args.includes('--help')) {
   console.log(['Show why a function ship failed', 'Usage: telnyx-edge ship status ${shipStatusFunctionUsage ? "<function>" : "[flags]"}', ...(${shipStatusLogs} ? ['      --logs  Also print the build log or crash output'] : [])].join('\\n'));
+  process.exit(0);
+}
+if (args[0] === 'logs' && args.includes('--help')) {
+  console.log(['Read deployed function runtime logs', 'Usage: telnyx-edge logs ${runtimeLogsFunctionUsage ? "<function>" : "[flags]"}', ...(${runtimeLogsSince} ? ['      --since duration  Look back over a historical window'] : []), ...(${runtimeLogsLast} ? ['  -n, --last int  Maximum number of log lines'] : []), ...(${runtimeLogsJson} ? ['      --json  Print JSON output'] : [])].join('\\n'));
   process.exit(0);
 }
 if (args[0] === 'ship' && args.includes('--help')) {
@@ -150,11 +168,19 @@ if (args[0] === 'storage' && args[1] === 'kv' && args.includes('--help')) {
 }
 if (args[0] === 'storage' && args[1] === 'sqldb' && args[2] === 'execute' && args.includes('--help')) {
   if (${sqlDatabases}) {
-    console.log(['Run SQL against a SQL database', 'Usage: telnyx-edge storage sqldb execute <database> [flags]', '--remote  --command string  --file string', ...(${sqlParam} ? ['--param string'] : []), ...(${sqlParamJson} ? ['--param-json string'] : [])].join('\\n'));
+    console.log(['Run SQL against a SQL database', 'Usage: telnyx-edge storage sqldb execute <database> [flags]', '--remote  --command string  --file string', ...(${sqlStdinImport} ? ['Use --file - for standard input'] : []), ...(${sqlParam} ? ['--param string'] : []), ...(${sqlParamJson} ? ['--param-json string'] : [])].join('\\n'));
     process.exit(0);
   }
   console.log('Usage: telnyx-edge storage sqldb execute <database> [flags]\\n--remote --command string');
   process.exit(0);
+}
+if (args[0] === 'storage' && args[1] === 'sqldb' && args[2] === 'export' && args.includes('--help')) {
+  if (${sqlDatabaseExport}) {
+    console.log(['Export a remote SQL database', 'Usage: telnyx-edge storage sqldb export <database> [flags]', '--remote  --output string  --table strings  --no-data', ...(${sqlDatabaseExportNoSchema} ? ['--no-schema'] : [])].join('\\n'));
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "export"\\n');
+  process.exit(1);
 }
 if (args[0] === 'domains' && args[1] === 'cert' && args[2] === 'upload' && args.includes('--help')) {
   if (${customDomainCertUpload}) {
@@ -292,6 +318,7 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.secrets_add_supported, true);
     assert.equal(data.ship_supported, true);
     assert.equal(data.ship_status_supported, true);
+    assert.equal(data.runtime_logs_supported, true);
     assert.equal(data.stateful_actors_supported, true);
     assert.equal(data.inspect_supported, true);
     assert.equal(data.actor_instances_supported, true);
@@ -302,6 +329,8 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.kv_key_management_supported, true);
     assert.equal(data.sql_databases_supported, true);
     assert.equal(data.sql_bound_parameters_supported, true);
+    assert.equal(data.sql_database_export_supported, true);
+    assert.equal(data.sql_stdin_import_supported, true);
     assert.equal(data.custom_domains_supported, true);
   });
 
@@ -354,14 +383,18 @@ describe("CLI — Edge Compute handoff", () => {
       sqlDatabases: false,
       shipStatusFunctionUsage: false,
       shipStatusLogs: false,
+      runtimeLogsSince: false,
       sqlParam: false,
       sqlParamJson: false,
+      sqlDatabaseExport: false,
+      sqlStdinImport: false,
       argLog: true,
     });
     const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
     assert.equal(data.telnyx_edge_version, "v0.5.0");
     assert.equal(data.ready, true, "optional capabilities do not block the core handoff");
     assert.equal(data.ship_status_supported, false);
+    assert.equal(data.runtime_logs_supported, false);
     assert.equal(data.reset_func_supported, false);
     assert.equal(data.noninteractive_confirmation_supported, false);
     assert.equal(data.types_supported, false);
@@ -369,17 +402,21 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.kv_key_management_supported, false);
     assert.equal(data.sql_databases_supported, false);
     assert.equal(data.sql_bound_parameters_supported, false);
+    assert.equal(data.sql_database_export_supported, false);
+    assert.equal(data.sql_stdin_import_supported, false);
     assert.ok(data.next_steps.some((step: string) => step.includes("Optional capabilities not detected")));
     const calls = readFileSync(fake.argsLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
     for (const expected of [
       ["reset-func", "--help"],
       ["ship", "status", "--help"],
+      ["logs", "--help"],
       ["delete-func", "--help"],
       ["secrets", "add", "--help"],
       ["types", "--help"],
       ["storage", "kv", "--help"],
       ["storage", "kv", "key", "--help"],
       ["storage", "sqldb", "execute", "--help"],
+      ["storage", "sqldb", "export", "--help"],
     ]) {
       assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(expected)), `missing probe ${expected.join(" ")}`);
     }
@@ -398,6 +435,57 @@ describe("CLI — Edge Compute handoff", () => {
       assert.ok(data.next_steps.some((step: string) => step.includes("ship status <function> --logs diagnostics")));
       const calls = readFileSync(fake.argsLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
       assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["ship", "status", "--help"])));
+    }
+  });
+
+  it("detects only the released runtime-log help surface", () => {
+    const positive = withFakeEdgeCli({ auth: "api_key", argLog: true });
+    const available = JSON.parse(run(["edge-doctor", "--json"], positive.env));
+    assert.equal(available.ready, true);
+    assert.equal(available.runtime_logs_supported, true);
+    assert.ok(available.checks.some((check: { name: string; ok: boolean }) =>
+      check.name === "Function runtime logs" && check.ok));
+    assert.ok(available.next_steps.some((step: string) =>
+      step.includes("telnyx-edge logs <function-name> --since 10m --last 200")));
+    const calls = readFileSync(positive.argsLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["logs", "--help"])));
+
+    for (const config of [
+      { runtimeLogsFunctionUsage: false },
+      { runtimeLogsSince: false },
+      { runtimeLogsLast: false },
+      { runtimeLogsJson: false },
+    ]) {
+      const fake = withFakeEdgeCli({ auth: "api_key", ...config });
+      const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+      assert.equal(data.ready, true, "runtime logs must remain optional for setup handoffs");
+      assert.equal(data.runtime_logs_supported, false);
+      assert.ok(data.next_steps.some((step: string) => step.includes("runtime logs")));
+    }
+  });
+
+  it("requires complete SQL export and standard-input help surfaces", () => {
+    const positive = withFakeEdgeCli({ auth: "api_key", argLog: true });
+    const available = JSON.parse(run(["edge-doctor", "--json"], positive.env));
+    assert.equal(available.ready, true);
+    assert.equal(available.sql_database_export_supported, true);
+    assert.equal(available.sql_stdin_import_supported, true);
+    assert.ok(available.next_steps.some((step: string) =>
+      step.includes("storage sqldb export <source-database> --remote --output - | telnyx-edge storage sqldb execute <destination-database> --remote --file -")));
+    const calls = readFileSync(positive.argsLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["storage", "sqldb", "export", "--help"])));
+    assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["storage", "sqldb", "execute", "--help"])));
+
+    for (const [config, exportSupported, stdinSupported] of [
+      [{ sqlDatabaseExport: false }, false, true],
+      [{ sqlDatabaseExportNoSchema: false }, false, true],
+      [{ sqlStdinImport: false }, true, false],
+    ] as const) {
+      const fake = withFakeEdgeCli({ auth: "api_key", ...config });
+      const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+      assert.equal(data.ready, true, "SQL export/import must remain optional for setup handoffs");
+      assert.equal(data.sql_database_export_supported, exportSupported);
+      assert.equal(data.sql_stdin_import_supported, stdinSupported);
     }
   });
 

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -36,6 +36,7 @@ type FakeEdgeOptions = {
   sqlParamJson?: boolean;
   sqlDatabaseExport?: boolean;
   sqlDatabaseExportNoSchema?: boolean;
+  sqlDatabaseExportStdout?: boolean;
   sqlStdinImport?: boolean;
   customDomainCommands?: Array<"add" | "verify" | "list" | "delete" | "cert">;
   customDomainCertUpload?: boolean;
@@ -72,6 +73,7 @@ function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
   const sqlParamJson = config.sqlParamJson ?? true;
   const sqlDatabaseExport = config.sqlDatabaseExport ?? true;
   const sqlDatabaseExportNoSchema = config.sqlDatabaseExportNoSchema ?? true;
+  const sqlDatabaseExportStdout = config.sqlDatabaseExportStdout ?? true;
   const sqlStdinImport = config.sqlStdinImport ?? true;
   const customDomainCommands = config.customDomainCommands ?? ["add", "verify", "list", "delete", "cert"];
   const customDomainCertUpload = config.customDomainCertUpload ?? true;
@@ -176,7 +178,7 @@ if (args[0] === 'storage' && args[1] === 'sqldb' && args[2] === 'execute' && arg
 }
 if (args[0] === 'storage' && args[1] === 'sqldb' && args[2] === 'export' && args.includes('--help')) {
   if (${sqlDatabaseExport}) {
-    console.log(['Export a remote SQL database', 'Usage: telnyx-edge storage sqldb export <database> [flags]', '--remote  --output string  --table strings  --no-data', ...(${sqlDatabaseExportNoSchema} ? ['--no-schema'] : [])].join('\\n'));
+    console.log(['Export a remote SQL database', 'Usage: telnyx-edge storage sqldb export <database> [flags]', '--remote  --table strings  --no-data', '--output string  Path to SQL file' + (${sqlDatabaseExportStdout} ? ' (- writes to stdout)' : ''), ...(${sqlDatabaseExportNoSchema} ? ['--no-schema'] : [])].join('\\n'));
     process.exit(0);
   }
   process.stderr.write('unknown command "export"\\n');
@@ -479,6 +481,7 @@ describe("CLI — Edge Compute handoff", () => {
     for (const [config, exportSupported, stdinSupported] of [
       [{ sqlDatabaseExport: false }, false, true],
       [{ sqlDatabaseExportNoSchema: false }, false, true],
+      [{ sqlDatabaseExportStdout: false }, false, true],
       [{ sqlStdinImport: false }, true, false],
     ] as const) {
       const fake = withFakeEdgeCli({ auth: "api_key", ...config });
@@ -486,6 +489,7 @@ describe("CLI — Edge Compute handoff", () => {
       assert.equal(data.ready, true, "SQL export/import must remain optional for setup handoffs");
       assert.equal(data.sql_database_export_supported, exportSupported);
       assert.equal(data.sql_stdin_import_supported, stdinSupported);
+      assert.equal(data.next_steps.some((step: string) => step.includes('--output - |')), exportSupported && stdinSupported);
     }
   });
 

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -384,7 +384,7 @@ telnyx-edge types
 Do not confuse shared account SQLDB with actor-local SQL. `[storage.sqldb.DB]` exposes one account database as `env.DB` to any functions that bind the same UUID. `ctx.storage.sql` belongs to one StatefulActor instance, is reached only inside that actor, and has no `storage sqldb execute` or migration CLI surface.
 
 ### SQL export and standard-input import (v0.5.1)
-Export creates SQL data for backup or a deliberate copy; it is not a point-in-time snapshot, refuses virtual tables, and may contain sensitive data. Protect the output, verify the destination before importing, and do not combine `--no-data` with `--no-schema`.
+Export creates SQL data for backup or a deliberate copy; it is not a point-in-time snapshot, refuses virtual tables, and may contain sensitive data. Import executes schema and data statements, can partially modify the destination on failure, and is not a transactional restore. Use an empty/disposable destination, or review the SQL and back up the target first; never pipe blindly into a populated production database. Protect the output, verify the destination before importing, and do not combine `--no-data` with `--no-schema`.
 ```bash
 telnyx-edge storage sqldb export "$SQLDB_ID" --remote --output ./database.sql
 telnyx-edge storage sqldb export "$SOURCE_SQLDB_ID" --remote --output - | telnyx-edge storage sqldb execute "$DEST_SQLDB_ID" --remote --file -

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -50,7 +50,6 @@ Names must be 1–64 characters, contain only alphanumeric characters and dashes
 ## Quick Start
 
 Use one of the repository-aware handoff commands below for a complete clone, build, secrets, deploy, and inspect sequence. The expanded manual flows show exactly what each helper emits.
-
 ### Classic Node lockfile prerequisite
 
 Before shipping a classic Node function whose `package.json` declares dependencies, ensure the function directory contains either `package-lock.json` or `npm-shrinkwrap.json`. These are the accepted npm lockfile forms; without one, `telnyx-edge ship` fails before upload.
@@ -156,7 +155,6 @@ curl -X POST "https://<your-edge-endpoint>/" \
 Do not put `WEBHOOK_SECRET` in the request body or an Authorization header unless your own handler explicitly defines that separate protocol. Its purpose in this example is HMAC verification.
 
 ## API Reference
-
 ### List, create, deploy, inspect, and recover
 
 ```bash
@@ -176,7 +174,7 @@ telnyx-edge inspect my-function
 
 `inspect <function>` is the per-function detail view: deployment status, invoke URL, timestamps, and **every binding the deployed function declares**. Binding rows show the `env.<NAME>` handle, kind, target, and status; actor rows also show their owner/reference role. Probe it with `telnyx-edge inspect --help` when supporting multiple CLI releases.
 
-Before resetting a failed function, inspect the latest ship outcome: `ship status <function>` prints one actionable, stage-classified reason, and `--logs` adds the build-log or crash-output snippet when the platform supplied one. A failed function can then be reset to `created` without changing its identity, fixed, and shipped again:
+Before resetting a failed function, inspect the latest ship outcome: `ship status <function>` prints one actionable, stage-classified reason, and `--logs` adds the build-log or crash-output snippet when the platform supplied one. These are ship-failure logs, not deployed-function runtime output. A failed function can then be reset to `created` without changing its identity, fixed, and shipped again:
 
 ```bash
 telnyx-edge ship status my-function --logs
@@ -193,7 +191,11 @@ telnyx-edge delete-func my-function --yes
 ```
 
 `delete-func` is irreversible. Use `--yes` (`-y`) in scripts, agents, and CI to skip the interactive confirmation; see [Non-interactive destructive commands](#non-interactive-destructive-commands) for the full list.
-
+### Runtime logs (v0.5.1)
+`logs <function>` reads runtime output from a deployed function, unlike `ship status <function> --logs`, which only adds logs associated with a failed ship. It reads a historical window; lines can arrive a few seconds after the function writes them.
+```bash
+telnyx-edge logs my-function --since 10m --last 200; telnyx-edge logs my-function --json
+```
 ### Custom domains (v0.5.0)
 
 `domains add` prints the DNS TXT record needed for ownership verification. After publishing it, complete the workflow and use `--yes` for destructive teardown:
@@ -205,7 +207,6 @@ telnyx-edge domains list
 telnyx-edge domains delete api.example.com --yes
 ```
 DNS propagation can delay verification; retry `verify` before certificate upload. `domains list` reports verification and certificate status.
-
 ### Revisions and rollback
 
 Every successful ship creates an immutable revision.
@@ -216,7 +217,6 @@ telnyx-edge rollback my-function <revision-id>
 ```
 
 Rollback retargets traffic to a prior healthy revision without rebuilding or re-uploading it.
-
 ### Secrets and Telnyx bindings
 
 ```bash
@@ -265,7 +265,6 @@ const mcpToken: string = await env.SECRETS.get("MCP_TOKEN");
 ```
 
 `binding` is the code-facing handle; `name` is the secret-store key. `types` covers all declared actor, Telnyx, secret, KV, SQL database, and Cloud Storage bindings, runs offline without authentication, and should be rerun whenever the manifest changes.
-
 ### Rate limiter bindings
 
 Declare each fixed-window limiter in `func.toml` or `telnyx.toml`. `limit` is the allowed call count and `period` is the window in seconds:
@@ -293,7 +292,6 @@ if (!success) return new Response("Too many requests", { status: 429 });
 ```
 
 The runtime handle is canonicalized to uppercase with hyphens replaced by underscores (`api-limit` becomes `env.API_LIMIT`). `namespace_id` is optional and must be a positive integer string; functions using the same value share a counter pool, so reuse it only when cross-function limiting is intentional.
-
 ### Non-interactive destructive commands
 
 Destructive commands prompt in a terminal and deliberately fail rather than hang when stdin is not a terminal. Scripts, agents, and CI must pass `--yes` (`-y`) to `delete-func`, `reset-func`, `domains delete`, `secrets delete`, `bindings delete`, `actors delete`, `storage sqldb delete`, `storage kv delete`, and `storage kv key delete`. Piping the output of `yes` is not accepted.
@@ -306,7 +304,6 @@ telnyx-edge storage sqldb delete "$SQLDB_ID" --yes
 `--yes` only waives the CLI's local intent check. On SQL database and KV namespace deletion, `--force` (`-f`) separately tells the API to override its "still bound/in use" precondition; it does **not** confirm intent. To do both in CI, pass both flags, for example `telnyx-edge storage sqldb delete "$SQLDB_ID" --yes --force`. Functions that still bind the deleted resource are not deleted and will break.
 
 For a whole shell or CI job, `TELNYX_EDGE_SKIP_CONFIRMATIONS=1` has the same effect as `--yes`. For a persistent local preference, use `telnyx-edge config set skip_confirmations true` (undo with `false`). Neither setting implies `--force`, which remains per invocation.
-
 ### Persistent KV storage
 
 ```bash
@@ -332,7 +329,6 @@ id = "<namespace-uuid>"
 ```
 
 Then run `telnyx-edge types`: it generates `telnyx-env.d.ts` with KV handles typed as `KvNamespace`. Rerun it whenever binding declarations change.
-
 ### SQL databases (v0.3.0; bound parameters v0.4.1)
 
 A SQL database is an account-scoped SQLite database. It exists independently of functions and can be shared by every function that binds its UUID.
@@ -371,7 +367,6 @@ telnyx-edge storage sqldb migrations create "$SQLDB_ID" add-links-table
 telnyx-edge storage sqldb migrations list "$SQLDB_ID" --remote
 telnyx-edge storage sqldb migrations apply "$SQLDB_ID" --remote
 ```
-
 Bind the database in `func.toml` or `telnyx.toml`, using the real UUID, and regenerate declarations:
 
 ```toml
@@ -388,6 +383,12 @@ telnyx-edge types
 
 Do not confuse shared account SQLDB with actor-local SQL. `[storage.sqldb.DB]` exposes one account database as `env.DB` to any functions that bind the same UUID. `ctx.storage.sql` belongs to one StatefulActor instance, is reached only inside that actor, and has no `storage sqldb execute` or migration CLI surface.
 
+### SQL export and standard-input import (v0.5.1)
+Export creates SQL data for backup or a deliberate copy; it is not a point-in-time snapshot, refuses virtual tables, and may contain sensitive data. Protect the output, verify the destination before importing, and do not combine `--no-data` with `--no-schema`.
+```bash
+telnyx-edge storage sqldb export "$SQLDB_ID" --remote --output ./database.sql
+telnyx-edge storage sqldb export "$SOURCE_SQLDB_ID" --remote --output - | telnyx-edge storage sqldb execute "$DEST_SQLDB_ID" --remote --file -
+```
 ### Cloud Storage binding types (v0.2.4)
 
 CLI v0.2.4 added `[storage.cloudstorage.<name>]` manifest bindings and `CloudStorageBucket` output from `telnyx-edge types`. JavaScript/TypeScript scaffolds include the Cloud Storage dependencies.
@@ -431,7 +432,6 @@ The two inspect commands answer different questions:
 
 - `inspect <function>` shows one function and every declared binding (including actor owner/reference roles).
 - `actors inspect <type>` shows one account-scoped actor type, attached functions, and a best-effort live instance count.
-
 ### v0.2.5 actor-instance support and limitations
 
 v0.2.5 added `actors instances <type>` and the instance count in `actors inspect <type>`. The instance command is intentionally limited:

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -387,6 +387,9 @@ describe("Edge Compute v0.5.1 guide regression", () => {
     assert.match(guide, /storage sqldb execute "\$DEST_SQLDB_ID" --remote --file -/);
     assert.match(guide, /not a point-in-time snapshot, refuses virtual tables, and may contain sensitive data/);
     assert.match(guide, /do not combine `--no-data` with `--no-schema`/);
+    assert.match(guide, /can partially modify the destination on failure, and is not a transactional restore/);
+    assert.match(guide, /empty\/disposable destination/);
+    assert.match(guide, /never pipe blindly into a populated production database/);
   });
 
   it("does not advertise post-v0.5.1 metrics, deployments, or invocation-log flags", () => {

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -369,6 +369,33 @@ describe("Verify discovery parity", () => {
   });
 });
 
+describe("Edge Compute v0.5.1 guide regression", () => {
+  const guide = readFileSync(join(GUIDES_DIR, "edge-compute.md"), "utf-8");
+
+  it("distinguishes released runtime logs from ship-failure logs", () => {
+    assert.match(guide, /### Runtime logs \(v0\.5\.1\)/);
+    assert.match(guide, /ship-failure logs, not deployed-function runtime output/);
+    assert.match(guide, /telnyx-edge logs my-function --since 10m --last 200/);
+    assert.match(guide, /telnyx-edge logs my-function --json/);
+    assert.match(guide, /historical window; lines can arrive a few seconds/);
+  });
+
+  it("documents released SQL export and standard-input import safety boundaries", () => {
+    assert.match(guide, /### SQL export and standard-input import \(v0\.5\.1\)/);
+    assert.match(guide, /storage sqldb export "\$SQLDB_ID" --remote --output \.\/database\.sql/);
+    assert.match(guide, /storage sqldb export "\$SOURCE_SQLDB_ID" --remote --output -/);
+    assert.match(guide, /storage sqldb execute "\$DEST_SQLDB_ID" --remote --file -/);
+    assert.match(guide, /not a point-in-time snapshot, refuses virtual tables, and may contain sensitive data/);
+    assert.match(guide, /do not combine `--no-data` with `--no-schema`/);
+  });
+
+  it("does not advertise post-v0.5.1 metrics, deployments, or invocation-log flags", () => {
+    assert.doesNotMatch(guide, /telnyx-edge metrics\b/);
+    assert.doesNotMatch(guide, /telnyx-edge deployments\b/);
+    assert.doesNotMatch(guide, /telnyx-edge logs[^\n]*--type\b/);
+  });
+});
+
 describe("guide content requirements", () => {
   for (const file of guideFiles) {
     const filepath = join(GUIDES_DIR, file);


### PR DESCRIPTION
## Audit finding
Weekly CLI parity audit (2026-09-07): Edge CLI v0.5.1 added deployed-function runtime logs and SQL export / standard-input import, but agent discovery and the Edge guide omitted them.

## Scope
- Probe the released runtime-log, SQL export/stdout, and SQL stdin help surfaces independently.
- Expose optional edge-doctor checks and next steps without changing setup readiness.
- Update guides/edge-compute.md with runtime vs failed-ship logs, export/import examples, and explicit partial-import, empty-target, non-snapshot, and sensitive-data caveats.
- Add positive/negative mock-binary and guide regressions; do not advertise unreleased capabilities.

## Validation
- `npx tsc --noEmit`: passed.
- Full no-key CLI suite: 571 passed, 0 failed.
- Guide suite: 135 passed, 0 failed.
- Real v0.5.1 executable help probes: all three capabilities detected; no live API, SQL, or deployment actions.
- Independent exact-head review: PASS at `5e800ca3773cee020469884d572bbe794c2c3ade` after addressing initial review findings.

No merge or deployment performed. Generated by the weekly Telnyx CLI parity audit.

Tracking: [AIF-525](https://linear.app/telnyx/issue/AIF-525/feat-add-edge-v051-capability-detection-to-agent-cli)
