### PR TITLE
feat(payments): add telnyx-acp-payment skill and ACP account-funding guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file is a complement to `README.md` (human-facing) and `.github/CONTRIBUTIN
 
 ## What this repo is
 
-The one-stop shop for AI agents and AI-first developers building with Telnyx. It contains agent toolkits (Python/TypeScript), an agent CLI, per-product plugins for Claude Code / Cursor / Gemini CLI / OpenCode, an MCP proxy, <!-- SKILL_COUNT -->237<!-- /SKILL_COUNT --> Agent Skills, and operational guides.
+The one-stop shop for AI agents and AI-first developers building with Telnyx. It contains agent toolkits (Python/TypeScript), an agent CLI, per-product plugins for Claude Code / Cursor / Gemini CLI / OpenCode, an MCP proxy, <!-- SKILL_COUNT -->238<!-- /SKILL_COUNT --> Agent Skills, and operational guides.
 
 ---
 
@@ -48,7 +48,7 @@ Run the relevant package's test suite before declaring a task done. Don't run al
 
 | Path                    | What it contains                                                          |
 | ----------------------- | ------------------------------------------------------------------------- |
-| `skills/`               | Canonical agent skills (SKILL.md files). <!-- SKILL_COUNT -->237<!-- /SKILL_COUNT --> skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration. |
+| `skills/`               | Canonical agent skills (SKILL.md files). <!-- SKILL_COUNT -->238<!-- /SKILL_COUNT --> skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration. |
 | `providers/claude/`     | Claude Code plugin packaging — synced from `skills/` via `scripts/sync-skills.sh`. Don't edit by hand. |
 | `providers/cursor/`     | Cursor plugin packaging — synced from `skills/` via `scripts/sync-skills.sh`. Don't edit by hand. |
 | `plugins/opencode/`     | OpenCode plugin (auth + TUI for Telnyx-hosted models).                    |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo is the one-stop shop for AI Agents and AI-first developers building wi
 
 - [Agent Toolkit](#agent-toolkit) - integrate Telnyx APIs with popular agent frameworks including OpenAI's Agent SDK, LangChain, CrewAI, and Vercel's AI SDK through function calling — available in [Python](#python) and [TypeScript](#typescript).
   
-- [Agent Skills](#agent-skills) - give AI agents accurate, up-to-date context about Telnyx APIs and SDKs, plus account-management skills for signup and payments (MPP and x402 account funding).
+- [Agent Skills](#agent-skills) - give AI agents accurate, up-to-date context about Telnyx APIs and SDKs, plus account-management skills for signup and payments (ACP, MPP, and x402 account funding).
   
 - [Agent CLI](#agent-cli) - provision and build on Telnyx infrastructure in a single command.
 
@@ -25,7 +25,7 @@ This repo is the one-stop shop for AI Agents and AI-first developers building wi
 
 ## Plugins and Extensions
 
-Install the Telnyx plugins you need to give your AI coding assistant Telnyx Agent Skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, account management (signup, MPP/x402 payments), and more. Plugins are split by product area so you only load the skills your project uses — see the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need). For direct Telnyx API access from your assistant, also add the hosted MCP server — see [MCP](#model-context-protocol-mcp).
+Install the Telnyx plugins you need to give your AI coding assistant Telnyx Agent Skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, account management (signup, ACP/MPP/x402 payments), and more. Plugins are split by product area so you only load the skills your project uses — see the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need). For direct Telnyx API access from your assistant, also add the hosted MCP server — see [MCP](#model-context-protocol-mcp).
 
 Empowers agents to generate correct, production-ready code — and to manage their own accounts — without relying on pre-training or fragile doc retrieval.
 
@@ -183,7 +183,7 @@ Install individual skills for your coding assistant via the [Skills CLI](https:/
 npx skills add team-telnyx/ai --skill <SKILL> --agent <AGENT>
 ```
 
-Skills cover two areas: **building with Telnyx** (messaging, voice, numbers, AI inference, WebRTC, Twilio migration, and more) and **account management** (programmatic [signup](https://telnyx.com/agent-signup.md), plus funding an account via MPP or x402 payments).
+Skills cover two areas: **building with Telnyx** (messaging, voice, numbers, AI inference, WebRTC, Twilio migration, and more) and **account management** (programmatic [signup](https://telnyx.com/agent-signup.md), plus funding an account via ACP, MPP, or x402 payments).
 
 Skills are also published on telnyx.com for runtime discovery at [`/.well-known/agent-skills/index.json`](https://telnyx.com/.well-known/agent-skills/index.json).
 
@@ -234,7 +234,7 @@ From `tools/mcp-apps`, use `npm install`, `npm run typecheck`, `npm run build`, 
 
 ## Guides
 
-Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, MPP and x402 account payments, and Edge Compute handoff patterns.
+Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, ACP, MPP, and x402 account payments, and Edge Compute handoff patterns.
 
 See [Guides](/guides) for the full list.
 

--- a/agent.json
+++ b/agent.json
@@ -4,7 +4,6 @@
   "description": "Programmable telecom platform — voice, messaging, email, IoT, AI, networking, storage.",
   "version": "1.0.0",
   "updated": "2026-09-03T00:00:00Z",
-
   "auth": {
     "type": "api_key",
     "header": "Authorization",
@@ -13,7 +12,6 @@
     "signup_manifest": "https://telnyx.com/.well-known/agent-access.json",
     "docs": "https://developers.telnyx.com/docs/api/v2/overview#authentication"
   },
-
   "capabilities": [
     {
       "id": "messaging",
@@ -23,7 +21,11 @@
       "cli": "telnyx message send --from +15551234567 --to +15559876543 --text 'Hello'",
       "api": "POST /v2/messages",
       "docs": "https://developers.telnyx.com/docs/messaging",
-      "requires": ["messaging_profile", "phone_number", "10dlc_registration"]
+      "requires": [
+        "messaging_profile",
+        "phone_number",
+        "10dlc_registration"
+      ]
     },
     {
       "id": "rcs",
@@ -33,7 +35,10 @@
       "cli": "telnyx-agent rcs-send --agent-id AGENT_ID --messaging-profile-id PROFILE_ID --to +15559876543 --text 'Hello from RCS'",
       "api": "POST /v2/messages/rcs",
       "docs": "https://developers.telnyx.com/docs/messaging/messages/rcs-capabilities",
-      "requires": ["rcs_agent", "messaging_profile"]
+      "requires": [
+        "rcs_agent",
+        "messaging_profile"
+      ]
     },
     {
       "id": "voice",
@@ -43,7 +48,10 @@
       "cli": "telnyx call dial --from +15551234567 --to +15559876543",
       "api": "POST /v2/calls",
       "docs": "https://developers.telnyx.com/docs/voice",
-      "requires": ["voice_connection", "phone_number"]
+      "requires": [
+        "voice_connection",
+        "phone_number"
+      ]
     },
     {
       "id": "ai_assistants",
@@ -53,7 +61,9 @@
       "cli": "telnyx assistant create --name 'Support Bot'",
       "api": "POST /v2/ai/assistants",
       "docs": "https://developers.telnyx.com/docs/ai/assistants",
-      "requires": ["phone_number"]
+      "requires": [
+        "phone_number"
+      ]
     },
     {
       "id": "ai_inference",
@@ -80,7 +90,10 @@
       "guide": "/guides/email.md",
       "api": "POST /v2/email_messages",
       "docs": "https://developers.telnyx.com/docs/email",
-      "requires": ["sending_domain", "api_key"]
+      "requires": [
+        "sending_domain",
+        "api_key"
+      ]
     },
     {
       "id": "numbers",
@@ -100,7 +113,9 @@
       "cli": "telnyx-agent verify-send --phone-number +15551234567 --verify-profile-id prof_xxx --method whatsapp",
       "api": "POST /v2/verifications/whatsapp",
       "docs": "https://developers.telnyx.com/docs/verify",
-      "requires": ["verify_profile"]
+      "requires": [
+        "verify_profile"
+      ]
     },
     {
       "id": "fax",
@@ -109,7 +124,9 @@
       "cli": "telnyx fax send --to +15551234567 --media-url https://example.com/doc.pdf",
       "api": "POST /v2/faxes",
       "docs": "https://developers.telnyx.com/docs/fax",
-      "requires": ["phone_number"]
+      "requires": [
+        "phone_number"
+      ]
     },
     {
       "id": "iot",
@@ -185,6 +202,15 @@
       "requires": []
     },
     {
+      "id": "acp_payments",
+      "name": "ACP Payments",
+      "description": "Fund account through an Agentic Commerce Protocol (ACP) checkout with Stripe Link or Tempo USDC — create, complete, retrieve, and cancel checkouts with idempotency keys.",
+      "guide": "/guides/acp-payments.md",
+      "api": "POST /v2/checkout_sessions",
+      "docs": "https://telnyx.com/.well-known/agent-skills/telnyx-acp-payment/SKILL.md",
+      "requires": []
+    },
+    {
       "id": "porting",
       "name": "Number Porting",
       "description": "Check portability, create and manage port-in orders, upload LOA and supporting documents, track requirements and activation status, and monitor port-out activity.",
@@ -195,38 +221,180 @@
       "requires": []
     }
   ],
-
   "cli": {
     "package": "@telnyx/api-cli",
     "version": "1.1.0",
     "install": "npm install -g @telnyx/api-cli",
-    "global_flags": ["--json", "-o table|json|csv|tsv|ids", "-v", "-p <profile>"],
+    "global_flags": [
+      "--json",
+      "-o table|json|csv|tsv|ids",
+      "-v",
+      "-p <profile>"
+    ],
     "topics": {
-      "10dlc": ["brand list", "brand get", "brand create", "brand delete", "campaign list", "campaign get", "campaign create", "campaign delete", "campaign submit", "assign", "usecases", "verticals", "wizard"],
-      "ai": ["chat", "embed", "models"],
-      "assistant": ["create", "delete", "get", "list", "call"],
-      "auth": ["setup", "status", "whoami"],
-      "billing": ["balance", "group list", "group get", "group create", "group delete"],
-      "call": ["dial", "hangup", "list", "speak", "transfer"],
-      "connection": ["create", "delete", "get", "list"],
-      "debugger": ["get", "list"],
-      "e911": ["address list", "address get", "address create", "address delete", "assign"],
-      "fax": ["send", "get", "list", "delete"],
-      "lookup": ["number"],
-      "message": ["send", "get", "list"],
-      "messaging-profile": ["create", "delete", "get", "list"],
-      "number": ["search", "order", "get", "list", "update", "delete"],
-      "porting": ["check", "order list", "order get", "order create", "order update", "order delete", "order submit", "order cancel", "order activate", "phone-numbers", "comments", "documents", "events", "requirements"],
-      "profile": ["list", "use", "delete"],
-      "sim": ["enable", "disable", "get", "list"],
-      "storage": ["bucket list", "bucket get", "bucket create", "bucket delete", "object list", "object get", "object put", "object delete", "presign"],
-      "usage": ["report", "options"],
-      "verify": ["send", "check", "profile list", "profile get", "profile create", "profile delete", "template list", "template get", "template create"],
-      "video": ["room list", "room get", "room create", "room delete", "session list", "session get", "recording list", "recording get", "recording delete"],
-      "voice-profile": ["create", "delete", "get", "list"]
+      "10dlc": [
+        "brand list",
+        "brand get",
+        "brand create",
+        "brand delete",
+        "campaign list",
+        "campaign get",
+        "campaign create",
+        "campaign delete",
+        "campaign submit",
+        "assign",
+        "usecases",
+        "verticals",
+        "wizard"
+      ],
+      "ai": [
+        "chat",
+        "embed",
+        "models"
+      ],
+      "assistant": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "call"
+      ],
+      "auth": [
+        "setup",
+        "status",
+        "whoami"
+      ],
+      "billing": [
+        "balance",
+        "group list",
+        "group get",
+        "group create",
+        "group delete"
+      ],
+      "call": [
+        "dial",
+        "hangup",
+        "list",
+        "speak",
+        "transfer"
+      ],
+      "connection": [
+        "create",
+        "delete",
+        "get",
+        "list"
+      ],
+      "debugger": [
+        "get",
+        "list"
+      ],
+      "e911": [
+        "address list",
+        "address get",
+        "address create",
+        "address delete",
+        "assign"
+      ],
+      "fax": [
+        "send",
+        "get",
+        "list",
+        "delete"
+      ],
+      "lookup": [
+        "number"
+      ],
+      "message": [
+        "send",
+        "get",
+        "list"
+      ],
+      "messaging-profile": [
+        "create",
+        "delete",
+        "get",
+        "list"
+      ],
+      "number": [
+        "search",
+        "order",
+        "get",
+        "list",
+        "update",
+        "delete"
+      ],
+      "porting": [
+        "check",
+        "order list",
+        "order get",
+        "order create",
+        "order update",
+        "order delete",
+        "order submit",
+        "order cancel",
+        "order activate",
+        "phone-numbers",
+        "comments",
+        "documents",
+        "events",
+        "requirements"
+      ],
+      "profile": [
+        "list",
+        "use",
+        "delete"
+      ],
+      "sim": [
+        "enable",
+        "disable",
+        "get",
+        "list"
+      ],
+      "storage": [
+        "bucket list",
+        "bucket get",
+        "bucket create",
+        "bucket delete",
+        "object list",
+        "object get",
+        "object put",
+        "object delete",
+        "presign"
+      ],
+      "usage": [
+        "report",
+        "options"
+      ],
+      "verify": [
+        "send",
+        "check",
+        "profile list",
+        "profile get",
+        "profile create",
+        "profile delete",
+        "template list",
+        "template get",
+        "template create"
+      ],
+      "video": [
+        "room list",
+        "room get",
+        "room create",
+        "room delete",
+        "session list",
+        "session get",
+        "recording list",
+        "recording get",
+        "recording delete"
+      ],
+      "voice-profile": [
+        "create",
+        "delete",
+        "get",
+        "list"
+      ]
     }
   },
-
   "quickstart": {
     "signup": "curl -s https://telnyx.com/agent-signup.md",
     "signup_guide": "https://telnyx.com/agent-signup.md",
@@ -269,7 +437,6 @@
       }
     ]
   },
-
   "sdks": {
     "cli": {
       "name": "@telnyx/api-cli",
@@ -302,7 +469,6 @@
       "docs": "https://github.com/team-telnyx/telnyx-go"
     }
   },
-
   "links": {
     "api_reference": "https://developers.telnyx.com/docs/api/v2",
     "portal": "https://portal.telnyx.com",

--- a/guides/acp-payments.md
+++ b/guides/acp-payments.md
@@ -41,7 +41,7 @@ export ACP_BASE_URL='https://api.telnyx.com'
 
 # Step 1: Create the checkout (expect HTTP 201, status ready_for_payment)
 umask 077
-CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX.json)"
+CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX)"
 curl -sS --output "$CHECKOUT" --write-out '%{http_code}\n' \
   -X POST "$ACP_BASE_URL/v2/checkout_sessions" \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
@@ -75,8 +75,8 @@ npx --yes @stripe/link-cli@0.16.0 spend-request create \
 export LINK_SPEND_REQUEST_ID='<lsrq-id>'
 
 # Retrieve the approved token into a private file and complete once
-SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX.json)"
-COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX)"
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
   --include shared_payment_token --format json > "$SPEND"
 jq '{payment_data: {handler_id: "stripe_shared_payment_token",
@@ -101,7 +101,7 @@ jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") 
 npx --yes mppx@0.6.28 sign --network mainnet --dry-run --challenge "$(cat "$TEMPO_CHALLENGE")"
 npx --yes mppx@0.6.28 sign --account my-telnyx-payer --network mainnet --format json \
   --challenge "$(cat "$TEMPO_CHALLENGE")" | jq -r '.authorization' > "$TEMPO_CREDENTIAL"
-COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX)"
 jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
         instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \
   "$TEMPO_CREDENTIAL" > "$COMPLETE_BODY"

--- a/guides/acp-payments.md
+++ b/guides/acp-payments.md
@@ -97,7 +97,10 @@ curl -sS -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" 
 TEMPO_CHALLENGE="$(mktemp /tmp/telnyx-acp-tempo-challenge.XXXXXX)"
 TEMPO_CREDENTIAL="$(mktemp /tmp/telnyx-acp-tempo-credential.XXXXXX)"
 jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") | .config.challenge' "$CHECKOUT" > "$TEMPO_CHALLENGE"
-# Sign with the mppx SDK (see the telnyx-acp-payment skill for the signing script), producing $TEMPO_CREDENTIAL
+# Validate, then sign with mppx (signing authorizes the transfer — once per checkout)
+npx --yes mppx@0.6.28 sign --network mainnet --dry-run --challenge "$(cat "$TEMPO_CHALLENGE")"
+npx --yes mppx@0.6.28 sign --account my-telnyx-payer --network mainnet --format json \
+  --challenge "$(cat "$TEMPO_CHALLENGE")" | jq -r '.authorization' > "$TEMPO_CREDENTIAL"
 COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
 jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
         instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \

--- a/guides/acp-payments.md
+++ b/guides/acp-payments.md
@@ -1,0 +1,230 @@
+# ACP Payments (Agentic Commerce Protocol)
+
+> Fund your Telnyx account through an Agentic Commerce Protocol (ACP) checkout, paying with a Stripe Link agent wallet or USDC from a Tempo wallet.
+
+This is **authenticated account funding**: every call carries your Telnyx API key, and the credit lands on the account that owns the key. A funded balance pays for any Telnyx product. ACP wraps the same Link and Tempo payment steps as [MPP](./mpp-payments.md) in a checkout you can create, retrieve, complete, and cancel, with idempotency keys on every write and an order record on completion. For the single-request HTTP `402` version see [mpp-payments.md](./mpp-payments.md); for funding with USDC on Base see [x402-payments.md](./x402-payments.md); for paying per request without any Telnyx account (inference/TTS/STT only), use the keyless x402 endpoints at [x402.telnyx.com](https://x402.telnyx.com/).
+
+## Prerequisites
+
+- Telnyx API key ([get one free](https://telnyx.com/agent-signup.md)) for the account you want to credit
+- `curl`, `jq`, Node.js, and npm
+- One of:
+  - **Stripe Link** — an eligible card in a supported region (currently cards issued in the United States or Canada), paid via `@stripe/link-cli@0.16.0`
+  - **Tempo** — a funded mainnet USDC wallet, paid via `mppx@0.6.28`
+- ACP checkout must be available for your account (a `403` with code `acp_unavailable` means it isn't — contact Telnyx Support)
+
+**Endpoints:**
+
+| Operation | Endpoint |
+|---|---|
+| Create checkout | `POST https://api.telnyx.com/v2/checkout_sessions` |
+| Retrieve checkout | `GET https://api.telnyx.com/v2/checkout_sessions/{checkout_id}` |
+| Complete checkout | `POST https://api.telnyx.com/v2/checkout_sessions/{checkout_id}/complete` |
+| Cancel checkout | `POST https://api.telnyx.com/v2/checkout_sessions/{checkout_id}/cancel` |
+
+Every request needs `Authorization: Bearer <key>` and `API-Version: 2026-04-17`. Every `POST` needs a fresh `Idempotency-Key`. Checkouts cannot be updated (`POST /v2/checkout_sessions/{id}` returns `400 checkout_not_updatable`); create a new one instead.
+
+## How the flow works
+
+1. You `POST` a checkout for the catalog item `account_credit_usd` with the amount in whole US cents. The response is HTTP `201` with `status: "ready_for_payment"` and the payment handlers the checkout accepts.
+2. You pick a handler and pay it: `com.telnyx.mpp.stripe` (handler ID `stripe_shared_payment_token`) with a Link Shared Payment Token, or `com.telnyx.mpp.tempo` (handler ID `tempo_usdc_mpp`) by signing the handler's MPP challenge with `mppx`.
+3. You `POST` the credential to `/complete` exactly once. Telnyx returns HTTP `200`, `status: "completed"`, and an `order` whose `id` is the Telnyx transaction for the credit.
+
+Do not send `account_id` — Telnyx derives the account from your API key. Per-payment amount limits apply and may change; error responses state the current values.
+
+## Quick Start
+
+```bash
+export TELNYX_API_KEY='KEYxxxxx'
+export ACP_AMOUNT_CENTS='1200'     # $12.00
+export ACP_BASE_URL='https://api.telnyx.com'
+
+# Step 1: Create the checkout (expect HTTP 201, status ready_for_payment)
+umask 077
+CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX.json)"
+curl -sS --output "$CHECKOUT" --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data "{\"line_items\":[{\"id\":\"account_credit_usd\",\"unit_amount\":$ACP_AMOUNT_CENTS}],\"currency\":\"usd\",\"capabilities\":{}}"
+export ACP_CHECKOUT_ID="$(jq -r '.id' "$CHECKOUT")"
+jq '{status, expires_at, handlers: [.capabilities.payment.handlers[] | {id, name}]}' "$CHECKOUT"
+```
+
+### Pay with Stripe Link
+
+```bash
+# Sign in and pick a card marked eligible for agentic payments (supported regions — currently US/CA)
+npx --yes @stripe/link-cli@0.16.0 auth status
+npx --yes @stripe/link-cli@0.16.0 payment-methods list --format json
+export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'
+
+# The merchant to pay comes from the checkout's Stripe handler
+export LINK_NETWORK_ID="$(jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.stripe") | .config.merchant_id' "$CHECKOUT")"
+
+# Create a one-time spend request, approve it at the URL it prints
+npx --yes @stripe/link-cli@0.16.0 spend-request create \
+  --payment-method-id "$LINK_PAYMENT_METHOD_ID" \
+  --credential-type shared_payment_token \
+  --network-id "$LINK_NETWORK_ID" \
+  --amount "$ACP_AMOUNT_CENTS" --currency usd \
+  --context 'Add USD credit to my Telnyx account via an ACP checkout.' \
+  --request-approval --format json
+export LINK_SPEND_REQUEST_ID='<lsrq-id>'
+
+# Retrieve the approved token into a private file and complete once
+SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX.json)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
+  --include shared_payment_token --format json > "$SPEND"
+jq '{payment_data: {handler_id: "stripe_shared_payment_token",
+     instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
+  "$SPEND" > "$COMPLETE_BODY"
+curl -sS -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$COMPLETE_BODY"
+```
+
+### Pay with Tempo USDC
+
+```bash
+# Extract the Tempo handler's MPP challenge, sign it once with mppx, complete once
+TEMPO_CHALLENGE="$(mktemp /tmp/telnyx-acp-tempo-challenge.XXXXXX)"
+TEMPO_CREDENTIAL="$(mktemp /tmp/telnyx-acp-tempo-credential.XXXXXX)"
+jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") | .config.challenge' "$CHECKOUT" > "$TEMPO_CHALLENGE"
+# Sign with the mppx SDK (see the telnyx-acp-payment skill for the signing script), producing $TEMPO_CREDENTIAL
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
+        instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \
+  "$TEMPO_CREDENTIAL" > "$COMPLETE_BODY"
+curl -sS -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$COMPLETE_BODY"
+```
+
+## API Reference
+
+### Create a checkout
+
+**`POST /v2/checkout_sessions`**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `line_items[0].id` | string | Yes | Must be `account_credit_usd` |
+| `line_items[0].unit_amount` | integer | Yes | Amount in whole US cents (e.g. `1200`) |
+| `currency` | string | Yes | Must be `usd` |
+| `capabilities` | object | Yes | Send `{}` |
+
+Returns HTTP `201` with the checkout: `id`, `status`, `currency`, `line_items`, `totals`, `expires_at`, and `capabilities.payment.handlers[]`. Each handler has `id`, `name`, and a `config` carrying the MPP `challenge`; the Stripe handler also carries `config.merchant_id`. Re-sending the same key and body returns the same checkout with `Idempotent-Replayed: true`.
+
+**Python** (create):
+
+```python
+import os
+import uuid
+import requests
+
+resp = requests.post(
+    "https://api.telnyx.com/v2/checkout_sessions",
+    headers={
+        "Authorization": f"Bearer {os.environ['TELNYX_API_KEY']}",
+        "API-Version": "2026-04-17",
+        "Idempotency-Key": str(uuid.uuid4()),
+    },
+    json={
+        "line_items": [{"id": "account_credit_usd", "unit_amount": 1200}],
+        "currency": "usd",
+        "capabilities": {},
+    },
+)
+assert resp.status_code == 201
+checkout = resp.json()
+handlers = {h["name"]: h for h in checkout["capabilities"]["payment"]["handlers"]}
+```
+
+**TypeScript** (create):
+
+```typescript
+const resp = await fetch("https://api.telnyx.com/v2/checkout_sessions", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.TELNYX_API_KEY}`,
+    "API-Version": "2026-04-17",
+    "Idempotency-Key": crypto.randomUUID(),
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    line_items: [{ id: "account_credit_usd", unit_amount: 1200 }],
+    currency: "usd",
+    capabilities: {},
+  }),
+});
+const checkout = await resp.json(); // status 201, checkout.status === "ready_for_payment"
+```
+
+### Complete a checkout
+
+**`POST /v2/checkout_sessions/{checkout_id}/complete`**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `payment_data.handler_id` | string | Yes | `stripe_shared_payment_token` or `tempo_usdc_mpp` |
+| `payment_data.instrument` | object | Yes | Link: `{"type":"card","credential":{"type":"spt","token":"spt_..."}}`. Tempo: `{"type":"tempo_usdc","credential":{"type":"mpp_payment","token":"Payment ..."}}` |
+
+Returns HTTP `200` with `status: "completed"` and an `order` (`id`, `checkout_session_id`, `status`, `line_items`, `totals`). `order.id` is the Telnyx transaction ID. HTTP `202` means the provider outcome is not yet known: retrieve the checkout, do not resubmit.
+
+### Retrieve and cancel
+
+**`GET /v2/checkout_sessions/{checkout_id}`** returns the current checkout. Statuses: `ready_for_payment`, `complete_in_progress`, `completed`, `canceled`.
+
+**`POST /v2/checkout_sessions/{checkout_id}/cancel`** cancels a `ready_for_payment` checkout. Completed or already cancelled checkouts return HTTP `405`.
+
+## Verify the credit
+
+```bash
+# The order ID is the Telnyx transaction
+curl -sS "https://api.telnyx.com/v2/payment/crypto_transactions/<order-id>" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+
+# Check the balance
+curl -sS 'https://api.telnyx.com/v2/balance' \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+## Error Handling
+
+Errors use the ACP shape `{"type","code","message"}`.
+
+| HTTP Status | Code | Meaning | Resolution |
+|-------------|------|---------|------------|
+| `400` | `invalid_request` | Bad `API-Version`, missing `Idempotency-Key`, or malformed body | Fix the headers or body |
+| `400` | `checkout_not_updatable` | Checkouts cannot be changed | Create a new checkout |
+| `401` | — | Bad or missing API key | Use `Authorization: Bearer` with a key for the account to credit |
+| `403` | `acp_unavailable` / `forbidden` | ACP not available for this account, or rejected by policy | Contact Telnyx Support |
+| `404` | `checkout_not_found` | Unknown checkout or wrong account | Check the ID and key |
+| `405` | `checkout_not_cancelable` | Already completed or cancelled | Nothing to do |
+| `422` | `checkout_not_payable` | Expired, cancelled, or already complete | Create a new checkout |
+| `422` | `idempotency_conflict` | Key reused with a different body | Use a new key |
+
+## Safety notes
+
+- These payments move real funds — confirm the amount, payment method, and account before approving.
+- Complete a checkout exactly once. Spend requests, Shared Payment Tokens, and Tempo credentials are one-time use. Never pay again just because a response was lost — retrieve the checkout and check the balance first.
+- Never print, commit, or share your API key, Link access token, Shared Payment Token, wallet private key, or signed `Payment ...` credential.
+- Save the checkout ID, both idempotency keys, and the order ID for support tracing.
+
+## Full skill
+
+For the complete step-by-step flow (handler validation, spend-request approval, the Tempo signing script, verification, and support handoff), install the `telnyx-acp-payment` skill:
+
+```bash
+npx skills add team-telnyx/ai --skill telnyx-acp-payment --agent <AGENT>
+```

--- a/guides/mpp-payments.md
+++ b/guides/mpp-payments.md
@@ -2,7 +2,7 @@
 
 > Fund your Telnyx account through an HTTP `402 Payment Required` flow, paying with a Stripe Link agent wallet or USDC from a Tempo wallet.
 
-This is **authenticated account funding**: every call carries your Telnyx API key, and the credit lands on the account that owns the key. A funded balance pays for any Telnyx product. For paying per request without any Telnyx account (inference/TTS/STT only), use the keyless x402 endpoints at [x402.telnyx.com](https://x402.telnyx.com/) instead; for funding with USDC on Base rather than Link/Tempo, see [x402-payments.md](./x402-payments.md).
+This is **authenticated account funding**: every call carries your Telnyx API key, and the credit lands on the account that owns the key. A funded balance pays for any Telnyx product. For paying per request without any Telnyx account (inference/TTS/STT only), use the keyless x402 endpoints at [x402.telnyx.com](https://x402.telnyx.com/) instead; for funding with USDC on Base rather than Link/Tempo, see [x402-payments.md](./x402-payments.md); for the same Link/Tempo payment wrapped in an ACP checkout with idempotency keys and an order record, see [acp-payments.md](./acp-payments.md).
 
 ## Prerequisites
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -18,7 +18,7 @@ Telnyx ships one Claude Code plugin per product area. Install only what your pro
 | `telnyx-numbers` | Phone numbers — search, buy, manage, 10DLC compliance, porting | 42 |
 | `telnyx-webrtc` | WebRTC — video rooms and browser/mobile client SDKs | 17 |
 | `telnyx-ai` | AI — LLM inference, chat completions, embeddings, AI assistants, Meeting Bot, conversation insights | 13 |
-| `telnyx-platform` | Everything account-level and cross-product — account management, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration | 98 |
+| `telnyx-platform` | Everything account-level and cross-product — account management, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration | 99 |
 
 Install with:
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-acp-payment/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-acp-payment/SKILL.md
@@ -53,7 +53,7 @@ There is one product: USD account credit, catalog item `account_credit_usd`. Eac
 
 ## Setup
 
-You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet.
+You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet. Both tools run through `npx`, so nothing is installed into your project.
 
 ## Environment variables
 
@@ -144,7 +144,7 @@ Open the URL shown by the CLI, confirm the phrase, and approve access.
 npx --yes @stripe/link-cli@0.16.0 payment-methods list --format json
 ```
 
-Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+Choose a card whose `capabilities.agentic_payments.eligible` is not `false`. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 
 ```sh
 export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'
@@ -175,7 +175,7 @@ npx --yes @stripe/link-cli@0.16.0 spend-request create \
   --format json
 ```
 
-The response has `status: "pending_approval"` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. Open it, check the card and amount, and click **Approve**. Save the spend-request ID:
+The output includes the spend-request `id` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. The CLI may return at once with `status: "pending_approval"` or keep waiting until the request is approved, denied, or expired. Either way, open the URL, check the card and amount, and click **Approve**. Save the spend-request ID:
 
 ```sh
 export LINK_SPEND_REQUEST_ID='<lsrq-id>'
@@ -196,7 +196,8 @@ COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
   --include shared_payment_token --format json > "$SPEND"
 
-jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null
+jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null \
+  || echo 'NOT APPROVED: stop here, wait for the Link approval, then retrieve again'
 jq '{payment_data: {handler_id: "stripe_shared_payment_token",
      instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
   "$SPEND" > "$COMPLETE_BODY"
@@ -212,7 +213,7 @@ curl -sS \
   --data-binary "@$COMPLETE_BODY"
 ```
 
-Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+If the status check prints `NOT APPROVED`, do not run the completion. Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
 
 ## Pay with Tempo USDC
 
@@ -230,9 +231,9 @@ Back up the wallet and keep its private key secret. Transfer enough USDC to cove
 npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
 ```
 
-### Sign the checkout's challenge
+### Inspect the checkout's challenge
 
-The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Decode its `request` parameter and confirm the chain is Tempo mainnet (`chainId` `4217`), the amount matches your checkout in six-decimal USDC units (cents × 10000), and the recipient is the address you expect. Then create one payment credential with `mppx`:
+The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Save it, validate it, and decode its `request` parameter (base64url JSON):
 
 ```sh
 umask 077
@@ -240,24 +241,34 @@ TEMPO_CHALLENGE="$(mktemp /tmp/telnyx-acp-tempo-challenge.XXXXXX)"
 TEMPO_CREDENTIAL="$(mktemp /tmp/telnyx-acp-tempo-credential.XXXXXX)"
 jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") | .config.challenge' "$CHECKOUT" > "$TEMPO_CHALLENGE"
 
-npm install --silent --no-save mppx@0.6.28
-cat > /tmp/telnyx-acp-sign.mjs <<'EOF'
-import fs from 'node:fs'
-import { Mppx, tempo } from 'mppx/client'
-import { resolveAccount } from 'mppx/cli'
-const [challengePath, outPath, accountName] = process.argv.slice(2)
-const challenge = fs.readFileSync(challengePath, 'utf8').trim()
-const account = await resolveAccount(accountName)
-const mppx = Mppx.create({ methods: [tempo({ account, autoSwap: false })], polyfill: false })
-const credential = await mppx.createCredential(
-  new Response(null, { status: 402, headers: { 'WWW-Authenticate': challenge } })
-)
-fs.writeFileSync(outPath, credential, { mode: 0o600 })
-EOF
-node /tmp/telnyx-acp-sign.mjs "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" my-telnyx-payer
+npx --yes mppx@0.6.28 sign --network mainnet --dry-run --challenge "$(cat "$TEMPO_CHALLENGE")"
+
+sed -E 's/.*request="([^"]+)".*/\1/' "$TEMPO_CHALLENGE" \
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.stringify(JSON.parse(Buffer.from(s.trim(),"base64url").toString()),null,2)))'
 ```
 
-Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout.
+The dry run should print `Challenge is valid.` In the decoded request, confirm before you sign:
+
+| Field | Expected |
+|---|---|
+| `methodDetails.chainId` | `4217` (Tempo mainnet) |
+| `currency` | `0x20C000000000000000000000b9537d11c60E8b50` (USDC.e on Tempo, 6 decimals) |
+| `amount` | `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `12000000`) |
+| `externalId` | `telnyx:account-credit:<your account id>:usd:<amount>` |
+| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts. Record it; it is where your USDC goes |
+
+### Sign the challenge
+
+Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout:
+
+```sh
+npx --yes mppx@0.6.28 sign --account my-telnyx-payer --network mainnet --format json \
+  --challenge "$(cat "$TEMPO_CHALLENGE")" \
+  | jq -r '.authorization' > "$TEMPO_CREDENTIAL"
+test -s "$TEMPO_CREDENTIAL" && echo 'credential saved'
+```
+
+`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key.
 
 ### Complete the checkout
 
@@ -292,9 +303,9 @@ A successful completion returns HTTP `200` with `status: "completed"` and an `or
 jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
 ```
 
-`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both.
+`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both. The checkout `status` of `completed` is the success signal; `order.status` is `created` on a successful completion, and its line item shows `status: "fulfilled"`.
 
-HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout until its status settles.
+HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout every 5 seconds for up to a minute until its status settles, then follow the balance and support steps below if it has not.
 
 ### Retrieve the checkout
 
@@ -318,7 +329,7 @@ curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
 
 ### Check your Telnyx balance
 
@@ -327,7 +338,7 @@ curl -sS "$ACP_BASE_URL/v2/balance" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-Confirm that `available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
+Confirm that `data.available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
 
 ### Check Link or Tempo
 
@@ -356,7 +367,7 @@ Only a checkout in `ready_for_payment` can be cancelled. A completed or already 
 Delete the temporary files once you have recorded the checkout ID, order ID, and balance:
 
 ```sh
-rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" /tmp/telnyx-acp-sign.mjs
+rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL"
 ```
 
 ## What to save for support
@@ -377,7 +388,7 @@ Send these identifiers to Telnyx Support if you need help tracing a payment. Do 
 
 ## If something goes wrong
 
-Errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`.
+Checkout errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`. Authentication failures (`401`) use the standard Telnyx envelope instead: `{"errors": [{"code": "10009", "title": "Authentication failed", "detail": "..."}]}`.
 
 ### HTTP `400`
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-acp-payment/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-acp-payment/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: telnyx-acp-payment
+description: >-
+  Add credit to a Telnyx account through an Agentic Commerce Protocol (ACP)
+  checkout, paying with a Stripe Link agent wallet or Tempo USDC, then verify
+  the order and balance.
+metadata:
+  author: telnyx
+  product: payments
+  requires:
+    bins:
+      - curl
+      - jq
+      - node
+      - npm
+      - npx
+    env:
+      - TELNYX_API_KEY
+---
+
+# Pay into your Telnyx account with ACP
+
+Use Agentic Commerce Protocol (ACP) to add USD credit to your Telnyx account. You create a checkout, pay it with a Stripe Link agent wallet backed by an eligible card or with USDC from a funded Tempo wallet, and complete the checkout once. Telnyx credits the account that owns the API key.
+
+## When to use this skill
+
+Use this skill when you want an ACP checkout lifecycle around a Telnyx account-credit payment: a checkout you can retrieve, cancel, and reconcile, with idempotency keys on every write and an order record when it completes. If you only want the single-request HTTP `402` flow, the `telnyx-mpp-payment` skill funds the same account with the same Link or Tempo credentials.
+
+All Telnyx ACP account-credit checkouts use these endpoints:
+
+```text
+POST https://api.telnyx.com/v2/checkout_sessions
+GET  https://api.telnyx.com/v2/checkout_sessions/{checkout_id}
+POST https://api.telnyx.com/v2/checkout_sessions/{checkout_id}/complete
+POST https://api.telnyx.com/v2/checkout_sessions/{checkout_id}/cancel
+```
+
+There is one product: USD account credit, catalog item `account_credit_usd`. Each checkout advertises the payment handlers it accepts. Telnyx uses Machine Payment Protocol (MPP) challenges inside those handlers, so the Link and Tempo payment steps are the same ones used for a direct MPP payment.
+
+## Before you pay
+
+- These payments move real funds. Check the amount, payment method, and Telnyx account before you approve anything.
+- Use an API key for the account you want to credit. Telnyx gets the account from your API key. Do not send `account_id`.
+- Write the amount in whole US cents as an integer, such as `1200` for `$12.00`.
+- Per-payment amount limits apply and may change. An error response states the current values.
+- Send `API-Version: 2026-04-17` on every request. Other versions are rejected.
+- Send a fresh `Idempotency-Key` on every `POST`. Use a different key for the create, complete, and cancel requests of the same checkout.
+- A checkout expires. Check `expires_at` and start a new checkout if it has passed. Checkouts cannot be updated; create a new one instead.
+- The payment is tied to the account and amount in the checkout's challenge. Do not change either after you approve or sign it.
+- Complete a checkout exactly once. Never reuse a Link spend request, Shared Payment Token, Tempo payment credential, or completed challenge.
+- Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+- Never print, commit, or send your API key, Link access token, Shared Payment Token, wallet private key, or a signed `Payment ...` credential.
+
+## Setup
+
+You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `TELNYX_API_KEY` | Yes | API key for the Telnyx account that will receive the credit |
+| `ACP_AMOUNT_CENTS` | Yes | Positive integer amount in US cents |
+| `ACP_BASE_URL` | Yes | `https://api.telnyx.com` |
+| `ACP_CHECKOUT_ID` | After create | Checkout `id` returned by the create request |
+| `LINK_PAYMENT_METHOD_ID` | Link only | Eligible Link card payment-method ID |
+| `LINK_NETWORK_ID` | Link only | `config.merchant_id` from the checkout's Stripe handler |
+| `LINK_SPEND_REQUEST_ID` | Link only | Approved, one-time Link spend-request ID |
+
+Keep the API key in your shell environment rather than putting it directly in a command or file:
+
+```sh
+export TELNYX_API_KEY='KEYxxxxx'
+export ACP_AMOUNT_CENTS='1200'
+export ACP_BASE_URL='https://api.telnyx.com'
+```
+
+## Read your starting balance
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/balance" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+Save `data.available_credit` so you can confirm the credit later.
+
+## Create the checkout
+
+Save the response in a private temporary file because it contains the payment challenge for your account:
+
+```sh
+umask 077
+CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX.json)"
+
+curl -sS \
+  --output "$CHECKOUT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data "{\"line_items\":[{\"id\":\"account_credit_usd\",\"unit_amount\":$ACP_AMOUNT_CENTS}],\"currency\":\"usd\",\"capabilities\":{}}"
+```
+
+The response should be HTTP `201` with `status: "ready_for_payment"`. Check the checkout before you pay:
+
+```sh
+jq '{id, status, currency, total: (.totals[] | select(.type=="total") | .amount), expires_at,
+     handlers: [.capabilities.payment.handlers[] | {id, name}]}' "$CHECKOUT"
+export ACP_CHECKOUT_ID="$(jq -r '.id' "$CHECKOUT")"
+```
+
+Confirm that the total equals `ACP_AMOUNT_CENTS`, that `expires_at` is in the future, and that the handler you plan to use is listed:
+
+| Handler `name` | Handler `id` | Pays with |
+|---|---|---|
+| `com.telnyx.mpp.stripe` | `stripe_shared_payment_token` | Stripe Link Shared Payment Token backed by an eligible card |
+| `com.telnyx.mpp.tempo` | `tempo_usdc_mpp` | USDC on Tempo from a funded wallet |
+
+Each handler's `config.challenge` is an MPP `Payment ...` challenge bound to your account and amount. Keep it private. Repeating the create request with the same `Idempotency-Key` and body returns the same checkout with an `Idempotent-Replayed: true` header instead of creating a second one.
+
+## Pay with Link
+
+### Sign in
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 auth status
+```
+
+If you are not signed in:
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 auth login \
+  --client-name 'Telnyx ACP payer' \
+  --timeout 600
+```
+
+Open the URL shown by the CLI, confirm the phrase, and approve access.
+
+### Choose a card
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 payment-methods list --format json
+```
+
+Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+
+```sh
+export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'
+```
+
+### Read the merchant from the checkout
+
+The Stripe handler carries the merchant profile that Link must pay. Always take it from the current checkout:
+
+```sh
+export LINK_NETWORK_ID="$(jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.stripe") | .config.merchant_id' "$CHECKOUT")"
+echo "$LINK_NETWORK_ID"
+```
+
+The value looks like `profile_...`.
+
+### Create and approve the spend request
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 spend-request create \
+  --payment-method-id "$LINK_PAYMENT_METHOD_ID" \
+  --credential-type shared_payment_token \
+  --network-id "$LINK_NETWORK_ID" \
+  --amount "$ACP_AMOUNT_CENTS" \
+  --currency usd \
+  --context 'Authorize one card payment to add the specified USD credit to my Telnyx account through an ACP checkout using Stripe Link.' \
+  --request-approval \
+  --format json
+```
+
+The response has `status: "pending_approval"` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. Open it, check the card and amount, and click **Approve**. Save the spend-request ID:
+
+```sh
+export LINK_SPEND_REQUEST_ID='<lsrq-id>'
+```
+
+Each spend request can be used once. Create and approve a new one for every payment.
+
+### Retrieve the token and complete the checkout
+
+Write the token and completion body to private files. Never put the token in a command argument:
+
+```sh
+umask 077
+SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX.json)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+
+npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
+  --include shared_payment_token --format json > "$SPEND"
+
+jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null
+jq '{payment_data: {handler_id: "stripe_shared_payment_token",
+     instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
+  "$SPEND" > "$COMPLETE_BODY"
+
+curl -sS \
+  --output "$COMPLETE_RESULT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$COMPLETE_BODY"
+```
+
+Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+
+## Pay with Tempo USDC
+
+### Prepare your wallet
+
+Create a named mainnet wallet if you do not already have one:
+
+```sh
+npx --yes mppx@0.6.28 account create --account my-telnyx-payer --network mainnet
+```
+
+Back up the wallet and keep its private key secret. Transfer enough USDC to cover the payment and network fees, then check the wallet:
+
+```sh
+npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
+```
+
+### Sign the checkout's challenge
+
+The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Decode its `request` parameter and confirm the chain is Tempo mainnet (`chainId` `4217`), the amount matches your checkout in six-decimal USDC units (cents × 10000), and the recipient is the address you expect. Then create one payment credential with `mppx`:
+
+```sh
+umask 077
+TEMPO_CHALLENGE="$(mktemp /tmp/telnyx-acp-tempo-challenge.XXXXXX)"
+TEMPO_CREDENTIAL="$(mktemp /tmp/telnyx-acp-tempo-credential.XXXXXX)"
+jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") | .config.challenge' "$CHECKOUT" > "$TEMPO_CHALLENGE"
+
+npm install --silent --no-save mppx@0.6.28
+cat > /tmp/telnyx-acp-sign.mjs <<'EOF'
+import fs from 'node:fs'
+import { Mppx, tempo } from 'mppx/client'
+import { resolveAccount } from 'mppx/cli'
+const [challengePath, outPath, accountName] = process.argv.slice(2)
+const challenge = fs.readFileSync(challengePath, 'utf8').trim()
+const account = await resolveAccount(accountName)
+const mppx = Mppx.create({ methods: [tempo({ account, autoSwap: false })], polyfill: false })
+const credential = await mppx.createCredential(
+  new Response(null, { status: 402, headers: { 'WWW-Authenticate': challenge } })
+)
+fs.writeFileSync(outPath, credential, { mode: 0o600 })
+EOF
+node /tmp/telnyx-acp-sign.mjs "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" my-telnyx-payer
+```
+
+Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout.
+
+### Complete the checkout
+
+```sh
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+
+jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
+        instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \
+  "$TEMPO_CREDENTIAL" > "$COMPLETE_BODY"
+
+curl -sS \
+  --output "$COMPLETE_RESULT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$COMPLETE_BODY"
+```
+
+Submit the completion once. If the response is slow or interrupted, check the checkout and your wallet activity before doing anything else.
+
+## Check whether the payment went through
+
+### Read the completion response
+
+A successful completion returns HTTP `200` with `status: "completed"` and an `order` object:
+
+```sh
+jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
+```
+
+`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both.
+
+HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout until its status settles.
+
+### Retrieve the checkout
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17'
+```
+
+| `status` | Meaning |
+|---|---|
+| `ready_for_payment` | Created and payable until `expires_at` |
+| `complete_in_progress` | A completion is being processed. Wait and retrieve again |
+| `completed` | Paid and credited. `order` is present |
+| `canceled` | Cancelled before payment |
+
+### Find the transaction in Telnyx
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+
+### Check your Telnyx balance
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/balance" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+Confirm that `available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
+
+### Check Link or Tempo
+
+For Link, retrieve the spend request without the token:
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" --format json
+```
+
+A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, look up the transaction in your wallet or a Tempo transaction viewer and confirm that it succeeded.
+
+## Cancel a checkout you will not pay
+
+```sh
+curl -sS \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/cancel" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')"
+```
+
+Only a checkout in `ready_for_payment` can be cancelled. A completed or already cancelled checkout returns HTTP `405`.
+
+## Clean up
+
+Delete the temporary files once you have recorded the checkout ID, order ID, and balance:
+
+```sh
+rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" /tmp/telnyx-acp-sign.mjs
+```
+
+## What to save for support
+
+Save these details for each payment:
+
+- checkout `id`, `created_at`, and `expires_at`;
+- the `Idempotency-Key` values you used for create and complete;
+- `order.id` from the completion response;
+- amount in cents and currency;
+- handler `id` you used;
+- Link spend-request ID, if you used Link;
+- Tempo transaction hash, if you used Tempo;
+- the approximate UTC time you completed the checkout; and
+- the final HTTP status and error body if the payment did not complete.
+
+Send these identifiers to Telnyx Support if you need help tracing a payment. Do not send your API key, wallet private key, Link access token, Shared Payment Token, or signed `Payment ...` credential in a normal support message. Use a secure channel if support asks for sensitive material.
+
+## If something goes wrong
+
+Errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`.
+
+### HTTP `400`
+
+`API-Version` is missing or not `2026-04-17`, `Idempotency-Key` is missing, or the body is malformed. A `checkout_not_updatable` code means you sent `POST /v2/checkout_sessions/{id}` to change a checkout. Checkouts cannot be changed; create a new one.
+
+### HTTP `401`
+
+Make sure the request used `Authorization: Bearer $TELNYX_API_KEY` and that the key belongs to the account you want to credit.
+
+### HTTP `403`
+
+`acp_unavailable` means ACP checkout is not available for your account. `forbidden` means the request was rejected by policy. Contact Telnyx Support with the checkout ID if you have one.
+
+### HTTP `404`
+
+The checkout does not exist or belongs to a different account.
+
+### HTTP `405`
+
+`checkout_not_cancelable`: the checkout is already completed or cancelled.
+
+### HTTP `422`
+
+`checkout_not_payable` means the checkout is not in `ready_for_payment`, usually because it expired, was cancelled, or is already complete. `idempotency_conflict` means you reused an `Idempotency-Key` with a different body. Use a new key.
+
+### Link or Tempo shows success, but your balance did not change
+
+Do not pay again right away. Retrieve the checkout and the Telnyx transaction, check the balance, then check the Link spend request or Tempo transaction. If the credit still does not appear, contact Telnyx Support with the saved identifiers.
+
+### You lost the response or do not know whether payment completed
+
+Retrieve the checkout by ID. If it is `completed`, the payment went through. If it is still `ready_for_payment`, no completion was recorded, but check the Link spend request or your Tempo wallet before signing again. Do not reuse a one-time credential or repeat the completion just because the original response was lost. Contact Telnyx Support if those checks do not resolve it.

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-acp-payment/SKILL.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-acp-payment/SKILL.md
@@ -55,6 +55,8 @@ There is one product: USD account credit, catalog item `account_credit_usd`. Eac
 
 You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet. Both tools run through `npx`, so nothing is installed into your project.
 
+Run every command block below in the same shell session. Later blocks reuse variables such as `CHECKOUT` and `ACP_CHECKOUT_ID` that earlier blocks set.
+
 ## Environment variables
 
 | Variable | Required | Description |
@@ -90,7 +92,7 @@ Save the response in a private temporary file because it contains the payment ch
 
 ```sh
 umask 077
-CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX.json)"
+CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX)"
 
 curl -sS \
   --output "$CHECKOUT" \
@@ -183,21 +185,30 @@ export LINK_SPEND_REQUEST_ID='<lsrq-id>'
 
 Each spend request can be used once. Create and approve a new one for every payment.
 
-### Retrieve the token and complete the checkout
+### Retrieve the token
 
-Write the token and completion body to private files. Never put the token in a command argument:
+Write the token to a private file. Never put the token in a command argument:
 
 ```sh
 umask 077
-SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX.json)"
-COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
-COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX)"
 
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
   --include shared_payment_token --format json > "$SPEND"
 
 jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null \
-  || echo 'NOT APPROVED: stop here, wait for the Link approval, then retrieve again'
+  && echo 'APPROVED' \
+  || echo 'NOT APPROVED: wait for the Link approval, then run this block again'
+```
+
+Continue only when the check prints `APPROVED`. If it prints `NOT APPROVED`, wait about 10 seconds and run this block again; give up and cancel the checkout if the spend request is denied or expires.
+
+### Complete the checkout
+
+```sh
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX)"
+
 jq '{payment_data: {handler_id: "stripe_shared_payment_token",
      instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
   "$SPEND" > "$COMPLETE_BODY"
@@ -213,7 +224,7 @@ curl -sS \
   --data-binary "@$COMPLETE_BODY"
 ```
 
-If the status check prints `NOT APPROVED`, do not run the completion. Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
 
 ## Pay with Tempo USDC
 
@@ -225,10 +236,10 @@ Create a named mainnet wallet if you do not already have one:
 npx --yes mppx@0.6.28 account create --account my-telnyx-payer --network mainnet
 ```
 
-Back up the wallet and keep its private key secret. Transfer enough USDC to cover the payment and network fees, then check the wallet:
+Back up the wallet and keep its private key secret. Transfer enough USDC.e (`0x20C000000000000000000000b9537d11c60E8b50` on Tempo) to cover the payment plus network fees, then confirm the wallet address and check its balance in your wallet tooling:
 
 ```sh
-npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
+npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --format json
 ```
 
 ### Inspect the checkout's challenge
@@ -247,15 +258,15 @@ sed -E 's/.*request="([^"]+)".*/\1/' "$TEMPO_CHALLENGE" \
   | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.stringify(JSON.parse(Buffer.from(s.trim(),"base64url").toString()),null,2)))'
 ```
 
-The dry run should print `Challenge is valid.` In the decoded request, confirm before you sign:
+The dry run prints `Challenge is valid.` (on stderr) and nothing else. In the decoded request, confirm before you sign:
 
 | Field | Expected |
 |---|---|
 | `methodDetails.chainId` | `4217` (Tempo mainnet) |
 | `currency` | `0x20C000000000000000000000b9537d11c60E8b50` (USDC.e on Tempo, 6 decimals) |
-| `amount` | `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `12000000`) |
-| `externalId` | `telnyx:account-credit:<your account id>:usd:<amount>` |
-| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts. Record it; it is where your USDC goes |
+| `amount` | A string equal to `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `"12000000"`) |
+| `externalId` | `telnyx:account-credit:<account id>:usd:<dollars>` where `<dollars>` is the amount with two decimals (for example `12.00`). The account ID is the numeric ID of the account that owns your API key; if you do not know it, check only the shape |
+| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts and there is no published value to compare it with; the signed challenge binds it. Record it for your records; it is where your USDC goes |
 
 ### Sign the challenge
 
@@ -268,13 +279,13 @@ npx --yes mppx@0.6.28 sign --account my-telnyx-payer --network mainnet --format 
 test -s "$TEMPO_CREDENTIAL" && echo 'credential saved'
 ```
 
-`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key.
+`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key. If `credential saved` is not printed, the file is empty: do not continue, check the wallet has enough USDC.e and fees, and do not run the sign again until you have read the error.
 
 ### Complete the checkout
 
 ```sh
-COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
-COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX)"
 
 jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
         instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \
@@ -300,8 +311,11 @@ Submit the completion once. If the response is slow or interrupted, check the ch
 A successful completion returns HTTP `200` with `status: "completed"` and an `order` object:
 
 ```sh
-jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
+jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status,
+     fulfilled: (.order.line_items[0].status)}, matches_checkout: (.order.checkout_session_id == env.ACP_CHECKOUT_ID)}' "$COMPLETE_RESULT"
 ```
+
+`matches_checkout` must be `true`.
 
 `order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both. The checkout `status` of `completed` is the success signal; `order.status` is `created` on a successful completion, and its line item shows `status: "fulfilled"`.
 
@@ -329,7 +343,7 @@ curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. For Tempo payments its `receipt_reference` is the on-chain transaction hash. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
 
 ### Check your Telnyx balance
 
@@ -348,7 +362,7 @@ For Link, retrieve the spend request without the token:
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" --format json
 ```
 
-A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, look up the transaction in your wallet or a Tempo transaction viewer and confirm that it succeeded.
+A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, take the `receipt_reference` hash from the Telnyx transaction above and confirm in your wallet or a Tempo block explorer that it succeeded.
 
 ## Cancel a checkout you will not pay
 
@@ -380,7 +394,7 @@ Save these details for each payment:
 - amount in cents and currency;
 - handler `id` you used;
 - Link spend-request ID, if you used Link;
-- Tempo transaction hash, if you used Tempo;
+- Tempo transaction hash and the recipient address from the challenge, if you used Tempo;
 - the approximate UTC time you completed the checkout; and
 - the final HTTP status and error body if the payment did not complete.
 

--- a/providers/cursor/plugin/skills/telnyx-acp-payment/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-acp-payment/SKILL.md
@@ -53,7 +53,7 @@ There is one product: USD account credit, catalog item `account_credit_usd`. Eac
 
 ## Setup
 
-You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet.
+You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet. Both tools run through `npx`, so nothing is installed into your project.
 
 ## Environment variables
 
@@ -144,7 +144,7 @@ Open the URL shown by the CLI, confirm the phrase, and approve access.
 npx --yes @stripe/link-cli@0.16.0 payment-methods list --format json
 ```
 
-Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+Choose a card whose `capabilities.agentic_payments.eligible` is not `false`. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 
 ```sh
 export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'
@@ -175,7 +175,7 @@ npx --yes @stripe/link-cli@0.16.0 spend-request create \
   --format json
 ```
 
-The response has `status: "pending_approval"` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. Open it, check the card and amount, and click **Approve**. Save the spend-request ID:
+The output includes the spend-request `id` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. The CLI may return at once with `status: "pending_approval"` or keep waiting until the request is approved, denied, or expired. Either way, open the URL, check the card and amount, and click **Approve**. Save the spend-request ID:
 
 ```sh
 export LINK_SPEND_REQUEST_ID='<lsrq-id>'
@@ -196,7 +196,8 @@ COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
   --include shared_payment_token --format json > "$SPEND"
 
-jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null
+jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null \
+  || echo 'NOT APPROVED: stop here, wait for the Link approval, then retrieve again'
 jq '{payment_data: {handler_id: "stripe_shared_payment_token",
      instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
   "$SPEND" > "$COMPLETE_BODY"
@@ -212,7 +213,7 @@ curl -sS \
   --data-binary "@$COMPLETE_BODY"
 ```
 
-Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+If the status check prints `NOT APPROVED`, do not run the completion. Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
 
 ## Pay with Tempo USDC
 
@@ -230,9 +231,9 @@ Back up the wallet and keep its private key secret. Transfer enough USDC to cove
 npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
 ```
 
-### Sign the checkout's challenge
+### Inspect the checkout's challenge
 
-The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Decode its `request` parameter and confirm the chain is Tempo mainnet (`chainId` `4217`), the amount matches your checkout in six-decimal USDC units (cents × 10000), and the recipient is the address you expect. Then create one payment credential with `mppx`:
+The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Save it, validate it, and decode its `request` parameter (base64url JSON):
 
 ```sh
 umask 077
@@ -240,24 +241,34 @@ TEMPO_CHALLENGE="$(mktemp /tmp/telnyx-acp-tempo-challenge.XXXXXX)"
 TEMPO_CREDENTIAL="$(mktemp /tmp/telnyx-acp-tempo-credential.XXXXXX)"
 jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") | .config.challenge' "$CHECKOUT" > "$TEMPO_CHALLENGE"
 
-npm install --silent --no-save mppx@0.6.28
-cat > /tmp/telnyx-acp-sign.mjs <<'EOF'
-import fs from 'node:fs'
-import { Mppx, tempo } from 'mppx/client'
-import { resolveAccount } from 'mppx/cli'
-const [challengePath, outPath, accountName] = process.argv.slice(2)
-const challenge = fs.readFileSync(challengePath, 'utf8').trim()
-const account = await resolveAccount(accountName)
-const mppx = Mppx.create({ methods: [tempo({ account, autoSwap: false })], polyfill: false })
-const credential = await mppx.createCredential(
-  new Response(null, { status: 402, headers: { 'WWW-Authenticate': challenge } })
-)
-fs.writeFileSync(outPath, credential, { mode: 0o600 })
-EOF
-node /tmp/telnyx-acp-sign.mjs "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" my-telnyx-payer
+npx --yes mppx@0.6.28 sign --network mainnet --dry-run --challenge "$(cat "$TEMPO_CHALLENGE")"
+
+sed -E 's/.*request="([^"]+)".*/\1/' "$TEMPO_CHALLENGE" \
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.stringify(JSON.parse(Buffer.from(s.trim(),"base64url").toString()),null,2)))'
 ```
 
-Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout.
+The dry run should print `Challenge is valid.` In the decoded request, confirm before you sign:
+
+| Field | Expected |
+|---|---|
+| `methodDetails.chainId` | `4217` (Tempo mainnet) |
+| `currency` | `0x20C000000000000000000000b9537d11c60E8b50` (USDC.e on Tempo, 6 decimals) |
+| `amount` | `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `12000000`) |
+| `externalId` | `telnyx:account-credit:<your account id>:usd:<amount>` |
+| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts. Record it; it is where your USDC goes |
+
+### Sign the challenge
+
+Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout:
+
+```sh
+npx --yes mppx@0.6.28 sign --account my-telnyx-payer --network mainnet --format json \
+  --challenge "$(cat "$TEMPO_CHALLENGE")" \
+  | jq -r '.authorization' > "$TEMPO_CREDENTIAL"
+test -s "$TEMPO_CREDENTIAL" && echo 'credential saved'
+```
+
+`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key.
 
 ### Complete the checkout
 
@@ -292,9 +303,9 @@ A successful completion returns HTTP `200` with `status: "completed"` and an `or
 jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
 ```
 
-`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both.
+`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both. The checkout `status` of `completed` is the success signal; `order.status` is `created` on a successful completion, and its line item shows `status: "fulfilled"`.
 
-HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout until its status settles.
+HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout every 5 seconds for up to a minute until its status settles, then follow the balance and support steps below if it has not.
 
 ### Retrieve the checkout
 
@@ -318,7 +329,7 @@ curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
 
 ### Check your Telnyx balance
 
@@ -327,7 +338,7 @@ curl -sS "$ACP_BASE_URL/v2/balance" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-Confirm that `available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
+Confirm that `data.available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
 
 ### Check Link or Tempo
 
@@ -356,7 +367,7 @@ Only a checkout in `ready_for_payment` can be cancelled. A completed or already 
 Delete the temporary files once you have recorded the checkout ID, order ID, and balance:
 
 ```sh
-rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" /tmp/telnyx-acp-sign.mjs
+rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL"
 ```
 
 ## What to save for support
@@ -377,7 +388,7 @@ Send these identifiers to Telnyx Support if you need help tracing a payment. Do 
 
 ## If something goes wrong
 
-Errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`.
+Checkout errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`. Authentication failures (`401`) use the standard Telnyx envelope instead: `{"errors": [{"code": "10009", "title": "Authentication failed", "detail": "..."}]}`.
 
 ### HTTP `400`
 

--- a/providers/cursor/plugin/skills/telnyx-acp-payment/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-acp-payment/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: telnyx-acp-payment
+description: >-
+  Add credit to a Telnyx account through an Agentic Commerce Protocol (ACP)
+  checkout, paying with a Stripe Link agent wallet or Tempo USDC, then verify
+  the order and balance.
+metadata:
+  author: telnyx
+  product: payments
+  requires:
+    bins:
+      - curl
+      - jq
+      - node
+      - npm
+      - npx
+    env:
+      - TELNYX_API_KEY
+---
+
+# Pay into your Telnyx account with ACP
+
+Use Agentic Commerce Protocol (ACP) to add USD credit to your Telnyx account. You create a checkout, pay it with a Stripe Link agent wallet backed by an eligible card or with USDC from a funded Tempo wallet, and complete the checkout once. Telnyx credits the account that owns the API key.
+
+## When to use this skill
+
+Use this skill when you want an ACP checkout lifecycle around a Telnyx account-credit payment: a checkout you can retrieve, cancel, and reconcile, with idempotency keys on every write and an order record when it completes. If you only want the single-request HTTP `402` flow, the `telnyx-mpp-payment` skill funds the same account with the same Link or Tempo credentials.
+
+All Telnyx ACP account-credit checkouts use these endpoints:
+
+```text
+POST https://api.telnyx.com/v2/checkout_sessions
+GET  https://api.telnyx.com/v2/checkout_sessions/{checkout_id}
+POST https://api.telnyx.com/v2/checkout_sessions/{checkout_id}/complete
+POST https://api.telnyx.com/v2/checkout_sessions/{checkout_id}/cancel
+```
+
+There is one product: USD account credit, catalog item `account_credit_usd`. Each checkout advertises the payment handlers it accepts. Telnyx uses Machine Payment Protocol (MPP) challenges inside those handlers, so the Link and Tempo payment steps are the same ones used for a direct MPP payment.
+
+## Before you pay
+
+- These payments move real funds. Check the amount, payment method, and Telnyx account before you approve anything.
+- Use an API key for the account you want to credit. Telnyx gets the account from your API key. Do not send `account_id`.
+- Write the amount in whole US cents as an integer, such as `1200` for `$12.00`.
+- Per-payment amount limits apply and may change. An error response states the current values.
+- Send `API-Version: 2026-04-17` on every request. Other versions are rejected.
+- Send a fresh `Idempotency-Key` on every `POST`. Use a different key for the create, complete, and cancel requests of the same checkout.
+- A checkout expires. Check `expires_at` and start a new checkout if it has passed. Checkouts cannot be updated; create a new one instead.
+- The payment is tied to the account and amount in the checkout's challenge. Do not change either after you approve or sign it.
+- Complete a checkout exactly once. Never reuse a Link spend request, Shared Payment Token, Tempo payment credential, or completed challenge.
+- Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+- Never print, commit, or send your API key, Link access token, Shared Payment Token, wallet private key, or a signed `Payment ...` credential.
+
+## Setup
+
+You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `TELNYX_API_KEY` | Yes | API key for the Telnyx account that will receive the credit |
+| `ACP_AMOUNT_CENTS` | Yes | Positive integer amount in US cents |
+| `ACP_BASE_URL` | Yes | `https://api.telnyx.com` |
+| `ACP_CHECKOUT_ID` | After create | Checkout `id` returned by the create request |
+| `LINK_PAYMENT_METHOD_ID` | Link only | Eligible Link card payment-method ID |
+| `LINK_NETWORK_ID` | Link only | `config.merchant_id` from the checkout's Stripe handler |
+| `LINK_SPEND_REQUEST_ID` | Link only | Approved, one-time Link spend-request ID |
+
+Keep the API key in your shell environment rather than putting it directly in a command or file:
+
+```sh
+export TELNYX_API_KEY='KEYxxxxx'
+export ACP_AMOUNT_CENTS='1200'
+export ACP_BASE_URL='https://api.telnyx.com'
+```
+
+## Read your starting balance
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/balance" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+Save `data.available_credit` so you can confirm the credit later.
+
+## Create the checkout
+
+Save the response in a private temporary file because it contains the payment challenge for your account:
+
+```sh
+umask 077
+CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX.json)"
+
+curl -sS \
+  --output "$CHECKOUT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data "{\"line_items\":[{\"id\":\"account_credit_usd\",\"unit_amount\":$ACP_AMOUNT_CENTS}],\"currency\":\"usd\",\"capabilities\":{}}"
+```
+
+The response should be HTTP `201` with `status: "ready_for_payment"`. Check the checkout before you pay:
+
+```sh
+jq '{id, status, currency, total: (.totals[] | select(.type=="total") | .amount), expires_at,
+     handlers: [.capabilities.payment.handlers[] | {id, name}]}' "$CHECKOUT"
+export ACP_CHECKOUT_ID="$(jq -r '.id' "$CHECKOUT")"
+```
+
+Confirm that the total equals `ACP_AMOUNT_CENTS`, that `expires_at` is in the future, and that the handler you plan to use is listed:
+
+| Handler `name` | Handler `id` | Pays with |
+|---|---|---|
+| `com.telnyx.mpp.stripe` | `stripe_shared_payment_token` | Stripe Link Shared Payment Token backed by an eligible card |
+| `com.telnyx.mpp.tempo` | `tempo_usdc_mpp` | USDC on Tempo from a funded wallet |
+
+Each handler's `config.challenge` is an MPP `Payment ...` challenge bound to your account and amount. Keep it private. Repeating the create request with the same `Idempotency-Key` and body returns the same checkout with an `Idempotent-Replayed: true` header instead of creating a second one.
+
+## Pay with Link
+
+### Sign in
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 auth status
+```
+
+If you are not signed in:
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 auth login \
+  --client-name 'Telnyx ACP payer' \
+  --timeout 600
+```
+
+Open the URL shown by the CLI, confirm the phrase, and approve access.
+
+### Choose a card
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 payment-methods list --format json
+```
+
+Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+
+```sh
+export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'
+```
+
+### Read the merchant from the checkout
+
+The Stripe handler carries the merchant profile that Link must pay. Always take it from the current checkout:
+
+```sh
+export LINK_NETWORK_ID="$(jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.stripe") | .config.merchant_id' "$CHECKOUT")"
+echo "$LINK_NETWORK_ID"
+```
+
+The value looks like `profile_...`.
+
+### Create and approve the spend request
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 spend-request create \
+  --payment-method-id "$LINK_PAYMENT_METHOD_ID" \
+  --credential-type shared_payment_token \
+  --network-id "$LINK_NETWORK_ID" \
+  --amount "$ACP_AMOUNT_CENTS" \
+  --currency usd \
+  --context 'Authorize one card payment to add the specified USD credit to my Telnyx account through an ACP checkout using Stripe Link.' \
+  --request-approval \
+  --format json
+```
+
+The response has `status: "pending_approval"` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. Open it, check the card and amount, and click **Approve**. Save the spend-request ID:
+
+```sh
+export LINK_SPEND_REQUEST_ID='<lsrq-id>'
+```
+
+Each spend request can be used once. Create and approve a new one for every payment.
+
+### Retrieve the token and complete the checkout
+
+Write the token and completion body to private files. Never put the token in a command argument:
+
+```sh
+umask 077
+SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX.json)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+
+npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
+  --include shared_payment_token --format json > "$SPEND"
+
+jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null
+jq '{payment_data: {handler_id: "stripe_shared_payment_token",
+     instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
+  "$SPEND" > "$COMPLETE_BODY"
+
+curl -sS \
+  --output "$COMPLETE_RESULT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$COMPLETE_BODY"
+```
+
+Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+
+## Pay with Tempo USDC
+
+### Prepare your wallet
+
+Create a named mainnet wallet if you do not already have one:
+
+```sh
+npx --yes mppx@0.6.28 account create --account my-telnyx-payer --network mainnet
+```
+
+Back up the wallet and keep its private key secret. Transfer enough USDC to cover the payment and network fees, then check the wallet:
+
+```sh
+npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
+```
+
+### Sign the checkout's challenge
+
+The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Decode its `request` parameter and confirm the chain is Tempo mainnet (`chainId` `4217`), the amount matches your checkout in six-decimal USDC units (cents × 10000), and the recipient is the address you expect. Then create one payment credential with `mppx`:
+
+```sh
+umask 077
+TEMPO_CHALLENGE="$(mktemp /tmp/telnyx-acp-tempo-challenge.XXXXXX)"
+TEMPO_CREDENTIAL="$(mktemp /tmp/telnyx-acp-tempo-credential.XXXXXX)"
+jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") | .config.challenge' "$CHECKOUT" > "$TEMPO_CHALLENGE"
+
+npm install --silent --no-save mppx@0.6.28
+cat > /tmp/telnyx-acp-sign.mjs <<'EOF'
+import fs from 'node:fs'
+import { Mppx, tempo } from 'mppx/client'
+import { resolveAccount } from 'mppx/cli'
+const [challengePath, outPath, accountName] = process.argv.slice(2)
+const challenge = fs.readFileSync(challengePath, 'utf8').trim()
+const account = await resolveAccount(accountName)
+const mppx = Mppx.create({ methods: [tempo({ account, autoSwap: false })], polyfill: false })
+const credential = await mppx.createCredential(
+  new Response(null, { status: 402, headers: { 'WWW-Authenticate': challenge } })
+)
+fs.writeFileSync(outPath, credential, { mode: 0o600 })
+EOF
+node /tmp/telnyx-acp-sign.mjs "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" my-telnyx-payer
+```
+
+Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout.
+
+### Complete the checkout
+
+```sh
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+
+jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
+        instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \
+  "$TEMPO_CREDENTIAL" > "$COMPLETE_BODY"
+
+curl -sS \
+  --output "$COMPLETE_RESULT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$COMPLETE_BODY"
+```
+
+Submit the completion once. If the response is slow or interrupted, check the checkout and your wallet activity before doing anything else.
+
+## Check whether the payment went through
+
+### Read the completion response
+
+A successful completion returns HTTP `200` with `status: "completed"` and an `order` object:
+
+```sh
+jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
+```
+
+`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both.
+
+HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout until its status settles.
+
+### Retrieve the checkout
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17'
+```
+
+| `status` | Meaning |
+|---|---|
+| `ready_for_payment` | Created and payable until `expires_at` |
+| `complete_in_progress` | A completion is being processed. Wait and retrieve again |
+| `completed` | Paid and credited. `order` is present |
+| `canceled` | Cancelled before payment |
+
+### Find the transaction in Telnyx
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+
+### Check your Telnyx balance
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/balance" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+Confirm that `available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
+
+### Check Link or Tempo
+
+For Link, retrieve the spend request without the token:
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" --format json
+```
+
+A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, look up the transaction in your wallet or a Tempo transaction viewer and confirm that it succeeded.
+
+## Cancel a checkout you will not pay
+
+```sh
+curl -sS \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/cancel" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')"
+```
+
+Only a checkout in `ready_for_payment` can be cancelled. A completed or already cancelled checkout returns HTTP `405`.
+
+## Clean up
+
+Delete the temporary files once you have recorded the checkout ID, order ID, and balance:
+
+```sh
+rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" /tmp/telnyx-acp-sign.mjs
+```
+
+## What to save for support
+
+Save these details for each payment:
+
+- checkout `id`, `created_at`, and `expires_at`;
+- the `Idempotency-Key` values you used for create and complete;
+- `order.id` from the completion response;
+- amount in cents and currency;
+- handler `id` you used;
+- Link spend-request ID, if you used Link;
+- Tempo transaction hash, if you used Tempo;
+- the approximate UTC time you completed the checkout; and
+- the final HTTP status and error body if the payment did not complete.
+
+Send these identifiers to Telnyx Support if you need help tracing a payment. Do not send your API key, wallet private key, Link access token, Shared Payment Token, or signed `Payment ...` credential in a normal support message. Use a secure channel if support asks for sensitive material.
+
+## If something goes wrong
+
+Errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`.
+
+### HTTP `400`
+
+`API-Version` is missing or not `2026-04-17`, `Idempotency-Key` is missing, or the body is malformed. A `checkout_not_updatable` code means you sent `POST /v2/checkout_sessions/{id}` to change a checkout. Checkouts cannot be changed; create a new one.
+
+### HTTP `401`
+
+Make sure the request used `Authorization: Bearer $TELNYX_API_KEY` and that the key belongs to the account you want to credit.
+
+### HTTP `403`
+
+`acp_unavailable` means ACP checkout is not available for your account. `forbidden` means the request was rejected by policy. Contact Telnyx Support with the checkout ID if you have one.
+
+### HTTP `404`
+
+The checkout does not exist or belongs to a different account.
+
+### HTTP `405`
+
+`checkout_not_cancelable`: the checkout is already completed or cancelled.
+
+### HTTP `422`
+
+`checkout_not_payable` means the checkout is not in `ready_for_payment`, usually because it expired, was cancelled, or is already complete. `idempotency_conflict` means you reused an `Idempotency-Key` with a different body. Use a new key.
+
+### Link or Tempo shows success, but your balance did not change
+
+Do not pay again right away. Retrieve the checkout and the Telnyx transaction, check the balance, then check the Link spend request or Tempo transaction. If the credit still does not appear, contact Telnyx Support with the saved identifiers.
+
+### You lost the response or do not know whether payment completed
+
+Retrieve the checkout by ID. If it is `completed`, the payment went through. If it is still `ready_for_payment`, no completion was recorded, but check the Link spend request or your Tempo wallet before signing again. Do not reuse a one-time credential or repeat the completion just because the original response was lost. Contact Telnyx Support if those checks do not resolve it.

--- a/providers/cursor/plugin/skills/telnyx-acp-payment/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-acp-payment/SKILL.md
@@ -55,6 +55,8 @@ There is one product: USD account credit, catalog item `account_credit_usd`. Eac
 
 You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet. Both tools run through `npx`, so nothing is installed into your project.
 
+Run every command block below in the same shell session. Later blocks reuse variables such as `CHECKOUT` and `ACP_CHECKOUT_ID` that earlier blocks set.
+
 ## Environment variables
 
 | Variable | Required | Description |
@@ -90,7 +92,7 @@ Save the response in a private temporary file because it contains the payment ch
 
 ```sh
 umask 077
-CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX.json)"
+CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX)"
 
 curl -sS \
   --output "$CHECKOUT" \
@@ -183,21 +185,30 @@ export LINK_SPEND_REQUEST_ID='<lsrq-id>'
 
 Each spend request can be used once. Create and approve a new one for every payment.
 
-### Retrieve the token and complete the checkout
+### Retrieve the token
 
-Write the token and completion body to private files. Never put the token in a command argument:
+Write the token to a private file. Never put the token in a command argument:
 
 ```sh
 umask 077
-SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX.json)"
-COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
-COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX)"
 
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
   --include shared_payment_token --format json > "$SPEND"
 
 jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null \
-  || echo 'NOT APPROVED: stop here, wait for the Link approval, then retrieve again'
+  && echo 'APPROVED' \
+  || echo 'NOT APPROVED: wait for the Link approval, then run this block again'
+```
+
+Continue only when the check prints `APPROVED`. If it prints `NOT APPROVED`, wait about 10 seconds and run this block again; give up and cancel the checkout if the spend request is denied or expires.
+
+### Complete the checkout
+
+```sh
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX)"
+
 jq '{payment_data: {handler_id: "stripe_shared_payment_token",
      instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
   "$SPEND" > "$COMPLETE_BODY"
@@ -213,7 +224,7 @@ curl -sS \
   --data-binary "@$COMPLETE_BODY"
 ```
 
-If the status check prints `NOT APPROVED`, do not run the completion. Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
 
 ## Pay with Tempo USDC
 
@@ -225,10 +236,10 @@ Create a named mainnet wallet if you do not already have one:
 npx --yes mppx@0.6.28 account create --account my-telnyx-payer --network mainnet
 ```
 
-Back up the wallet and keep its private key secret. Transfer enough USDC to cover the payment and network fees, then check the wallet:
+Back up the wallet and keep its private key secret. Transfer enough USDC.e (`0x20C000000000000000000000b9537d11c60E8b50` on Tempo) to cover the payment plus network fees, then confirm the wallet address and check its balance in your wallet tooling:
 
 ```sh
-npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
+npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --format json
 ```
 
 ### Inspect the checkout's challenge
@@ -247,15 +258,15 @@ sed -E 's/.*request="([^"]+)".*/\1/' "$TEMPO_CHALLENGE" \
   | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.stringify(JSON.parse(Buffer.from(s.trim(),"base64url").toString()),null,2)))'
 ```
 
-The dry run should print `Challenge is valid.` In the decoded request, confirm before you sign:
+The dry run prints `Challenge is valid.` (on stderr) and nothing else. In the decoded request, confirm before you sign:
 
 | Field | Expected |
 |---|---|
 | `methodDetails.chainId` | `4217` (Tempo mainnet) |
 | `currency` | `0x20C000000000000000000000b9537d11c60E8b50` (USDC.e on Tempo, 6 decimals) |
-| `amount` | `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `12000000`) |
-| `externalId` | `telnyx:account-credit:<your account id>:usd:<amount>` |
-| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts. Record it; it is where your USDC goes |
+| `amount` | A string equal to `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `"12000000"`) |
+| `externalId` | `telnyx:account-credit:<account id>:usd:<dollars>` where `<dollars>` is the amount with two decimals (for example `12.00`). The account ID is the numeric ID of the account that owns your API key; if you do not know it, check only the shape |
+| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts and there is no published value to compare it with; the signed challenge binds it. Record it for your records; it is where your USDC goes |
 
 ### Sign the challenge
 
@@ -268,13 +279,13 @@ npx --yes mppx@0.6.28 sign --account my-telnyx-payer --network mainnet --format 
 test -s "$TEMPO_CREDENTIAL" && echo 'credential saved'
 ```
 
-`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key.
+`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key. If `credential saved` is not printed, the file is empty: do not continue, check the wallet has enough USDC.e and fees, and do not run the sign again until you have read the error.
 
 ### Complete the checkout
 
 ```sh
-COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
-COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX)"
 
 jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
         instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \
@@ -300,8 +311,11 @@ Submit the completion once. If the response is slow or interrupted, check the ch
 A successful completion returns HTTP `200` with `status: "completed"` and an `order` object:
 
 ```sh
-jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
+jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status,
+     fulfilled: (.order.line_items[0].status)}, matches_checkout: (.order.checkout_session_id == env.ACP_CHECKOUT_ID)}' "$COMPLETE_RESULT"
 ```
+
+`matches_checkout` must be `true`.
 
 `order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both. The checkout `status` of `completed` is the success signal; `order.status` is `created` on a successful completion, and its line item shows `status: "fulfilled"`.
 
@@ -329,7 +343,7 @@ curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. For Tempo payments its `receipt_reference` is the on-chain transaction hash. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
 
 ### Check your Telnyx balance
 
@@ -348,7 +362,7 @@ For Link, retrieve the spend request without the token:
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" --format json
 ```
 
-A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, look up the transaction in your wallet or a Tempo transaction viewer and confirm that it succeeded.
+A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, take the `receipt_reference` hash from the Telnyx transaction above and confirm in your wallet or a Tempo block explorer that it succeeded.
 
 ## Cancel a checkout you will not pay
 
@@ -380,7 +394,7 @@ Save these details for each payment:
 - amount in cents and currency;
 - handler `id` you used;
 - Link spend-request ID, if you used Link;
-- Tempo transaction hash, if you used Tempo;
+- Tempo transaction hash and the recipient address from the challenge, if you used Tempo;
 - the approximate UTC time you completed the checkout; and
 - the final HTTP status and error body if the payment did not complete.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -191,10 +191,11 @@ Available payment skills:
 
 | Skill | Description |
 |-------|-------------|
+| `telnyx-acp-payment` | Add account credit through an Agentic Commerce Protocol (ACP) checkout paid with Stripe Link or Tempo USDC — create, complete, and verify the order and balance |
 | `telnyx-mpp-payment` | Add account credit via Machine Payment Protocol (HTTP 402) using Stripe Link or Tempo USDC, then verify the transaction and balance |
 | `telnyx-x402-payment` | Fund an account with USDC on Base via the x402 protocol — quoting, EIP-712 signing, and settlement |
 
-> **Note:** These payments move real funds. Both skills include verification steps and safe support-handoff guidance.
+> **Note:** These payments move real funds. All three skills include verification steps and safe support-handoff guidance.
 
 ## WebRTC Client SDKs
 

--- a/skills/telnyx-acp-payment/SKILL.md
+++ b/skills/telnyx-acp-payment/SKILL.md
@@ -53,7 +53,7 @@ There is one product: USD account credit, catalog item `account_credit_usd`. Eac
 
 ## Setup
 
-You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet.
+You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet. Both tools run through `npx`, so nothing is installed into your project.
 
 ## Environment variables
 
@@ -144,7 +144,7 @@ Open the URL shown by the CLI, confirm the phrase, and approve access.
 npx --yes @stripe/link-cli@0.16.0 payment-methods list --format json
 ```
 
-Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+Choose a card whose `capabilities.agentic_payments.eligible` is not `false`. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
 
 ```sh
 export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'
@@ -175,7 +175,7 @@ npx --yes @stripe/link-cli@0.16.0 spend-request create \
   --format json
 ```
 
-The response has `status: "pending_approval"` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. Open it, check the card and amount, and click **Approve**. Save the spend-request ID:
+The output includes the spend-request `id` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. The CLI may return at once with `status: "pending_approval"` or keep waiting until the request is approved, denied, or expired. Either way, open the URL, check the card and amount, and click **Approve**. Save the spend-request ID:
 
 ```sh
 export LINK_SPEND_REQUEST_ID='<lsrq-id>'
@@ -196,7 +196,8 @@ COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
   --include shared_payment_token --format json > "$SPEND"
 
-jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null
+jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null \
+  || echo 'NOT APPROVED: stop here, wait for the Link approval, then retrieve again'
 jq '{payment_data: {handler_id: "stripe_shared_payment_token",
      instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
   "$SPEND" > "$COMPLETE_BODY"
@@ -212,7 +213,7 @@ curl -sS \
   --data-binary "@$COMPLETE_BODY"
 ```
 
-Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+If the status check prints `NOT APPROVED`, do not run the completion. Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
 
 ## Pay with Tempo USDC
 
@@ -230,9 +231,9 @@ Back up the wallet and keep its private key secret. Transfer enough USDC to cove
 npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
 ```
 
-### Sign the checkout's challenge
+### Inspect the checkout's challenge
 
-The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Decode its `request` parameter and confirm the chain is Tempo mainnet (`chainId` `4217`), the amount matches your checkout in six-decimal USDC units (cents × 10000), and the recipient is the address you expect. Then create one payment credential with `mppx`:
+The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Save it, validate it, and decode its `request` parameter (base64url JSON):
 
 ```sh
 umask 077
@@ -240,24 +241,34 @@ TEMPO_CHALLENGE="$(mktemp /tmp/telnyx-acp-tempo-challenge.XXXXXX)"
 TEMPO_CREDENTIAL="$(mktemp /tmp/telnyx-acp-tempo-credential.XXXXXX)"
 jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") | .config.challenge' "$CHECKOUT" > "$TEMPO_CHALLENGE"
 
-npm install --silent --no-save mppx@0.6.28
-cat > /tmp/telnyx-acp-sign.mjs <<'EOF'
-import fs from 'node:fs'
-import { Mppx, tempo } from 'mppx/client'
-import { resolveAccount } from 'mppx/cli'
-const [challengePath, outPath, accountName] = process.argv.slice(2)
-const challenge = fs.readFileSync(challengePath, 'utf8').trim()
-const account = await resolveAccount(accountName)
-const mppx = Mppx.create({ methods: [tempo({ account, autoSwap: false })], polyfill: false })
-const credential = await mppx.createCredential(
-  new Response(null, { status: 402, headers: { 'WWW-Authenticate': challenge } })
-)
-fs.writeFileSync(outPath, credential, { mode: 0o600 })
-EOF
-node /tmp/telnyx-acp-sign.mjs "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" my-telnyx-payer
+npx --yes mppx@0.6.28 sign --network mainnet --dry-run --challenge "$(cat "$TEMPO_CHALLENGE")"
+
+sed -E 's/.*request="([^"]+)".*/\1/' "$TEMPO_CHALLENGE" \
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.stringify(JSON.parse(Buffer.from(s.trim(),"base64url").toString()),null,2)))'
 ```
 
-Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout.
+The dry run should print `Challenge is valid.` In the decoded request, confirm before you sign:
+
+| Field | Expected |
+|---|---|
+| `methodDetails.chainId` | `4217` (Tempo mainnet) |
+| `currency` | `0x20C000000000000000000000b9537d11c60E8b50` (USDC.e on Tempo, 6 decimals) |
+| `amount` | `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `12000000`) |
+| `externalId` | `telnyx:account-credit:<your account id>:usd:<amount>` |
+| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts. Record it; it is where your USDC goes |
+
+### Sign the challenge
+
+Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout:
+
+```sh
+npx --yes mppx@0.6.28 sign --account my-telnyx-payer --network mainnet --format json \
+  --challenge "$(cat "$TEMPO_CHALLENGE")" \
+  | jq -r '.authorization' > "$TEMPO_CREDENTIAL"
+test -s "$TEMPO_CREDENTIAL" && echo 'credential saved'
+```
+
+`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key.
 
 ### Complete the checkout
 
@@ -292,9 +303,9 @@ A successful completion returns HTTP `200` with `status: "completed"` and an `or
 jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
 ```
 
-`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both.
+`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both. The checkout `status` of `completed` is the success signal; `order.status` is `created` on a successful completion, and its line item shows `status: "fulfilled"`.
 
-HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout until its status settles.
+HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout every 5 seconds for up to a minute until its status settles, then follow the balance and support steps below if it has not.
 
 ### Retrieve the checkout
 
@@ -318,7 +329,7 @@ curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
 
 ### Check your Telnyx balance
 
@@ -327,7 +338,7 @@ curl -sS "$ACP_BASE_URL/v2/balance" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-Confirm that `available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
+Confirm that `data.available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
 
 ### Check Link or Tempo
 
@@ -356,7 +367,7 @@ Only a checkout in `ready_for_payment` can be cancelled. A completed or already 
 Delete the temporary files once you have recorded the checkout ID, order ID, and balance:
 
 ```sh
-rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" /tmp/telnyx-acp-sign.mjs
+rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL"
 ```
 
 ## What to save for support
@@ -377,7 +388,7 @@ Send these identifiers to Telnyx Support if you need help tracing a payment. Do 
 
 ## If something goes wrong
 
-Errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`.
+Checkout errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`. Authentication failures (`401`) use the standard Telnyx envelope instead: `{"errors": [{"code": "10009", "title": "Authentication failed", "detail": "..."}]}`.
 
 ### HTTP `400`
 

--- a/skills/telnyx-acp-payment/SKILL.md
+++ b/skills/telnyx-acp-payment/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: telnyx-acp-payment
+description: >-
+  Add credit to a Telnyx account through an Agentic Commerce Protocol (ACP)
+  checkout, paying with a Stripe Link agent wallet or Tempo USDC, then verify
+  the order and balance.
+metadata:
+  author: telnyx
+  product: payments
+  requires:
+    bins:
+      - curl
+      - jq
+      - node
+      - npm
+      - npx
+    env:
+      - TELNYX_API_KEY
+---
+
+# Pay into your Telnyx account with ACP
+
+Use Agentic Commerce Protocol (ACP) to add USD credit to your Telnyx account. You create a checkout, pay it with a Stripe Link agent wallet backed by an eligible card or with USDC from a funded Tempo wallet, and complete the checkout once. Telnyx credits the account that owns the API key.
+
+## When to use this skill
+
+Use this skill when you want an ACP checkout lifecycle around a Telnyx account-credit payment: a checkout you can retrieve, cancel, and reconcile, with idempotency keys on every write and an order record when it completes. If you only want the single-request HTTP `402` flow, the `telnyx-mpp-payment` skill funds the same account with the same Link or Tempo credentials.
+
+All Telnyx ACP account-credit checkouts use these endpoints:
+
+```text
+POST https://api.telnyx.com/v2/checkout_sessions
+GET  https://api.telnyx.com/v2/checkout_sessions/{checkout_id}
+POST https://api.telnyx.com/v2/checkout_sessions/{checkout_id}/complete
+POST https://api.telnyx.com/v2/checkout_sessions/{checkout_id}/cancel
+```
+
+There is one product: USD account credit, catalog item `account_credit_usd`. Each checkout advertises the payment handlers it accepts. Telnyx uses Machine Payment Protocol (MPP) challenges inside those handlers, so the Link and Tempo payment steps are the same ones used for a direct MPP payment.
+
+## Before you pay
+
+- These payments move real funds. Check the amount, payment method, and Telnyx account before you approve anything.
+- Use an API key for the account you want to credit. Telnyx gets the account from your API key. Do not send `account_id`.
+- Write the amount in whole US cents as an integer, such as `1200` for `$12.00`.
+- Per-payment amount limits apply and may change. An error response states the current values.
+- Send `API-Version: 2026-04-17` on every request. Other versions are rejected.
+- Send a fresh `Idempotency-Key` on every `POST`. Use a different key for the create, complete, and cancel requests of the same checkout.
+- A checkout expires. Check `expires_at` and start a new checkout if it has passed. Checkouts cannot be updated; create a new one instead.
+- The payment is tied to the account and amount in the checkout's challenge. Do not change either after you approve or sign it.
+- Complete a checkout exactly once. Never reuse a Link spend request, Shared Payment Token, Tempo payment credential, or completed challenge.
+- Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+- Never print, commit, or send your API key, Link access token, Shared Payment Token, wallet private key, or a signed `Payment ...` credential.
+
+## Setup
+
+You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `TELNYX_API_KEY` | Yes | API key for the Telnyx account that will receive the credit |
+| `ACP_AMOUNT_CENTS` | Yes | Positive integer amount in US cents |
+| `ACP_BASE_URL` | Yes | `https://api.telnyx.com` |
+| `ACP_CHECKOUT_ID` | After create | Checkout `id` returned by the create request |
+| `LINK_PAYMENT_METHOD_ID` | Link only | Eligible Link card payment-method ID |
+| `LINK_NETWORK_ID` | Link only | `config.merchant_id` from the checkout's Stripe handler |
+| `LINK_SPEND_REQUEST_ID` | Link only | Approved, one-time Link spend-request ID |
+
+Keep the API key in your shell environment rather than putting it directly in a command or file:
+
+```sh
+export TELNYX_API_KEY='KEYxxxxx'
+export ACP_AMOUNT_CENTS='1200'
+export ACP_BASE_URL='https://api.telnyx.com'
+```
+
+## Read your starting balance
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/balance" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+Save `data.available_credit` so you can confirm the credit later.
+
+## Create the checkout
+
+Save the response in a private temporary file because it contains the payment challenge for your account:
+
+```sh
+umask 077
+CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX.json)"
+
+curl -sS \
+  --output "$CHECKOUT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data "{\"line_items\":[{\"id\":\"account_credit_usd\",\"unit_amount\":$ACP_AMOUNT_CENTS}],\"currency\":\"usd\",\"capabilities\":{}}"
+```
+
+The response should be HTTP `201` with `status: "ready_for_payment"`. Check the checkout before you pay:
+
+```sh
+jq '{id, status, currency, total: (.totals[] | select(.type=="total") | .amount), expires_at,
+     handlers: [.capabilities.payment.handlers[] | {id, name}]}' "$CHECKOUT"
+export ACP_CHECKOUT_ID="$(jq -r '.id' "$CHECKOUT")"
+```
+
+Confirm that the total equals `ACP_AMOUNT_CENTS`, that `expires_at` is in the future, and that the handler you plan to use is listed:
+
+| Handler `name` | Handler `id` | Pays with |
+|---|---|---|
+| `com.telnyx.mpp.stripe` | `stripe_shared_payment_token` | Stripe Link Shared Payment Token backed by an eligible card |
+| `com.telnyx.mpp.tempo` | `tempo_usdc_mpp` | USDC on Tempo from a funded wallet |
+
+Each handler's `config.challenge` is an MPP `Payment ...` challenge bound to your account and amount. Keep it private. Repeating the create request with the same `Idempotency-Key` and body returns the same checkout with an `Idempotent-Replayed: true` header instead of creating a second one.
+
+## Pay with Link
+
+### Sign in
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 auth status
+```
+
+If you are not signed in:
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 auth login \
+  --client-name 'Telnyx ACP payer' \
+  --timeout 600
+```
+
+Open the URL shown by the CLI, confirm the phrase, and approve access.
+
+### Choose a card
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 payment-methods list --format json
+```
+
+Choose a card marked as eligible for agentic payments. Link accepts eligible cards in supported regions — currently cards issued in the United States or Canada.
+
+```sh
+export LINK_PAYMENT_METHOD_ID='<csmrpd-id>'
+```
+
+### Read the merchant from the checkout
+
+The Stripe handler carries the merchant profile that Link must pay. Always take it from the current checkout:
+
+```sh
+export LINK_NETWORK_ID="$(jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.stripe") | .config.merchant_id' "$CHECKOUT")"
+echo "$LINK_NETWORK_ID"
+```
+
+The value looks like `profile_...`.
+
+### Create and approve the spend request
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 spend-request create \
+  --payment-method-id "$LINK_PAYMENT_METHOD_ID" \
+  --credential-type shared_payment_token \
+  --network-id "$LINK_NETWORK_ID" \
+  --amount "$ACP_AMOUNT_CENTS" \
+  --currency usd \
+  --context 'Authorize one card payment to add the specified USD credit to my Telnyx account through an ACP checkout using Stripe Link.' \
+  --request-approval \
+  --format json
+```
+
+The response has `status: "pending_approval"` and an approval URL of the form `https://app.link.com/activity/approve/<lsrq-id>`. Open it, check the card and amount, and click **Approve**. Save the spend-request ID:
+
+```sh
+export LINK_SPEND_REQUEST_ID='<lsrq-id>'
+```
+
+Each spend request can be used once. Create and approve a new one for every payment.
+
+### Retrieve the token and complete the checkout
+
+Write the token and completion body to private files. Never put the token in a command argument:
+
+```sh
+umask 077
+SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX.json)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+
+npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
+  --include shared_payment_token --format json > "$SPEND"
+
+jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null
+jq '{payment_data: {handler_id: "stripe_shared_payment_token",
+     instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
+  "$SPEND" > "$COMPLETE_BODY"
+
+curl -sS \
+  --output "$COMPLETE_RESULT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$COMPLETE_BODY"
+```
+
+Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+
+## Pay with Tempo USDC
+
+### Prepare your wallet
+
+Create a named mainnet wallet if you do not already have one:
+
+```sh
+npx --yes mppx@0.6.28 account create --account my-telnyx-payer --network mainnet
+```
+
+Back up the wallet and keep its private key secret. Transfer enough USDC to cover the payment and network fees, then check the wallet:
+
+```sh
+npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
+```
+
+### Sign the checkout's challenge
+
+The Tempo handler's `config.challenge` is the exact MPP challenge to pay. Decode its `request` parameter and confirm the chain is Tempo mainnet (`chainId` `4217`), the amount matches your checkout in six-decimal USDC units (cents × 10000), and the recipient is the address you expect. Then create one payment credential with `mppx`:
+
+```sh
+umask 077
+TEMPO_CHALLENGE="$(mktemp /tmp/telnyx-acp-tempo-challenge.XXXXXX)"
+TEMPO_CREDENTIAL="$(mktemp /tmp/telnyx-acp-tempo-credential.XXXXXX)"
+jq -r '.capabilities.payment.handlers[] | select(.name=="com.telnyx.mpp.tempo") | .config.challenge' "$CHECKOUT" > "$TEMPO_CHALLENGE"
+
+npm install --silent --no-save mppx@0.6.28
+cat > /tmp/telnyx-acp-sign.mjs <<'EOF'
+import fs from 'node:fs'
+import { Mppx, tempo } from 'mppx/client'
+import { resolveAccount } from 'mppx/cli'
+const [challengePath, outPath, accountName] = process.argv.slice(2)
+const challenge = fs.readFileSync(challengePath, 'utf8').trim()
+const account = await resolveAccount(accountName)
+const mppx = Mppx.create({ methods: [tempo({ account, autoSwap: false })], polyfill: false })
+const credential = await mppx.createCredential(
+  new Response(null, { status: 402, headers: { 'WWW-Authenticate': challenge } })
+)
+fs.writeFileSync(outPath, credential, { mode: 0o600 })
+EOF
+node /tmp/telnyx-acp-sign.mjs "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" my-telnyx-payer
+```
+
+Signing authorizes the USDC transfer, so treat it as the payment step. Sign once per checkout.
+
+### Complete the checkout
+
+```sh
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+
+jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
+        instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \
+  "$TEMPO_CREDENTIAL" > "$COMPLETE_BODY"
+
+curl -sS \
+  --output "$COMPLETE_RESULT" \
+  --write-out '%{http_code}\n' \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/complete" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$COMPLETE_BODY"
+```
+
+Submit the completion once. If the response is slow or interrupted, check the checkout and your wallet activity before doing anything else.
+
+## Check whether the payment went through
+
+### Read the completion response
+
+A successful completion returns HTTP `200` with `status: "completed"` and an `order` object:
+
+```sh
+jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
+```
+
+`order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both.
+
+HTTP `202` means Telnyx could not confirm the payment provider's outcome yet. Do not submit the completion again and do not create a replacement checkout. Retrieve the checkout until its status settles.
+
+### Retrieve the checkout
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17'
+```
+
+| `status` | Meaning |
+|---|---|
+| `ready_for_payment` | Created and payable until `expires_at` |
+| `complete_in_progress` | A completion is being processed. Wait and retrieve again |
+| `completed` | Paid and credited. `order` is present |
+| `canceled` | Cancelled before payment |
+
+### Find the transaction in Telnyx
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+
+### Check your Telnyx balance
+
+```sh
+curl -sS "$ACP_BASE_URL/v2/balance" \
+  -H "Authorization: Bearer $TELNYX_API_KEY"
+```
+
+Confirm that `available_credit` rose by the checkout amount. The balance may update shortly after the completion response, so check again after a brief wait before contacting support.
+
+### Check Link or Tempo
+
+For Link, retrieve the spend request without the token:
+
+```sh
+npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" --format json
+```
+
+A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, look up the transaction in your wallet or a Tempo transaction viewer and confirm that it succeeded.
+
+## Cancel a checkout you will not pay
+
+```sh
+curl -sS \
+  -X POST "$ACP_BASE_URL/v2/checkout_sessions/$ACP_CHECKOUT_ID/cancel" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H 'API-Version: 2026-04-17' \
+  -H "Idempotency-Key: $(node -e 'console.log(crypto.randomUUID())')"
+```
+
+Only a checkout in `ready_for_payment` can be cancelled. A completed or already cancelled checkout returns HTTP `405`.
+
+## Clean up
+
+Delete the temporary files once you have recorded the checkout ID, order ID, and balance:
+
+```sh
+rm -f "$CHECKOUT" "$SPEND" "$COMPLETE_BODY" "$COMPLETE_RESULT" "$TEMPO_CHALLENGE" "$TEMPO_CREDENTIAL" /tmp/telnyx-acp-sign.mjs
+```
+
+## What to save for support
+
+Save these details for each payment:
+
+- checkout `id`, `created_at`, and `expires_at`;
+- the `Idempotency-Key` values you used for create and complete;
+- `order.id` from the completion response;
+- amount in cents and currency;
+- handler `id` you used;
+- Link spend-request ID, if you used Link;
+- Tempo transaction hash, if you used Tempo;
+- the approximate UTC time you completed the checkout; and
+- the final HTTP status and error body if the payment did not complete.
+
+Send these identifiers to Telnyx Support if you need help tracing a payment. Do not send your API key, wallet private key, Link access token, Shared Payment Token, or signed `Payment ...` credential in a normal support message. Use a secure channel if support asks for sensitive material.
+
+## If something goes wrong
+
+Errors use the ACP error shape: `{"type": "...", "code": "...", "message": "..."}`.
+
+### HTTP `400`
+
+`API-Version` is missing or not `2026-04-17`, `Idempotency-Key` is missing, or the body is malformed. A `checkout_not_updatable` code means you sent `POST /v2/checkout_sessions/{id}` to change a checkout. Checkouts cannot be changed; create a new one.
+
+### HTTP `401`
+
+Make sure the request used `Authorization: Bearer $TELNYX_API_KEY` and that the key belongs to the account you want to credit.
+
+### HTTP `403`
+
+`acp_unavailable` means ACP checkout is not available for your account. `forbidden` means the request was rejected by policy. Contact Telnyx Support with the checkout ID if you have one.
+
+### HTTP `404`
+
+The checkout does not exist or belongs to a different account.
+
+### HTTP `405`
+
+`checkout_not_cancelable`: the checkout is already completed or cancelled.
+
+### HTTP `422`
+
+`checkout_not_payable` means the checkout is not in `ready_for_payment`, usually because it expired, was cancelled, or is already complete. `idempotency_conflict` means you reused an `Idempotency-Key` with a different body. Use a new key.
+
+### Link or Tempo shows success, but your balance did not change
+
+Do not pay again right away. Retrieve the checkout and the Telnyx transaction, check the balance, then check the Link spend request or Tempo transaction. If the credit still does not appear, contact Telnyx Support with the saved identifiers.
+
+### You lost the response or do not know whether payment completed
+
+Retrieve the checkout by ID. If it is `completed`, the payment went through. If it is still `ready_for_payment`, no completion was recorded, but check the Link spend request or your Tempo wallet before signing again. Do not reuse a one-time credential or repeat the completion just because the original response was lost. Contact Telnyx Support if those checks do not resolve it.

--- a/skills/telnyx-acp-payment/SKILL.md
+++ b/skills/telnyx-acp-payment/SKILL.md
@@ -55,6 +55,8 @@ There is one product: USD account credit, catalog item `account_credit_usd`. Eac
 
 You need `curl`, `jq`, Node.js, npm, and a Telnyx API key. Link payments use `@stripe/link-cli@0.16.0`. Tempo payments use `mppx@0.6.28` and a funded Tempo wallet. Both tools run through `npx`, so nothing is installed into your project.
 
+Run every command block below in the same shell session. Later blocks reuse variables such as `CHECKOUT` and `ACP_CHECKOUT_ID` that earlier blocks set.
+
 ## Environment variables
 
 | Variable | Required | Description |
@@ -90,7 +92,7 @@ Save the response in a private temporary file because it contains the payment ch
 
 ```sh
 umask 077
-CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX.json)"
+CHECKOUT="$(mktemp /tmp/telnyx-acp-checkout.XXXXXX)"
 
 curl -sS \
   --output "$CHECKOUT" \
@@ -183,21 +185,30 @@ export LINK_SPEND_REQUEST_ID='<lsrq-id>'
 
 Each spend request can be used once. Create and approve a new one for every payment.
 
-### Retrieve the token and complete the checkout
+### Retrieve the token
 
-Write the token and completion body to private files. Never put the token in a command argument:
+Write the token to a private file. Never put the token in a command argument:
 
 ```sh
 umask 077
-SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX.json)"
-COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
-COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+SPEND="$(mktemp /tmp/telnyx-acp-spend.XXXXXX)"
 
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" \
   --include shared_payment_token --format json > "$SPEND"
 
 jq -e '.status == "approved" or .status == "succeeded"' "$SPEND" > /dev/null \
-  || echo 'NOT APPROVED: stop here, wait for the Link approval, then retrieve again'
+  && echo 'APPROVED' \
+  || echo 'NOT APPROVED: wait for the Link approval, then run this block again'
+```
+
+Continue only when the check prints `APPROVED`. If it prints `NOT APPROVED`, wait about 10 seconds and run this block again; give up and cancel the checkout if the spend request is denied or expires.
+
+### Complete the checkout
+
+```sh
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX)"
+
 jq '{payment_data: {handler_id: "stripe_shared_payment_token",
      instrument: {type: "card", credential: {type: "spt", token: .shared_payment_token.id}}}}' \
   "$SPEND" > "$COMPLETE_BODY"
@@ -213,7 +224,7 @@ curl -sS \
   --data-binary "@$COMPLETE_BODY"
 ```
 
-If the status check prints `NOT APPROVED`, do not run the completion. Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
+Submit the completion once. Read [Check whether the payment went through](#check-whether-the-payment-went-through) before doing anything else.
 
 ## Pay with Tempo USDC
 
@@ -225,10 +236,10 @@ Create a named mainnet wallet if you do not already have one:
 npx --yes mppx@0.6.28 account create --account my-telnyx-payer --network mainnet
 ```
 
-Back up the wallet and keep its private key secret. Transfer enough USDC to cover the payment and network fees, then check the wallet:
+Back up the wallet and keep its private key secret. Transfer enough USDC.e (`0x20C000000000000000000000b9537d11c60E8b50` on Tempo) to cover the payment plus network fees, then confirm the wallet address and check its balance in your wallet tooling:
 
 ```sh
-npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --json
+npx --yes mppx@0.6.28 account view --account my-telnyx-payer --network mainnet --format json
 ```
 
 ### Inspect the checkout's challenge
@@ -247,15 +258,15 @@ sed -E 's/.*request="([^"]+)".*/\1/' "$TEMPO_CHALLENGE" \
   | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.stringify(JSON.parse(Buffer.from(s.trim(),"base64url").toString()),null,2)))'
 ```
 
-The dry run should print `Challenge is valid.` In the decoded request, confirm before you sign:
+The dry run prints `Challenge is valid.` (on stderr) and nothing else. In the decoded request, confirm before you sign:
 
 | Field | Expected |
 |---|---|
 | `methodDetails.chainId` | `4217` (Tempo mainnet) |
 | `currency` | `0x20C000000000000000000000b9537d11c60E8b50` (USDC.e on Tempo, 6 decimals) |
-| `amount` | `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `12000000`) |
-| `externalId` | `telnyx:account-credit:<your account id>:usd:<amount>` |
-| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts. Record it; it is where your USDC goes |
+| `amount` | A string equal to `ACP_AMOUNT_CENTS` × 10000 (for example `1200` cents → `"12000000"`) |
+| `externalId` | `telnyx:account-credit:<account id>:usd:<dollars>` where `<dollars>` is the amount with two decimals (for example `12.00`). The account ID is the numeric ID of the account that owns your API key; if you do not know it, check only the shape |
+| `recipient` | The Tempo deposit address Telnyx assigned to this checkout. It can differ between checkouts and there is no published value to compare it with; the signed challenge binds it. Record it for your records; it is where your USDC goes |
 
 ### Sign the challenge
 
@@ -268,13 +279,13 @@ npx --yes mppx@0.6.28 sign --account my-telnyx-payer --network mainnet --format 
 test -s "$TEMPO_CREDENTIAL" && echo 'credential saved'
 ```
 
-`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key.
+`mppx` signs the exact challenge and writes the `Payment ...` credential to the private file. It never prints your private key. If `credential saved` is not printed, the file is empty: do not continue, check the wallet has enough USDC.e and fees, and do not run the sign again until you have read the error.
 
 ### Complete the checkout
 
 ```sh
-COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX.json)"
-COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX.json)"
+COMPLETE_BODY="$(mktemp /tmp/telnyx-acp-complete.XXXXXX)"
+COMPLETE_RESULT="$(mktemp /tmp/telnyx-acp-result.XXXXXX)"
 
 jq -Rs '{payment_data: {handler_id: "tempo_usdc_mpp",
         instrument: {type: "tempo_usdc", credential: {type: "mpp_payment", token: (. | rtrimstr("\n"))}}}}' \
@@ -300,8 +311,11 @@ Submit the completion once. If the response is slow or interrupted, check the ch
 A successful completion returns HTTP `200` with `status: "completed"` and an `order` object:
 
 ```sh
-jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status}}' "$COMPLETE_RESULT"
+jq '{status, order: {id: .order.id, checkout_session_id: .order.checkout_session_id, status: .order.status,
+     fulfilled: (.order.line_items[0].status)}, matches_checkout: (.order.checkout_session_id == env.ACP_CHECKOUT_ID)}' "$COMPLETE_RESULT"
 ```
+
+`matches_checkout` must be `true`.
 
 `order.checkout_session_id` must equal `ACP_CHECKOUT_ID`. `order.id` is the Telnyx transaction ID for the credit. Save both. The checkout `status` of `completed` is the success signal; `order.status` is `created` on a successful completion, and its line item shows `status: "fulfilled"`.
 
@@ -329,7 +343,7 @@ curl -sS "$ACP_BASE_URL/v2/payment/crypto_transactions/<order-id>" \
   -H "Authorization: Bearer $TELNYX_API_KEY"
 ```
 
-Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
+Despite the path name, this endpoint lists every machine payment, including Link card payments. A completed transaction normally has `status: "settled"`. For Tempo payments its `receipt_reference` is the on-chain transaction hash. The list endpoint `GET /v2/payment/crypto_transactions` shows recent machine payments if you lost the order ID.
 
 ### Check your Telnyx balance
 
@@ -348,7 +362,7 @@ For Link, retrieve the spend request without the token:
 npx --yes @stripe/link-cli@0.16.0 spend-request retrieve "$LINK_SPEND_REQUEST_ID" --format json
 ```
 
-A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, look up the transaction in your wallet or a Tempo transaction viewer and confirm that it succeeded.
+A completed Link payment shows `status: "succeeded"` and a successful payment outcome. For Tempo, take the `receipt_reference` hash from the Telnyx transaction above and confirm in your wallet or a Tempo block explorer that it succeeded.
 
 ## Cancel a checkout you will not pay
 
@@ -380,7 +394,7 @@ Save these details for each payment:
 - amount in cents and currency;
 - handler `id` you used;
 - Link spend-request ID, if you used Link;
-- Tempo transaction hash, if you used Tempo;
+- Tempo transaction hash and the recipient address from the challenge, if you used Tempo;
 - the approximate UTC time you completed the checkout; and
 - the final HTTP status and error body if the payment did not complete.
 


### PR DESCRIPTION
## Why

Telnyx now accepts **Agentic Commerce Protocol (ACP)** checkouts for USD account credit (`POST https://api.telnyx.com/v2/checkout_sessions`), paid with a Stripe Link Shared Payment Token or Tempo USDC. The payments team completed a live production Link purchase through it on 2026-09-10. It is the third account-funding rail alongside MPP and x402, and until now nothing in this repo mentioned it.

## What

- `skills/telnyx-acp-payment/SKILL.md` — canonical single-file skill in the same shape as `telnyx-mpp-payment`: create checkout → validate handlers → pay with Link (spend request → approval → SPT) or Tempo (sign the handler's MPP challenge with `mppx`) → complete once → verify order, transaction and balance → cancel / troubleshoot. Converted from the payments team's Hermes/OpenClaw draft: bundled scripts and test-harness-only checks removed, draft hedging removed, contract aligned with the Rails implementation.
- `guides/acp-payments.md` — curl-first guide with Python/TypeScript create examples and the full error table; cross-linked from `guides/mpp-payments.md`.
- `agent.json` — new `acp_payments` capability.
- `skills/README.md`, `README.md`, `plugins/README.md` — payment rows/prose now name ACP, MPP and x402; `SKILL_COUNT` 237 → 238; `telnyx-platform` plugin 98 → 99.
- Provider sync output (`providers/claude/...`, `providers/cursor/...`).

## Contract facts (from `team-telnyx/api` `Api::V2::CheckoutSessionsController` / `Acp::CheckoutContract`)

- `API-Version: 2026-04-17` required on every request; `Idempotency-Key` required on every POST (echoed back; `Idempotent-Replayed: true` on create replay).
- One catalog item `account_credit_usd`, `unit_amount` in integer US cents. Shares the MPP min/max; **limits are not published**.
- Handlers: `com.telnyx.mpp.stripe` → id `stripe_shared_payment_token`; `com.telnyx.mpp.tempo` → id `tempo_usdc_mpp`.
- Operations: create, retrieve, complete, cancel. Update is deliberately rejected (`400 checkout_not_updatable`).
- Statuses: `ready_for_payment` / `complete_in_progress` / `completed` / `canceled`. `order.id` is the Telnyx transaction id (`GET /v2/payment/crypto_transactions/{id}`).

## Checks

- `./scripts/sync-skills.sh`, `./scripts/check-skills-sync.sh`, `./scripts/check-skill-count.sh` — all pass (238).
- `npm run test:guides` — 143/143 pass.
- `mppx@0.6.28` export paths (`mppx/client`, `mppx/cli`) and `@stripe/link-cli@0.16.0` commands verified against the published packages.

## Review applied (2026-09-15)

Payments-team review (Slack, 2026-09-11) applied in `fe456e5`: Tempo sign+complete in one block (credential valid ~25s) with stop-on-error and an `MPPX_PRIVATE_KEY` guard; per-operation idempotency keys generated and recorded up front; no "new key" / "new checkout" advice after a submitted completion; 202 / `complete_in_progress` may need Support; `receipt_reference` removed (not public); amount-limit failures are a generic 400; account identifier may be UUID-shaped. Rewritten blocks exercised with fake sign/curl on all success and stop paths.

## Second review applied (2026-09-17)

`59a38c6`: verification drops `/v2/payment/crypto_transactions` (gateway exposes it to `temporary_token` auth only — verified in `api_service.5-temp-token-only-endpoints.toml`); guide Link `--context` meets link-cli's 100-char minimum; guide Tempo quick start gains the `MPPX_PRIVATE_KEY` guard; Python/TypeScript create examples keep the idempotency key in a variable.

## Related

- dotcom-monorepo#3466 (https://github.com/team-telnyx/dotcom-monorepo/pull/3466) publishing this skill at `telnyx.com/.well-known/agent-skills/telnyx-acp-payment/SKILL.md` and adding ACP to every agent surface. Merge together.
- Open ask for the payments team: `/v2/checkout_sessions` (and `/v2/machine-payments/account-credit`) are still missing from `team-telnyx/openapi` spec3.json.
- Tempo path: DEV-verified by the payments team; a production Tempo purchase is still pending on their side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015feWrhRDj9M8vmPH5cfrbG
